### PR TITLE
Remove unused test dependencies `org.reflections` & `maven-rewrite`

### DIFF
--- a/modules/openapi-generator-cli/pom.xml
+++ b/modules/openapi-generator-cli/pom.xml
@@ -6,7 +6,7 @@
         <!-- RELEASE_VERSION -->
         <version>7.7.0-SNAPSHOT</version>
         <!-- /RELEASE_VERSION -->
-        <relativePath>../..</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openapi-generator-cli</artifactId>

--- a/modules/openapi-generator-core/pom.xml
+++ b/modules/openapi-generator-core/pom.xml
@@ -8,7 +8,7 @@
     <!-- RELEASE_VERSION -->
     <version>7.7.0-SNAPSHOT</version>
     <!-- /RELEASE_VERSION -->
-    <relativePath>../..</relativePath>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -6,7 +6,7 @@
         <!-- RELEASE_VERSION -->
         <version>7.7.0-SNAPSHOT</version>
         <!-- /RELEASE_VERSION -->
-        <relativePath>../..</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/modules/openapi-generator-maven-plugin/pom.xml
+++ b/modules/openapi-generator-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
         <!-- RELEASE_VERSION -->
         <version>7.7.0-SNAPSHOT</version>
         <!-- /RELEASE_VERSION -->
-        <relativePath>../..</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>openapi-generator-maven-plugin</artifactId>
     <name>openapi-generator (maven-plugin)</name>

--- a/modules/openapi-generator-online/pom.xml
+++ b/modules/openapi-generator-online/pom.xml
@@ -6,7 +6,7 @@
         <!-- RELEASE_VERSION -->
         <version>7.7.0-SNAPSHOT</version>
         <!-- /RELEASE_VERSION -->
-        <relativePath>../..</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>openapi-generator-online</artifactId>
     <packaging>jar</packaging>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -344,11 +344,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrewrite</groupId>
-            <artifactId>rewrite-maven</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.googlecode.java-diff-utils</groupId>
             <artifactId>diffutils</artifactId>
             <version>${diffutils.version}</version>
@@ -379,6 +374,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>${jackson.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -349,12 +349,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>${reflections.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.googlecode.java-diff-utils</groupId>
             <artifactId>diffutils</artifactId>
             <version>${diffutils.version}</version>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -6,7 +6,7 @@
         <!-- RELEASE_VERSION -->
         <version>7.7.0-SNAPSHOT</version>
         <!-- /RELEASE_VERSION -->
-        <relativePath>../..</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openapi-generator</artifactId>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -140,7 +140,7 @@ public class TestUtils {
                     String fileName = f.getName();
                     if ("pom.xml".equals(fileName)) {
                         try {
-                            String fileContents = new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8);
+                            String fileContents = Files.readString(f.toPath());
                             assertValidPomXml(fileContents);
                         } catch (IOException exception) {
                             throw new RuntimeException(exception);
@@ -178,7 +178,7 @@ public class TestUtils {
                     if (f.getName().endsWith(".java")) {
                         String fileContents = "";
                         try {
-                            fileContents = new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8);
+                            fileContents = Files.readString(f.toPath());
                         } catch (IOException ignored) {
 
                         }
@@ -198,7 +198,7 @@ public class TestUtils {
 
     public static void assertFileContains(Path path, String... lines) {
         try {
-            String generatedFile = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+            String generatedFile = Files.readString(path);
             String file = linearize(generatedFile);
             assertNotNull(file);
             for (String line : lines)
@@ -215,7 +215,7 @@ public class TestUtils {
     public static void assertFileNotContains(Path path, String... lines) {
         String generatedFile = null;
         try {
-            generatedFile = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+            generatedFile = Files.readString(path);
         } catch (IOException e) {
             fail("Unable to evaluate file " + path);
         }
@@ -227,7 +227,7 @@ public class TestUtils {
 
     public static void assertFileNotExists(Path path) {
         try {
-            new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+            Files.readString(path);
             fail("File exists when it should not: " + path);
         } catch (IOException e) {
             // File exists, pass.
@@ -237,7 +237,7 @@ public class TestUtils {
 
     public static void assertFileExists(Path path) {
         try {
-            new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+            Files.readString(path);
             // File exists, pass.
             assertTrue(true);
         } catch (IOException e) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -175,7 +175,7 @@ public class TestUtils {
     public static void validateJavaSourceFiles(Map<String, String> fileMap) {
         fileMap.forEach( (fileName, fileContents) -> {
                 if (fileName.endsWith(".java")) {
-                    assertValidJavaSourceCode(fileContents, fileName);
+                    assertValidJavaSourceCode(fileContents);
                 }
             }
         );
@@ -183,21 +183,20 @@ public class TestUtils {
 
     public static void validateJavaSourceFiles(List<File> files) {
         files.forEach( f -> {
-                    String fileName = f.getName();
-                    if (fileName.endsWith(".java")) {
+                    if (f.getName().endsWith(".java")) {
                         String fileContents = "";
                         try {
                             fileContents = new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8);
                         } catch (IOException ignored) {
 
                         }
-                        assertValidJavaSourceCode(fileContents, fileName);
+                        assertValidJavaSourceCode(fileContents);
                     }
                 }
         );
     }
 
-    public static void assertValidJavaSourceCode(String javaSourceCode, String filename) {
+    public static void assertValidJavaSourceCode(String javaSourceCode) {
         ParserConfiguration config = new ParserConfiguration();
         config.setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_11);
         JavaParser parser = new JavaParser(config);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -135,14 +135,6 @@ public class TestUtils {
         assertFalse(generatedFiles.contains(path.toFile()), "File '" + path.toAbsolutePath() + "' was found in the list of generated files");
     }
 
-    public static void validatePomXmlFiles(final Map<String, String> fileMap) {
-        fileMap.forEach( (fileName, fileContents) -> {
-            if ("pom.xml".equals(fileName)) {
-                assertValidPomXml(fileContents);
-            }
-        });
-    }
-
     public static void validatePomXmlFiles(final List<File> files) {
         files.forEach( f -> {
                     String fileName = f.getName();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -100,7 +100,7 @@ public class TestUtils {
         return openAPI;
     }
 
-    public static OpenAPI createOpenAPIWithOneSchema(String name, Schema schema) {
+    public static OpenAPI createOpenAPIWithOneSchema(String name, Schema<?> schema) {
         OpenAPI openAPI = createOpenAPI();
         openAPI.setComponents(new Components());
         openAPI.getComponents().addSchemas(name, schema);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtilsTest.java
@@ -1,0 +1,176 @@
+package org.openapitools.codegen;
+
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("NewClassNamingConvention")
+public class TestUtilsTest {
+
+    // forbiddenapis check will fail if we don't explicitly define localization when using String.format
+    static final Locale L = null;
+    
+    public static class validatePomXmlFiles {
+
+        static final String POM_SCAFFOLD = "<project>%s<dependencies>%s</dependencies></project>";
+        static final String POM_PROJECT_INFO = "<name>foo</name><artifactId>foo.bar</artifactId><groupId>foobar</groupId><version>13.12</version>";
+        
+        @Test void doesNotThrow_ifNotPom_doesNotExist() {
+            final var vaporFile = newTempDir().resolve("other.xml").toFile();
+            
+            assertThatCode(() -> TestUtils.validatePomXmlFiles(List.of(vaporFile)))
+                .doesNotThrowAnyException();
+        }
+        
+        @Test void throwsRuntimeException_ifPomDoesNotExist() {
+            final var vaporBom = newTempDir().resolve("pom.xml").toFile();
+
+            assertThatThrownBy(() -> TestUtils.validatePomXmlFiles(List.of(vaporBom)))
+                .isExactlyInstanceOf(RuntimeException.class);
+        }
+        
+        @Test void throwsUncheckedIoException_ifXmlIsJson() {
+            Path testFile = newPomXmlFile("{\"not_xml\": 12345}");
+
+            assertThatThrownBy(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
+                .isExactlyInstanceOf(UncheckedIOException.class);
+        }
+
+        @Test void throwsUncheckedIoException_ifXmlIsInvalid() {
+            final Path testFile = newPomXmlFile("<IAmNotClosed>");
+
+            assertThatThrownBy(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
+                .isExactlyInstanceOf(UncheckedIOException.class);
+        }
+        
+        @Test void throwsAssertionError_ifNameTagIsMissing() {
+            final Path testFile = newPomXmlFile(replaceTag("name", "", getMinimalValidPomContent()));
+            
+            assertThatThrownBy(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
+                .isExactlyInstanceOf(AssertionError.class);
+        }
+        
+        @Test void doesNotThrow_ifNameIsEmpty() {
+            final Path testFile = newPomXmlFile(
+                replaceTag("name", "<name></name>", getMinimalValidPomContent())
+            );
+            
+            assertThatCode(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
+                .doesNotThrowAnyException();
+        }
+        
+        @Test void throwsAssertionError_ifArtifactIdTagIsMissing() {
+            final Path testFile = newPomXmlFile(replaceTag("artifactId", "", getMinimalValidPomContent()));
+            
+            assertThatThrownBy(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
+                .isExactlyInstanceOf(AssertionError.class);
+        }
+        
+        @Test void doesNotThrow_ifArtifactIdIsEmpty() {
+            final Path testFile = newPomXmlFile(
+                replaceTag("artifactId", "<artifactId></artifactId>", getMinimalValidPomContent())
+            );
+            
+            assertThatCode(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
+                .doesNotThrowAnyException();
+        }
+        
+        @Test void throwsAssertionError_ifGroupIdTagIsMissing() {
+            final Path testFile = newPomXmlFile(replaceTag("groupId", "", getMinimalValidPomContent()));
+            
+            assertThatThrownBy(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
+                .isExactlyInstanceOf(AssertionError.class);
+        }
+        
+        @Test void doesNotThrow_ifGroupIdIsEmpty() {
+            final Path testFile = newPomXmlFile(
+                replaceTag("groupId", "<groupId></groupId>", getMinimalValidPomContent())
+            );
+            
+            assertThatCode(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
+                .doesNotThrowAnyException();
+        }
+        
+        @Test void throwsAssertionError_ifVersionTagIsMissing() {
+            final Path testFile = newPomXmlFile(replaceTag("version", "", getMinimalValidPomContent()));
+            
+            assertThatThrownBy(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
+                .isExactlyInstanceOf(AssertionError.class);
+        }
+        
+        @Test void doesNotThrow_ifVersionIsEmpty() {
+            final Path testFile = newPomXmlFile(
+                replaceTag("version", "<version></version>", getMinimalValidPomContent())
+            );
+            
+            assertThatCode(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
+                .doesNotThrowAnyException();
+        }
+        
+        @Test void throwsAssertionError_ifZeroDependencies() {
+            final Path testFile = newPomXmlFile(String.format(L, POM_SCAFFOLD, POM_PROJECT_INFO, ""));
+            
+            assertThatThrownBy(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
+                .isExactlyInstanceOf(AssertionError.class);
+        }
+        
+        @Test void doesNotThrow_ifAtLeastOneDependency() {
+            final Path testFile = newPomXmlFile(String.format(L, POM_SCAFFOLD, POM_PROJECT_INFO, "<dependency />"));
+            
+            assertThatCode(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
+                .doesNotThrowAnyException();
+        }
+        
+        @Test void throwsAssertionError_withTwoValidPoms_whereSecondHasNoName() {
+            final File testFile1 = newPomXmlFile(getMinimalValidPomContent()).toFile();
+            final File testFile2 = newPomXmlFile(replaceTag("name", "", getMinimalValidPomContent())).toFile();
+            
+            assertThatThrownBy(() -> TestUtils.validatePomXmlFiles(List.of(testFile1, testFile2)))
+                .isExactlyInstanceOf(AssertionError.class);
+        }
+        
+        @Test void doesNotThrow_withTwoValidPoms() {
+            final File testFile1 = newPomXmlFile(getMinimalValidPomContent()).toFile();
+            final File testFile2 = newPomXmlFile(getMinimalValidPomContent()).toFile();
+            
+            assertThatCode(() -> TestUtils.validatePomXmlFiles(List.of(testFile1, testFile2)))
+                .doesNotThrowAnyException();
+        }
+        
+        private String replaceTag(String tagToReplace, String replaceWith, String xml) {
+            return xml.replaceAll("<" + tagToReplace + ">[\\s\\S]*?</" + tagToReplace + ">", replaceWith);
+        }
+        
+        private String getMinimalValidPomContent() {
+            return String.format(L, POM_SCAFFOLD, POM_PROJECT_INFO, "<dependency />");
+        }
+
+        private Path newPomXmlFile(String content) {
+            try {
+                return Files.writeString(newTempDir().resolve("pom.xml"), content);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        
+        private Path newTempDir() {
+            final Path tempDir;
+            try {
+                tempDir = Files.createTempDirectory("test");
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            tempDir.toFile().deleteOnExit();
+            return tempDir;
+        }
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtilsTest.java
@@ -4,7 +4,6 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -38,18 +37,18 @@ public class TestUtilsTest {
                 .isExactlyInstanceOf(RuntimeException.class);
         }
         
-        @Test void throwsUncheckedIoException_ifXmlIsJson() {
+        @Test void throwsRuntimeException_ifXmlIsJson() {
             Path testFile = newPomXmlFile("{\"not_xml\": 12345}");
 
             assertThatThrownBy(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
-                .isExactlyInstanceOf(UncheckedIOException.class);
+                .isExactlyInstanceOf(RuntimeException.class);
         }
 
-        @Test void throwsUncheckedIoException_ifXmlIsInvalid() {
+        @Test void throwsRuntimeException_ifXmlIsInvalid() {
             final Path testFile = newPomXmlFile("<IAmNotClosed>");
 
             assertThatThrownBy(() -> TestUtils.validatePomXmlFiles(List.of(testFile.toFile())))
-                .isExactlyInstanceOf(UncheckedIOException.class);
+                .isExactlyInstanceOf(RuntimeException.class);
         }
         
         @Test void throwsAssertionError_ifNameTagIsMissing() {

--- a/pom.xml
+++ b/pom.xml
@@ -1249,7 +1249,6 @@
         <mockito.version>4.10.0</mockito.version>
         <openrewrite.version>8.8.3</openrewrite.version>
         <pmd-plugin.version>3.12.0</pmd-plugin.version>
-        <reflections.version>0.10.2</reflections.version>
         <resolver-util-version>1.9.18</resolver-util-version>
         <rxgen.version>1.4</rxgen.version>
         <scala-maven-plugin.version>4.6.1</scala-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1197,12 +1197,6 @@
                 <version>${testng.version}</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>org.openrewrite</groupId>
-                <artifactId>rewrite-maven</artifactId>
-                <version>${openrewrite.version}</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
     <repositories>
@@ -1247,7 +1241,6 @@
         <maven-site-plugin.version>4.0.0-M8</maven-site-plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <mockito.version>4.10.0</mockito.version>
-        <openrewrite.version>8.8.3</openrewrite.version>
         <pmd-plugin.version>3.12.0</pmd-plugin.version>
         <resolver-util-version>1.9.18</resolver-util-version>
         <rxgen.version>1.4</rxgen.version>


### PR DESCRIPTION
This PR:
- removes dependency `org.reflections`  
  …is not used anywhere
- remove unused code and some minor optimizations for `TestUtils`
- covers `TestUtils.validatePomXmlFiles(List)` with tests  
  Yo, dawg, i heard you like tests, so i wrote some tests for your test helpers :wink: (well really it was to make sure the following step produced runtime behavior)
- Reimplemented the method with Jackson XML mapper  
  Although the `RawPom.parse` method implements tight checks by databinding to its own sophisticated pom POJO, it is really only the five assertions in `TestUtils.validatePomXmlFiles(List)` that we're after. `rewrite-maven` imports a whopping 73 MB onto the classpath with dozens of transitive dependencies having to be gulped by our IDEs – a little overkill just for a single test helper method.
- Remove `org.openrewrite:rewrite-maven` and keep `jackson-dataformat-xml` explicitly (was a transitive dependency of `rewrite-maven`)  
  NB: Open Rewrite (big fan here BTW) does not need to be included in the pom in order to use it – one can just use the "Maven command line" option tab on the recipe pages.

All in all, this brings down the number of total dependencies in the `openapi-generator` module from 143 to 105 :rocket: 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
