### PR TITLE
[JAVA] Fix jackson (de)serializer annotation breaking libs using gson when `bigDecimalAsString=true`

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1779,7 +1779,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
-        if (serializeBigDecimalAsString) {
+        if (serializeBigDecimalAsString && additionalProperties.containsKey(JACKSON)) {
             if ("decimal".equals(property.baseType) || "bigdecimal".equalsIgnoreCase(property.baseType)) {
                 // we serialize BigDecimal as `string` to avoid precision loss
                 property.vendorExtensions.put("x-extra-annotation", "@JsonSerialize(using = ToStringSerializer.class)");
@@ -1804,7 +1804,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             model.imports.add("Arrays");
         } else if ("set".equals(property.containerType)) {
             model.imports.add("LinkedHashSet");
-            if (!openApiNullable || !property.isNullable) { // cannot be wrapped to nullable
+            if ((!openApiNullable || !property.isNullable) && additionalProperties.containsKey(JACKSON)) { // cannot be wrapped to nullable
                 model.imports.add("JsonDeserialize");
                 property.vendorExtensions.put("x-setter-extra-annotation", "@JsonDeserialize(as = LinkedHashSet.class)");
             }

--- a/modules/openapi-generator/src/test/resources/2_0/java/issue-6496.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/java/issue-6496.yaml
@@ -1,0 +1,88 @@
+swagger: '2.0'
+info:
+  description: "This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\"
+  version: 1.0.0
+  title: OpenAPI Petstore
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+basePath: /v2
+schemes:
+  - http
+paths:
+  /:
+    get:
+      operationId: addPet
+      responses:
+        '200':
+          description: successful operation
+definitions:
+  FormatTest:
+    type: object
+    required:
+      - number
+      - byte
+      - date
+      - password
+    properties:
+      integer:
+        type: integer
+        maximum: 100
+        minimum: 10
+      int32:
+        type: integer
+        format: int32
+        maximum: 200
+        minimum: 20
+      int64:
+        type: integer
+        format: int64
+      number:
+        maximum: 543.2
+        minimum: 32.1
+        type: number
+      float:
+        type: number
+        format: float
+        maximum: 987.6
+        minimum: 54.3
+      double:
+        type: number
+        format: double
+        maximum: 123.4
+        minimum: 67.8
+      string:
+        type: string
+        pattern: /[a-z]/i
+      byte:
+        type: string
+        format: byte
+      binary:
+        type: string
+        format: binary
+      date:
+        type: string
+        format: date
+      dateTime:
+        type: string
+        format: date-time
+      uuid:
+        type: string
+        format: uuid
+        example: 72f98069-206d-4f12-9f12-3d1e525a8e84
+      password:
+        type: string
+        format: password
+        maxLength: 64
+        minLength: 10
+      BigDecimal:
+        type: string
+        format: number
+      enumContainer:
+        type: array
+        uniqueItems: true
+        items:
+          enum:
+            - placed
+            - approved
+            - delivered


### PR DESCRIPTION
Closes #6496

See linked issue and implemented regression tests for details.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
