### PR TITLE
[php-slim4-server] fix php syntax error in RegisterRoutes class (missing semicolon)

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-slim4-server/register_routes.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/register_routes.mustache
@@ -206,19 +206,19 @@ class RegisterRoutes
                                 'header' => $authMethod['keyParamName'],
                                 'parameter' => null,
                                 'cookie' => null,
-                            ]
+                            ];
                         } else if ($authMethod['isKeyInQuery']) {
                             $authenticatorConfig = [
                                 'header' => null,
                                 'parameter' => $authMethod['keyParamName'],
                                 'cookie' => null,
-                            ]
+                            ];
                         } else if ($authMethod['isKeyInCookie']) {
                             $authenticatorConfig = [
                                 'header' => null,
                                 'parameter' => null,
                                 'cookie' => $authMethod['keyParamName'],
-                            ]
+                            ];
                         }
                         $route->add(new TokenAuthentication($authenticatorConfig));
                     }


### PR DESCRIPTION
Fixed a PHP Syntax Error (mssing semicolon) in the php-slim4-server templates.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), [@ybelenko](https://github.com/ybelenko) (2018/07), @renepardon (2018/12)

@mvarchdev