### PR TITLE
Bugfix/activate helidon versionutil tests

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/HelidonCommonCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/HelidonCommonCodegenTest.java
@@ -16,32 +16,26 @@
  */
 package org.openapitools.codegen.languages;
 
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 // This test class is in this package, not org.openapitools.codegen.java.helidon, so it can refer to elements of
 // JavaHelidonCommonCodegen without making them public; package-private is sufficient and we don't want to expose those methods
 // more broadly.
 public class HelidonCommonCodegenTest {
 
+    JavaHelidonCommonCodegen.VersionUtil test = JavaHelidonCommonCodegen.VersionUtil.instance();
+    
     @Test void checkMajorVersionMatch() {
-        final var actual = JavaHelidonCommonCodegen.VersionUtil.instance().chooseVersion(
-            "1", List.of("3.2.1", "3.2.0", "2.0.4", "1.2.3", "1.2.2", "1.1.0")
-        );
-
-        Assert.assertEquals("1.2.3", actual);
+        assertThat(test.chooseVersion("1", List.of("3.2.1", "3.2.0", "2.0.4", "1.2.3", "1.2.2", "1.1.0")))
+            .isEqualTo("1.2.3");
     }
 
-    @Test
-    void checkExactMatch() {
-        final var actual = JavaHelidonCommonCodegen.VersionUtil.instance().chooseVersion(
-            "1.2.2", List.of("3.2.1", "3.2.0", "2.0.4", "1.2.3", "1.2.2", "1.1.0")
-        );
-            
-        Assert.assertEquals(
-            "1.2.2", actual
-        );
+    @Test void checkExactMatch() {
+        assertThat(test.chooseVersion("1.2.2", List.of("3.2.1", "3.2.0", "2.0.4", "1.2.3", "1.2.2", "1.1.0")))
+            .isEqualTo("1.2.2");
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/HelidonCommonCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/HelidonCommonCodegenTest.java
@@ -24,7 +24,7 @@ import org.testng.annotations.Test;
 // This test class is in this package, not org.openapitools.codegen.java.helidon, so it can refer to elements of
 // JavaHelidonCommonCodegen without making them public; package-private is sufficient and we don't want to expose those methods
 // more broadly.
-class HelidonCommonCodegenTest {
+public class HelidonCommonCodegenTest {
 
     @Test
     void checkMajorVersionMatch() {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/HelidonCommonCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/HelidonCommonCodegenTest.java
@@ -16,37 +16,32 @@
  */
 package org.openapitools.codegen.languages;
 
-import java.util.List;
-
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.List;
 
 // This test class is in this package, not org.openapitools.codegen.java.helidon, so it can refer to elements of
 // JavaHelidonCommonCodegen without making them public; package-private is sufficient and we don't want to expose those methods
 // more broadly.
 public class HelidonCommonCodegenTest {
 
-    @Test
-    void checkMajorVersionMatch() {
-        Assert.assertEquals("1.2.3",
-                            JavaHelidonCommonCodegen.VersionUtil.instance().chooseVersion("1",
-                                                                                          List.of("3.2.1",
-                                                                                                  "3.2.0",
-                                                                                                  "2.0.4",
-                                                                                                  "1.2.3",
-                                                                                                  "1.2.2",
-                                                                                                  "1.1.0")));
+    @Test void checkMajorVersionMatch() {
+        final var actual = JavaHelidonCommonCodegen.VersionUtil.instance().chooseVersion(
+            "1", List.of("3.2.1", "3.2.0", "2.0.4", "1.2.3", "1.2.2", "1.1.0")
+        );
+
+        Assert.assertEquals("1.2.3", actual);
     }
 
     @Test
     void checkExactMatch() {
-        Assert.assertEquals("1.2.2",
-                            JavaHelidonCommonCodegen.VersionUtil.instance().chooseVersion("1.2.2",
-                                                                                          List.of("3.2.1",
-                                                                                                  "3.2.0",
-                                                                                                  "2.0.4",
-                                                                                                  "1.2.3",
-                                                                                                  "1.2.2",
-                                                                                                  "1.1.0")));
+        final var actual = JavaHelidonCommonCodegen.VersionUtil.instance().chooseVersion(
+            "1.2.2", List.of("3.2.1", "3.2.0", "2.0.4", "1.2.3", "1.2.2", "1.1.0")
+        );
+            
+        Assert.assertEquals(
+            "1.2.2", actual
+        );
     }
 }


### PR DESCRIPTION
Contrary to Junit5, classes containing TestNG tests need to have   public visibility, otherwise the tests will not be discovered and run.

This PR fixes the visibility and refactors the test code for readability. Adds to #18627

@tjquinno 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
