### PR TITLE
[python] Add an option to add ensure_ascii=False to json.dumps

### DIFF
--- a/.github/workflows/samples-python-client-echo-api.yaml
+++ b/.github/workflows/samples-python-client-echo-api.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - samples/client/echo_api/python/**
+      - samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/**
       - .github/workflows/samples-python-client-echo-api.yaml
 jobs:
   build:

--- a/bin/configs/python-echo-api-disallowAdditionalPropertiesIfNotPresent-true.yaml
+++ b/bin/configs/python-echo-api-disallowAdditionalPropertiesIfNotPresent-true.yaml
@@ -5,3 +5,4 @@ templateDir: modules/openapi-generator/src/main/resources/python
 additionalProperties:
   hideGenerationTimestamp: "true"
   disallowAdditionalPropertiesIfNotPresent: "true"
+  setEnsureAsciiToFalse: true

--- a/bin/configs/python.yaml
+++ b/bin/configs/python.yaml
@@ -7,7 +7,6 @@ additionalProperties:
   useOneOfDiscriminatorLookup: "true"
   disallowAdditionalPropertiesIfNotPresent: false
   mapNumberTo: StrictFloat
-  ensureAscii: False
 nameMappings:
   _type: underscore_type
   type_: type_with_underscore

--- a/docs/generators/python.md
+++ b/docs/generators/python.md
@@ -31,6 +31,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |packageVersion|python package version.| |1.0.0|
 |projectName|python project name in setup.py (e.g. petstore-api).| |null|
 |recursionLimit|Set the recursion limit. If not set, use the system default value.| |null|
+|setEnsureAsciiToFalse|When set to true, add `ensure_ascii=False` in json.dumps when creating the HTTP request body.| |false|
 |useOneOfDiscriminatorLookup|Use the discriminator's mapping in oneOf to speed up the model lookup. IMPORTANT: Validation (e.g. one and only one match in oneOf's schemas) will be skipped.| |false|
 
 ## IMPORT MAPPING

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -43,6 +43,7 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
     public static final String RECURSION_LIMIT = "recursionLimit";
     public static final String DATETIME_FORMAT = "datetimeFormat";
     public static final String DATE_FORMAT = "dateFormat";
+    public static final String SET_ENSURE_ASCII_TO_FALSE = "setEnsureAsciiToFalse";
 
     @Setter protected String packageUrl;
     protected String apiDocPath = "docs/";
@@ -50,7 +51,7 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
     @Setter protected boolean useOneOfDiscriminatorLookup = false; // use oneOf discriminator's mapping for model lookup
     @Setter protected String datetimeFormat = "%Y-%m-%dT%H:%M:%S.%f%z";
     @Setter protected String dateFormat = "%Y-%m-%d";
-
+    @Setter protected boolean setEnsureAsciiToFalse = false;
 
     private String testFolder;
 
@@ -134,6 +135,8 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
         cliOptions.add(new CliOption(CodegenConstants.HIDE_GENERATION_TIMESTAMP, CodegenConstants.HIDE_GENERATION_TIMESTAMP_DESC)
                 .defaultValue(Boolean.TRUE.toString()));
         cliOptions.add(new CliOption(CodegenConstants.SOURCECODEONLY_GENERATION, CodegenConstants.SOURCECODEONLY_GENERATION_DESC)
+                .defaultValue(Boolean.FALSE.toString()));
+        cliOptions.add(new CliOption(SET_ENSURE_ASCII_TO_FALSE, "When set to true, add `ensure_ascii=False` in json.dumps when creating the HTTP request body.")
                 .defaultValue(Boolean.FALSE.toString()));
         cliOptions.add(new CliOption(RECURSION_LIMIT, "Set the recursion limit. If not set, use the system default value."));
         cliOptions.add(new CliOption(MAP_NUMBER_TO, "Map number to Union[StrictFloat, StrictInt], StrictStr or float.")
@@ -221,6 +224,10 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
         // make api and model doc path available in mustache template
         additionalProperties.put("apiDocPath", apiDocPath);
         additionalProperties.put("modelDocPath", modelDocPath);
+
+        if (additionalProperties.containsKey(SET_ENSURE_ASCII_TO_FALSE)) {
+            additionalProperties.put(SET_ENSURE_ASCII_TO_FALSE, Boolean.valueOf(additionalProperties.get(SET_ENSURE_ASCII_TO_FALSE).toString()));
+        }
 
         if (additionalProperties.containsKey(PACKAGE_URL)) {
             setPackageUrl((String) additionalProperties.get(PACKAGE_URL));

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -168,7 +168,7 @@ class RESTClientObject:
                 ):
                     request_body = None
                     if body is not None:
-                        request_body = json.dumps(body, ensure_ascii={{ensureAscii}})
+                        request_body = json.dumps(body{{#setEnsureAsciiToFalse}}, ensure_ascii=False{{/setEnsureAsciiToFalse}})
                     r = self.pool_manager.request(
                         method,
                         url,

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/rest.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/rest.py
@@ -179,7 +179,7 @@ class RESTClientObject:
                 ):
                     request_body = None
                     if body is not None:
-                        request_body = json.dumps(body)
+                        request_body = json.dumps(body, ensure_ascii=False)
                     r = self.pool_manager.request(
                         method,
                         url,


### PR DESCRIPTION
Add an option to add ensure_ascii=False to json.dumps

based on https://github.com/OpenAPITools/openapi-generator/pull/18787

cc 
@cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10) @multani (2023/10)


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

