### PR TITLE
[javascript-closure-angular] Change metadata to reflect beta status and non-existing xml capability in docs

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -34,7 +34,7 @@ The following generators are available:
 * [java-micronaut-client (beta)](generators/java-micronaut-client.md)  
 * [javascript](generators/javascript.md)  
 * [javascript-apollo-deprecated (deprecated)](generators/javascript-apollo-deprecated.md)  
-* [javascript-closure-angular](generators/javascript-closure-angular.md)  
+* [javascript-closure-angular (beta)](generators/javascript-closure-angular.md)  
 * [javascript-flowtyped](generators/javascript-flowtyped.md)  
 * [jaxrs-cxf-client](generators/jaxrs-cxf-client.md)  
 * [jetbrains-http-client (experimental)](generators/jetbrains-http-client.md)  

--- a/docs/generators/javascript-closure-angular.md
+++ b/docs/generators/javascript-closure-angular.md
@@ -7,11 +7,11 @@ title: Documentation for the javascript-closure-angular Generator
 | Property | Value | Notes |
 | -------- | ----- | ----- |
 | generator name | javascript-closure-angular | pass this to the generate command after -g |
-| generator stability | STABLE | |
+| generator stability | BETA | |
 | generator type | CLIENT | |
 | generator language | Javascript | |
 | generator default templating engine | mustache | |
-| helpTxt | Generates a Javascript AngularJS client library (beta) annotated with Google Closure Compiler annotations(https://developers.google.com/closure/compiler/docs/js-for-compiler?hl=en) | |
+| helpTxt | Generates a Javascript AngularJS client library annotated with Google Closure Compiler annotations(https://developers.google.com/closure/compiler/docs/js-for-compiler?hl=en) | |
 
 ## CONFIG OPTIONS
 These options may be applied as additional-properties (cli) or configOptions (plugins). Refer to [configuration docs](https://openapi-generator.tech/docs/configuration) for more details.
@@ -217,6 +217,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Name | Supported | Defined By |
 | ---- | --------- | ---------- |
 |JSON|✓|OAS2,OAS3
-|XML|✓|OAS2,OAS3
+|XML|✗|OAS2,OAS3
 |PROTOBUF|✗|ToolingExtension
 |Custom|✗|OAS2,OAS3

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClosureAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClosureAngularClientCodegen.java
@@ -22,6 +22,10 @@ import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
+import org.openapitools.codegen.meta.FeatureSet;
+import org.openapitools.codegen.meta.GeneratorMetadata;
+import org.openapitools.codegen.meta.Stability;
+import org.openapitools.codegen.meta.features.WireFormatFeature;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationsMap;
@@ -44,6 +48,15 @@ public class JavascriptClosureAngularClientCodegen extends DefaultCodegen implem
 
     public JavascriptClosureAngularClientCodegen() {
         super();
+        
+        generatorMetadata = GeneratorMetadata.newBuilder(generatorMetadata)
+            .stability(Stability.BETA)
+            .featureSet(
+                FeatureSet.newBuilder(generatorMetadata.getFeatureSet())
+                    .excludeWireFormatFeatures(WireFormatFeature.XML).build()
+            )
+            .build();
+        
         outputFolder = "generated-code/javascript-closure-angular";
 
         // default HIDE_GENERATION_TIMESTAMP to true
@@ -140,7 +153,7 @@ public class JavascriptClosureAngularClientCodegen extends DefaultCodegen implem
 
     @Override
     public String getHelp() {
-        return "Generates a Javascript AngularJS client library (beta) annotated with Google Closure Compiler annotations" +
+        return "Generates a Javascript AngularJS client library annotated with Google Closure Compiler annotations" +
             "(https://developers.google.com/closure/compiler/docs/js-for-compiler?hl=en)";
     }
 


### PR DESCRIPTION
It says on https://openapi-generator.tech/docs/generators/javascript-closure-angular in the helpTxt that this generator is `(beta)`, however the stability is shown as `STABLE`.

It also suggests that XML is supported, while the templates clearly show it isn't.

This PR amends that.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
