### PR TITLE
Change/reintroduce junit5

### DIFF
--- a/modules/openapi-generator-maven-plugin/examples/multi-module/pom.xml
+++ b/modules/openapi-generator-maven-plugin/examples/multi-module/pom.xml
@@ -19,7 +19,7 @@
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <jodatime-version>2.7</jodatime-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
-        <junit-version>4.13.2</junit-version>
+        <junit-version>5.10.2</junit-version>
         <http-signature-version>1.4</http-signature-version>
     </properties>
 </project>

--- a/modules/openapi-generator-maven-plugin/pom.xml
+++ b/modules/openapi-generator-maven-plugin/pom.xml
@@ -59,8 +59,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>

--- a/modules/openapi-generator-maven-plugin/src/test/java/org/openapitools/codegen/plugin/CodeGenMojoTest.java
+++ b/modules/openapi-generator-maven-plugin/src/test/java/org/openapitools/codegen/plugin/CodeGenMojoTest.java
@@ -16,7 +16,7 @@
 
 package org.openapitools.codegen.plugin;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.nio.file.Files;

--- a/modules/openapi-generator-online/pom.xml
+++ b/modules/openapi-generator-online/pom.xml
@@ -127,8 +127,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>

--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
@@ -1,14 +1,14 @@
 package org.openapitools.codegen.online.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.openapitools.codegen.online.model.ResponseCode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.hasItem;
@@ -18,7 +18,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest(GenApiController.class)
 public class GenApiControllerTest {
 

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -434,6 +434,12 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava-testlib</artifactId>
             <version>31.1-jre</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -433,7 +433,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava-testlib</artifactId>
-            <version>31.1-jre</version>
+            <version>${guava.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>junit</groupId>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -338,9 +338,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -327,8 +327,14 @@
         </dependency>
         <dependency>
             <groupId>com.tngtech.archunit</groupId>
-            <artifactId>archunit-junit4</artifactId>
+            <artifactId>archunit-junit5</artifactId>
             <version>${archunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/openapi-generator/src/main/resources/codegen/generatorClassTest.mustache
+++ b/modules/openapi-generator/src/main/resources/codegen/generatorClassTest.mustache
@@ -1,6 +1,6 @@
 package {{generatorPackage}};
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.config.CodegenConfigurator;

--- a/modules/openapi-generator/src/main/resources/codegen/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/codegen/pom.mustache
@@ -41,7 +41,6 @@
                     </systemPropertyVariables>
                     <argLine>-Xms512m -Xmx1500m</argLine>
                     <parallel>methods</parallel>
-		    <forkMode>pertest</forkMode>
                 </configuration>
             </plugin>
 
@@ -114,8 +113,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <version>${junit-version}</version>
             <scope>test</scope>
         </dependency>
@@ -124,6 +123,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <openapi-generator-version>{{openapiGeneratorVersion}}</openapi-generator-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
-        <junit-version>4.13.2</junit-version>
+        <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
@@ -30,25 +30,21 @@ public class AllGeneratorsTest {
     @Test
     public void testEachWithPetstore() throws IOException {
         for (final CodegenConfig codegenConfig : CodegenConfigLoader.getAll()) {
-            try {
-                File output = Files.createTempDirectory("test").toFile();
-                output.deleteOnExit();
+            File output = Files.createTempDirectory("test").toFile();
+            output.deleteOnExit();
 
-                final CodegenConfigurator configurator = new CodegenConfigurator()
-                        .setGeneratorName(codegenConfig.getName())
-                        .setInputSpec("src/test/resources/3_0/petstore.yaml")
-                        .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+            final CodegenConfigurator configurator = new CodegenConfigurator()
+                    .setGeneratorName(codegenConfig.getName())
+                    .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                    .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
-                final ClientOptInput clientOptInput = configurator.toClientOptInput();
-                DefaultGenerator generator = new DefaultGenerator();
-                List<File> files = generator.opts(clientOptInput).generate();
+            final ClientOptInput clientOptInput = configurator.toClientOptInput();
+            DefaultGenerator generator = new DefaultGenerator();
+            List<File> files = generator.opts(clientOptInput).generate();
 
-                // Main intention of this test is to check that nothing crashes. Besides, we check here that
-                // at least 1 file is generated, besides the common ".openapi-generator-ignore", "FILES" and "VERSION" files.
-                Assert.assertTrue(files.size() >= 4);
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to run " + codegenConfig.getName() + " with petstore.yaml: " + e.getMessage());
-            }
+            // Main intention of this test is to check that nothing crashes. Besides, we check here that
+            // at least 1 file is generated, besides the common ".openapi-generator-ignore", "FILES" and "VERSION" files.
+            Assert.assertTrue(files.size() >= 4);
         }
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
@@ -30,7 +30,7 @@ public class AllGeneratorsTest {
     @Test
     public void testEachWithPetstore() throws IOException {
         for (final CodegenConfig codegenConfig : CodegenConfigLoader.getAll()) {
-            File output = Files.createTempDirectory("test").toFile();
+            final File output = Files.createTempDirectory("test").toFile();
             output.deleteOnExit();
 
             final CodegenConfigurator configurator = new CodegenConfigurator()
@@ -39,13 +39,17 @@ public class AllGeneratorsTest {
                     .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
             final ClientOptInput clientOptInput = configurator.toClientOptInput();
-            DefaultGenerator generator = new DefaultGenerator();
-            List<File> files = generator.opts(clientOptInput).generate();
-
+            List<File> files = List.of();
+            try {
+                DefaultGenerator generator = new DefaultGenerator();
+                files = generator.opts(clientOptInput).generate();
+            } catch (Exception e) {
+                Assert.fail("Generator " + codegenConfig.getName() + " threw an exception (generating " + codegenConfig.getInputSpec() + "): " + e.getMessage(), e);
+            }
+            
             // Main intention of this test is to check that nothing crashes. Besides, we check here that
             // at least 1 file is generated, besides the common ".openapi-generator-ignore", "FILES" and "VERSION" files.
             Assert.assertTrue(files.size() >= 4);
         }
     }
-
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ArchUnitRulesTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ArchUnitRulesTest.java
@@ -4,7 +4,7 @@ import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.lang.ArchRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
 import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -49,6 +49,8 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
+import org.junit.jupiter.api.Assertions;
+
 
 import java.io.File;
 import java.io.IOException;
@@ -70,7 +72,7 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openApi);
         PathItem path = openApi.getPaths().get("/ping");
         CodegenOperation operation = codegen.fromOperation("/ping", "post", path.getPost(), path.getServers());
-        assertEquals(Sets.intersection(operation.imports, Sets.newHashSet("Person")).size(), 1);
+        Assertions.assertEquals(Sets.intersection(operation.imports, Sets.newHashSet("Person")).size(), 1);
     }
 
     @Test
@@ -80,7 +82,7 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openApi);
         PathItem path = openApi.getPaths().get("/api/Users/{userId}");
         CodegenOperation operation = codegen.fromOperation("/api/Users/{userId}", "get", path.getGet(), path.getServers());
-        assertTrue(operation.isResponseOptional);
+        Assertions.assertTrue(operation.isResponseOptional);
     }
 
     @Test
@@ -90,7 +92,7 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openApi);
         PathItem path = openApi.getPaths().get("/pets/petType/{type}");
         CodegenOperation operation = codegen.fromOperation("/pets/petType/{type}", "get", path.getGet(), path.getServers());
-        assertEquals(Sets.intersection(operation.imports, Sets.newHashSet("PetByType")).size(), 1);
+        Assertions.assertEquals(Sets.intersection(operation.imports, Sets.newHashSet("PetByType")).size(), 1);
     }
 
     @Test
@@ -114,8 +116,8 @@ public class DefaultCodegenTest {
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
 
-        assertFalse(codegen.hasBodyParameter(pingOperation));
-        assertTrue(codegen.hasBodyParameter(createOperation));
+        Assertions.assertFalse(codegen.hasBodyParameter(pingOperation));
+        Assertions.assertTrue(codegen.hasBodyParameter(createOperation));
     }
 
     @Test(expectedExceptions = RuntimeException.class)
@@ -149,35 +151,35 @@ public class DefaultCodegenTest {
                         new ApiResponses().addApiResponse("201", new ApiResponse()
                                 .description("Created response")));
         Set<String> createConsumesInfo = DefaultCodegen.getConsumesInfo(openAPI, createOperation);
-        assertEquals(createConsumesInfo.size(), 2);
-        assertTrue(createConsumesInfo.contains("application/json"), "contains 'application/json'");
-        assertTrue(createConsumesInfo.contains("application/xml"), "contains 'application/xml'");
+        Assertions.assertEquals(createConsumesInfo.size(), 2);
+        Assertions.assertTrue(createConsumesInfo.contains("application/json"), "contains 'application/json'");
+        Assertions.assertTrue(createConsumesInfo.contains("application/xml"), "contains 'application/xml'");
         Set<String> createProducesInfo = DefaultCodegen.getProducesInfo(openAPI, createOperation);
-        assertEquals(createProducesInfo.size(), 0);
+        Assertions.assertEquals(createProducesInfo.size(), 0);
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
         CodegenOperation coCreate = codegen.fromOperation("somepath", "post", createOperation, null);
-        assertTrue(coCreate.hasConsumes);
-        assertEquals(coCreate.consumes.size(), 2);
-        assertFalse(coCreate.hasProduces);
+        Assertions.assertTrue(coCreate.hasConsumes);
+        Assertions.assertEquals(coCreate.consumes.size(), 2);
+        Assertions.assertFalse(coCreate.hasProduces);
 
         Operation updateOperationWithRef = new Operation()
                 .requestBody(new RequestBody().$ref("#/components/requestBodies/MyRequestBody"))
                 .responses(new ApiResponses().addApiResponse("201", new ApiResponse().$ref("#/components/responses/MyResponse")));
         Set<String> updateConsumesInfo = DefaultCodegen.getConsumesInfo(openAPI, updateOperationWithRef);
-        assertEquals(updateConsumesInfo.size(), 1);
-        assertTrue(updateConsumesInfo.contains("application/json"), "contains 'application/json'");
+        Assertions.assertEquals(updateConsumesInfo.size(), 1);
+        Assertions.assertTrue(updateConsumesInfo.contains("application/json"), "contains 'application/json'");
         Set<String> updateProducesInfo = DefaultCodegen.getProducesInfo(openAPI, updateOperationWithRef);
-        assertEquals(updateProducesInfo.size(), 1);
-        assertTrue(updateProducesInfo.contains("application/xml"), "contains 'application/xml'");
+        Assertions.assertEquals(updateProducesInfo.size(), 1);
+        Assertions.assertTrue(updateProducesInfo.contains("application/xml"), "contains 'application/xml'");
 
         CodegenOperation coUpdate = codegen.fromOperation("somepath", "post", updateOperationWithRef, null);
-        assertTrue(coUpdate.hasConsumes);
-        assertEquals(coUpdate.consumes.size(), 1);
-        assertEquals(coUpdate.consumes.get(0).get("mediaType"), "application/json");
-        assertTrue(coUpdate.hasProduces);
-        assertEquals(coUpdate.produces.size(), 1);
-        assertEquals(coUpdate.produces.get(0).get("mediaType"), "application/xml");
+        Assertions.assertTrue(coUpdate.hasConsumes);
+        Assertions.assertEquals(coUpdate.consumes.size(), 1);
+        Assertions.assertEquals(coUpdate.consumes.get(0).get("mediaType"), "application/json");
+        Assertions.assertTrue(coUpdate.hasProduces);
+        Assertions.assertEquals(coUpdate.produces.size(), 1);
+        Assertions.assertEquals(coUpdate.produces.get(0).get("mediaType"), "application/xml");
     }
 
     @Test
@@ -188,22 +190,22 @@ public class DefaultCodegenTest {
 
         Operation textOperation = openAPI.getPaths().get("/ping/text").getGet();
         CodegenOperation coText = codegen.fromOperation("/ping/text", "get", textOperation, null);
-        assertTrue(coText.hasProduces);
-        assertEquals(coText.produces.size(), 1);
-        assertEquals(coText.produces.get(0).get("mediaType"), "text/plain");
+        Assertions.assertTrue(coText.hasProduces);
+        Assertions.assertEquals(coText.produces.size(), 1);
+        Assertions.assertEquals(coText.produces.get(0).get("mediaType"), "text/plain");
 
         Operation jsonOperation = openAPI.getPaths().get("/ping/json").getGet();
         CodegenOperation coJson = codegen.fromOperation("/ping/json", "get", jsonOperation, null);
-        assertTrue(coJson.hasProduces);
-        assertEquals(coJson.produces.size(), 1);
-        assertEquals(coJson.produces.get(0).get("mediaType"), "application/json");
+        Assertions.assertTrue(coJson.hasProduces);
+        Assertions.assertEquals(coJson.produces.size(), 1);
+        Assertions.assertEquals(coJson.produces.get(0).get("mediaType"), "application/json");
 
         Operation issue443Operation = openAPI.getPaths().get("/other/issue443").getGet();
         CodegenOperation coIssue443 = codegen.fromOperation("/other/issue443", "get", issue443Operation, null);
-        assertTrue(coIssue443.hasProduces);
-        assertEquals(coIssue443.produces.size(), 2);
-        assertEquals(coIssue443.produces.get(0).get("mediaType"), "application/json");
-        assertEquals(coIssue443.produces.get(1).get("mediaType"), "application/text");
+        Assertions.assertTrue(coIssue443.hasProduces);
+        Assertions.assertEquals(coIssue443.produces.size(), 2);
+        Assertions.assertEquals(coIssue443.produces.get(0).get("mediaType"), "application/json");
+        Assertions.assertEquals(coIssue443.produces.get(1).get("mediaType"), "application/text");
     }
 
     @Test
@@ -211,8 +213,8 @@ public class DefaultCodegenTest {
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.processOpts();
 
-        assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
-        assertTrue(codegen.isHideGenerationTimestamp());
+        Assertions.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
+        Assertions.assertTrue(codegen.isHideGenerationTimestamp());
     }
 
     @Test
@@ -221,8 +223,8 @@ public class DefaultCodegenTest {
         codegen.setHideGenerationTimestamp(false);
         codegen.processOpts();
 
-        assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
-        assertFalse(codegen.isHideGenerationTimestamp());
+        Assertions.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
+        Assertions.assertFalse(codegen.isHideGenerationTimestamp());
     }
 
     @Test
@@ -231,8 +233,8 @@ public class DefaultCodegenTest {
         codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, false);
         codegen.processOpts();
 
-        assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
-        assertFalse(codegen.isHideGenerationTimestamp());
+        Assertions.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
+        Assertions.assertFalse(codegen.isHideGenerationTimestamp());
     }
 
     @Test
@@ -247,7 +249,7 @@ public class DefaultCodegenTest {
 
         Map<String, String> aliases = codegen.getAllAliases(schemas);
 
-        assertEquals(aliases.size(), 0);
+        Assertions.assertEquals(aliases.size(), 0);
     }
 
     @Test
@@ -260,8 +262,8 @@ public class DefaultCodegenTest {
                 ModelUtils.getSchemaFromRequestBody(openAPI.getPaths().get("/fake").getGet().getRequestBody()));
         CodegenParameter codegenParameter = codegen.fromFormProperty("enum_form_string", (Schema) requestBodySchema.getProperties().get("enum_form_string"), new HashSet<String>());
 
-        assertEquals(codegenParameter.defaultValue, "-efg");
-        assertNull(codegenParameter.getSchema());
+        Assertions.assertEquals(codegenParameter.defaultValue, "-efg");
+        Assertions.assertNull(codegenParameter.getSchema());
     }
 
     @Test
@@ -276,8 +278,8 @@ public class DefaultCodegenTest {
         CodegenParameter codegenParameter = codegen.fromFormProperty("visitDate", (Schema) requestBodySchema.getProperties().get("visitDate"),
                 new HashSet<>());
 
-        assertEquals(codegenParameter.defaultValue, "1971-12-19T03:39:57-08:00");
-        assertNull(codegenParameter.getSchema());
+        Assertions.assertEquals(codegenParameter.defaultValue, "1971-12-19T03:39:57-08:00");
+        Assertions.assertNull(codegenParameter.getSchema());
     }
 
     @Test
@@ -286,13 +288,13 @@ public class DefaultCodegenTest {
         String location = "src/test/resources/2_0/python-prior/petstore-with-fake-endpoints-models-for-testing.yaml";
         OpenAPI openAPI = TestUtils.parseFlattenSpec(location);
         SemVer version = ModelUtils.getOpenApiVersion(openAPI, location, null);
-        assertEquals(version, new SemVer("2.0.0"));
+        Assertions.assertEquals(version, new SemVer("2.0.0"));
 
         // Test with OAS 3.0 document.
         location = "src/test/resources/3_0/python/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml";
         openAPI = TestUtils.parseFlattenSpec(location);
         version = ModelUtils.getOpenApiVersion(openAPI, location, null);
-        assertEquals(version, new SemVer("3.0.0"));
+        Assertions.assertEquals(version, new SemVer("3.0.0"));
     }
 
     @Test
@@ -304,14 +306,14 @@ public class DefaultCodegenTest {
         codegen.setDisallowAdditionalPropertiesIfNotPresent(true);
 
         Schema schema = openAPI.getComponents().getSchemas().get("AdditionalPropertiesClass");
-        assertNull(schema.getAdditionalProperties());
+        Assertions.assertNull(schema.getAdditionalProperties());
 
         Schema addProps = ModelUtils.getAdditionalProperties(schema);
         // The petstore-with-fake-endpoints-models-for-testing.yaml does not set the
         // 'additionalProperties' keyword for this model, hence assert the value to be null.
-        assertNull(addProps);
+        Assertions.assertNull(addProps);
         CodegenModel cm = codegen.fromModel("AdditionalPropertiesClass", schema);
-        assertNull(cm.getAdditionalProperties());
+        Assertions.assertNull(cm.getAdditionalProperties());
         // When the 'additionalProperties' keyword is not present, the model
         // should allow undeclared properties. However, due to bug
         // https://github.com/swagger-api/swagger-parser/issues/1369, the swagger
@@ -339,41 +341,41 @@ public class DefaultCodegenTest {
         // This property has the following inline schema.
         // additionalProperties:
         //   type: string
-        assertNotNull(map_string_sc);
-        assertNotNull(map_string_sc.getAdditionalProperties());
-        assertNotNull(map_string_cp.getAdditionalProperties());
+        Assertions.assertNotNull(map_string_sc);
+        Assertions.assertNotNull(map_string_sc.getAdditionalProperties());
+        Assertions.assertNotNull(map_string_cp.getAdditionalProperties());
 
         // map_with_additional_properties
         // This property has the following inline schema.
         // additionalProperties: true
-        assertNotNull(map_with_additional_properties_sc);
+        Assertions.assertNotNull(map_with_additional_properties_sc);
         // It is unfortunate that child.getAdditionalProperties() returns null for a V2 schema.
         // We cannot differentiate between 'additionalProperties' not present and
         // additionalProperties: true.
         // UPDATE fixed in swagger parser 2.1.14
-        assertTrue((Boolean) map_with_additional_properties_sc.getAdditionalProperties());
+        Assertions.assertTrue((Boolean) map_with_additional_properties_sc.getAdditionalProperties());
         addProps = ModelUtils.getAdditionalProperties(map_with_additional_properties_sc);
-        assertEquals(addProps, new Schema());
-        assertNotNull(map_with_additional_properties_cp.getAdditionalProperties());
+        Assertions.assertEquals(addProps, new Schema());
+        Assertions.assertNotNull(map_with_additional_properties_cp.getAdditionalProperties());
 
         // map_without_additional_properties
         // This property has the following inline schema.
         // additionalProperties: false
-        assertNotNull(map_without_additional_properties_sc);
+        Assertions.assertNotNull(map_without_additional_properties_sc);
         // It is unfortunate that child.getAdditionalProperties() returns null for a V2 schema.
         // We cannot differentiate between 'additionalProperties' not present and
         // additionalProperties: false.
         // UPDATE fixed in swagger parser 2.1.14
-        assertFalse((Boolean) map_without_additional_properties_sc.getAdditionalProperties());
+        Assertions.assertFalse((Boolean) map_without_additional_properties_sc.getAdditionalProperties());
         addProps = ModelUtils.getAdditionalProperties(map_without_additional_properties_sc);
-        assertNull(addProps);
-        assertNull(map_without_additional_properties_cp.getAdditionalProperties());
+        Assertions.assertNull(addProps);
+        Assertions.assertNull(map_without_additional_properties_cp.getAdditionalProperties());
 
         // check of composed schema model
         String schemaName = "Parent";
         schema = openAPI.getComponents().getSchemas().get(schemaName);
         cm = codegen.fromModel(schemaName, schema);
-        assertNull(cm.getAdditionalProperties());
+        Assertions.assertNull(cm.getAdditionalProperties());
     }
 
     @Test
@@ -395,14 +397,14 @@ public class DefaultCodegenTest {
          */
 
         Schema schema = openAPI.getComponents().getSchemas().get("AdditionalPropertiesClass");
-        assertNull(schema.getAdditionalProperties());
+        Assertions.assertNull(schema.getAdditionalProperties());
 
         Schema addProps = ModelUtils.getAdditionalProperties(schema);
         // The petstore-with-fake-endpoints-models-for-testing.yaml does not set the
         // 'additionalProperties' keyword for this model, hence assert the value to be null.
-        assertNull(addProps);
+        Assertions.assertNull(addProps);
         CodegenModel cm = codegen.fromModel("AdditionalPropertiesClass", schema);
-        assertNotNull(cm.getAdditionalProperties());
+        Assertions.assertNotNull(cm.getAdditionalProperties());
         // When the 'additionalProperties' keyword is not present, the model
         // should allow undeclared properties. However, due to bug
         // https://github.com/swagger-api/swagger-parser/issues/1369, the swagger
@@ -430,41 +432,41 @@ public class DefaultCodegenTest {
         // This property has the following inline schema.
         // additionalProperties:
         //   type: string
-        assertNotNull(map_string_sc);
-        assertNotNull(map_string_sc.getAdditionalProperties());
-        assertNotNull(map_string_cp.getAdditionalProperties());
+        Assertions.assertNotNull(map_string_sc);
+        Assertions.assertNotNull(map_string_sc.getAdditionalProperties());
+        Assertions.assertNotNull(map_string_cp.getAdditionalProperties());
 
         // map_with_additional_properties
         // This property has the following inline schema.
         // additionalProperties: true
-        assertNotNull(map_with_additional_properties_sc);
+        Assertions.assertNotNull(map_with_additional_properties_sc);
         // It is unfortunate that child.getAdditionalProperties() returns null for a V2 schema.
         // We cannot differentiate between 'additionalProperties' not present and
         // additionalProperties: true.
         // UPDATE fixed in swagger parser 2.1.14
-        assertTrue((Boolean) map_with_additional_properties_sc.getAdditionalProperties());
+        Assertions.assertTrue((Boolean) map_with_additional_properties_sc.getAdditionalProperties());
         addProps = ModelUtils.getAdditionalProperties(map_with_additional_properties_sc);
-        assertEquals(addProps, new Schema());
-        assertNotNull(map_with_additional_properties_cp.getAdditionalProperties());
+        Assertions.assertEquals(addProps, new Schema());
+        Assertions.assertNotNull(map_with_additional_properties_cp.getAdditionalProperties());
 
         // map_without_additional_properties
         // This property has the following inline schema.
         // additionalProperties: false
-        assertNotNull(map_without_additional_properties_sc);
+        Assertions.assertNotNull(map_without_additional_properties_sc);
         // It is unfortunate that child.getAdditionalProperties() returns null for a V2 schema.
         // We cannot differentiate between 'additionalProperties' not present and
         // additionalProperties: false.
         // UPDATE fixed in swagger parser 2.1.14
-        assertFalse((Boolean) map_without_additional_properties_sc.getAdditionalProperties());
+        Assertions.assertFalse((Boolean) map_without_additional_properties_sc.getAdditionalProperties());
         addProps = ModelUtils.getAdditionalProperties(map_without_additional_properties_sc);
-        assertEquals(addProps, null);
-        assertNull(map_without_additional_properties_cp.getAdditionalProperties());
+        Assertions.assertEquals(addProps, null);
+        Assertions.assertNull(map_without_additional_properties_cp.getAdditionalProperties());
 
         // check of composed schema model
         String schemaName = "Parent";
         schema = openAPI.getComponents().getSchemas().get(schemaName);
         cm = codegen.fromModel(schemaName, schema);
-        assertNotNull(cm.getAdditionalProperties());
+        Assertions.assertNotNull(cm.getAdditionalProperties());
     }
 
     @Test
@@ -476,15 +478,15 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         Schema componentSchema = openAPI.getComponents().getSchemas().get("AdditionalPropertiesClass");
-        assertNull(componentSchema.getAdditionalProperties());
+        Assertions.assertNull(componentSchema.getAdditionalProperties());
 
         // When the 'additionalProperties' keyword is not present, the schema may be
         // extended with any undeclared properties.
         Schema addProps = ModelUtils.getAdditionalProperties(componentSchema);
-        assertNotNull(addProps);
-        assertEquals(addProps, new Schema());
+        Assertions.assertNotNull(addProps);
+        Assertions.assertEquals(addProps, new Schema());
         CodegenModel cm = codegen.fromModel("AdditionalPropertiesClass", componentSchema);
-        assertNotNull(cm.getAdditionalProperties());
+        Assertions.assertNotNull(cm.getAdditionalProperties());
 
         Map<String, Schema> modelPropSchemas = componentSchema.getProperties();
         Schema map_with_undeclared_properties_string_sc = modelPropSchemas.get("map_with_undeclared_properties_string");
@@ -516,60 +518,60 @@ public class DefaultCodegenTest {
         // This property has the following inline schema.
         // additionalProperties:
         //   type: string
-        assertNotNull(map_with_undeclared_properties_string_sc);
-        assertNotNull(map_with_undeclared_properties_string_sc.getAdditionalProperties());
-        assertNotNull(map_with_undeclared_properties_string_cp.getAdditionalProperties());
+        Assertions.assertNotNull(map_with_undeclared_properties_string_sc);
+        Assertions.assertNotNull(map_with_undeclared_properties_string_sc.getAdditionalProperties());
+        Assertions.assertNotNull(map_with_undeclared_properties_string_cp.getAdditionalProperties());
 
         // map_with_undeclared_properties_anytype_1
         // This property does not use the additionalProperties keyword,
         // which means by default undeclared properties are allowed.
-        assertNotNull(map_with_undeclared_properties_anytype_1_sc);
-        assertNull(map_with_undeclared_properties_anytype_1_sc.getAdditionalProperties());
+        Assertions.assertNotNull(map_with_undeclared_properties_anytype_1_sc);
+        Assertions.assertNull(map_with_undeclared_properties_anytype_1_sc.getAdditionalProperties());
         addProps = ModelUtils.getAdditionalProperties(map_with_undeclared_properties_anytype_1_sc);
-        assertNotNull(addProps);
-        assertEquals(addProps, new Schema());
-        assertNotNull(map_with_undeclared_properties_anytype_1_cp.getAdditionalProperties());
+        Assertions.assertNotNull(addProps);
+        Assertions.assertEquals(addProps, new Schema());
+        Assertions.assertNotNull(map_with_undeclared_properties_anytype_1_cp.getAdditionalProperties());
 
         // map_with_undeclared_properties_anytype_2
         // This property does not use the additionalProperties keyword,
         // which means by default undeclared properties are allowed.
-        assertNotNull(map_with_undeclared_properties_anytype_2_sc);
-        assertNull(map_with_undeclared_properties_anytype_2_sc.getAdditionalProperties());
+        Assertions.assertNotNull(map_with_undeclared_properties_anytype_2_sc);
+        Assertions.assertNull(map_with_undeclared_properties_anytype_2_sc.getAdditionalProperties());
         addProps = ModelUtils.getAdditionalProperties(map_with_undeclared_properties_anytype_2_sc);
-        assertNotNull(addProps);
-        assertEquals(addProps, new Schema());
-        assertNotNull(map_with_undeclared_properties_anytype_2_cp.getAdditionalProperties());
+        Assertions.assertNotNull(addProps);
+        Assertions.assertEquals(addProps, new Schema());
+        Assertions.assertNotNull(map_with_undeclared_properties_anytype_2_cp.getAdditionalProperties());
 
         // map_with_undeclared_properties_anytype_3
         // This property has the following inline schema.
         // additionalProperties: true
-        assertNotNull(map_with_undeclared_properties_anytype_3_sc);
+        Assertions.assertNotNull(map_with_undeclared_properties_anytype_3_sc);
         // Unlike the V2 spec, in V3 we CAN differentiate between 'additionalProperties' not present and
         // additionalProperties: true.
-        assertNotNull(map_with_undeclared_properties_anytype_3_sc.getAdditionalProperties());
-        assertEquals(map_with_undeclared_properties_anytype_3_sc.getAdditionalProperties(), Boolean.TRUE);
+        Assertions.assertNotNull(map_with_undeclared_properties_anytype_3_sc.getAdditionalProperties());
+        Assertions.assertEquals(map_with_undeclared_properties_anytype_3_sc.getAdditionalProperties(), Boolean.TRUE);
         addProps = ModelUtils.getAdditionalProperties(map_with_undeclared_properties_anytype_3_sc);
-        assertNotNull(addProps);
-        assertEquals(addProps, new Schema());
-        assertNotNull(map_with_undeclared_properties_anytype_3_cp.getAdditionalProperties());
+        Assertions.assertNotNull(addProps);
+        Assertions.assertEquals(addProps, new Schema());
+        Assertions.assertNotNull(map_with_undeclared_properties_anytype_3_cp.getAdditionalProperties());
 
         // empty_map
         // This property has the following inline schema.
         // additionalProperties: false
-        assertNotNull(empty_map_sc);
+        Assertions.assertNotNull(empty_map_sc);
         // Unlike the V2 spec, in V3 we CAN differentiate between 'additionalProperties' not present and
         // additionalProperties: false.
-        assertNotNull(empty_map_sc.getAdditionalProperties());
-        assertEquals(empty_map_sc.getAdditionalProperties(), Boolean.FALSE);
+        Assertions.assertNotNull(empty_map_sc.getAdditionalProperties());
+        Assertions.assertEquals(empty_map_sc.getAdditionalProperties(), Boolean.FALSE);
         addProps = ModelUtils.getAdditionalProperties(empty_map_sc);
-        assertNull(addProps);
-        assertNull(empty_map_cp.getAdditionalProperties());
+        Assertions.assertNull(addProps);
+        Assertions.assertNull(empty_map_cp.getAdditionalProperties());
 
         // check of composed schema model
         String schemaName = "SomeObject";
         Schema schema = openAPI.getComponents().getSchemas().get(schemaName);
         cm = codegen.fromModel(schemaName, schema);
-        assertNotNull(cm.getAdditionalProperties());
+        Assertions.assertNotNull(cm.getAdditionalProperties());
     }
 
     @Test
@@ -584,10 +586,10 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         Schema schema = openAPI.getComponents().getSchemas().get("AdditionalPropertiesClass");
-        assertNull(schema.getAdditionalProperties());
+        Assertions.assertNull(schema.getAdditionalProperties());
 
         Schema addProps = ModelUtils.getAdditionalProperties(schema);
-        assertNull(addProps);
+        Assertions.assertNull(addProps);
     }
 
     @Test
@@ -599,8 +601,8 @@ public class DefaultCodegenTest {
         Operation operation = openAPI.getPaths().get("/test").getGet();
         CodegenOperation co = codegen.fromOperation("/test", "get", operation, null);
 
-        assertEquals(co.produces.size(), 1);
-        assertEquals(co.produces.get(0).get("mediaType"), "application/json");
+        Assertions.assertEquals(co.produces.size(), 1);
+        Assertions.assertEquals(co.produces.get(0).get("mediaType"), "application/json");
     }
 
     @Test
@@ -615,14 +617,14 @@ public class DefaultCodegenTest {
         DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
         CodegenOperation co = codegen.fromOperation("/some/path", "get", operation, null);
-        assertEquals(co.path, "/some/path");
-        assertEquals(co.allParams.size(), 2);
+        Assertions.assertEquals(co.path, "/some/path");
+        Assertions.assertEquals(co.allParams.size(), 2);
         List<String> allParamsNames = co.allParams.stream().map(p -> p.paramName).collect(Collectors.toList());
-        assertTrue(allParamsNames.contains("myparam"));
-        assertTrue(allParamsNames.contains("myparam2"));
+        Assertions.assertTrue(allParamsNames.contains("myparam"));
+        Assertions.assertTrue(allParamsNames.contains("myparam2"));
         List<String> queryParamsNames = co.queryParams.stream().map(p -> p.paramName).collect(Collectors.toList());
-        assertTrue(queryParamsNames.contains("myparam"));
-        assertTrue(queryParamsNames.contains("myparam2"));
+        Assertions.assertTrue(queryParamsNames.contains("myparam"));
+        Assertions.assertTrue(queryParamsNames.contains("myparam2"));
     }
 
     @Test
@@ -632,11 +634,11 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
         Operation operation = openAPI.getPaths().get("/form-param-poc/{id}").getPut();
         CodegenOperation co = codegen.fromOperation("/form-param-poc/{id}", "put", operation, null);
-        assertEquals(co.path, "/form-param-poc/{id}");
-        assertEquals(co.allParams.size(), 2);
+        Assertions.assertEquals(co.path, "/form-param-poc/{id}");
+        Assertions.assertEquals(co.allParams.size(), 2);
         List<String> allParamsNames = co.allParams.stream().map(p -> p.paramName).collect(Collectors.toList());
-        assertTrue(allParamsNames.contains("id"));
-        assertTrue(allParamsNames.contains("id2"));
+        Assertions.assertTrue(allParamsNames.contains("id"));
+        Assertions.assertTrue(allParamsNames.contains("id2"));
     }
 
     @Test
@@ -649,8 +651,8 @@ public class DefaultCodegenTest {
                 ModelUtils.getSchemaFromRequestBody(operation.getRequestBody()));
         String type = codegen.getSchemaType(schema);
 
-        assertNotNull(type);
-        assertEquals(type, "oneOf<ObjA,ObjB>");
+        Assertions.assertNotNull(type);
+        Assertions.assertEquals(type, "oneOf<ObjA,ObjB>");
     }
 
     @Test
@@ -666,7 +668,7 @@ public class DefaultCodegenTest {
         Set<String> oneOf = new TreeSet<String>();
         oneOf.add("Dog");
         oneOf.add("Cat");
-        assertEquals(petItems.oneOf, oneOf);
+        Assertions.assertEquals(petItems.oneOf, oneOf);
         // make sure that animal has the property type
         boolean typeSeen = false;
         boolean typeContainsEnums = false;
@@ -679,14 +681,14 @@ public class DefaultCodegenTest {
                 break;
             }
         }
-        assertTrue(typeSeen);
-        assertTrue(typeContainsEnums);
+        Assertions.assertTrue(typeSeen);
+        Assertions.assertTrue(typeContainsEnums);
 
-        assertEquals(
+        Assertions.assertEquals(
                 ((StringSchema) openAPI.getComponents().getSchemas().get("Dog").getProperties().get("type")).getEnum().size(),
                 1
         );
-        assertEquals(
+        Assertions.assertEquals(
                 ((StringSchema) openAPI.getComponents().getSchemas().get("Cat").getProperties().get("type")).getEnum().size(),
                 1
         );
@@ -705,7 +707,7 @@ public class DefaultCodegenTest {
         Set<String> oneOf = new TreeSet<String>();
         oneOf.add("Dog");
         oneOf.add("Cat");
-        assertEquals(pet.oneOf, oneOf);
+        Assertions.assertEquals(pet.oneOf, oneOf);
         // make sure that animal has the property type
         boolean typeSeen = false;
         for (CodegenProperty cp : pet.vars) {
@@ -714,7 +716,7 @@ public class DefaultCodegenTest {
                 break;
             }
         }
-        assertTrue(typeSeen);
+        Assertions.assertTrue(typeSeen);
     }
 
     @Test
@@ -729,9 +731,9 @@ public class DefaultCodegenTest {
         Set<String> oneOf = new TreeSet<String>();
         oneOf.add("Apple");
         oneOf.add("Banana");
-        assertEquals(fruit.oneOf, oneOf);
-        assertEquals(fruit.optionalVars.size(), 3);
-        assertEquals(fruit.vars.size(), 3);
+        Assertions.assertEquals(fruit.oneOf, oneOf);
+        Assertions.assertEquals(fruit.optionalVars.size(), 3);
+        Assertions.assertEquals(fruit.vars.size(), 3);
         // make sure that fruit has the property color
         boolean colorSeen = false;
         for (CodegenProperty cp : fruit.vars) {
@@ -740,7 +742,7 @@ public class DefaultCodegenTest {
                 break;
             }
         }
-        assertTrue(colorSeen);
+        Assertions.assertTrue(colorSeen);
         colorSeen = false;
         for (CodegenProperty cp : fruit.optionalVars) {
             if ("color".equals(cp.name)) {
@@ -748,19 +750,19 @@ public class DefaultCodegenTest {
                 break;
             }
         }
-        assertTrue(colorSeen);
+        Assertions.assertTrue(colorSeen);
     }
 
     @Test
     public void testEscapeText() {
         final DefaultCodegen codegen = new DefaultCodegen();
 
-        assertEquals(codegen.escapeText("\n"), " ");
-        assertEquals(codegen.escapeText("\r"), " ");
-        assertEquals(codegen.escapeText("\t"), " ");
-        assertEquals(codegen.escapeText("\\"), "\\\\");
-        assertEquals(codegen.escapeText("\""), "\\\"");
-        assertEquals(codegen.escapeText("\\/"), "/");
+        Assertions.assertEquals(codegen.escapeText("\n"), " ");
+        Assertions.assertEquals(codegen.escapeText("\r"), " ");
+        Assertions.assertEquals(codegen.escapeText("\t"), " ");
+        Assertions.assertEquals(codegen.escapeText("\\"), "\\\\");
+        Assertions.assertEquals(codegen.escapeText("\""), "\\\"");
+        Assertions.assertEquals(codegen.escapeText("\\/"), "/");
     }
 
     @Test
@@ -768,14 +770,14 @@ public class DefaultCodegenTest {
         final DefaultCodegen codegen = new DefaultCodegen();
 
         // allow new lines
-        assertEquals(codegen.escapeTextWhileAllowingNewLines("\n"), "\n");
-        assertEquals(codegen.escapeTextWhileAllowingNewLines("\r"), "\r");
+        Assertions.assertEquals(codegen.escapeTextWhileAllowingNewLines("\n"), "\n");
+        Assertions.assertEquals(codegen.escapeTextWhileAllowingNewLines("\r"), "\r");
 
         // escape other special characters
-        assertEquals(codegen.escapeTextWhileAllowingNewLines("\t"), " ");
-        assertEquals(codegen.escapeTextWhileAllowingNewLines("\\"), "\\\\");
-        assertEquals(codegen.escapeTextWhileAllowingNewLines("\""), "\\\"");
-        assertEquals(codegen.escapeTextWhileAllowingNewLines("\\/"), "/");
+        Assertions.assertEquals(codegen.escapeTextWhileAllowingNewLines("\t"), " ");
+        Assertions.assertEquals(codegen.escapeTextWhileAllowingNewLines("\\"), "\\\\");
+        Assertions.assertEquals(codegen.escapeTextWhileAllowingNewLines("\""), "\\\"");
+        Assertions.assertEquals(codegen.escapeTextWhileAllowingNewLines("\\/"), "/");
     }
 
     @Test
@@ -786,12 +788,12 @@ public class DefaultCodegenTest {
         codegen.updateCodegenPropertyEnum(array);
 
         List<Map<String, Object>> enumVars = (List<Map<String, Object>>) array.getItems().getAllowableValues().get("enumVars");
-        assertNotNull(enumVars);
+        Assertions.assertNotNull(enumVars);
         Map<String, Object> testedEnumVar = enumVars.get(0);
-        assertNotNull(testedEnumVar);
-        assertEquals(testedEnumVar.getOrDefault("name", ""), "_1");
-        assertEquals(testedEnumVar.getOrDefault("value", ""), "\"1\"");
-        assertEquals(testedEnumVar.getOrDefault("isString", ""), false);
+        Assertions.assertNotNull(testedEnumVar);
+        Assertions.assertEquals(testedEnumVar.getOrDefault("name", ""), "_1");
+        Assertions.assertEquals(testedEnumVar.getOrDefault("value", ""), "\"1\"");
+        Assertions.assertEquals(testedEnumVar.getOrDefault("isString", ""), false);
     }
 
     @Test
@@ -800,39 +802,39 @@ public class DefaultCodegenTest {
             CodegenProperty enumProperty = codegenPropertyWithXEnumVarName(Arrays.asList("dog", "cat"), Arrays.asList("DOGVAR", "CATVAR"));
             (new DefaultCodegen()).updateCodegenPropertyEnum(enumProperty);
             List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.getAllowableValues().get("enumVars");
-            assertNotNull(enumVars);
-            assertNotNull(enumVars.get(0));
-            assertEquals(enumVars.get(0).getOrDefault("name", ""), "DOGVAR");
-            assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"dog\"");
-            assertNotNull(enumVars.get(1));
-            assertEquals(enumVars.get(1).getOrDefault("name", ""), "CATVAR");
-            assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"cat\"");
+            Assertions.assertNotNull(enumVars);
+            Assertions.assertNotNull(enumVars.get(0));
+            Assertions.assertEquals(enumVars.get(0).getOrDefault("name", ""), "DOGVAR");
+            Assertions.assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"dog\"");
+            Assertions.assertNotNull(enumVars.get(1));
+            Assertions.assertEquals(enumVars.get(1).getOrDefault("name", ""), "CATVAR");
+            Assertions.assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"cat\"");
         }
         {
             CodegenProperty enumProperty = codegenPropertyWithXEnumVarName(Arrays.asList("1", "2"), Arrays.asList("ONE", "TWO"));
             (new DefaultCodegen()).updateCodegenPropertyEnum(enumProperty);
             List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.getAllowableValues().get("enumVars");
-            assertEquals(enumVars.get(0).getOrDefault("name", ""), "ONE");
-            assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"1\"");
-            assertEquals(enumVars.get(1).getOrDefault("name", ""), "TWO");
-            assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"2\"");
+            Assertions.assertEquals(enumVars.get(0).getOrDefault("name", ""), "ONE");
+            Assertions.assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"1\"");
+            Assertions.assertEquals(enumVars.get(1).getOrDefault("name", ""), "TWO");
+            Assertions.assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"2\"");
         }
         {
             CodegenProperty enumProperty = codegenPropertyWithXEnumVarName(Arrays.asList("a", "b", "c", "d"), Arrays.asList("FOO", "BAR"));
             (new DefaultCodegen()).updateCodegenPropertyEnum(enumProperty);
             List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.getAllowableValues().get("enumVars");
-            assertEquals(enumVars.get(0).getOrDefault("name", ""), "FOO");
-            assertEquals(enumVars.get(1).getOrDefault("name", ""), "BAR");
-            assertEquals(enumVars.get(2).getOrDefault("name", ""), "C");
-            assertEquals(enumVars.get(3).getOrDefault("name", ""), "D");
+            Assertions.assertEquals(enumVars.get(0).getOrDefault("name", ""), "FOO");
+            Assertions.assertEquals(enumVars.get(1).getOrDefault("name", ""), "BAR");
+            Assertions.assertEquals(enumVars.get(2).getOrDefault("name", ""), "C");
+            Assertions.assertEquals(enumVars.get(3).getOrDefault("name", ""), "D");
         }
         {
             CodegenProperty enumProperty = codegenPropertyWithXEnumVarName(Arrays.asList("a", "b"), Arrays.asList("FOO", "BAR", "BAZ"));
             (new DefaultCodegen()).updateCodegenPropertyEnum(enumProperty);
             List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.getAllowableValues().get("enumVars");
-            assertEquals(enumVars.get(0).getOrDefault("name", ""), "FOO");
-            assertEquals(enumVars.get(1).getOrDefault("name", ""), "BAR");
-            assertEquals(enumVars.size(), 2);
+            Assertions.assertEquals(enumVars.get(0).getOrDefault("name", ""), "FOO");
+            Assertions.assertEquals(enumVars.get(1).getOrDefault("name", ""), "BAR");
+            Assertions.assertEquals(enumVars.size(), 2);
         }
     }
 
@@ -844,13 +846,13 @@ public class DefaultCodegenTest {
         codegen.updateCodegenPropertyEnum(enumProperty);
 
         List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.getItems().getAllowableValues().get("enumVars");
-        assertNotNull(enumVars);
-        assertNotNull(enumVars.get(0));
-        assertEquals(enumVars.get(0).getOrDefault("name", ""), "DOG");
-        assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"animal_dog\"");
-        assertNotNull(enumVars.get(1));
-        assertEquals(enumVars.get(1).getOrDefault("name", ""), "CAT");
-        assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"animal_cat\"");
+        Assertions.assertNotNull(enumVars);
+        Assertions.assertNotNull(enumVars.get(0));
+        Assertions.assertEquals(enumVars.get(0).getOrDefault("name", ""), "DOG");
+        Assertions.assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"animal_dog\"");
+        Assertions.assertNotNull(enumVars.get(1));
+        Assertions.assertEquals(enumVars.get(1).getOrDefault("name", ""), "CAT");
+        Assertions.assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"animal_cat\"");
     }
 
     @Test
@@ -863,13 +865,13 @@ public class DefaultCodegenTest {
         codegen.updateCodegenPropertyEnum(enumProperty);
 
         List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.getItems().getAllowableValues().get("enumVars");
-        assertNotNull(enumVars);
-        assertNotNull(enumVars.get(0));
-        assertEquals(enumVars.get(0).getOrDefault("name", ""), "ANIMAL_DOG");
-        assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"animal_dog\"");
-        assertNotNull(enumVars.get(1));
-        assertEquals(enumVars.get(1).getOrDefault("name", ""), "ANIMAL_CAT");
-        assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"animal_cat\"");
+        Assertions.assertNotNull(enumVars);
+        Assertions.assertNotNull(enumVars.get(0));
+        Assertions.assertEquals(enumVars.get(0).getOrDefault("name", ""), "ANIMAL_DOG");
+        Assertions.assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"animal_dog\"");
+        Assertions.assertNotNull(enumVars.get(1));
+        Assertions.assertEquals(enumVars.get(1).getOrDefault("name", ""), "ANIMAL_CAT");
+        Assertions.assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"animal_cat\"");
     }
 
     @Test
@@ -881,13 +883,13 @@ public class DefaultCodegenTest {
         codegen.postProcessModelsEnum(objs);
 
         List<Map<String, Object>> enumVars = (List<Map<String, Object>>) cm.getAllowableValues().get("enumVars");
-        assertNotNull(enumVars);
-        assertNotNull(enumVars.get(0));
-        assertEquals(enumVars.get(0).getOrDefault("name", ""), "DOG");
-        assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"animal_dog\"");
-        assertNotNull(enumVars.get(1));
-        assertEquals(enumVars.get(1).getOrDefault("name", ""), "CAT");
-        assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"animal_cat\"");
+        Assertions.assertNotNull(enumVars);
+        Assertions.assertNotNull(enumVars.get(0));
+        Assertions.assertEquals(enumVars.get(0).getOrDefault("name", ""), "DOG");
+        Assertions.assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"animal_dog\"");
+        Assertions.assertNotNull(enumVars.get(1));
+        Assertions.assertEquals(enumVars.get(1).getOrDefault("name", ""), "CAT");
+        Assertions.assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"animal_cat\"");
     }
 
     @Test
@@ -900,13 +902,13 @@ public class DefaultCodegenTest {
         codegen.postProcessModelsEnum(objs);
 
         List<Map<String, Object>> enumVars = (List<Map<String, Object>>) cm.getAllowableValues().get("enumVars");
-        assertNotNull(enumVars);
-        assertNotNull(enumVars.get(0));
-        assertEquals(enumVars.get(0).getOrDefault("name", ""), "ANIMAL_DOG");
-        assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"animal_dog\"");
-        assertNotNull(enumVars.get(1));
-        assertEquals(enumVars.get(1).getOrDefault("name", ""), "ANIMAL_CAT");
-        assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"animal_cat\"");
+        Assertions.assertNotNull(enumVars);
+        Assertions.assertNotNull(enumVars.get(0));
+        Assertions.assertEquals(enumVars.get(0).getOrDefault("name", ""), "ANIMAL_DOG");
+        Assertions.assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"animal_dog\"");
+        Assertions.assertNotNull(enumVars.get(1));
+        Assertions.assertEquals(enumVars.get(1).getOrDefault("name", ""), "ANIMAL_CAT");
+        Assertions.assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"animal_cat\"");
     }
 
     @Test
@@ -918,15 +920,15 @@ public class DefaultCodegenTest {
         codegen.postProcessModelsEnum(objs);
 
         List<Map<String, Object>> enumVars = (List<Map<String, Object>>) cm.getAllowableValues().get("enumVars");
-        assertNotNull(enumVars);
-        assertNotNull(enumVars.get(0));
-        assertEquals(enumVars.get(0).getOrDefault("name", ""), "DOGVAR");
-        assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"dog\"");
-        assertEquals(enumVars.get(0).getOrDefault("enumDescription", ""), "This is a dog");
-        assertNotNull(enumVars.get(1));
-        assertEquals(enumVars.get(1).getOrDefault("name", ""), "CATVAR");
-        assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"cat\"");
-        assertEquals(enumVars.get(1).getOrDefault("enumDescription", ""), "This is a cat");
+        Assertions.assertNotNull(enumVars);
+        Assertions.assertNotNull(enumVars.get(0));
+        Assertions.assertEquals(enumVars.get(0).getOrDefault("name", ""), "DOGVAR");
+        Assertions.assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"dog\"");
+        Assertions.assertEquals(enumVars.get(0).getOrDefault("enumDescription", ""), "This is a dog");
+        Assertions.assertNotNull(enumVars.get(1));
+        Assertions.assertEquals(enumVars.get(1).getOrDefault("name", ""), "CATVAR");
+        Assertions.assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"cat\"");
+        Assertions.assertEquals(enumVars.get(1).getOrDefault("enumDescription", ""), "This is a cat");
     }
 
     @Test
@@ -938,15 +940,15 @@ public class DefaultCodegenTest {
         CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
         codegen.setParameterExampleValue(codegenParameter, operation.getParameters().get(0));
 
-        assertEquals(codegenParameter.example, "example1 value");
+        Assertions.assertEquals(codegenParameter.example, "example1 value");
 
         Operation operation2 = openAPI.getPaths().get("/example1/plural").getGet();
         CodegenParameter codegenParameter2 = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
         codegen.setParameterExampleValue(codegenParameter2, operation2.getParameters().get(0));
-        assertEquals(codegenParameter2.example, "An example1 value");
+        Assertions.assertEquals(codegenParameter2.example, "An example1 value");
         // verify examples are available
         codegen.setParameterExamples(codegenParameter2, operation2.getParameters().get(0));
-        assertEquals(codegenParameter2.examples.size(), 1);
+        Assertions.assertEquals(codegenParameter2.examples.size(), 1);
     }
 
     @Test
@@ -958,7 +960,7 @@ public class DefaultCodegenTest {
         CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
         codegen.setParameterExampleValue(codegenParameter, operation.getParameters().get(0));
 
-        assertEquals(codegenParameter.example, "example2 value");
+        Assertions.assertEquals(codegenParameter.example, "example2 value");
     }
 
     @Test
@@ -970,13 +972,13 @@ public class DefaultCodegenTest {
         CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
         codegen.setParameterExampleValue(codegenParameter, operation.getParameters().get(0));
 
-        assertEquals(codegenParameter.example, "example3: parameter value");
+        Assertions.assertEquals(codegenParameter.example, "example3: parameter value");
 
         Operation operation2 = openAPI.getPaths().get("/example3/plural").getGet();
         CodegenParameter codegenParameter2 = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
         codegen.setParameterExampleValue(codegenParameter2, operation2.getParameters().get(0));
 
-        assertEquals(codegenParameter2.example, "An example3 value");
+        Assertions.assertEquals(codegenParameter2.example, "An example3 value");
     }
 
     @Test
@@ -988,13 +990,13 @@ public class DefaultCodegenTest {
         CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
         codegen.setParameterExampleValue(codegenParameter, operation.getRequestBody());
 
-        assertEquals(codegenParameter.example, "example4 value");
+        Assertions.assertEquals(codegenParameter.example, "example4 value");
 
         Operation operation2 = openAPI.getPaths().get("/example4/plural").getPost();
         CodegenParameter codegenParameter2 = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
         codegen.setParameterExampleValue(codegenParameter2, operation2.getRequestBody());
 
-        assertEquals(codegenParameter2.example, "An example4 value");
+        Assertions.assertEquals(codegenParameter2.example, "An example4 value");
     }
 
     @Test
@@ -1008,23 +1010,23 @@ public class DefaultCodegenTest {
         CodegenOperation codegenOperation = codegen.fromOperation(path, "GET", operation, null);
         List<Map<String, String>> examples = codegenOperation.examples;
 
-        assertEquals(examples.size(), 4);
+        Assertions.assertEquals(examples.size(), 4);
         // 200 response example
-        assertEquals(examples.get(0).get("contentType"), "application/json");
-        assertEquals(examples.get(0).get("example"), "\"a successful response example\"");
-        assertEquals(examples.get(0).get("statusCode"), "200");
+        Assertions.assertEquals(examples.get(0).get("contentType"), "application/json");
+        Assertions.assertEquals(examples.get(0).get("example"), "\"a successful response example\"");
+        Assertions.assertEquals(examples.get(0).get("statusCode"), "200");
         // 301 response example
-        assertEquals(examples.get(1).get("contentType"), "application/json");
-        assertEquals(examples.get(1).get("example"), "\"a redirect response example\"");
-        assertEquals(examples.get(1).get("statusCode"), "301");
+        Assertions.assertEquals(examples.get(1).get("contentType"), "application/json");
+        Assertions.assertEquals(examples.get(1).get("example"), "\"a redirect response example\"");
+        Assertions.assertEquals(examples.get(1).get("statusCode"), "301");
         // 404 response example
-        assertEquals(examples.get(2).get("contentType"), "application/json");
-        assertEquals(examples.get(2).get("example"), "\"a not found response example\"");
-        assertEquals(examples.get(2).get("statusCode"), "404");
+        Assertions.assertEquals(examples.get(2).get("contentType"), "application/json");
+        Assertions.assertEquals(examples.get(2).get("example"), "\"a not found response example\"");
+        Assertions.assertEquals(examples.get(2).get("statusCode"), "404");
         // 500 response example
-        assertEquals(examples.get(3).get("contentType"), "application/json");
-        assertEquals(examples.get(3).get("example"), "\"an internal server error response example\"");
-        assertEquals(examples.get(3).get("statusCode"), "500");
+        Assertions.assertEquals(examples.get(3).get("contentType"), "application/json");
+        Assertions.assertEquals(examples.get(3).get("example"), "\"an internal server error response example\"");
+        Assertions.assertEquals(examples.get(3).get("statusCode"), "500");
     }
 
     @Test
@@ -1042,8 +1044,8 @@ public class DefaultCodegenTest {
         test.getMappedModels().add(new CodegenDiscriminator.MappedModel("Dog", "Dog"));
         test.getMappedModels().add(new CodegenDiscriminator.MappedModel("Cat", "Cat"));
         test.getMappedModels().add(new CodegenDiscriminator.MappedModel("BigCat", "BigCat"));
-        assertEquals(discriminator, test);
-        assertTrue(animalModel.getHasDiscriminatorWithNonEmptyMapping());
+        Assertions.assertEquals(discriminator, test);
+        Assertions.assertTrue(animalModel.getHasDiscriminatorWithNonEmptyMapping());
     }
 
     @Test
@@ -1062,7 +1064,7 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
         CodegenModel personModel = codegen.fromModel("Person", person);
         verifyPersonDiscriminator(personModel.discriminator);
-        assertTrue(personModel.getHasDiscriminatorWithNonEmptyMapping());
+        Assertions.assertTrue(personModel.getHasDiscriminatorWithNonEmptyMapping());
     }
 
     @Test
@@ -1073,8 +1075,8 @@ public class DefaultCodegenTest {
         Schema child = openAPI.getComponents().getSchemas().get("Child");
         codegen.setOpenAPI(openAPI);
         CodegenModel childModel = codegen.fromModel("Child", child);
-        assertEquals(childModel.parentSchema, "Person");
-        assertFalse(childModel.getHasDiscriminatorWithNonEmptyMapping());
+        Assertions.assertEquals(childModel.parentSchema, "Person");
+        Assertions.assertFalse(childModel.getHasDiscriminatorWithNonEmptyMapping());
     }
 
     @Test
@@ -1085,7 +1087,7 @@ public class DefaultCodegenTest {
         Schema child = openAPI.getComponents().getSchemas().get("clubForCreation");
         codegen.setOpenAPI(openAPI);
         CodegenModel childModel = codegen.fromModel("clubForCreation", child);
-        assertEquals(getRequiredVars(childModel), Collections.singletonList("name"));
+        Assertions.assertEquals(getRequiredVars(childModel), Collections.singletonList("name"));
     }
 
     @Test
@@ -1098,20 +1100,20 @@ public class DefaultCodegenTest {
         // to test allOf with double refs
         Schema supermanSchema = openAPI.getComponents().getSchemas().get("SuperMan");
         CodegenModel supermanModel = codegen.fromModel("SuperMan", supermanSchema);
-        assertNull(supermanModel.parent);
-        assertNull(supermanModel.allParents);
+        Assertions.assertNull(supermanModel.parent);
+        Assertions.assertNull(supermanModel.allParents);
 
         // to test allOf with single ref
         Schema superboySchema = openAPI.getComponents().getSchemas().get("SuperBoy");
         CodegenModel superboyModel = codegen.fromModel("SuperBoy", superboySchema);
-        assertNull(superboyModel.parent);
-        assertNull(superboyModel.allParents);
+        Assertions.assertNull(superboyModel.parent);
+        Assertions.assertNull(superboyModel.allParents);
 
         // to test allOf with single ref and no "type: object" in the (last) inline schema
         Schema superbabySchema = openAPI.getComponents().getSchemas().get("SuperBaby");
         CodegenModel superbabyModel = codegen.fromModel("SuperBaby", superbabySchema);
-        assertNull(superbabyModel.parent);
-        assertNull(superbabyModel.allParents);
+        Assertions.assertNull(superbabyModel.parent);
+        Assertions.assertNull(superbabyModel.allParents);
     }
 
     @Test
@@ -1123,8 +1125,8 @@ public class DefaultCodegenTest {
 
         Schema adultSchema = openAPI.getComponents().getSchemas().get("Adult");
         CodegenModel adultModel = codegen.fromModel("Adult", adultSchema);
-        assertEquals(adultModel.parent, "Person");
-        assertEquals(adultModel.allParents, Collections.singletonList("Person"));
+        Assertions.assertEquals(adultModel.parent, "Person");
+        Assertions.assertEquals(adultModel.allParents, Collections.singletonList("Person"));
     }
 
     @Test
@@ -1147,8 +1149,8 @@ public class DefaultCodegenTest {
         for (String leafModelName : leafModelNames) {
             Schema leafSc = openAPI.getComponents().getSchemas().get(leafModelName);
             CodegenModel leafCm = codegen.fromModel(leafModelName, leafSc);
-            assertEquals(leafCm.discriminator, emptyMapDisc);
-            assertFalse(leafCm.getHasDiscriminatorWithNonEmptyMapping());
+            Assertions.assertEquals(leafCm.discriminator, emptyMapDisc);
+            Assertions.assertFalse(leafCm.getHasDiscriminatorWithNonEmptyMapping());
         }
 
         // the Pet discriminator map contains all animals + Reptile (children + grandchildren)
@@ -1164,8 +1166,8 @@ public class DefaultCodegenTest {
         modelName = "Pet";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel pet = codegen.fromModel(modelName, sc);
-        assertTrue(pet.getHasDiscriminatorWithNonEmptyMapping());
-        assertEquals(pet.discriminator, petDisc);
+        Assertions.assertTrue(pet.getHasDiscriminatorWithNonEmptyMapping());
+        Assertions.assertEquals(pet.discriminator, petDisc);
 
         // the Reptile discriminator contains both reptiles
         List<String> reptileModelNames = Arrays.asList("Lizard", "Snake");
@@ -1180,8 +1182,8 @@ public class DefaultCodegenTest {
         modelName = "Reptile";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel reptile = codegen.fromModel(modelName, sc);
-        assertTrue(reptile.getHasDiscriminatorWithNonEmptyMapping());
-        assertEquals(reptile.discriminator, reptileDisc);
+        Assertions.assertTrue(reptile.getHasDiscriminatorWithNonEmptyMapping());
+        Assertions.assertEquals(reptile.discriminator, reptileDisc);
 
         // the MyPets discriminator contains Cat and Lizard
         List<String> myPetNames = Arrays.asList("Cat", "Lizard");
@@ -1196,15 +1198,15 @@ public class DefaultCodegenTest {
         modelName = "MyPets";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel myPets = codegen.fromModel(modelName, sc);
-        assertTrue(myPets.getHasDiscriminatorWithNonEmptyMapping());
-        assertEquals(myPets.discriminator, myPetDisc);
+        Assertions.assertTrue(myPets.getHasDiscriminatorWithNonEmptyMapping());
+        Assertions.assertEquals(myPets.discriminator, myPetDisc);
 
         // the MyPetsNoDisc discriminator is created because all oneOf classes have the same discriminator
         modelName = "MyPetsNoDisc";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel myPetsNoDisc = codegen.fromModel(modelName, sc);
-        assertTrue(myPetsNoDisc.getHasDiscriminatorWithNonEmptyMapping());
-        assertEquals(myPetsNoDisc.discriminator, myPetDisc);
+        Assertions.assertTrue(myPetsNoDisc.getHasDiscriminatorWithNonEmptyMapping());
+        Assertions.assertEquals(myPetsNoDisc.discriminator, myPetDisc);
 
         CodegenModel cm;
 
@@ -1215,8 +1217,8 @@ public class DefaultCodegenTest {
         hs.clear();
         hs.add(new CodegenDiscriminator.MappedModel("b", codegen.toModelName("B"), true));
         hs.add(new CodegenDiscriminator.MappedModel("C", codegen.toModelName("C")));
-        assertTrue(cm.getHasDiscriminatorWithNonEmptyMapping());
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertTrue(cm.getHasDiscriminatorWithNonEmptyMapping());
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
 
         // the mapping in b is in B
         modelName = "B";
@@ -1225,8 +1227,8 @@ public class DefaultCodegenTest {
         hs.clear();
         hs.add(new CodegenDiscriminator.MappedModel("b", codegen.toModelName("B"), true));
         hs.add(new CodegenDiscriminator.MappedModel("C", codegen.toModelName("C")));
-        assertTrue(cm.getHasDiscriminatorWithNonEmptyMapping());
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertTrue(cm.getHasDiscriminatorWithNonEmptyMapping());
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
 
         // the mapping in b is in C
         modelName = "C";
@@ -1234,8 +1236,8 @@ public class DefaultCodegenTest {
         cm = codegen.fromModel(modelName, sc);
         hs.clear();
         hs.add(new CodegenDiscriminator.MappedModel("b", codegen.toModelName("B"), true));
-        assertTrue(cm.getHasDiscriminatorWithNonEmptyMapping());
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertTrue(cm.getHasDiscriminatorWithNonEmptyMapping());
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
     }
 
     @Test
@@ -1258,7 +1260,7 @@ public class DefaultCodegenTest {
         for (String leafModelName : leafModelNames) {
             Schema leafSc = openAPI.getComponents().getSchemas().get(leafModelName);
             CodegenModel leafCm = codegen.fromModel(leafModelName, leafSc);
-            assertNull(leafCm.discriminator);
+            Assertions.assertNull(leafCm.discriminator);
         }
 
         // the Pet discriminator map contains all animals + Reptile (children + grandchildren)
@@ -1274,7 +1276,7 @@ public class DefaultCodegenTest {
         modelName = "Pet";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel pet = codegen.fromModel(modelName, sc);
-        assertEquals(pet.discriminator, petDisc);
+        Assertions.assertEquals(pet.discriminator, petDisc);
 
         // the Reptile discriminator contains both reptiles
         List<String> reptileModelNames = Arrays.asList("Lizard", "Snake");
@@ -1289,7 +1291,7 @@ public class DefaultCodegenTest {
         modelName = "Reptile";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel reptile = codegen.fromModel(modelName, sc);
-        assertNull(reptile.discriminator);
+        Assertions.assertNull(reptile.discriminator);
 
         // the MyPets discriminator contains Cat and Lizard
         CodegenDiscriminator myPetDisc = new CodegenDiscriminator();
@@ -1299,13 +1301,13 @@ public class DefaultCodegenTest {
         modelName = "MyPets";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel myPets = codegen.fromModel(modelName, sc);
-        assertEquals(myPets.discriminator, myPetDisc);
+        Assertions.assertEquals(myPets.discriminator, myPetDisc);
 
         // the MyPetsNoDisc discriminator is created because all oneOf classes have the same discriminator
         modelName = "MyPetsNoDisc";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel myPetsNoDisc = codegen.fromModel(modelName, sc);
-        assertNull(myPetsNoDisc.discriminator);
+        Assertions.assertNull(myPetsNoDisc.discriminator);
 
         CodegenModel cm;
 
@@ -1315,19 +1317,19 @@ public class DefaultCodegenTest {
         cm = codegen.fromModel(modelName, sc);
         hs.clear();
         hs.add(new CodegenDiscriminator.MappedModel("b", codegen.toModelName("B"), true));
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
 
         // the mapping in b is in B
         modelName = "B";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         cm = codegen.fromModel(modelName, sc);
-        assertNull(cm.discriminator);
+        Assertions.assertNull(cm.discriminator);
 
         // the mapping in b is in C
         modelName = "C";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         cm = codegen.fromModel(modelName, sc);
-        assertNull(cm.discriminator);
+        Assertions.assertNull(cm.discriminator);
     }
 
     @Test
@@ -1357,9 +1359,9 @@ public class DefaultCodegenTest {
             // comment out below as we're now showing warnings instead of throwing exceptions
             try {
                 codegen.fromModel(modelName, sc);
-                assertTrue(false, "A RuntimeException should have been thrown when processing "+modelName+ " but it was not");
+                Assertions.assertTrue(false, "A RuntimeException should have been thrown when processing "+modelName+ " but it was not");
             } catch (RuntimeException re) {
-                assertEquals(re.getMessage(), errorMessageExpected);
+                Assertions.assertEquals(re.getMessage(), errorMessageExpected);
             }
             */
         }
@@ -1392,9 +1394,9 @@ public class DefaultCodegenTest {
             // comment out below as we're now showing warnings instead of throwing exceptions
             try {
                 codegen.fromModel(modelName, sc);
-                assertTrue(false, "A RuntimeException should have been thrown when processing "+modelName+ " but it was not");
+                Assertions.assertTrue(false, "A RuntimeException should have been thrown when processing "+modelName+ " but it was not");
             } catch (RuntimeException re) {
-                assertEquals(re.getMessage(), errorMessageExpected);
+                Assertions.assertEquals(re.getMessage(), errorMessageExpected);
             }
             */
         }
@@ -1422,13 +1424,13 @@ public class DefaultCodegenTest {
         hs.add(new CodegenDiscriminator.MappedModel(mn, codegen.toModelName(mn)));
         mn = "FruitInlineDisc_anyOf_1";
         hs.add(new CodegenDiscriminator.MappedModel(mn, codegen.toModelName(mn)));
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
 
         // inline anyOf with inline anyOf model doesn't work because we have null $refs and we throw an exception
         final String fmodelName = "FruitInlineInlineDisc";
         final Schema fsc = openAPI.getComponents().getSchemas().get(fmodelName);
         // comment out below as we're now showing warnings instead of throwing exceptions
-        //assertThrows(() -> codegen.fromModel(fmodelName, fsc));
+        //Assertions.assertThrows(() -> codegen.fromModel(fmodelName, fsc));
 
         // ref anyOf models with discriminator in properties in those models
         modelName = "FruitReqDisc";
@@ -1439,7 +1441,7 @@ public class DefaultCodegenTest {
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
         mn = "BananaReqDisc";
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
 
         // ref oneOf models with discriminator in allOf in those models
         modelName = "FruitAllOfDisc";
@@ -1450,7 +1452,7 @@ public class DefaultCodegenTest {
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
         mn = "BananaAllOfDisc";
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
 
         // ref oneOf models with discriminator in anyOf in those models
         modelName = "FruitAnyOfDisc";
@@ -1461,7 +1463,7 @@ public class DefaultCodegenTest {
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
         mn = "BananaAnyOfDisc";
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
 
         // ref oneOf models with discriminator in anyOf in those models
         modelName = "FruitAnyOfDisc";
@@ -1472,7 +1474,7 @@ public class DefaultCodegenTest {
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
         mn = "BananaAnyOfDisc";
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
 
         // ref oneOf models with discriminator in the grandparent schemas of those anyof models
         modelName = "FruitGrandparentDisc";
@@ -1483,7 +1485,7 @@ public class DefaultCodegenTest {
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
         mn = "BananaGrandparentDisc";
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
     }
 
     @Test
@@ -1508,13 +1510,13 @@ public class DefaultCodegenTest {
         hs.add(new CodegenDiscriminator.MappedModel(mn, codegen.toModelName(mn)));
         mn = "FruitInlineDisc_oneOf_1";
         hs.add(new CodegenDiscriminator.MappedModel(mn, codegen.toModelName(mn)));
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
 
         // inline oneOf with inline oneOf model doesn't work because we have null $refs and we throw an exception
         final String fmodelName = "FruitInlineInlineDisc";
         final Schema fsc = openAPI.getComponents().getSchemas().get(fmodelName);
         // comment out below as we're now showing warnings instead of throwing exceptions
-        //assertThrows(() -> codegen.fromModel(fmodelName, fsc));
+        //Assertions.assertThrows(() -> codegen.fromModel(fmodelName, fsc));
 
         // ref oneOf models with discriminator in properties in those models
         modelName = "FruitReqDisc";
@@ -1525,7 +1527,7 @@ public class DefaultCodegenTest {
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
         mn = "BananaReqDisc";
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
 
         // ref oneOf models with discriminator in allOf in those models
         modelName = "FruitAllOfDisc";
@@ -1536,7 +1538,7 @@ public class DefaultCodegenTest {
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
         mn = "BananaAllOfDisc";
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
 
         // ref oneOf models with discriminator in anyOf in those models
         modelName = "FruitAnyOfDisc";
@@ -1547,7 +1549,7 @@ public class DefaultCodegenTest {
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
         mn = "BananaAnyOfDisc";
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
 
         // ref oneOf models with discriminator in oneOf in those models
         modelName = "FruitOneOfDisc";
@@ -1558,7 +1560,7 @@ public class DefaultCodegenTest {
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
         mn = "BananaOneOfDisc";
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
 
         // ref oneOf models with enum property discriminator
         modelName = "FruitOneOfEnumMappingDisc";
@@ -1575,7 +1577,7 @@ public class DefaultCodegenTest {
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
         mn = "BananaGrandparentDisc";
         hs.add(new CodegenDiscriminator.MappedModel(mn, mn));
-        assertEquals(cm.discriminator.getMappedModels(), hs);
+        Assertions.assertEquals(cm.discriminator.getMappedModels(), hs);
     }
 
     @Test
@@ -1707,8 +1709,8 @@ public class DefaultCodegenTest {
         // check that the model's children contain the x-discriminator-values
         modelName = "BaseObj";
         cm = getModel(allModels, modelName);
-        assertNotNull(cm);
-        assertNotNull(cm.children);
+        Assertions.assertNotNull(cm);
+        Assertions.assertNotNull(cm.children);
         List<String> expectedDiscriminatorValues = new ArrayList<>(Arrays.asList("daily", "sub-obj"));
         ArrayList<String> xDiscriminatorValues = new ArrayList<>();
         for (CodegenModel child : cm.children) {
@@ -1737,9 +1739,9 @@ public class DefaultCodegenTest {
         Schema schema = openAPI.getComponents().getSchemas().get("NewMessageEventCoreNoOwnProps");
         codegen.setOpenAPI(openAPI);
         CodegenModel model = codegen.fromModel("NewMessageEventCoreNoOwnProps", schema);
-        assertEquals(getNames(model.getVars()), Arrays.asList("id", "message"));
-        assertNull(model.parent);
-        assertNull(model.allParents);
+        Assertions.assertEquals(getNames(model.getVars()), Arrays.asList("id", "message"));
+        Assertions.assertNull(model.parent);
+        Assertions.assertNull(model.allParents);
     }
 
     @Test
@@ -1750,15 +1752,15 @@ public class DefaultCodegenTest {
 
         Schema person = openAPI.getComponents().getSchemas().get("person");
         CodegenModel personModel = codegen.fromModel("person", person);
-        assertEquals(getRequiredVars(personModel), Arrays.asList("firstName", "name", "email", "id"));
+        Assertions.assertEquals(getRequiredVars(personModel), Arrays.asList("firstName", "name", "email", "id"));
 
         Schema personForCreation = openAPI.getComponents().getSchemas().get("personForCreation");
         CodegenModel personForCreationModel = codegen.fromModel("personForCreation", personForCreation);
-        assertEquals(getRequiredVars(personForCreationModel), Arrays.asList("firstName", "name", "email"));
+        Assertions.assertEquals(getRequiredVars(personForCreationModel), Arrays.asList("firstName", "name", "email"));
 
         Schema personForUpdate = openAPI.getComponents().getSchemas().get("personForUpdate");
         CodegenModel personForUpdateModel = codegen.fromModel("personForUpdate", personForUpdate);
-        assertEquals(getRequiredVars(personForUpdateModel), Collections.emptyList());
+        Assertions.assertEquals(getRequiredVars(personForUpdateModel), Collections.emptyList());
     }
 
     private List<String> getRequiredVars(CodegenModel model) {
@@ -1780,40 +1782,40 @@ public class DefaultCodegenTest {
         Operation subscriptionOperation = openAPI.getPaths().get("/streams").getPost();
         CodegenOperation op = codegen.fromOperation(path, "post", subscriptionOperation, null);
 
-        assertFalse(op.isCallbackRequest);
-        assertNotNull(op.operationId);
-        assertEquals(op.callbacks.size(), 2);
+        Assertions.assertFalse(op.isCallbackRequest);
+        Assertions.assertNotNull(op.operationId);
+        Assertions.assertEquals(op.callbacks.size(), 2);
 
         CodegenCallback cbB = op.callbacks.get(1);
-        assertEquals(cbB.name, "dummy");
-        assertEquals(cbB.urls.size(), 0);
+        Assertions.assertEquals(cbB.name, "dummy");
+        Assertions.assertEquals(cbB.urls.size(), 0);
 
         CodegenCallback cbA = op.callbacks.get(0);
-        assertEquals(cbA.name, "onData");
+        Assertions.assertEquals(cbA.name, "onData");
 
-        assertEquals(cbA.urls.size(), 2);
+        Assertions.assertEquals(cbA.urls.size(), 2);
 
         CodegenCallback.Url urlB = cbA.urls.get(1);
-        assertEquals(urlB.expression, "{$request.query.callbackUrl}/test");
-        assertEquals(urlB.requests.size(), 0);
+        Assertions.assertEquals(urlB.expression, "{$request.query.callbackUrl}/test");
+        Assertions.assertEquals(urlB.requests.size(), 0);
 
         CodegenCallback.Url urlA = cbA.urls.get(0);
-        assertEquals(urlA.expression, "{$request.query.callbackUrl}/data");
-        assertEquals(urlA.requests.size(), 2);
+        Assertions.assertEquals(urlA.expression, "{$request.query.callbackUrl}/data");
+        Assertions.assertEquals(urlA.requests.size(), 2);
 
         urlA.requests.forEach(req -> {
-            assertTrue(req.isCallbackRequest);
-            assertNotNull(req.bodyParam);
-            assertEquals(req.responses.size(), 2);
+            Assertions.assertTrue(req.isCallbackRequest);
+            Assertions.assertNotNull(req.bodyParam);
+            Assertions.assertEquals(req.responses.size(), 2);
 
             switch (req.httpMethod.toLowerCase(Locale.getDefault())) {
                 case "post":
-                    assertEquals(req.operationId, "onDataDataPost");
-                    assertEquals(req.bodyParam.dataType, "NewNotificationData");
+                    Assertions.assertEquals(req.operationId, "onDataDataPost");
+                    Assertions.assertEquals(req.bodyParam.dataType, "NewNotificationData");
                     break;
                 case "delete":
-                    assertEquals(req.operationId, "onDataDataDelete");
-                    assertEquals(req.bodyParam.dataType, "DeleteNotificationData");
+                    Assertions.assertEquals(req.operationId, "onDataDataDelete");
+                    Assertions.assertEquals(req.bodyParam.dataType, "DeleteNotificationData");
                     break;
                 default:
                     Assert.fail(String.format(Locale.getDefault(), "invalid callback request http method '%s'", req.httpMethod));
@@ -1832,9 +1834,9 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         CodegenOperation co1 = codegen.fromOperation("/here", "get", operation2, null);
-        assertEquals(co1.path, "/here");
+        Assertions.assertEquals(co1.path, "/here");
         CodegenOperation co2 = codegen.fromOperation("some/path", "get", operation2, null);
-        assertEquals(co2.path, "/some/path");
+        Assertions.assertEquals(co2.path, "/some/path");
     }
 
     @Test
@@ -1852,8 +1854,8 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         CodegenOperation co = codegen.fromOperation("/here", "get", myOperation, null);
-        assertEquals(co.responses.get(0).message, "Error");
-        assertEquals(co.responses.get(1).message, "Default");
+        Assertions.assertEquals(co.responses.get(0).message, "Error");
+        Assertions.assertEquals(co.responses.get(1).message, "Default");
     }
 
     @Test
@@ -1870,8 +1872,8 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         CodegenResponse cr = codegen.fromResponse("2XX", response2XX);
-        assertNotNull(cr);
-        assertTrue(cr.hasHeaders);
+        Assertions.assertNotNull(cr);
+        Assertions.assertTrue(cr.hasHeaders);
     }
 
     @Test
@@ -1883,7 +1885,7 @@ public class DefaultCodegenTest {
 
         CodegenProperty property = codegen.fromProperty("address", (Schema) openAPI.getComponents().getSchemas().get("User").getProperties().get("address"));
 
-        assertTrue(property.isNullable);
+        Assertions.assertTrue(property.isNullable);
     }
 
     @Test
@@ -1894,10 +1896,10 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         CodegenModel codegenPetModel = codegen.fromModel("Pet", openAPI.getComponents().getSchemas().get("Pet"));
-        assertTrue(codegenPetModel.isDeprecated);
+        Assertions.assertTrue(codegenPetModel.isDeprecated);
 
         CodegenModel codegenFoodModel = codegen.fromModel("Food", openAPI.getComponents().getSchemas().get("Food"));
-        assertTrue(codegenFoodModel.isDeprecated);
+        Assertions.assertTrue(codegenFoodModel.isDeprecated);
     }
 
     @Test
@@ -1910,10 +1912,10 @@ public class DefaultCodegenTest {
         final Map responseProperties = Collections.unmodifiableMap(openAPI.getComponents().getSchemas().get("Response").getProperties());
         final Map requestProperties = Collections.unmodifiableMap(openAPI.getComponents().getSchemas().get("Response").getProperties());
 
-        assertTrue(codegen.fromProperty("firstName", (Schema) responseProperties.get("firstName")).deprecated);
-        assertFalse(codegen.fromProperty("customerCode", (Schema) responseProperties.get("customerCode")).deprecated);
-        assertTrue(codegen.fromProperty("firstName", (Schema) requestProperties.get("firstName")).deprecated);
-        assertFalse(codegen.fromProperty("customerCode", (Schema) requestProperties.get("customerCode")).deprecated);
+        Assertions.assertTrue(codegen.fromProperty("firstName", (Schema) responseProperties.get("firstName")).deprecated);
+        Assertions.assertFalse(codegen.fromProperty("customerCode", (Schema) responseProperties.get("customerCode")).deprecated);
+        Assertions.assertTrue(codegen.fromProperty("firstName", (Schema) requestProperties.get("firstName")).deprecated);
+        Assertions.assertFalse(codegen.fromProperty("customerCode", (Schema) requestProperties.get("customerCode")).deprecated);
     }
 
     @Test
@@ -1925,8 +1927,8 @@ public class DefaultCodegenTest {
 
         final Map testProperties = Collections.unmodifiableMap(openAPI.getComponents().getSchemas().get("ModelWithTitledProperties").getProperties());
 
-        assertEquals("Simple-Property-Title", codegen.fromProperty("simpleProperty", (Schema) testProperties.get("simpleProperty")).title);
-        assertEquals("Ref-Property-Title", codegen.fromProperty("refProperty", (Schema) testProperties.get("refProperty")).title);
+        Assertions.assertEquals("Simple-Property-Title", codegen.fromProperty("simpleProperty", (Schema) testProperties.get("simpleProperty")).title);
+        Assertions.assertEquals("Ref-Property-Title", codegen.fromProperty("refProperty", (Schema) testProperties.get("refProperty")).title);
     }
 
     @Test
@@ -1938,8 +1940,8 @@ public class DefaultCodegenTest {
 
         final Map requestProperties = Collections.unmodifiableMap(openAPI.getComponents().getSchemas().get("complex").getProperties());
 
-        assertTrue(codegen.fromProperty("deprecated", (Schema) requestProperties.get("deprecated")).deprecated);
-        assertFalse(codegen.fromProperty("current", (Schema) requestProperties.get("current")).deprecated);
+        Assertions.assertTrue(codegen.fromProperty("deprecated", (Schema) requestProperties.get("deprecated")).deprecated);
+        Assertions.assertFalse(codegen.fromProperty("current", (Schema) requestProperties.get("current")).deprecated);
     }
 
     @Test
@@ -1951,27 +1953,27 @@ public class DefaultCodegenTest {
 
         //Property:
         final CodegenProperty cp = codegen.fromProperty("someProperty", schema);
-        assertEquals(cp.baseType, "integer");
-        assertEquals(cp.baseName, "someProperty");
-        assertFalse(cp.isString);
-        assertTrue(cp.isInteger);
-        assertFalse(cp.isLong);
-        assertFalse(cp.isNumber);
-        assertTrue(cp.isNumeric);
-        assertFalse(cp.isFloat);
-        assertFalse(cp.isDouble);
+        Assertions.assertEquals(cp.baseType, "integer");
+        Assertions.assertEquals(cp.baseName, "someProperty");
+        Assertions.assertFalse(cp.isString);
+        Assertions.assertTrue(cp.isInteger);
+        Assertions.assertFalse(cp.isLong);
+        Assertions.assertFalse(cp.isNumber);
+        Assertions.assertTrue(cp.isNumeric);
+        Assertions.assertFalse(cp.isFloat);
+        Assertions.assertFalse(cp.isDouble);
 
         //Model:
         final CodegenModel cm = codegen.fromModel("someModel", schema);
-        assertEquals(cm.dataType, "integer");
-        assertEquals(cm.name, "someModel");
-        assertFalse(cm.isString);
-        assertTrue(cm.isInteger);
-        assertFalse(cm.isLong);
-        assertFalse(cm.isNumber);
-        assertTrue(cm.isNumeric);
-        assertFalse(cm.isFloat);
-        assertFalse(cm.isDouble);
+        Assertions.assertEquals(cm.dataType, "integer");
+        Assertions.assertEquals(cm.name, "someModel");
+        Assertions.assertFalse(cm.isString);
+        Assertions.assertTrue(cm.isInteger);
+        Assertions.assertFalse(cm.isLong);
+        Assertions.assertFalse(cm.isNumber);
+        Assertions.assertTrue(cm.isNumeric);
+        Assertions.assertFalse(cm.isFloat);
+        Assertions.assertFalse(cm.isDouble);
     }
 
     @Test
@@ -1983,27 +1985,27 @@ public class DefaultCodegenTest {
 
         //Property:
         final CodegenProperty cp = codegen.fromProperty("someProperty", schema);
-        assertEquals(cp.baseType, "long");
-        assertEquals(cp.baseName, "someProperty");
-        assertFalse(cp.isString);
-        assertFalse(cp.isInteger);
-        assertTrue(cp.isLong);
-        assertFalse(cp.isNumber);
-        assertTrue(cp.isNumeric);
-        assertFalse(cp.isFloat);
-        assertFalse(cp.isDouble);
+        Assertions.assertEquals(cp.baseType, "long");
+        Assertions.assertEquals(cp.baseName, "someProperty");
+        Assertions.assertFalse(cp.isString);
+        Assertions.assertFalse(cp.isInteger);
+        Assertions.assertTrue(cp.isLong);
+        Assertions.assertFalse(cp.isNumber);
+        Assertions.assertTrue(cp.isNumeric);
+        Assertions.assertFalse(cp.isFloat);
+        Assertions.assertFalse(cp.isDouble);
 
         //Model:
         final CodegenModel cm = codegen.fromModel("someModel", schema);
-        assertEquals(cm.dataType, "long");
-        assertEquals(cm.name, "someModel");
-        assertFalse(cm.isString);
-        assertFalse(cm.isInteger);
-        assertTrue(cm.isLong);
-        assertFalse(cm.isNumber);
-        assertTrue(cm.isNumeric);
-        assertFalse(cm.isFloat);
-        assertFalse(cm.isDouble);
+        Assertions.assertEquals(cm.dataType, "long");
+        Assertions.assertEquals(cm.name, "someModel");
+        Assertions.assertFalse(cm.isString);
+        Assertions.assertFalse(cm.isInteger);
+        Assertions.assertTrue(cm.isLong);
+        Assertions.assertFalse(cm.isNumber);
+        Assertions.assertTrue(cm.isNumeric);
+        Assertions.assertFalse(cm.isFloat);
+        Assertions.assertFalse(cm.isDouble);
     }
 
     @Test
@@ -2015,27 +2017,27 @@ public class DefaultCodegenTest {
 
         //Property:
         final CodegenProperty cp = codegen.fromProperty("someProperty", schema);
-        assertEquals(cp.baseType, "number");
-        assertEquals(cp.baseName, "someProperty");
-        assertFalse(cp.isString);
-        assertFalse(cp.isInteger);
-        assertFalse(cp.isLong);
-        assertTrue(cp.isNumber);
-        assertTrue(cp.isNumeric);
-        assertFalse(cp.isFloat);
-        assertFalse(cp.isDouble);
+        Assertions.assertEquals(cp.baseType, "number");
+        Assertions.assertEquals(cp.baseName, "someProperty");
+        Assertions.assertFalse(cp.isString);
+        Assertions.assertFalse(cp.isInteger);
+        Assertions.assertFalse(cp.isLong);
+        Assertions.assertTrue(cp.isNumber);
+        Assertions.assertTrue(cp.isNumeric);
+        Assertions.assertFalse(cp.isFloat);
+        Assertions.assertFalse(cp.isDouble);
 
         //Model:
         final CodegenModel cm = codegen.fromModel("someModel", schema);
-        assertEquals(cm.dataType, "number");
-        assertEquals(cm.name, "someModel");
-        assertFalse(cm.isString);
-        assertFalse(cm.isInteger);
-        assertFalse(cm.isLong);
-        assertTrue(cm.isNumber);
-        assertTrue(cm.isNumeric);
-        assertFalse(cm.isFloat);
-        assertFalse(cm.isDouble);
+        Assertions.assertEquals(cm.dataType, "number");
+        Assertions.assertEquals(cm.name, "someModel");
+        Assertions.assertFalse(cm.isString);
+        Assertions.assertFalse(cm.isInteger);
+        Assertions.assertFalse(cm.isLong);
+        Assertions.assertTrue(cm.isNumber);
+        Assertions.assertTrue(cm.isNumeric);
+        Assertions.assertFalse(cm.isFloat);
+        Assertions.assertFalse(cm.isDouble);
     }
 
     @Test
@@ -2047,27 +2049,27 @@ public class DefaultCodegenTest {
 
         //Property:
         final CodegenProperty cp = codegen.fromProperty("someProperty", schema);
-        assertEquals(cp.baseType, "float");
-        assertEquals(cp.baseName, "someProperty");
-        assertFalse(cp.isString);
-        assertFalse(cp.isInteger);
-        assertFalse(cp.isLong);
-        assertFalse(cp.isNumber);
-        assertTrue(cp.isNumeric);
-        assertTrue(cp.isFloat);
-        assertFalse(cp.isDouble);
+        Assertions.assertEquals(cp.baseType, "float");
+        Assertions.assertEquals(cp.baseName, "someProperty");
+        Assertions.assertFalse(cp.isString);
+        Assertions.assertFalse(cp.isInteger);
+        Assertions.assertFalse(cp.isLong);
+        Assertions.assertFalse(cp.isNumber);
+        Assertions.assertTrue(cp.isNumeric);
+        Assertions.assertTrue(cp.isFloat);
+        Assertions.assertFalse(cp.isDouble);
 
         //Model:
         final CodegenModel cm = codegen.fromModel("someModel", schema);
-        assertEquals(cm.dataType, "float");
-        assertEquals(cm.name, "someModel");
-        assertFalse(cm.isString);
-        assertFalse(cm.isInteger);
-        assertFalse(cm.isLong);
-        assertFalse(cm.isNumber);
-        assertTrue(cm.isNumeric);
-        assertTrue(cm.isFloat);
-        assertFalse(cm.isDouble);
+        Assertions.assertEquals(cm.dataType, "float");
+        Assertions.assertEquals(cm.name, "someModel");
+        Assertions.assertFalse(cm.isString);
+        Assertions.assertFalse(cm.isInteger);
+        Assertions.assertFalse(cm.isLong);
+        Assertions.assertFalse(cm.isNumber);
+        Assertions.assertTrue(cm.isNumeric);
+        Assertions.assertTrue(cm.isFloat);
+        Assertions.assertFalse(cm.isDouble);
     }
 
     @Test
@@ -2079,27 +2081,27 @@ public class DefaultCodegenTest {
 
         //Property:
         final CodegenProperty cp = codegen.fromProperty("someProperty", schema);
-        assertEquals(cp.baseType, "double");
-        assertEquals(cp.baseName, "someProperty");
-        assertFalse(cp.isString);
-        assertFalse(cp.isInteger);
-        assertFalse(cp.isLong);
-        assertFalse(cp.isNumber);
-        assertTrue(cp.isNumeric);
-        assertFalse(cp.isFloat);
-        assertTrue(cp.isDouble);
+        Assertions.assertEquals(cp.baseType, "double");
+        Assertions.assertEquals(cp.baseName, "someProperty");
+        Assertions.assertFalse(cp.isString);
+        Assertions.assertFalse(cp.isInteger);
+        Assertions.assertFalse(cp.isLong);
+        Assertions.assertFalse(cp.isNumber);
+        Assertions.assertTrue(cp.isNumeric);
+        Assertions.assertFalse(cp.isFloat);
+        Assertions.assertTrue(cp.isDouble);
 
         //Model:
         final CodegenModel cm = codegen.fromModel("someModel", schema);
-        assertEquals(cm.dataType, "double");
-        assertEquals(cm.name, "someModel");
-        assertFalse(cm.isString);
-        assertFalse(cm.isInteger);
-        assertFalse(cm.isLong);
-        assertFalse(cm.isNumber);
-        assertTrue(cm.isNumeric);
-        assertFalse(cm.isFloat);
-        assertTrue(cm.isDouble);
+        Assertions.assertEquals(cm.dataType, "double");
+        Assertions.assertEquals(cm.name, "someModel");
+        Assertions.assertFalse(cm.isString);
+        Assertions.assertFalse(cm.isInteger);
+        Assertions.assertFalse(cm.isLong);
+        Assertions.assertFalse(cm.isNumber);
+        Assertions.assertTrue(cm.isNumeric);
+        Assertions.assertFalse(cm.isFloat);
+        Assertions.assertTrue(cm.isDouble);
     }
 
     @Test
@@ -2114,14 +2116,14 @@ public class DefaultCodegenTest {
                 "MyParameterTextField",
                 openAPI.getComponents().getSchemas().get("MyParameterTextField")
         );
-        assertTrue(typeAliasModel.isAlias);
-        assertEquals(typeAliasModel.dataType, "string");
+        Assertions.assertTrue(typeAliasModel.isAlias);
+        Assertions.assertEquals(typeAliasModel.dataType, "string");
 
         CodegenModel composedModel = codegen.fromModel(
                 "ComposedModel",
                 openAPI.getComponents().getSchemas().get("ComposedModel")
         );
-        assertFalse(composedModel.isAlias);
+        Assertions.assertFalse(composedModel.isAlias);
     }
 
     private void verifyPersonDiscriminator(CodegenDiscriminator discriminator) {
@@ -2133,7 +2135,7 @@ public class DefaultCodegenTest {
         test.getMapping().put("c", "Child");
         test.getMappedModels().add(new CodegenDiscriminator.MappedModel("a", "Adult", true));
         test.getMappedModels().add(new CodegenDiscriminator.MappedModel("c", "Child", true));
-        assertEquals(discriminator, test);
+        Assertions.assertEquals(discriminator, test);
     }
 
     private CodegenProperty codegenPropertyWithArrayOfIntegerValues() {
@@ -2211,13 +2213,13 @@ public class DefaultCodegenTest {
         CodegenParameter parameter = codegen.fromParameter(openAPI.getPaths().get("/pony").getGet().getParameters().get(0), imports);
 
         // TODO: This must be updated to work with flattened inline models
-        assertEquals(parameter.dataType, "ListPageQueryParameter");
-        assertEquals(imports.size(), 1);
-        assertEquals(imports.iterator().next(), "ListPageQueryParameter");
+        Assertions.assertEquals(parameter.dataType, "ListPageQueryParameter");
+        Assertions.assertEquals(imports.size(), 1);
+        Assertions.assertEquals(imports.iterator().next(), "ListPageQueryParameter");
 
-        assertNotNull(parameter.getSchema());
-        assertEquals(parameter.getSchema().dataType, "Object");
-        assertEquals(parameter.getSchema().baseType, "object");
+        Assertions.assertNotNull(parameter.getSchema());
+        Assertions.assertEquals(parameter.getSchema().dataType, "Object");
+        Assertions.assertEquals(parameter.getSchema().baseType, "object");
     }
 
     @Test
@@ -2233,7 +2235,7 @@ public class DefaultCodegenTest {
 
         HashSet<String> expected = Sets.newHashSet("InstrumentDefinition", "map");
 
-        assertEquals(imports, expected);
+        Assertions.assertEquals(imports, expected);
     }
 
     @Test
@@ -2246,7 +2248,7 @@ public class DefaultCodegenTest {
 
         CodegenModel codegenModel = codegen.fromModel("Dog", openAPI.getComponents().getSchemas().get("Dog"));
 
-        assertEquals(codegenModel.vars.size(), 1);
+        Assertions.assertEquals(codegenModel.vars.size(), 1);
     }
 
     @Test
@@ -2260,8 +2262,8 @@ public class DefaultCodegenTest {
 
         CodegenModel codegenModel = codegen.fromModel("ParentType", openAPI.getComponents().getSchemas().get("ParentType"));
 
-        assertEquals(codegenModel.vars.size(), 1);
-        assertEquals(codegenModel.vars.get(0).getBaseType(), "string");
+        Assertions.assertEquals(codegenModel.vars.size(), 1);
+        Assertions.assertEquals(codegenModel.vars.get(0).getBaseType(), "string");
     }
 
     @Test
@@ -2275,8 +2277,8 @@ public class DefaultCodegenTest {
 
         CodegenModel codegenModel = codegen.fromModel("ParentType", openAPI.getComponents().getSchemas().get("ParentType"));
 
-        assertEquals(codegenModel.vars.size(), 1);
-        assertEquals(codegenModel.vars.get(0).getBaseType(), "TypeAlias");
+        Assertions.assertEquals(codegenModel.vars.size(), 1);
+        Assertions.assertEquals(codegenModel.vars.get(0).getBaseType(), "TypeAlias");
     }
 
     @Test
@@ -2290,7 +2292,7 @@ public class DefaultCodegenTest {
 
         CodegenModel codegenModel = codegen.fromModel("Dog", openAPI.getComponents().getSchemas().get("Dog"));
 
-        assertEquals(codegenModel.vars.size(), 1);
+        Assertions.assertEquals(codegenModel.vars.size(), 1);
     }
 
     @Test
@@ -2304,7 +2306,7 @@ public class DefaultCodegenTest {
 
         CodegenModel codegenModel = codegen.fromModel("Dog", openAPI.getComponents().getSchemas().get("Dog"));
 
-        assertEquals(codegenModel.vars.size(), 1);
+        Assertions.assertEquals(codegenModel.vars.size(), 1);
     }
 
     @Test
@@ -2319,9 +2321,9 @@ public class DefaultCodegenTest {
 
         CodegenParameter codegenParameter = codegen.fromRequestBody(body, imports, "");
 
-        assertTrue(codegenParameter.isContainer);
-        assertTrue(codegenParameter.items.isModel);
-        assertFalse(codegenParameter.items.isContainer);
+        Assertions.assertTrue(codegenParameter.isContainer);
+        Assertions.assertTrue(codegenParameter.items.isModel);
+        Assertions.assertFalse(codegenParameter.items.isContainer);
     }
 
     @Test
@@ -2337,9 +2339,9 @@ public class DefaultCodegenTest {
 
         CodegenParameter codegenParameter = codegen.fromRequestBody(body, imports, "");
 
-        assertTrue(codegenParameter.isContainer);
-        assertTrue(codegenParameter.items.isModel);
-        assertFalse(codegenParameter.items.isContainer);
+        Assertions.assertTrue(codegenParameter.isContainer);
+        Assertions.assertTrue(codegenParameter.items.isModel);
+        Assertions.assertFalse(codegenParameter.items.isContainer);
     }
 
     @Test
@@ -2422,11 +2424,11 @@ public class DefaultCodegenTest {
         codegen.setCircularReferences(models);
 
         // then
-        assertFalse(inboundOut.isCircularReference);
-        assertTrue(roundANext.isCircularReference);
-        assertTrue(roundBNext.isCircularReference);
-        assertTrue(roundCNext.isCircularReference);
-        assertFalse(roundCOut.isCircularReference);
+        Assertions.assertFalse(inboundOut.isCircularReference);
+        Assertions.assertTrue(roundANext.isCircularReference);
+        Assertions.assertTrue(roundBNext.isCircularReference);
+        Assertions.assertTrue(roundCNext.isCircularReference);
+        Assertions.assertFalse(roundCOut.isCircularReference);
     }
 
     @Test
@@ -2444,9 +2446,9 @@ public class DefaultCodegenTest {
                 .getContent()
                 .get("application/json")
                 .getSchema());
-        assertEquals(s.getExtensions().get("x-one-of-name"), "CreateStateRequest");
+        Assertions.assertEquals(s.getExtensions().get("x-one-of-name"), "CreateStateRequest");
 
-        assertEquals(
+        Assertions.assertEquals(
                 openAPI.getPaths()
                         .get("/state")
                         .getGet()
@@ -2458,15 +2460,15 @@ public class DefaultCodegenTest {
                 "#/components/schemas/getState_200_response"
         );
         Schema getState200 = openAPI.getComponents().getSchemas().get("getState_200_response");
-        //assertEquals(getState200, "");
-        assertEquals(getState200.getExtensions().get("x-one-of-name"), "GetState200Response");
+        //Assertions.assertEquals(getState200, "");
+        Assertions.assertEquals(getState200.getExtensions().get("x-one-of-name"), "GetState200Response");
 
         // for the array schema, assert that a oneOf interface was added to schema map
         Schema items = ((ArraySchema) openAPI.getComponents().getSchemas().get("CustomOneOfArraySchema")).getItems();
-        assertEquals(items.get$ref(), "#/components/schemas/CustomOneOfArraySchema_inner");
-        //assertEquals(items.get$ref(), "#/components/schemas/createState_request");
+        Assertions.assertEquals(items.get$ref(), "#/components/schemas/CustomOneOfArraySchema_inner");
+        //Assertions.assertEquals(items.get$ref(), "#/components/schemas/createState_request");
         Schema innerItem = ModelUtils.getReferencedSchema(openAPI, openAPI.getComponents().getSchemas().get("CustomOneOfArraySchema_inner"));
-        assertEquals(innerItem.getExtensions().get("x-one-of-name"), "CustomOneOfArraySchemaInner");
+        Assertions.assertEquals(innerItem.getExtensions().get("x-one-of-name"), "CustomOneOfArraySchemaInner");
     }
 
     @Test
@@ -2527,7 +2529,7 @@ public class DefaultCodegenTest {
                 "post",
                 path.getPost(),
                 path.getServers());
-        assertEquals(operation.formParams.size(), 3,
+        Assertions.assertEquals(operation.formParams.size(), 3,
                 "The list of parameters should include inherited type");
 
         final List<String> names = operation.formParams.stream()
@@ -4324,21 +4326,21 @@ public class DefaultCodegenTest {
 
         Schema requestBodySchema = ModelUtils.getSchemaFromRequestBody(
                 openAPI.getPaths().get("/thingy/{date}").getPost().getRequestBody());
-        assertEquals(requestBodySchema.get$ref(), "#/components/schemas/updatePetWithForm_request");
-        assertEquals(ModelUtils.getSimpleRef(requestBodySchema.get$ref()), "updatePetWithForm_request");
-        assertNotNull(openAPI.getComponents().getSchemas().get(ModelUtils.getSimpleRef(requestBodySchema.get$ref())));
+        Assertions.assertEquals(requestBodySchema.get$ref(), "#/components/schemas/updatePetWithForm_request");
+        Assertions.assertEquals(ModelUtils.getSimpleRef(requestBodySchema.get$ref()), "updatePetWithForm_request");
+        Assertions.assertNotNull(openAPI.getComponents().getSchemas().get(ModelUtils.getSimpleRef(requestBodySchema.get$ref())));
 
         Schema requestBodySchema2 = ModelUtils.unaliasSchema(openAPI, requestBodySchema);
         // get$ref is not null as unaliasSchema returns the schema with the last $ref to the actual schema
-        assertNotNull(requestBodySchema2.get$ref());
-        assertEquals(requestBodySchema2.get$ref(), "#/components/schemas/updatePetWithForm_request");
+        Assertions.assertNotNull(requestBodySchema2.get$ref());
+        Assertions.assertEquals(requestBodySchema2.get$ref(), "#/components/schemas/updatePetWithForm_request");
 
         Schema requestBodySchema3 = ModelUtils.getReferencedSchema(openAPI, requestBodySchema);
         CodegenParameter codegenParameter = codegen.fromFormProperty("visitDate",
                 (Schema) requestBodySchema3.getProperties().get("visitDate"), new HashSet<>());
 
-        assertEquals(codegenParameter.defaultValue, "1971-12-19T03:39:57-08:00");
-        assertEquals(codegenParameter.getSchema(), null);
+        Assertions.assertEquals(codegenParameter.defaultValue, "1971-12-19T03:39:57-08:00");
+        Assertions.assertEquals(codegenParameter.getSchema(), null);
     }
 
     @Test
@@ -4678,7 +4680,7 @@ public class DefaultCodegenTest {
             Map<String, Object> additionalProperties = codegen.additionalProperties();
             additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, true);
             boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
-            assertTrue(result);
+            Assertions.assertTrue(result);
         }
 
         @Test
@@ -4687,7 +4689,7 @@ public class DefaultCodegenTest {
             Map<String, Object> additionalProperties = codegen.additionalProperties();
             additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, false);
             boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
-            assertFalse(result);
+            Assertions.assertFalse(result);
         }
 
         @Test
@@ -4696,7 +4698,7 @@ public class DefaultCodegenTest {
             Map<String, Object> additionalProperties = codegen.additionalProperties();
             additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, "true");
             boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
-            assertTrue(result);
+            Assertions.assertTrue(result);
         }
 
         @Test
@@ -4705,7 +4707,7 @@ public class DefaultCodegenTest {
             Map<String, Object> additionalProperties = codegen.additionalProperties();
             additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, "false");
             boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
-            assertFalse(result);
+            Assertions.assertFalse(result);
         }
 
         @Test
@@ -4714,7 +4716,7 @@ public class DefaultCodegenTest {
             Map<String, Object> additionalProperties = codegen.additionalProperties();
             additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, "blibb");
             boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
-            assertFalse(result);
+            Assertions.assertFalse(result);
         }
     }
 
@@ -4739,16 +4741,16 @@ public class DefaultCodegenTest {
         modelName = "FooOptional";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel fooOptional = codegen.fromModel(modelName, sc);
-        assertTrue(fooRequired.vars.get(0).required);
-        assertEquals(fooRequired.vars.get(0).name, "foo");
+        Assertions.assertTrue(fooRequired.vars.get(0).required);
+        Assertions.assertEquals(fooRequired.vars.get(0).name, "foo");
 
-        assertEquals(fooRequired.requiredVars.size(), 1);
-        assertEquals(fooRequired.requiredVars.get(0).name, "foo");
-        assertTrue(fooRequired.requiredVars.get(0).required);
+        Assertions.assertEquals(fooRequired.requiredVars.size(), 1);
+        Assertions.assertEquals(fooRequired.requiredVars.get(0).name, "foo");
+        Assertions.assertTrue(fooRequired.requiredVars.get(0).required);
 
-        assertFalse(fooOptional.vars.get(0).required);
-        assertEquals(fooOptional.vars.get(0).name, "foo");
-        assertEquals(fooOptional.requiredVars.size(), 0);
+        Assertions.assertFalse(fooOptional.vars.get(0).required);
+        Assertions.assertEquals(fooOptional.vars.get(0).name, "foo");
+        Assertions.assertEquals(fooOptional.requiredVars.size(), 0);
     }
 
     @Test
@@ -4770,16 +4772,16 @@ public class DefaultCodegenTest {
         CodegenModel modelWithReferencedSchema = codegen.fromModel(modelName, schemaWithReferencedEnum);
         CodegenProperty referencedEnumSchemaProperty = modelWithReferencedSchema.vars.get(1);
 
-        assertNotNull(schemaWithReferencedEnum);
-        assertTrue(modelWithReferencedSchema.hasEnums);
-        assertEquals(referencedEnumSchemaProperty.getName(), "enumType");
-        assertFalse(referencedEnumSchemaProperty.isEnum);
-        assertTrue(referencedEnumSchemaProperty.getIsEnumOrRef());
-        assertTrue(referencedEnumSchemaProperty.isEnumRef);
-        assertFalse(referencedEnumSchemaProperty.isInnerEnum);
-        assertFalse(referencedEnumSchemaProperty.isString);
-        assertFalse(referencedEnumSchemaProperty.isContainer);
-        assertFalse(referencedEnumSchemaProperty.isPrimitiveType);
+        Assertions.assertNotNull(schemaWithReferencedEnum);
+        Assertions.assertTrue(modelWithReferencedSchema.hasEnums);
+        Assertions.assertEquals(referencedEnumSchemaProperty.getName(), "enumType");
+        Assertions.assertFalse(referencedEnumSchemaProperty.isEnum);
+        Assertions.assertTrue(referencedEnumSchemaProperty.getIsEnumOrRef());
+        Assertions.assertTrue(referencedEnumSchemaProperty.isEnumRef);
+        Assertions.assertFalse(referencedEnumSchemaProperty.isInnerEnum);
+        Assertions.assertFalse(referencedEnumSchemaProperty.isString);
+        Assertions.assertFalse(referencedEnumSchemaProperty.isContainer);
+        Assertions.assertFalse(referencedEnumSchemaProperty.isPrimitiveType);
     }
 
     @Test
@@ -4794,30 +4796,30 @@ public class DefaultCodegenTest {
         CodegenModel modelWithReferencedSchema = codegen.fromModel(modelName, schemaWithReferencedEnum);
         CodegenProperty defaultEnumSchemaProperty = modelWithReferencedSchema.vars.get(4);
 
-        assertNotNull(schemaWithReferencedEnum);
-        assertTrue(modelWithReferencedSchema.hasEnums);
-        assertEquals(defaultEnumSchemaProperty.getName(), "defaultMinusnumberMinusenum");
-        assertFalse(defaultEnumSchemaProperty.isEnum);
-        assertTrue(defaultEnumSchemaProperty.getIsEnumOrRef());
-        assertTrue(defaultEnumSchemaProperty.isEnumRef);
-        assertFalse(defaultEnumSchemaProperty.isInnerEnum);
-        assertFalse(defaultEnumSchemaProperty.isString);
-        assertFalse(defaultEnumSchemaProperty.isContainer);
-        assertFalse(defaultEnumSchemaProperty.isPrimitiveType);
-        assertEquals(defaultEnumSchemaProperty.defaultValue, "2");
+        Assertions.assertNotNull(schemaWithReferencedEnum);
+        Assertions.assertTrue(modelWithReferencedSchema.hasEnums);
+        Assertions.assertEquals(defaultEnumSchemaProperty.getName(), "defaultMinusnumberMinusenum");
+        Assertions.assertFalse(defaultEnumSchemaProperty.isEnum);
+        Assertions.assertTrue(defaultEnumSchemaProperty.getIsEnumOrRef());
+        Assertions.assertTrue(defaultEnumSchemaProperty.isEnumRef);
+        Assertions.assertFalse(defaultEnumSchemaProperty.isInnerEnum);
+        Assertions.assertFalse(defaultEnumSchemaProperty.isString);
+        Assertions.assertFalse(defaultEnumSchemaProperty.isContainer);
+        Assertions.assertFalse(defaultEnumSchemaProperty.isPrimitiveType);
+        Assertions.assertEquals(defaultEnumSchemaProperty.defaultValue, "2");
 
         // test allOf with a single sub-schema and no default value set in the top level
         CodegenProperty allOfEnumSchemaProperty = modelWithReferencedSchema.vars.get(5);
-        assertEquals(allOfEnumSchemaProperty.getName(), "allofMinusnumberMinusenum");
-        assertFalse(allOfEnumSchemaProperty.isEnum);
-        assertTrue(allOfEnumSchemaProperty.getIsEnumOrRef());
-        assertTrue(allOfEnumSchemaProperty.isEnumRef);
-        assertFalse(allOfEnumSchemaProperty.isInnerEnum);
-        assertFalse(allOfEnumSchemaProperty.isString);
-        assertFalse(allOfEnumSchemaProperty.isContainer);
-        assertFalse(allOfEnumSchemaProperty.isPrimitiveType);
-        assertTrue(allOfEnumSchemaProperty.deprecated);
-        assertEquals(allOfEnumSchemaProperty.defaultValue, "null");
+        Assertions.assertEquals(allOfEnumSchemaProperty.getName(), "allofMinusnumberMinusenum");
+        Assertions.assertFalse(allOfEnumSchemaProperty.isEnum);
+        Assertions.assertTrue(allOfEnumSchemaProperty.getIsEnumOrRef());
+        Assertions.assertTrue(allOfEnumSchemaProperty.isEnumRef);
+        Assertions.assertFalse(allOfEnumSchemaProperty.isInnerEnum);
+        Assertions.assertFalse(allOfEnumSchemaProperty.isString);
+        Assertions.assertFalse(allOfEnumSchemaProperty.isContainer);
+        Assertions.assertFalse(allOfEnumSchemaProperty.isPrimitiveType);
+        Assertions.assertTrue(allOfEnumSchemaProperty.deprecated);
+        Assertions.assertEquals(allOfEnumSchemaProperty.defaultValue, "null");
     }
 
     @Test
@@ -4831,16 +4833,16 @@ public class DefaultCodegenTest {
         CodegenModel modelWithReferencedSchema = codegen.fromModel(modelName, schemaWithReferencedEnum);
         CodegenProperty inlineEnumSchemaProperty = modelWithReferencedSchema.vars.get(1);
 
-        assertNotNull(schemaWithReferencedEnum);
-        assertTrue(modelWithReferencedSchema.hasEnums);
-        assertEquals(inlineEnumSchemaProperty.getName(), "enumType");
-        assertTrue(inlineEnumSchemaProperty.isEnum);
-        assertTrue(inlineEnumSchemaProperty.isInnerEnum);
-        assertFalse(inlineEnumSchemaProperty.isEnumRef);
-        assertTrue(inlineEnumSchemaProperty.getIsEnumOrRef());
-        assertTrue(inlineEnumSchemaProperty.isString);
-        assertFalse(inlineEnumSchemaProperty.isContainer);
-        assertFalse(inlineEnumSchemaProperty.isPrimitiveType);
+        Assertions.assertNotNull(schemaWithReferencedEnum);
+        Assertions.assertTrue(modelWithReferencedSchema.hasEnums);
+        Assertions.assertEquals(inlineEnumSchemaProperty.getName(), "enumType");
+        Assertions.assertTrue(inlineEnumSchemaProperty.isEnum);
+        Assertions.assertTrue(inlineEnumSchemaProperty.isInnerEnum);
+        Assertions.assertFalse(inlineEnumSchemaProperty.isEnumRef);
+        Assertions.assertTrue(inlineEnumSchemaProperty.getIsEnumOrRef());
+        Assertions.assertTrue(inlineEnumSchemaProperty.isString);
+        Assertions.assertFalse(inlineEnumSchemaProperty.isContainer);
+        Assertions.assertFalse(inlineEnumSchemaProperty.isPrimitiveType);
     }
 
     @Test
@@ -4852,7 +4854,7 @@ public class DefaultCodegenTest {
         expected.setDefault("defaultValue");
         expected.setEnum(Map.of("defaultValue", "defaultDesc"));
 
-        assertTrue(codegen.cliOptions.contains(expected));
+        Assertions.assertTrue(codegen.cliOptions.contains(expected));
     }
 
     @Test
@@ -4862,7 +4864,7 @@ public class DefaultCodegenTest {
 
         CliOption expected = new CliOption("optionKey", "optionDesc");
 
-        assertTrue(codegen.cliOptions.contains(expected));
+        Assertions.assertTrue(codegen.cliOptions.contains(expected));
     }
 
     @Test
@@ -4873,7 +4875,7 @@ public class DefaultCodegenTest {
         CliOption expected = new CliOption("optionKey", "optionDesc");
         expected.setDefault("defaultValue");
 
-        assertTrue(codegen.cliOptions.contains(expected));
+        Assertions.assertTrue(codegen.cliOptions.contains(expected));
     }
 
     @Test
@@ -4896,8 +4898,8 @@ public class DefaultCodegenTest {
     @Test
     void testIsXML() {
         final DefaultCodegen codegen = new DefaultCodegen();
-        assertTrue(codegen.isXmlMimeType("application/xml"));
-        assertTrue(codegen.isXmlMimeType("application/rss+xml"));
+        Assertions.assertTrue(codegen.isXmlMimeType("application/xml"));
+        Assertions.assertTrue(codegen.isXmlMimeType("application/rss+xml"));
     }
 
     @Test
@@ -4909,8 +4911,8 @@ public class DefaultCodegenTest {
         Operation operation = openAPI.getWebhooks().get("newPet").getPost();
         CodegenOperation co = codegen.fromOperation("newPet", "get", operation, null);
 
-        assertEquals(co.path, "/newPet");
-        assertEquals(co.operationId, "newPetGet");
+        Assertions.assertEquals(co.path, "/newPet");
+        Assertions.assertEquals(co.operationId, "newPetGet");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
@@ -16,7 +16,7 @@
 
 package org.openapitools.codegen.csharpnetcore;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.openapitools.codegen.TestUtils.assertFileContains;
 
 import io.swagger.v3.oas.models.OpenAPI;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientDeepObjectTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientDeepObjectTest.java
@@ -32,8 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openapitools.codegen.TestUtils.assertFileContains;
 
 public class CSharpClientDeepObjectTest {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -17,7 +17,7 @@
 
 package org.openapitools.codegen.java;
 
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Assertions;
 import static org.openapitools.codegen.TestUtils.assertFileContains;
 import static org.openapitools.codegen.TestUtils.assertFileNotContains;
 import static org.openapitools.codegen.TestUtils.validateJavaSourceFiles;
@@ -109,9 +109,9 @@ public class JavaClientCodegenTest {
                                 "application/json",
                                 new MediaType().schema(new ArraySchema().items(new StringSchema()))));
         CodegenParameter codegenParameter1 = codegen.fromRequestBody(body1, new HashSet<String>(), null);
-        Assert.assertEquals(codegenParameter1.description, "A list of ids");
-        Assert.assertEquals(codegenParameter1.dataType, "List<String>");
-        Assert.assertEquals(codegenParameter1.baseType, "String");
+        Assertions.assertEquals(codegenParameter1.description, "A list of ids");
+        Assertions.assertEquals(codegenParameter1.dataType, "List<String>");
+        Assertions.assertEquals(codegenParameter1.baseType, "String");
 
         RequestBody body2 = new RequestBody();
         body2.setDescription("A list of list of values");
@@ -123,9 +123,9 @@ public class JavaClientCodegenTest {
                                         .schema(
                                                 new ArraySchema().items(new ArraySchema().items(new IntegerSchema())))));
         CodegenParameter codegenParameter2 = codegen.fromRequestBody(body2, new HashSet<String>(), null);
-        Assert.assertEquals(codegenParameter2.description, "A list of list of values");
-        Assert.assertEquals(codegenParameter2.dataType, "List<List<Integer>>");
-        Assert.assertEquals(codegenParameter2.baseType, "List");
+        Assertions.assertEquals(codegenParameter2.description, "A list of list of values");
+        Assertions.assertEquals(codegenParameter2.dataType, "List<List<Integer>>");
+        Assertions.assertEquals(codegenParameter2.baseType, "List");
 
         RequestBody body3 = new RequestBody();
         body3.setDescription("A list of points");
@@ -142,9 +142,9 @@ public class JavaClientCodegenTest {
         point.addProperty("x", new IntegerSchema().format(SchemaTypeUtil.INTEGER32_FORMAT));
         point.addProperty("y", new IntegerSchema().format(SchemaTypeUtil.INTEGER32_FORMAT));
         CodegenParameter codegenParameter3 = codegen.fromRequestBody(body3, new HashSet<String>(), null);
-        Assert.assertEquals(codegenParameter3.description, "A list of points");
-        Assert.assertEquals(codegenParameter3.dataType, "List<Point>");
-        Assert.assertEquals(codegenParameter3.baseType, "Point");
+        Assertions.assertEquals(codegenParameter3.description, "A list of points");
+        Assertions.assertEquals(codegenParameter3.dataType, "List<Point>");
+        Assertions.assertEquals(codegenParameter3.baseType, "Point");
     }
 
     @Test
@@ -153,7 +153,7 @@ public class JavaClientCodegenTest {
         ComposedSchema schema = new ComposedSchema();
         CodegenModel result = codegen.fromModel("CompSche",
                 schema);
-        Assert.assertEquals(result.name, "CompSche");
+        Assertions.assertEquals(result.name, "CompSche");
     }
 
     @Test
@@ -177,7 +177,7 @@ public class JavaClientCodegenTest {
 
         javaClientCodegen.postProcessOperationsWithModels(objs, Collections.emptyList());
 
-        Assert.assertEquals(Arrays.asList(pathParam1, pathParam2, queryParamRequired, queryParamOptional), codegenOperation.allParams);
+        Assertions.assertEquals(Arrays.asList(pathParam1, pathParam2, queryParamRequired, queryParamOptional), codegenOperation.allParams);
     }
 
     @Test
@@ -185,22 +185,22 @@ public class JavaClientCodegenTest {
         final JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.processOpts();
 
-        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
-        Assert.assertFalse(codegen.isHideGenerationTimestamp());
+        Assertions.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
+        Assertions.assertFalse(codegen.isHideGenerationTimestamp());
 
-        Assert.assertEquals(codegen.modelPackage(), "org.openapitools.client.model");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.modelPackage(), "org.openapitools.client.model");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
                 "org.openapitools.client.model");
-        Assert.assertEquals(codegen.apiPackage(), "org.openapitools.client.api");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.apiPackage(), "org.openapitools.client.api");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),
                 "org.openapitools.client.api");
-        Assert.assertEquals(codegen.getInvokerPackage(), "org.openapitools.client");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.getInvokerPackage(), "org.openapitools.client");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
                 "org.openapitools.client");
-        Assert.assertEquals(codegen.getSerializationLibrary(), JavaClientCodegen.SERIALIZATION_LIBRARY_GSON);
+        Assertions.assertEquals(codegen.getSerializationLibrary(), JavaClientCodegen.SERIALIZATION_LIBRARY_GSON);
     }
 
     @Test
@@ -213,20 +213,20 @@ public class JavaClientCodegenTest {
         codegen.setSerializationLibrary("JACKSON");
         codegen.processOpts();
 
-        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
-        Assert.assertTrue(codegen.isHideGenerationTimestamp());
-        Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.model");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
+        Assertions.assertTrue(codegen.isHideGenerationTimestamp());
+        Assertions.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.model");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
                 "xyz.yyyyy.zzzzzzz.model");
-        Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.api");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.api");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.zzzzzzz.api");
-        Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.invoker");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.invoker");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
                 "xyz.yyyyy.zzzzzzz.invoker");
-        Assert.assertEquals(codegen.getSerializationLibrary(), JavaClientCodegen.SERIALIZATION_LIBRARY_GSON); // the library JavaClientCodegen.OKHTTP_GSON only supports GSON
+        Assertions.assertEquals(codegen.getSerializationLibrary(), JavaClientCodegen.SERIALIZATION_LIBRARY_GSON); // the library JavaClientCodegen.OKHTTP_GSON only supports GSON
     }
 
     @Test
@@ -244,21 +244,21 @@ public class JavaClientCodegenTest {
         codegen.additionalProperties().put(CodegenConstants.LIBRARY, JavaClientCodegen.JERSEY2);
         codegen.processOpts();
 
-        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
-        Assert.assertTrue(codegen.isHideGenerationTimestamp());
-        Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.mmmmm.model");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
+        Assertions.assertTrue(codegen.isHideGenerationTimestamp());
+        Assertions.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
                 "xyz.yyyyy.zzzzzzz.mmmmm.model");
-        Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.aaaaa.api");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.aaaaa.api");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),
                 "xyz.yyyyy.zzzzzzz.aaaaa.api");
-        Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.iiii.invoker");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.iiii.invoker");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
                 "xyz.yyyyy.zzzzzzz.iiii.invoker");
-        Assert.assertEquals(codegen.getSerializationLibrary(), JavaClientCodegen.SERIALIZATION_LIBRARY_JACKSON);
+        Assertions.assertEquals(codegen.getSerializationLibrary(), JavaClientCodegen.SERIALIZATION_LIBRARY_JACKSON);
     }
 
     @Test
@@ -321,7 +321,7 @@ public class JavaClientCodegenTest {
         codegen.additionalProperties().put(CodegenConstants.LIBRARY, JavaClientCodegen.JERSEY3);
         codegen.processOpts();
 
-        Assert.assertTrue(codegen.getFeatureSet().getSecurityFeatures().contains(SecurityFeature.SignatureAuth));
+        Assertions.assertTrue(codegen.getFeatureSet().getSecurityFeatures().contains(SecurityFeature.SignatureAuth));
     }
 
     @Test
@@ -333,16 +333,16 @@ public class JavaClientCodegenTest {
         codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.zzzzzzz.aaaaa.api");
         codegen.processOpts();
 
-        Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.mmmmm.model");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
                 "xyz.yyyyy.zzzzzzz.mmmmm.model");
-        Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.aaaaa.api");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.aaaaa.api");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),
                 "xyz.yyyyy.zzzzzzz.aaaaa.api");
-        Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.aaaaa");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.aaaaa");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
                 "xyz.yyyyy.zzzzzzz.aaaaa");
     }
@@ -355,16 +355,16 @@ public class JavaClientCodegenTest {
                 .put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.zzzzzzz.mmmmm.model");
         codegen.processOpts();
 
-        Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.mmmmm.model");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
                 "xyz.yyyyy.zzzzzzz.mmmmm.model");
-        Assert.assertEquals(codegen.apiPackage(), "org.openapitools.client.api");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.apiPackage(), "org.openapitools.client.api");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),
                 "org.openapitools.client.api");
-        Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.mmmmm");
-        Assert.assertEquals(
+        Assertions.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.mmmmm");
+        Assertions.assertEquals(
                 codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
                 "xyz.yyyyy.zzzzzzz.mmmmm");
     }
@@ -377,8 +377,8 @@ public class JavaClientCodegenTest {
 
         Operation operation = openAPI.getPaths().get("/ping").getPost();
         CodegenOperation co = codegen.fromOperation("/ping", "POST", operation, null);
-        Assert.assertEquals(co.allParams.size(), 1);
-        Assert.assertEquals(co.allParams.get(0).baseType, "MessageEventCoreWithTimeListEntries");
+        Assertions.assertEquals(co.allParams.size(), 1);
+        Assertions.assertEquals(co.allParams.get(0).baseType, "MessageEventCoreWithTimeListEntries");
     }
 
     @Test
@@ -390,11 +390,11 @@ public class JavaClientCodegenTest {
 
         List<Map<String, String>> enumVars =
                 (List<Map<String, String>>) array.getItems().getAllowableValues().get("enumVars");
-        Assert.assertNotNull(enumVars);
+        Assertions.assertNotNull(enumVars);
         Map<String, String> testedEnumVar = enumVars.get(0);
-        Assert.assertNotNull(testedEnumVar);
-        Assert.assertEquals(testedEnumVar.getOrDefault("name", ""), "NUMBER_1");
-        Assert.assertEquals(testedEnumVar.getOrDefault("value", ""), "1");
+        Assertions.assertNotNull(testedEnumVar);
+        Assertions.assertEquals(testedEnumVar.getOrDefault("name", ""), "NUMBER_1");
+        Assertions.assertEquals(testedEnumVar.getOrDefault("value", ""), "1");
     }
 
     @Test
@@ -410,11 +410,11 @@ public class JavaClientCodegenTest {
 
         List<Map<String, String>> enumVars =
                 (List<Map<String, String>>) array.getItems().getAllowableValues().get("enumVars");
-        Assert.assertNotNull(enumVars);
+        Assertions.assertNotNull(enumVars);
         Map<String, String> testedEnumVar = enumVars.get(0);
-        Assert.assertNotNull(testedEnumVar);
-        Assert.assertEquals(testedEnumVar.getOrDefault("name", ""), "ONE");
-        Assert.assertEquals(testedEnumVar.getOrDefault("value", ""), "1");
+        Assertions.assertNotNull(testedEnumVar);
+        Assertions.assertEquals(testedEnumVar.getOrDefault("name", ""), "ONE");
+        Assertions.assertEquals(testedEnumVar.getOrDefault("value", ""), "1");
     }
 
     @Test
@@ -435,7 +435,7 @@ public class JavaClientCodegenTest {
         DefaultGenerator generator = new DefaultGenerator();
         List<File> files = generator.opts(clientOptInput).generate();
 
-        Assert.assertEquals(files.size(), 40);
+        Assertions.assertEquals(files.size(), 40);
         TestUtils.ensureContainsFile(files, output, ".gitignore");
         TestUtils.ensureContainsFile(files, output, ".openapi-generator-ignore");
         TestUtils.ensureContainsFile(files, output, ".openapi-generator/FILES");
@@ -511,7 +511,7 @@ public class JavaClientCodegenTest {
         DefaultGenerator generator = new DefaultGenerator();
         List<File> files = generator.opts(clientOptInput).generate();
 
-        Assert.assertEquals(files.size(), 43);
+        Assertions.assertEquals(files.size(), 43);
         TestUtils.ensureContainsFile(files, output, ".gitignore");
         TestUtils.ensureContainsFile(files, output, ".openapi-generator-ignore");
         TestUtils.ensureContainsFile(files, output, ".openapi-generator/FILES");
@@ -599,7 +599,7 @@ public class JavaClientCodegenTest {
         DefaultGenerator generator = new DefaultGenerator();
         List<File> files = generator.opts(clientOptInput).generate();
 
-        Assert.assertEquals(files.size(), 32);
+        Assertions.assertEquals(files.size(), 32);
         validateJavaSourceFiles(files);
 
         TestUtils.assertFileContains(
@@ -668,7 +668,7 @@ public class JavaClientCodegenTest {
         generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "true");
         List<File> files = generator.opts(clientOptInput).generate();
 
-        Assert.assertEquals(files.size(), 153);
+        Assertions.assertEquals(files.size(), 153);
         validateJavaSourceFiles(files);
 
         TestUtils.assertFileContains(Paths.get(output + "/src/main/java/xyz/abcdef/model/Dog.java"),
@@ -695,7 +695,7 @@ public class JavaClientCodegenTest {
         DefaultGenerator generator = new DefaultGenerator();
         List<File> files = generator.opts(clientOptInput).generate();
 
-        Assert.assertEquals(files.size(), 35);
+        Assertions.assertEquals(files.size(), 35);
         validateJavaSourceFiles(files);
 
         Path defaultApi = Paths.get(output + "/src/main/java/xyz/abcdef/api/PingApi.java");
@@ -722,10 +722,10 @@ public class JavaClientCodegenTest {
         ApiResponse ok_200 = openAPI.getComponents().getResponses().get("OK_200");
         CodegenResponse response = codegen.fromResponse("200", ok_200);
 
-        Assert.assertEquals(response.headers.size(), 1);
+        Assertions.assertEquals(response.headers.size(), 1);
         CodegenProperty header = response.headers.get(0);
-        Assert.assertEquals(header.dataType, "UUID");
-        Assert.assertEquals(header.baseName, "Request");
+        Assertions.assertEquals(header.dataType, "UUID");
+        Assertions.assertEquals(header.baseName, "Request");
     }
 
     @Test
@@ -791,7 +791,7 @@ public class JavaClientCodegenTest {
 
         validateJavaSourceFiles(files);
 
-        Assert.assertEquals(files.size(), 1);
+        Assertions.assertEquals(files.size(), 1);
         files.forEach(File::deleteOnExit);
     }
 
@@ -820,7 +820,7 @@ public class JavaClientCodegenTest {
 
         validateJavaSourceFiles(files);
 
-        Assert.assertEquals(files.size(), 9);
+        Assertions.assertEquals(files.size(), 9);
         files.forEach(File::deleteOnExit);
     }
 
@@ -899,29 +899,29 @@ public class JavaClientCodegenTest {
         Schema test1 = openAPI.getComponents().getSchemas().get("MapTest1");
         codegen.setOpenAPI(openAPI);
         CodegenModel cm1 = codegen.fromModel("MapTest1", test1);
-        Assert.assertEquals(cm1.getDataType(), "Map");
-        Assert.assertEquals(cm1.getParent(), "HashMap<String, Object>");
-        Assert.assertEquals(cm1.getClassname(), "MapTest1");
+        Assertions.assertEquals(cm1.getDataType(), "Map");
+        Assertions.assertEquals(cm1.getParent(), "HashMap<String, Object>");
+        Assertions.assertEquals(cm1.getClassname(), "MapTest1");
 
         Schema test2 = openAPI.getComponents().getSchemas().get("MapTest2");
         codegen.setOpenAPI(openAPI);
         CodegenModel cm2 = codegen.fromModel("MapTest2", test2);
-        Assert.assertEquals(cm2.getDataType(), "Map");
-        Assert.assertEquals(cm2.getParent(), "HashMap<String, Object>");
-        Assert.assertEquals(cm2.getClassname(), "MapTest2");
+        Assertions.assertEquals(cm2.getDataType(), "Map");
+        Assertions.assertEquals(cm2.getParent(), "HashMap<String, Object>");
+        Assertions.assertEquals(cm2.getClassname(), "MapTest2");
 
         Schema test3 = openAPI.getComponents().getSchemas().get("MapTest3");
         codegen.setOpenAPI(openAPI);
         CodegenModel cm3 = codegen.fromModel("MapTest3", test3);
-        Assert.assertEquals(cm3.getDataType(), "Map");
-        Assert.assertEquals(cm3.getParent(), "HashMap<String, Object>");
-        Assert.assertEquals(cm3.getClassname(), "MapTest3");
+        Assertions.assertEquals(cm3.getDataType(), "Map");
+        Assertions.assertEquals(cm3.getParent(), "HashMap<String, Object>");
+        Assertions.assertEquals(cm3.getClassname(), "MapTest3");
 
         Schema other = openAPI.getComponents().getSchemas().get("OtherObj");
         codegen.setOpenAPI(openAPI);
         CodegenModel cm = codegen.fromModel("OtherObj", other);
-        Assert.assertEquals(cm.getDataType(), "Object");
-        Assert.assertEquals(cm.getClassname(), "OtherObj");
+        Assertions.assertEquals(cm.getDataType(), "Object");
+        Assertions.assertEquals(cm.getClassname(), "OtherObj");
     }
 
     /**
@@ -949,7 +949,7 @@ public class JavaClientCodegenTest {
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 clientOptInput.getConfig().schemaMapping().get("TypeAlias"), "foo.bar.TypeAlias");
 
         DefaultGenerator generator = new DefaultGenerator();
@@ -964,7 +964,7 @@ public class JavaClientCodegenTest {
 
         validateJavaSourceFiles(files);
 
-        Assert.assertEquals(files.size(), 1);
+        Assertions.assertEquals(files.size(), 1);
         TestUtils.ensureContainsFile(
                 files, output, "src/main/java/org/openapitools/client/model/ParentType.java");
 
@@ -979,11 +979,11 @@ public class JavaClientCodegenTest {
 
         final Pattern FIELD_PATTERN = Pattern.compile(".* private (.*?) typeAlias;.*", Pattern.DOTALL);
         Matcher fieldMatcher = FIELD_PATTERN.matcher(parentTypeContents);
-        Assert.assertTrue(fieldMatcher.matches());
+        Assertions.assertTrue(fieldMatcher.matches());
 
         // this is the type of the field 'typeAlias'. With a working schemaMapping it should
         // be 'foo.bar.TypeAlias' or just 'TypeAlias'
-        Assert.assertEquals(fieldMatcher.group(1), "foo.bar.TypeAlias");
+        Assertions.assertEquals(fieldMatcher.group(1), "foo.bar.TypeAlias");
     }
 
     @Test
@@ -993,10 +993,10 @@ public class JavaClientCodegenTest {
         JavaClientCodegen codegen = new JavaClientCodegen();
 
         List<CodegenSecurity> security = codegen.fromSecurity(openAPI.getComponents().getSecuritySchemes());
-        Assert.assertEquals(security.size(), 1);
-        Assert.assertEquals(security.get(0).isBasic, Boolean.TRUE);
-        Assert.assertEquals(security.get(0).isBasicBasic, Boolean.FALSE);
-        Assert.assertEquals(security.get(0).isBasicBearer, Boolean.TRUE);
+        Assertions.assertEquals(security.size(), 1);
+        Assertions.assertEquals(security.get(0).isBasic, Boolean.TRUE);
+        Assertions.assertEquals(security.get(0).isBasicBasic, Boolean.FALSE);
+        Assertions.assertEquals(security.get(0).isBasicBearer, Boolean.TRUE);
     }
 
     @Test
@@ -1082,135 +1082,135 @@ public class JavaClientCodegenTest {
         Schema test1 = openAPI.getComponents().getSchemas().get("AnyValueModel");
         codegen.setOpenAPI(openAPI);
         CodegenModel cm1 = codegen.fromModel("AnyValueModel", test1);
-        Assert.assertEquals(cm1.getClassname(), "AnyValueModel");
+        Assertions.assertEquals(cm1.getClassname(), "AnyValueModel");
 
         final CodegenProperty property1 = cm1.allVars.get(0);
-        Assert.assertEquals(property1.baseName, "any_value");
-        Assert.assertEquals(property1.dataType, "Object");
-        Assert.assertTrue(property1.isPrimitiveType);
-        Assert.assertFalse(property1.isContainer);
-        Assert.assertFalse(property1.isFreeFormObject);
-        Assert.assertTrue(property1.isAnyType);
+        Assertions.assertEquals(property1.baseName, "any_value");
+        Assertions.assertEquals(property1.dataType, "Object");
+        Assertions.assertTrue(property1.isPrimitiveType);
+        Assertions.assertFalse(property1.isContainer);
+        Assertions.assertFalse(property1.isFreeFormObject);
+        Assertions.assertTrue(property1.isAnyType);
 
         final CodegenProperty property2 = cm1.allVars.get(1);
-        Assert.assertEquals(property2.baseName, "any_value_with_desc");
-        Assert.assertEquals(property2.dataType, "Object");
-        Assert.assertFalse(property2.required);
-        Assert.assertTrue(property2.isPrimitiveType);
-        Assert.assertFalse(property2.isContainer);
-        Assert.assertFalse(property2.isFreeFormObject);
-        Assert.assertTrue(property2.isAnyType);
+        Assertions.assertEquals(property2.baseName, "any_value_with_desc");
+        Assertions.assertEquals(property2.dataType, "Object");
+        Assertions.assertFalse(property2.required);
+        Assertions.assertTrue(property2.isPrimitiveType);
+        Assertions.assertFalse(property2.isContainer);
+        Assertions.assertFalse(property2.isFreeFormObject);
+        Assertions.assertTrue(property2.isAnyType);
 
         final CodegenProperty property3 = cm1.allVars.get(2);
-        Assert.assertEquals(property3.baseName, "any_value_nullable");
-        Assert.assertEquals(property3.dataType, "Object");
-        Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isPrimitiveType);
-        Assert.assertFalse(property3.isContainer);
-        Assert.assertFalse(property3.isFreeFormObject);
-        Assert.assertTrue(property3.isAnyType);
+        Assertions.assertEquals(property3.baseName, "any_value_nullable");
+        Assertions.assertEquals(property3.dataType, "Object");
+        Assertions.assertFalse(property3.required);
+        Assertions.assertTrue(property3.isPrimitiveType);
+        Assertions.assertFalse(property3.isContainer);
+        Assertions.assertFalse(property3.isFreeFormObject);
+        Assertions.assertTrue(property3.isAnyType);
 
         Schema test2 = openAPI.getComponents().getSchemas().get("AnyValueModelInline");
         codegen.setOpenAPI(openAPI);
         CodegenModel cm2 = codegen.fromModel("AnyValueModelInline", test2);
-        Assert.assertEquals(cm2.getClassname(), "AnyValueModelInline");
+        Assertions.assertEquals(cm2.getClassname(), "AnyValueModelInline");
 
         final CodegenProperty cp1 = cm2.vars.get(0);
-        Assert.assertEquals(cp1.baseName, "any_value");
-        Assert.assertEquals(cp1.dataType, "Object");
-        Assert.assertFalse(cp1.required);
-        Assert.assertTrue(cp1.isPrimitiveType);
-        Assert.assertFalse(cp1.isContainer);
-        Assert.assertFalse(cp1.isFreeFormObject);
-        Assert.assertTrue(cp1.isAnyType);
+        Assertions.assertEquals(cp1.baseName, "any_value");
+        Assertions.assertEquals(cp1.dataType, "Object");
+        Assertions.assertFalse(cp1.required);
+        Assertions.assertTrue(cp1.isPrimitiveType);
+        Assertions.assertFalse(cp1.isContainer);
+        Assertions.assertFalse(cp1.isFreeFormObject);
+        Assertions.assertTrue(cp1.isAnyType);
 
         final CodegenProperty cp2 = cm2.vars.get(1);
-        Assert.assertEquals(cp2.baseName, "any_value_with_desc");
-        Assert.assertEquals(cp2.dataType, "Object");
-        Assert.assertFalse(cp2.required);
-        Assert.assertTrue(cp2.isPrimitiveType);
-        Assert.assertFalse(cp2.isContainer);
-        Assert.assertFalse(cp2.isFreeFormObject);
-        Assert.assertTrue(cp2.isAnyType);
+        Assertions.assertEquals(cp2.baseName, "any_value_with_desc");
+        Assertions.assertEquals(cp2.dataType, "Object");
+        Assertions.assertFalse(cp2.required);
+        Assertions.assertTrue(cp2.isPrimitiveType);
+        Assertions.assertFalse(cp2.isContainer);
+        Assertions.assertFalse(cp2.isFreeFormObject);
+        Assertions.assertTrue(cp2.isAnyType);
 
         final CodegenProperty cp3 = cm2.vars.get(2);
-        Assert.assertEquals(cp3.baseName, "any_value_nullable");
-        Assert.assertEquals(cp3.dataType, "Object");
-        Assert.assertFalse(cp3.required);
-        Assert.assertTrue(cp3.isPrimitiveType);
-        Assert.assertFalse(cp3.isContainer);
-        Assert.assertFalse(cp3.isFreeFormObject);
-        Assert.assertTrue(cp3.isAnyType);
+        Assertions.assertEquals(cp3.baseName, "any_value_nullable");
+        Assertions.assertEquals(cp3.dataType, "Object");
+        Assertions.assertFalse(cp3.required);
+        Assertions.assertTrue(cp3.isPrimitiveType);
+        Assertions.assertFalse(cp3.isContainer);
+        Assertions.assertFalse(cp3.isFreeFormObject);
+        Assertions.assertTrue(cp3.isAnyType);
 
         // map
         // Should allow in any type including map, https://github.com/swagger-api/swagger-parser/issues/1603
         final CodegenProperty cp4 = cm2.vars.get(3);
-        Assert.assertEquals(cp4.baseName, "map_free_form_object");
-        Assert.assertEquals(cp4.dataType, "Map<String, Object>");
-        Assert.assertFalse(cp4.required);
-        Assert.assertTrue(cp4.isPrimitiveType);
-        Assert.assertTrue(cp4.isContainer);
-        Assert.assertTrue(cp4.isMap);
-        Assert.assertTrue(cp4.isFreeFormObject);
-        Assert.assertFalse(cp4.isAnyType);
-        Assert.assertFalse(cp4.isModel);
+        Assertions.assertEquals(cp4.baseName, "map_free_form_object");
+        Assertions.assertEquals(cp4.dataType, "Map<String, Object>");
+        Assertions.assertFalse(cp4.required);
+        Assertions.assertTrue(cp4.isPrimitiveType);
+        Assertions.assertTrue(cp4.isContainer);
+        Assertions.assertTrue(cp4.isMap);
+        Assertions.assertTrue(cp4.isFreeFormObject);
+        Assertions.assertFalse(cp4.isAnyType);
+        Assertions.assertFalse(cp4.isModel);
 
         // Should allow in any type including map, https://github.com/swagger-api/swagger-parser/issues/1603
         final CodegenProperty cp5 = cm2.vars.get(4);
-        Assert.assertEquals(cp5.baseName, "map_any_value_with_desc");
-        Assert.assertEquals(cp5.dataType, "Map<String, Object>");
-        Assert.assertFalse(cp5.required);
-        Assert.assertTrue(cp5.isPrimitiveType);
-        Assert.assertTrue(cp5.isContainer);
-        Assert.assertTrue(cp5.isMap);
-        Assert.assertTrue(cp5.isFreeFormObject);
-        Assert.assertFalse(cp5.isAnyType);
-        Assert.assertFalse(cp5.isModel);
+        Assertions.assertEquals(cp5.baseName, "map_any_value_with_desc");
+        Assertions.assertEquals(cp5.dataType, "Map<String, Object>");
+        Assertions.assertFalse(cp5.required);
+        Assertions.assertTrue(cp5.isPrimitiveType);
+        Assertions.assertTrue(cp5.isContainer);
+        Assertions.assertTrue(cp5.isMap);
+        Assertions.assertTrue(cp5.isFreeFormObject);
+        Assertions.assertFalse(cp5.isAnyType);
+        Assertions.assertFalse(cp5.isModel);
 
         // Should allow in any type including map, https://github.com/swagger-api/swagger-parser/issues/1603
         final CodegenProperty cp6 = cm2.vars.get(5);
-        Assert.assertEquals(cp6.baseName, "map_any_value_nullable");
-        Assert.assertEquals(cp6.dataType, "Map<String, Object>");
-        Assert.assertFalse(cp6.required);
-        Assert.assertTrue(cp6.isPrimitiveType);
-        Assert.assertTrue(cp6.isContainer);
-        Assert.assertTrue(cp6.isMap);
-        Assert.assertTrue(cp6.isFreeFormObject);
-        Assert.assertFalse(cp6.isAnyType);
+        Assertions.assertEquals(cp6.baseName, "map_any_value_nullable");
+        Assertions.assertEquals(cp6.dataType, "Map<String, Object>");
+        Assertions.assertFalse(cp6.required);
+        Assertions.assertTrue(cp6.isPrimitiveType);
+        Assertions.assertTrue(cp6.isContainer);
+        Assertions.assertTrue(cp6.isMap);
+        Assertions.assertTrue(cp6.isFreeFormObject);
+        Assertions.assertFalse(cp6.isAnyType);
 
         // array
         // Should allow in any type including array, https://github.com/swagger-api/swagger-parser/issues/1603
         final CodegenProperty cp7 = cm2.vars.get(6);
-        Assert.assertEquals(cp7.baseName, "array_any_value");
-        Assert.assertEquals(cp7.dataType, "List<Object>");
-        Assert.assertFalse(cp7.required);
-        Assert.assertTrue(cp7.isPrimitiveType);
-        Assert.assertTrue(cp7.isContainer);
-        Assert.assertTrue(cp7.isArray);
-        Assert.assertFalse(cp7.isFreeFormObject);
-        Assert.assertFalse(cp7.isAnyType);
+        Assertions.assertEquals(cp7.baseName, "array_any_value");
+        Assertions.assertEquals(cp7.dataType, "List<Object>");
+        Assertions.assertFalse(cp7.required);
+        Assertions.assertTrue(cp7.isPrimitiveType);
+        Assertions.assertTrue(cp7.isContainer);
+        Assertions.assertTrue(cp7.isArray);
+        Assertions.assertFalse(cp7.isFreeFormObject);
+        Assertions.assertFalse(cp7.isAnyType);
 
         // Should allow in any type including array, https://github.com/swagger-api/swagger-parser/issues/1603
         final CodegenProperty cp8 = cm2.vars.get(7);
-        Assert.assertEquals(cp8.baseName, "array_any_value_with_desc");
-        Assert.assertEquals(cp8.dataType, "List<Object>");
-        Assert.assertFalse(cp8.required);
-        Assert.assertTrue(cp8.isPrimitiveType);
-        Assert.assertTrue(cp8.isContainer);
-        Assert.assertTrue(cp8.isArray);
-        Assert.assertFalse(cp8.isFreeFormObject);
-        Assert.assertFalse(cp8.isAnyType);
+        Assertions.assertEquals(cp8.baseName, "array_any_value_with_desc");
+        Assertions.assertEquals(cp8.dataType, "List<Object>");
+        Assertions.assertFalse(cp8.required);
+        Assertions.assertTrue(cp8.isPrimitiveType);
+        Assertions.assertTrue(cp8.isContainer);
+        Assertions.assertTrue(cp8.isArray);
+        Assertions.assertFalse(cp8.isFreeFormObject);
+        Assertions.assertFalse(cp8.isAnyType);
 
         // Should allow in any type including array, https://github.com/swagger-api/swagger-parser/issues/1603
         final CodegenProperty cp9 = cm2.vars.get(8);
-        Assert.assertEquals(cp9.baseName, "array_any_value_nullable");
-        Assert.assertEquals(cp9.dataType, "List<Object>");
-        Assert.assertFalse(cp9.required);
-        Assert.assertTrue(cp9.isPrimitiveType);
-        Assert.assertTrue(cp9.isContainer);
-        Assert.assertTrue(cp9.isArray);
-        Assert.assertFalse(cp9.isFreeFormObject);
-        Assert.assertFalse(cp9.isAnyType);
+        Assertions.assertEquals(cp9.baseName, "array_any_value_nullable");
+        Assertions.assertEquals(cp9.dataType, "List<Object>");
+        Assertions.assertFalse(cp9.required);
+        Assertions.assertTrue(cp9.isPrimitiveType);
+        Assertions.assertTrue(cp9.isContainer);
+        Assertions.assertTrue(cp9.isArray);
+        Assertions.assertFalse(cp9.isFreeFormObject);
+        Assertions.assertFalse(cp9.isAnyType);
     }
 
     /**
@@ -1362,7 +1362,7 @@ public class JavaClientCodegenTest {
         DefaultGenerator generator = new DefaultGenerator();
         List<File> files = generator.opts(clientOptInput).generate();
 
-        Assert.assertEquals(files.size(), 49);
+        Assertions.assertEquals(files.size(), 49);
         TestUtils.ensureContainsFile(
                 files, output, "src/main/java/org/openapitools/client/model/RealCommand.java");
         TestUtils.ensureContainsFile(
@@ -1657,7 +1657,7 @@ public class JavaClientCodegenTest {
         DefaultGenerator generator = new DefaultGenerator();
         List<File> files = generator.opts(clientOptInput).generate();
 
-        Assert.assertEquals(files.size(), 35);
+        Assertions.assertEquals(files.size(), 35);
         validateJavaSourceFiles(files);
 
         TestUtils.assertFileContains(
@@ -1688,7 +1688,7 @@ public class JavaClientCodegenTest {
         DefaultGenerator generator = new DefaultGenerator();
         List<File> files = generator.opts(clientOptInput).generate();
 
-        Assert.assertEquals(files.size(), 38);
+        Assertions.assertEquals(files.size(), 38);
         validateJavaSourceFiles(files);
 
         TestUtils.assertFileContains(
@@ -2159,7 +2159,7 @@ public class JavaClientCodegenTest {
         generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "true");
         List<File> files = generator.opts(clientOptInput).generate();
 
-        Assert.assertEquals(files.size(), 27);
+        Assertions.assertEquals(files.size(), 27);
         validateJavaSourceFiles(files);
 
         TestUtils.assertFileContains(
@@ -2497,12 +2497,12 @@ public class JavaClientCodegenTest {
         CodegenModel cm1 = codegen.fromModel("Cat", test1);
 
         CodegenProperty cp0 = cm1.getAllVars().get(0);
-        Assert.assertEquals(cp0.getName(), "petType");
-        Assert.assertEquals(cp0.isOverridden, true);
+        Assertions.assertEquals(cp0.getName(), "petType");
+        Assertions.assertEquals(cp0.isOverridden, true);
 
         CodegenProperty cp1 = cm1.getAllVars().get(1);
-        Assert.assertEquals(cp1.getName(), "name");
-        Assert.assertEquals(cp1.isOverridden, false);
+        Assertions.assertEquals(cp1.getName(), "name");
+        Assertions.assertEquals(cp1.isOverridden, false);
     }
 
     @Test
@@ -3030,7 +3030,7 @@ public class JavaClientCodegenTest {
 
         File apiFile = files.get("HelloExampleApi.java");
 
-        Assert.assertNotNull(apiFile);
+        Assertions.assertNotNull(apiFile);
         JavaFileAssert.assertThat(apiFile)
                 .assertMethod("helloCall", "String", "ApiCallback")
                 .bodyContainsLines(
@@ -3154,12 +3154,12 @@ public class JavaClientCodegenTest {
 
         // enum
         File modelFile = files.get("Metadata.java");
-        Assert.assertNotNull(modelFile);
+        Assertions.assertNotNull(modelFile);
         JavaFileAssert.assertThat(modelFile).fileContains(expectedEnumLines);
 
         // Inner enum
         File apiFile = files.get("V1SchemasGetDefaultResponse.java");
-        Assert.assertNotNull(apiFile);
+        Assertions.assertNotNull(apiFile);
         JavaFileAssert.assertThat(apiFile).fileContains(expectedInnerEnumLines);
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -67,7 +67,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import junit.framework.AssertionFailedError;
 import lombok.SneakyThrows;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
@@ -851,7 +850,7 @@ public class JavaClientCodegenTest {
             File apiClient = files.stream()
                     .filter(f -> f.getName().equals("ApiClient.java"))
                     .findFirst()
-                    .orElseThrow(() -> new AssertionFailedError(
+                    .orElseThrow(() -> new AssertionError(
                             "ApiClient.java not found"));
 
             Stream<String> contents = Arrays.stream(Files.readString(apiClient.toPath(),

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/JavaHelidonCommonCodegenPackagePrefixTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/JavaHelidonCommonCodegenPackagePrefixTest.java
@@ -26,11 +26,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.config.CodegenConfigurator;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -76,18 +76,16 @@ public class JavaHelidonCommonCodegenPackagePrefixTest {
                                        String explicitPrefix,
                                        String generatorName,
                                        String libraryName) {
-    IllegalArgumentException e = Assert.assertThrows("Run invalid combo: " + assertMsg(explicitHelidonVersion,
-                                                                                       explicitPrefix,
-                                                                                       generatorName,
-                                                                                       libraryName),
-                                                     IllegalArgumentException.class,
-        () -> runTest(explicitHelidonVersion, explicitPrefix, generatorName, libraryName));
-    Assert.assertTrue("Exception message for " + assertMsg(explicitHelidonVersion,
-                                                           explicitPrefix,
-                                                           generatorName,
-                                                           libraryName)
-                              + "'" + e.getMessage() + "' containing '" + EXCEPTION_MESSAGE_FRAGMENT + "'",
-        e.getMessage().contains(EXCEPTION_MESSAGE_FRAGMENT));
+    IllegalArgumentException e = Assert.expectThrows(
+        "Run invalid combo: " + assertMsg(explicitHelidonVersion, explicitPrefix, generatorName, libraryName),
+       IllegalArgumentException.class,
+       () -> runTest(explicitHelidonVersion, explicitPrefix, generatorName, libraryName)
+    );
+    Assert.assertTrue(
+        e.getMessage().contains(EXCEPTION_MESSAGE_FRAGMENT),
+        "Exception message for " + assertMsg(explicitHelidonVersion, explicitPrefix, generatorName, libraryName)
+                          + "'" + e.getMessage() + "' containing '" + EXCEPTION_MESSAGE_FRAGMENT + "'"
+    );
   }
 
   private static String assertMsg(String explicitHelidonVersion, String explicitPrefix, String generatorName, String libraryName) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/JavaHelidonCommonCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/JavaHelidonCommonCodegenTest.java
@@ -26,12 +26,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.junit.Assert;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.JavaHelidonCommonCodegen;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -97,7 +97,7 @@ public class JavaHelidonCommonCodegenTest {
 
     @Test
     public void bothNotEqualsVersionTest() {
-        IllegalArgumentException e = Assert.assertThrows(IllegalArgumentException.class,() -> runServerVersionTest("1.0.0", "2.0.0"));
+        IllegalArgumentException e = Assert.expectThrows(IllegalArgumentException.class, () -> runServerVersionTest("1.0.0", "2.0.0"));
         Assert.assertEquals(
                 "Both parentVersion and helidonVersion properties were set with different value.",
                 e.getMessage());

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/jetbrains/http/client/JetbrainsHttpClientClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/jetbrains/http/client/JetbrainsHttpClientClientCodegenTest.java
@@ -1,7 +1,7 @@
 package org.openapitools.codegen.jetbrains.http.client;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.JetbrainsHttpClientClientCodegen;
@@ -403,7 +403,7 @@ public class JetbrainsHttpClientClientCodegenTest {
     }
 
     @Test
-    @Ignore // For some reason this test fails during Docker image generation. Investigate one day.
+    @Disabled // For some reason this test fails during Docker image generation. Investigate one day.
     public void testBasicGenerationMultipleRequests() throws IOException {
         // Checking that each request example is present in the output file
         File output = Files.createTempDirectory("jetbrainstest_").toFile();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinReservedWordsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinReservedWordsTest.java
@@ -8,6 +8,7 @@ import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.KotlinClientCodegen;
 import org.openapitools.codegen.languages.KotlinSpringServerCodegen;
 import org.openapitools.codegen.utils.StringUtils;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -22,7 +23,11 @@ import static org.testng.Assert.assertEquals;
 
 @SuppressWarnings("rawtypes")
 public class KotlinReservedWordsTest {
-    final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/kotlin/reserved_words.yaml");
+    OpenAPI openAPI;
+
+    @BeforeTest void loadOpenApi() {
+        openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/kotlin/reserved_words.yaml");
+    }
 
     @DataProvider(name = "reservedWords")
     static Object[][] reservedWords() {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -1,12 +1,12 @@
 package org.openapitools.codegen.kotlin.spring;
 
-import com.google.common.collect.testing.Helpers;
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import org.apache.commons.io.FileUtils;
+import org.assertj.core.api.Assertions;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.DefaultGenerator;
@@ -225,7 +225,7 @@ public class KotlinSpringServerCodegenTest {
             )
             .generate();
 
-        Helpers.assertContainsAllOf(files,
+        Assertions.assertThat(files).contains(
             new File(output, "src/main/kotlin/org/openapitools/api/TestV1ApiController.kt"),
             new File(output, "src/main/kotlin/org/openapitools/api/TestV1ApiDelegate.kt"),
             new File(output, "src/main/kotlin/org/openapitools/api/TestV2ApiController.kt"),
@@ -250,7 +250,7 @@ public class KotlinSpringServerCodegenTest {
             )
             .generate();
 
-        Helpers.assertContainsAllOf(files,
+        Assertions.assertThat(files).contains(
             new File(output, "src/main/kotlin/org/openapitools/api/TestV1Api.kt"),
             new File(output, "src/main/kotlin/org/openapitools/api/TestV1ApiController.kt"),
             new File(output, "src/main/kotlin/org/openapitools/api/TestV1ApiDelegate.kt"),

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/HelidonCommonCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/HelidonCommonCodegenTest.java
@@ -18,7 +18,7 @@ package org.openapitools.codegen.languages;
 
 import java.util.List;
 
-import org.junit.Assert;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 // This test class is in this package, not org.openapitools.codegen.java.helidon, so it can refer to elements of

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/n4js/N4jsClientCodegenOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/n4js/N4jsClientCodegenOptionsTest.java
@@ -1,7 +1,7 @@
 package org.openapitools.codegen.n4js;
 
 import static java.lang.Boolean.parseBoolean;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.openapitools.codegen.CodegenConstants.API_NAME_PREFIX;
 import static org.openapitools.codegen.CodegenConstants.API_PACKAGE;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.models.tags.Tag;
-import org.junit.Assert;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.PostmanCollectionCodegen;
@@ -22,10 +21,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openapitools.codegen.TestUtils.*;
 
 public class PostmanCollectionCodegenTest {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -17,7 +17,7 @@
 
 package org.openapitools.codegen.python;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.google.common.collect.Sets;
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -31,7 +31,6 @@ import org.openapitools.codegen.languages.features.CXFServerFeatures;
 import static org.openapitools.codegen.TestUtils.assertFileContains;
 import static org.openapitools.codegen.TestUtils.assertFileExists;
 import org.openapitools.codegen.TestUtils;
-import org.openapitools.codegen.java.assertions.JavaFileAssert;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import java.io.File;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/IndentedLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/IndentedLambdaTest.java
@@ -1,6 +1,6 @@
 package org.openapitools.codegen.templating.mustache;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/SharedTypeScriptTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/SharedTypeScriptTest.java
@@ -33,8 +33,7 @@ public class SharedTypeScriptTest {
                                 TypeScriptAxiosClientCodegen.SEPARATE_MODELS_AND_API, true);
 
         config.setGeneratorName("typescript-axios");
-        // TODO uncomment/fix the test below
-        //checkAPIFile(getGenerator(config).generate(), "default-api.ts");
+        checkAPIFile(getGenerator(config).generate(), "default-api.ts");
 
         config.setGeneratorName("typescript-node");
         checkAPIFile(getGenerator(config).generate(), "defaultApi.ts");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/OnceLoggerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/OnceLoggerTest.java
@@ -20,6 +20,8 @@ import static org.testng.Assert.*;
 @SuppressWarnings({"SameParameterValue", "UnstableApiUsage"})
 public class OnceLoggerTest {
     private Logger mockLogger = Mockito.mock(Logger.class);
+    
+    // TODO if we find a replacement for FakeTicker, we can drop the guava-testlib dependency altogether
     private FakeTicker ticker = new FakeTicker();
 
     @BeforeTest

--- a/pom.xml
+++ b/pom.xml
@@ -1186,8 +1186,8 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -1234,7 +1234,7 @@
         <jackson.version>2.16.2</jackson.version>
         <jacoco.version>0.8.10</jacoco.version>
         <jmustache.version>1.15</jmustache.version>
-        <junit.version>4.13.2</junit.version>
+        <junit.version>5.10.2</junit.version>
         <kotlin.version>1.6.21</kotlin.version>
         <kotlin-compiler-embeddable.version>1.6.21</kotlin-compiler-embeddable.version>
         <lombok.version>1.18.30</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1186,10 +1186,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
                 <version>${junit.version}</version>
-                <scope>test</scope>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>

--- a/samples/meta-codegen/lib/pom.xml
+++ b/samples/meta-codegen/lib/pom.xml
@@ -41,7 +41,6 @@
                     </systemPropertyVariables>
                     <argLine>-Xms512m -Xmx1500m</argLine>
                     <parallel>methods</parallel>
-		    <forkMode>pertest</forkMode>
                 </configuration>
             </plugin>
 
@@ -114,8 +113,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <version>${junit-version}</version>
             <scope>test</scope>
         </dependency>
@@ -124,6 +123,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <openapi-generator-version>7.7.0-SNAPSHOT</openapi-generator-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
-        <junit-version>4.13.2</junit-version>
+        <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/samples/meta-codegen/lib/src/test/java/com/my/company/codegen/MyclientcodegenGeneratorTest.java
+++ b/samples/meta-codegen/lib/src/test/java/com/my/company/codegen/MyclientcodegenGeneratorTest.java
@@ -1,6 +1,6 @@
 package com.my.company.codegen;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.config.CodegenConfigurator;


### PR DESCRIPTION
This is an effort to keep Junit 5 in the stack and instead drop Junit 4.

The main issue that led to the necessity for #18786 has been fixed following the hint at https://maven.apache.org/surefire/maven-surefire-plugin/examples/junit-platform.html#How_to_run_TestNG_tests_within_the_JUnit_Platform:

This gist is: whenever importing `org.junit.jupiter:junit-jupiter-api`, simply import `org.junit.support:testng-engine` alongside it to ensure the junit engine picks up TestNG tests.

## Before

![grafik](https://github.com/OpenAPITools/openapi-generator/assets/1634615/de492166-7cdc-4395-9d90-047cdd8f6d55)

https://github.com/OpenAPITools/openapi-generator/pull/18559/checks?check_run_id=25578252872

## After 

![grafik](https://github.com/OpenAPITools/openapi-generator/assets/1634615/1a865b07-beae-4cf6-b615-96bc4de39437)

https://github.com/OpenAPITools/openapi-generator/pull/18790/checks?check_run_id=25577304652

… so it transpires with this setup at least junit5 `@Disabled` tests are included in the "skipped"-count (this matches as there is currently only a single file `JetbrainsHttpClientClientCodegenTest` that uses this).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
