### PR TITLE
Avoid UnsupportedEncodingException by design, replacing magic string "UTF-8" with StandardCharsets.UTF_8

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/auth/AuthParser.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/auth/AuthParser.java
@@ -21,9 +21,9 @@ import io.swagger.v3.parser.core.models.AuthorizationValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,11 +40,11 @@ public class AuthParser {
             for (String part : parts) {
                 String[] kvPair = part.split(":");
                 if (kvPair.length == 2) {
-                    try {
-                        auths.add(new AuthorizationValue(URLDecoder.decode(kvPair[0], "UTF-8"), URLDecoder.decode(kvPair[1], "UTF-8"), "header"));
-                    } catch (UnsupportedEncodingException e) {
-                        LOGGER.warn(e.getMessage());
-                    }
+                    auths.add(new AuthorizationValue(
+                        URLDecoder.decode(kvPair[0], StandardCharsets.UTF_8), 
+                        URLDecoder.decode(kvPair[1], StandardCharsets.UTF_8), 
+                        "header"
+                    ));
                 }
             }
         }
@@ -55,17 +55,11 @@ public class AuthParser {
         if (authorizationValueList != null) {
             StringBuilder b = new StringBuilder();
             for (AuthorizationValue v : authorizationValueList) {
-                try {
-                    if (b.toString().length() > 0) {
-                        b.append(",");
-                    }
-                    b.append(URLEncoder.encode(v.getKeyName(), "UTF-8"))
-                            .append(":")
-                            .append(URLEncoder.encode(v.getValue(), "UTF-8"));
-                } catch (Exception e) {
-                    // continue
-                    LOGGER.error(e.getMessage(), e);
+                if (b.toString().length() > 0) {
+                    b.append(",");
                 }
+                b.append(URLEncoder.encode(v.getKeyName(), StandardCharsets.UTF_8))
+                    .append(":").append(URLEncoder.encode(v.getValue(), StandardCharsets.UTF_8));
             }
             return b.toString();
         } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
@@ -17,42 +17,35 @@
 
 package org.openapitools.codegen.languages;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.math.BigDecimal;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.*;
-
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.mifmif.common.regex.Generex;
+import io.swagger.v3.oas.models.media.Schema;
 import lombok.Setter;
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.openapitools.codegen.CliOption;
-import org.openapitools.codegen.CodegenModel;
-import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CodegenParameter;
-import org.openapitools.codegen.CodegenProperty;
-import org.openapitools.codegen.SupportingFile;
+import org.apache.commons.text.StringEscapeUtils;
+import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.features.CXFExtServerFeatures;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
 import org.openapitools.codegen.utils.JsonCache;
-import org.openapitools.codegen.utils.ModelUtils;
 import org.openapitools.codegen.utils.JsonCache.CacheException;
 import org.openapitools.codegen.utils.JsonCache.Root.MergePolicy;
+import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonPointer;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.mifmif.common.regex.Generex;
-
-import io.swagger.v3.oas.models.media.Schema;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 /**
  * An Apache CXF-based JAX-RS server with extended capabilities.
@@ -1289,11 +1282,11 @@ public class JavaCXFExtServerCodegen extends JavaCXFServerCodegen implements CXF
                 if (testDataCache.root().isDirty()) {
                     ByteArrayOutputStream out = new ByteArrayOutputStream();
                     testDataCache.root().flush(out);
-                    String testDataJson = out.toString("UTF-8");
+                    String testDataJson = out.toString(StandardCharsets.UTF_8);
                     objs.put("test-data.json", testDataJson);
                     supportingFiles.add(new SupportingFile("testData.mustache", testDataFile.getAbsolutePath()));
                 }
-            } catch (CacheException | UnsupportedEncodingException e) {
+            } catch (CacheException e) {
                 LOGGER.error("Error writing JSON test data file " + testDataFile, e);
             }
 
@@ -1301,12 +1294,12 @@ public class JavaCXFExtServerCodegen extends JavaCXFServerCodegen implements CXF
                 if (testDataControlCache.root().isDirty()) {
                     ByteArrayOutputStream out = new ByteArrayOutputStream();
                     testDataControlCache.root().flush(out);
-                    String testDataControlJson = out.toString("UTF-8");
+                    String testDataControlJson = out.toString(StandardCharsets.UTF_8);
                     objs.put("test-data-control.json", testDataControlJson);
                     supportingFiles
                             .add(new SupportingFile("testDataControl.mustache", testDataControlFile.getAbsolutePath()));
                 }
-            } catch (CacheException | UnsupportedEncodingException e) {
+            } catch (CacheException e) {
                 LOGGER.error("Error writing JSON test data control file " + testDataControlFile, e);
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlim4ServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlim4ServerCodegen.java
@@ -19,13 +19,9 @@ package org.openapitools.codegen.languages;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.servers.Server;
 import lombok.Getter;
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.openapitools.codegen.CodegenType;
-import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CliOption;
-import org.openapitools.codegen.CodegenConstants;
-import org.openapitools.codegen.SupportingFile;
+import org.apache.commons.text.StringEscapeUtils;
+import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.*;
@@ -37,9 +33,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.*;
+import java.nio.charset.StandardCharsets;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
 
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
@@ -349,23 +347,17 @@ public class PhpSlim4ServerCodegen extends AbstractPhpCodegen {
         // from AbstractPhpCodegen.java
         // Trim the string to avoid leading and trailing spaces.
         input = input.trim();
-        try {
 
-            input = URLEncoder.encode(input, "UTF-8")
-                    .replaceAll("\\+", "%20")
-                    .replaceAll("\\%2F", "/")
-                    .replaceAll("\\%7B", "{") // keep { part of complex placeholders
-                    .replaceAll("\\%7D", "}") // } part
-                    .replaceAll("\\%5B", "[") // [ part
-                    .replaceAll("\\%5D", "]") // ] part
-                    .replaceAll("\\%3A", ":") // : part
-                    .replaceAll("\\%2B", "+") // + part
-                    .replaceAll("\\%5C\\%5Cd", "\\\\d"); // \d part
-        } catch (UnsupportedEncodingException e) {
-            // continue
-            LOGGER.error(e.getMessage(), e);
-        }
-        return input;
+        return URLEncoder.encode(input, StandardCharsets.UTF_8)
+                .replaceAll("\\+", "%20")
+                .replaceAll("\\%2F", "/")
+                .replaceAll("\\%7B", "{") // keep { part of complex placeholders
+                .replaceAll("\\%7D", "}") // } part
+                .replaceAll("\\%5B", "[") // [ part
+                .replaceAll("\\%5D", "]") // ] part
+                .replaceAll("\\%3A", ":") // : part
+                .replaceAll("\\%2B", "+") // + part
+                .replaceAll("\\%5C\\%5Cd", "\\\\d"); // \d part
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -46,10 +46,10 @@ import org.openapitools.codegen.model.ModelsMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -400,11 +400,7 @@ public class ModelUtils {
             return null;
         }
 
-        try {
-            ref = URLDecoder.decode(ref, "UTF-8");
-        } catch (UnsupportedEncodingException ignored) {
-            once(LOGGER).warn("Found UnsupportedEncodingException: {}", ref);
-        }
+        ref = URLDecoder.decode(ref, StandardCharsets.UTF_8);
 
         // see https://tools.ietf.org/html/rfc6901#section-3
         // Because the characters '~' (%x7E) and '/' (%x2F) have special meanings in

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/auth/HttpBasicAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/auth/HttpBasicAuth.mustache
@@ -11,8 +11,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -43,7 +43,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/auth/HttpBasicAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/auth/HttpBasicAuth.mustache
@@ -1,6 +1,5 @@
 package {{invokerPackage}}.auth;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/auth/HttpBearerAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/auth/HttpBearerAuth.mustache
@@ -1,8 +1,5 @@
 package {{invokerPackage}}.auth;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinTestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinTestUtils.java
@@ -20,6 +20,7 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
 
@@ -51,12 +52,7 @@ public class KotlinTestUtils {
         CompilerConfiguration configuration = new CompilerConfiguration();
         configuration.put(CommonConfigurationKeys.MODULE_NAME, moduleName);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream ps = null;
-        try {
-            ps = new PrintStream(baos, true, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        PrintStream ps = new PrintStream(baos, true, StandardCharsets.UTF_8);
         configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, new PrintingMessageCollector(ps, MessageRenderer.PLAIN_FULL_PATHS, true));
         configuration.put(JVMConfigurationKeys.OUTPUT_DIRECTORY, saveClassesDir);
 //        configuration.put(JVMConfigurationKeys.RETAIN_OUTPUT_IN_MEMORY, true)

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/JsonCacheTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/JsonCacheTest.java
@@ -32,7 +32,6 @@ import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -205,7 +204,7 @@ public class JsonCacheTest {
     private JsonCache.Root root;
     private JsonCache cache;
 
-    private void reload() throws CacheException, UnsupportedEncodingException {
+    private void reload() throws CacheException {
         root.unload();
         root.load(new ByteArrayInputStream(JSON.getBytes(StandardCharsets.UTF_8)));
     }

--- a/samples/client/echo_api/java/okhttp-gson-user-defined-templates/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/echo_api/java/okhttp-gson-user-defined-templates/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/samples/client/others/java/okhttp-gson-oneOf/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/others/java/okhttp-gson-oneOf/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -41,7 +41,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;

--- a/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -1,6 +1,5 @@
 package org.openapitools.client.auth;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 

--- a/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
@@ -1,8 +1,5 @@
 package org.openapitools.client.auth;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-import java.io.UnsupportedEncodingException;
-
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -41,7 +41,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -1,6 +1,5 @@
 package org.openapitools.client.auth;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
@@ -1,8 +1,5 @@
 package org.openapitools.client.auth;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
@@ -41,7 +41,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -1,6 +1,5 @@
 package org.openapitools.client.auth;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
@@ -1,8 +1,5 @@
 package org.openapitools.client.auth;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -41,7 +41,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -1,6 +1,5 @@
 package org.openapitools.client.auth;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
@@ -1,8 +1,5 @@
 package org.openapitools.client.auth;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -41,7 +41,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -1,6 +1,5 @@
 package org.openapitools.client.auth;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
@@ -1,8 +1,5 @@
 package org.openapitools.client.auth;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 


### PR DESCRIPTION
This makes for much more concise code :smiley: 

Unfortunately that API is not available in Java 8, so most templates will have to stay as they are.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
