### PR TITLE
zapier: add request middleware to support other authentication schemes

### DIFF
--- a/modules/openapi-generator/src/main/resources/zapier/api.mustache
+++ b/modules/openapi-generator/src/main/resources/zapier/api.mustache
@@ -103,7 +103,7 @@ module.exports = {
                     {{/allParams}}
                     },{{/isMultipart}}
                 }
-                return z.request(options).then((response) => {
+                return z.request(utils.requestOptionsMiddleware(z, bundle, options)).then((response) => {
                     response.throwForStatus();
                     const results = response.json;
                     return {{#returnType}}{{#returnTypeIsPrimitive}}{ data: results }{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}results{{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}}results{{/returnType}};

--- a/modules/openapi-generator/src/main/resources/zapier/utils.mustache
+++ b/modules/openapi-generator/src/main/resources/zapier/utils.mustache
@@ -23,6 +23,13 @@ const searchMiddleware = (action) => {
     return action
 }
 
+const requestOptionsMiddleware = (z, bundle, requestOptions) => {
+  // TODO: modify the request options for all outgoing request to your api
+  //       if you are using session authentication without a Bearer token.
+  //       This may be true if your API uses basic authentication or api keys.
+  return requestOptions
+}
+
 module.exports = {
     replacePathParameters: replacePathParameters,
     childMapping: childMapping,
@@ -31,4 +38,5 @@ module.exports = {
     hasSearchRequisites: hasSearchRequisites,
     isSearchAction: isSearchAction,
     searchMiddleware: searchMiddleware,
+    requestOptionsMiddleware: requestOptionsMiddleware,
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
# closes https://github.com/OpenAPITools/openapi-generator/issues/18847

### PR checklist 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@valmoz @emajo