### PR TITLE
Fix list in kotlin client templates

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/anyof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/anyof_class.mustache
@@ -114,7 +114,7 @@ import java.io.IOException
                     {{/isPrimitiveType}}
                     {{^isPrimitiveType}}
                     {{#isArray}}
-                        List<?> list = (List<?>) value.actualInstance
+                        val list = value.actualInstance as List<Any>
                         if (list.get(0) is {{{items.dataType}}}) {
                             val array = adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}.toJsonTree(value.actualInstance as {{{dataType}}}?).getAsJsonArray()
                             elementAdapter.write(out, array)

--- a/modules/openapi-generator/src/main/resources/kotlin-client/anyof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/anyof_class.mustache
@@ -107,12 +107,6 @@ import java.io.IOException
                     {{^vendorExtensions.x-duplicated-data-type}}
                     // check if the actual instance is of the type `{{{dataType}}}`
                     if (value.actualInstance is {{#isArray}}List<*>{{/isArray}}{{^isArray}}{{{dataType}}}{{/isArray}}) {
-                    {{#isPrimitiveType}}
-                        val primitive = adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}.toJsonTree(value.actualInstance as {{{dataType}}}?).getAsJsonPrimitive()
-                        elementAdapter.write(out, primitive)
-                        return
-                    {{/isPrimitiveType}}
-                    {{^isPrimitiveType}}
                     {{#isArray}}
                         val list = value.actualInstance as List<Any>
                         if (list.get(0) is {{{items.dataType}}}) {
@@ -121,8 +115,12 @@ import java.io.IOException
                             return
                         }
                     {{/isArray}}
-                    {{/isPrimitiveType}}
                     {{^isArray}}
+                    {{#isPrimitiveType}}
+                        val primitive = adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}.toJsonTree(value.actualInstance as {{{dataType}}}?).getAsJsonPrimitive()
+                        elementAdapter.write(out, primitive)
+                        return
+                    {{/isPrimitiveType}}
                     {{^isPrimitiveType}}
                         val element = adapter{{{dataType}}}.toJsonTree(value.actualInstance as {{{dataType}}}?)
                         elementAdapter.write(out, element)

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -246,10 +246,10 @@ import {{packageName}}.infrastructure.ITransformForStorage
             {{#required}}
             // ensure the json data is an array
             if (!jsonObj.get("{{{baseName}}}").isJsonArray) {
-              throw new IllegalArgumentException(String.format("Expected the field `{{{baseName}}}` to be an array in the JSON string but got `%s`", jsonObj["{{{baseName}}}"].toString()))
+              throw IllegalArgumentException(String.format("Expected the field `{{{baseName}}}` to be an array in the JSON string but got `%s`", jsonObj["{{{baseName}}}"].toString()))
             }
       
-            JsonArray jsonArray{{name}} = jsonObj.getAsJsonArray("{{{baseName}}}")
+            val jsonArray{{name}} = jsonObj.getAsJsonArray("{{{baseName}}}")
             // validate the required field `{{{baseName}}}` (array)
             for (i in 0 until jsonArray{{name}}.size()) {
               {{{items.dataType}}}.validateJsonElement(jsonArray{{name}}.get(i))

--- a/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
@@ -114,7 +114,7 @@ import java.io.IOException
                     {{/isPrimitiveType}}
                     {{^isPrimitiveType}}
                     {{#isArray}}
-                        List<?> list = (List<?>) value.actualInstance
+                        val list = value.actualInstance as List<Any>
                         if (list.get(0) is {{{items.dataType}}}) {
                             val array = adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}.toJsonTree(value.actualInstance as {{{dataType}}}?).getAsJsonArray()
                             elementAdapter.write(out, array)

--- a/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
@@ -107,12 +107,6 @@ import java.io.IOException
                     {{^vendorExtensions.x-duplicated-data-type}}
                     // check if the actual instance is of the type `{{{dataType}}}`
                     if (value.actualInstance is {{#isArray}}List<*>{{/isArray}}{{^isArray}}{{{dataType}}}{{/isArray}}) {
-                    {{#isPrimitiveType}}
-                        val primitive = adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}.toJsonTree(value.actualInstance as {{{dataType}}}?).getAsJsonPrimitive()
-                        elementAdapter.write(out, primitive)
-                        return
-                    {{/isPrimitiveType}}
-                    {{^isPrimitiveType}}
                     {{#isArray}}
                         val list = value.actualInstance as List<Any>
                         if (list.get(0) is {{{items.dataType}}}) {
@@ -121,8 +115,12 @@ import java.io.IOException
                             return
                         }
                     {{/isArray}}
-                    {{/isPrimitiveType}}
                     {{^isArray}}
+                    {{#isPrimitiveType}}
+                        val primitive = adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}.toJsonTree(value.actualInstance as {{{dataType}}}?).getAsJsonPrimitive()
+                        elementAdapter.write(out, primitive)
+                        return
+                    {{/isPrimitiveType}}
                     {{^isPrimitiveType}}
                         val element = adapter{{{dataType}}}.toJsonTree(value.actualInstance as {{{dataType}}}?)
                         elementAdapter.write(out, element)

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiAnyOfUserOrPetOrArrayString.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiAnyOfUserOrPetOrArrayString.kt
@@ -73,9 +73,12 @@ data class ApiAnyOfUserOrPetOrArrayString(var actualInstance: Any? = null) {
                     }
                     // check if the actual instance is of the type `kotlin.collections.List<kotlin.String>`
                     if (value.actualInstance is List<*>) {
-                        val primitive = adapterkotlincollectionsListkotlinString.toJsonTree(value.actualInstance as kotlin.collections.List<kotlin.String>?).getAsJsonPrimitive()
-                        elementAdapter.write(out, primitive)
-                        return
+                        val list = value.actualInstance as List<Any>
+                        if (list.get(0) is kotlin.String) {
+                            val array = adapterkotlincollectionsListkotlinString.toJsonTree(value.actualInstance as kotlin.collections.List<kotlin.String>?).getAsJsonArray()
+                            elementAdapter.write(out, array)
+                            return
+                        }
                     }
                     throw IOException("Failed to serialize as the type doesn't match anyOf schemas: ApiPet, ApiUser, kotlin.collections.List<kotlin.String>")
                 }

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiUserOrPetOrArrayString.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiUserOrPetOrArrayString.kt
@@ -73,9 +73,12 @@ data class ApiUserOrPetOrArrayString(var actualInstance: Any? = null) {
                     }
                     // check if the actual instance is of the type `kotlin.collections.List<kotlin.String>`
                     if (value.actualInstance is List<*>) {
-                        val primitive = adapterkotlincollectionsListkotlinString.toJsonTree(value.actualInstance as kotlin.collections.List<kotlin.String>?).getAsJsonPrimitive()
-                        elementAdapter.write(out, primitive)
-                        return
+                        val list = value.actualInstance as List<Any>
+                        if (list.get(0) is kotlin.String) {
+                            val array = adapterkotlincollectionsListkotlinString.toJsonTree(value.actualInstance as kotlin.collections.List<kotlin.String>?).getAsJsonArray()
+                            elementAdapter.write(out, array)
+                            return
+                        }
                     }
                     throw IOException("Failed to serialize as the type doesn't match oneOf schemas: ApiPet, ApiUser, kotlin.collections.List<kotlin.String>")
                 }


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/issues/18890

remove java code in kotlin client template


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@jimschubert (2017/09) ❤️, @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06)
