### PR TITLE
[php-laravel] Fix file database/migrations/2019_08_19_000000 being written twice

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLaravelServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLaravelServerCodegen.java
@@ -199,9 +199,6 @@ public class PhpLaravelServerCodegen extends AbstractPhpCodegen {
         supportingFiles.add(new SupportingFile("config/session.php", outputFolder + File.separator + "config", "session.php"));
         supportingFiles.add(new SupportingFile("config/view.php", outputFolder + File.separator + "config", "view.php"));
 
-        // /database/
-        supportingFiles.add(new SupportingFile("database/migrations/2019_08_19_000000_create_failed_jobs_table.php", outputFolder + File.separator + "database" + File.separator + "migrations", "2019_08_19_000000_create_failed_jobs_table.php"));
-
         // /resources/
         supportingFiles.add(new SupportingFile("resources/js/app.js", outputFolder + File.separator + "resources" + File.separator + "assets" + File.separator + "js", "app.js"));
         supportingFiles.add(new SupportingFile("resources/js/bootstrap.js", outputFolder + File.separator + "resources" + File.separator + "assets" + File.separator + "js", "bootstrap.js"));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
@@ -86,8 +86,7 @@ public class AllGeneratorsTest {
         );
     }
     
-    @Test(dataProvider = "generators", enabled = false) // re-enable when https://github.com/OpenAPITools/openapi-generator/issues/18831 is fixed 
-    void noDuplicateSupportingFiles(CodegenConfig codegenConfig) {
+    @Test(dataProvider = "generators") void noDuplicateSupportingFiles(CodegenConfig codegenConfig) {
         final List<String> supportingFiles = codegenConfig.supportingFiles()
             .stream().map(SupportingFile::toString).collect(Collectors.toList());
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpLaravelServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpLaravelServerCodegenTest.java
@@ -17,18 +17,10 @@
 
 package org.openapitools.codegen.php;
 
-import org.assertj.core.api.Assertions;
 import org.openapitools.codegen.CodegenConstants;
-import org.openapitools.codegen.DefaultGenerator;
-import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.PhpLaravelServerCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.List;
 
 public class PhpLaravelServerCodegenTest {
 
@@ -59,23 +51,5 @@ public class PhpLaravelServerCodegenTest {
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
-    }
-
-    /**
-     * Transitional test, just to check the file is still in the list after the fix
-     */
-    @Test void SupportingFilesContainFailedJobsTableMigrationIn() throws IOException {
-        var tempDir = Files.createTempDirectory("temp");
-        tempDir.toFile().deleteOnExit();
-        final CodegenConfigurator configurator = new CodegenConfigurator()
-            .setGeneratorName("php-laravel")
-            .setInputSpec("src/test/resources/3_0/pingSomeObj.yaml")
-            .setOutputDir(tempDir.toString().replace("\\", "/"));
-
-        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
-        
-        Assertions.assertThat(files).contains(
-            tempDir.resolve( "lib/database/migrations/2019_08_19_000000_create_failed_jobs_table.php").toFile()
-        );
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpLaravelServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpLaravelServerCodegenTest.java
@@ -24,32 +24,29 @@ import org.testng.annotations.Test;
 
 public class PhpLaravelServerCodegenTest {
 
-    @Test
-    public void testInitialConfigValues() throws Exception {
+    @Test public void testInitialConfigValues() throws Exception {
         final PhpLaravelServerCodegen codegen = new PhpLaravelServerCodegen();
         codegen.processOpts();
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
-        Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+        Assert.assertTrue(codegen.isHideGenerationTimestamp());
     }
 
-    @Test
-    public void testSettersForConfigValues() throws Exception {
+    @Test public void testSettersForConfigValues() throws Exception {
         final PhpLaravelServerCodegen codegen = new PhpLaravelServerCodegen();
         codegen.setHideGenerationTimestamp(false);
         codegen.processOpts();
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
-        Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+        Assert.assertFalse(codegen.isHideGenerationTimestamp());
     }
 
-    @Test
-    public void testAdditionalPropertiesPutForConfigValues() throws Exception {
+    @Test public void testAdditionalPropertiesPutForConfigValues() throws Exception {
         final PhpLaravelServerCodegen codegen = new PhpLaravelServerCodegen();
         codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, false);
         codegen.processOpts();
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
-        Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+        Assert.assertFalse(codegen.isHideGenerationTimestamp());
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpLaravelServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpLaravelServerCodegenTest.java
@@ -17,10 +17,18 @@
 
 package org.openapitools.codegen.php;
 
+import org.assertj.core.api.Assertions;
 import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.PhpLaravelServerCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
 
 public class PhpLaravelServerCodegenTest {
 
@@ -53,4 +61,21 @@ public class PhpLaravelServerCodegenTest {
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
     }
 
+    /**
+     * Transitional test, just to check the file is still in the list after the fix
+     */
+    @Test void SupportingFilesContainFailedJobsTableMigrationIn() throws IOException {
+        var tempDir = Files.createTempDirectory("temp");
+        tempDir.toFile().deleteOnExit();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("php-laravel")
+            .setInputSpec("src/test/resources/3_0/pingSomeObj.yaml")
+            .setOutputDir(tempDir.toString().replace("\\", "/"));
+
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        
+        Assertions.assertThat(files).contains(
+            tempDir.resolve( "lib/database/migrations/2019_08_19_000000_create_failed_jobs_table.php").toFile()
+        );
+    }
 }

--- a/samples/server/petstore/php-laravel/.openapi-generator/FILES
+++ b/samples/server/petstore/php-laravel/.openapi-generator/FILES
@@ -100,7 +100,6 @@ lib/database/.gitignore
 lib/database/factories/UserFactory.php
 lib/database/migrations/2014_10_12_000000_create_users_table.php
 lib/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
-lib/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
 lib/database/seeds/DatabaseSeeder.php
 lib/package.json
 lib/phpunit.xml


### PR DESCRIPTION
Resolves #18831 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
