### PR TITLE
[csharp] OneOf should handle Inheritance based type

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/modelOneOf.mustache
@@ -56,7 +56,7 @@
             set
             {
                 {{#oneOf}}
-                {{^-first}}else {{/-first}}if (value.GetType() == typeof({{{.}}}))
+                {{^-first}}else {{/-first}}if (value.GetType() == typeof({{{.}}}) || value is {{{.}}})
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Apple))
+                if (value.GetType() == typeof(Apple) || value is Apple)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Banana))
+                else if (value.GetType() == typeof(Banana) || value is Banana)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -82,11 +82,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(AppleReq))
+                if (value.GetType() == typeof(AppleReq) || value is AppleReq)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(BananaReq))
+                else if (value.GetType() == typeof(BananaReq) || value is BananaReq)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -86,15 +86,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Pig))
+                if (value.GetType() == typeof(Pig) || value is Pig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Whale))
+                else if (value.GetType() == typeof(Whale) || value is Whale)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Zebra))
+                else if (value.GetType() == typeof(Zebra) || value is Zebra)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -109,23 +109,23 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(MixedSubId))
+                if (value.GetType() == typeof(MixedSubId) || value is MixedSubId)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(decimal))
+                else if (value.GetType() == typeof(decimal) || value is decimal)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(int))
+                else if (value.GetType() == typeof(int) || value is int)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -83,11 +83,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(string))
+                if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -74,11 +74,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(BasquePig))
+                if (value.GetType() == typeof(BasquePig) || value is BasquePig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(DanishPig))
+                else if (value.GetType() == typeof(DanishPig) || value is DanishPig)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -97,19 +97,19 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(List<string>))
+                if (value.GetType() == typeof(List<string>) || value is List<string>)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Object))
+                else if (value.GetType() == typeof(Object) || value is Object)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -74,11 +74,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(ComplexQuadrilateral))
+                if (value.GetType() == typeof(ComplexQuadrilateral) || value is ComplexQuadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(SimpleQuadrilateral))
+                else if (value.GetType() == typeof(SimpleQuadrilateral) || value is SimpleQuadrilateral)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -74,11 +74,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -83,11 +83,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -86,15 +86,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(EquilateralTriangle))
+                if (value.GetType() == typeof(EquilateralTriangle) || value is EquilateralTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(IsoscelesTriangle))
+                else if (value.GetType() == typeof(IsoscelesTriangle) || value is IsoscelesTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(ScaleneTriangle))
+                else if (value.GetType() == typeof(ScaleneTriangle) || value is ScaleneTriangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -72,11 +72,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Apple))
+                if (value.GetType() == typeof(Apple) || value is Apple)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Banana))
+                else if (value.GetType() == typeof(Banana) || value is Banana)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -81,11 +81,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(AppleReq))
+                if (value.GetType() == typeof(AppleReq) || value is AppleReq)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(BananaReq))
+                else if (value.GetType() == typeof(BananaReq) || value is BananaReq)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -85,15 +85,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Pig))
+                if (value.GetType() == typeof(Pig) || value is Pig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Whale))
+                else if (value.GetType() == typeof(Whale) || value is Whale)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Zebra))
+                else if (value.GetType() == typeof(Zebra) || value is Zebra)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -108,23 +108,23 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(MixedSubId))
+                if (value.GetType() == typeof(MixedSubId) || value is MixedSubId)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(decimal))
+                else if (value.GetType() == typeof(decimal) || value is decimal)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(int))
+                else if (value.GetType() == typeof(int) || value is int)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -82,11 +82,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(string))
+                if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(BasquePig))
+                if (value.GetType() == typeof(BasquePig) || value is BasquePig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(DanishPig))
+                else if (value.GetType() == typeof(DanishPig) || value is DanishPig)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -96,19 +96,19 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(List<string>))
+                if (value.GetType() == typeof(List<string>) || value is List<string>)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Object))
+                else if (value.GetType() == typeof(Object) || value is Object)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(ComplexQuadrilateral))
+                if (value.GetType() == typeof(ComplexQuadrilateral) || value is ComplexQuadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(SimpleQuadrilateral))
+                else if (value.GetType() == typeof(SimpleQuadrilateral) || value is SimpleQuadrilateral)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -82,11 +82,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -85,15 +85,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(EquilateralTriangle))
+                if (value.GetType() == typeof(EquilateralTriangle) || value is EquilateralTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(IsoscelesTriangle))
+                else if (value.GetType() == typeof(IsoscelesTriangle) || value is IsoscelesTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(ScaleneTriangle))
+                else if (value.GetType() == typeof(ScaleneTriangle) || value is ScaleneTriangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -72,11 +72,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Apple))
+                if (value.GetType() == typeof(Apple) || value is Apple)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Banana))
+                else if (value.GetType() == typeof(Banana) || value is Banana)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -81,11 +81,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(AppleReq))
+                if (value.GetType() == typeof(AppleReq) || value is AppleReq)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(BananaReq))
+                else if (value.GetType() == typeof(BananaReq) || value is BananaReq)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -85,15 +85,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Pig))
+                if (value.GetType() == typeof(Pig) || value is Pig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Whale))
+                else if (value.GetType() == typeof(Whale) || value is Whale)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Zebra))
+                else if (value.GetType() == typeof(Zebra) || value is Zebra)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -108,23 +108,23 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(MixedSubId))
+                if (value.GetType() == typeof(MixedSubId) || value is MixedSubId)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(decimal))
+                else if (value.GetType() == typeof(decimal) || value is decimal)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(int))
+                else if (value.GetType() == typeof(int) || value is int)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -82,11 +82,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(string))
+                if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(BasquePig))
+                if (value.GetType() == typeof(BasquePig) || value is BasquePig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(DanishPig))
+                else if (value.GetType() == typeof(DanishPig) || value is DanishPig)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -96,19 +96,19 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(List<string>))
+                if (value.GetType() == typeof(List<string>) || value is List<string>)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Object))
+                else if (value.GetType() == typeof(Object) || value is Object)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(ComplexQuadrilateral))
+                if (value.GetType() == typeof(ComplexQuadrilateral) || value is ComplexQuadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(SimpleQuadrilateral))
+                else if (value.GetType() == typeof(SimpleQuadrilateral) || value is SimpleQuadrilateral)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -82,11 +82,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -85,15 +85,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(EquilateralTriangle))
+                if (value.GetType() == typeof(EquilateralTriangle) || value is EquilateralTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(IsoscelesTriangle))
+                else if (value.GetType() == typeof(IsoscelesTriangle) || value is IsoscelesTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(ScaleneTriangle))
+                else if (value.GetType() == typeof(ScaleneTriangle) || value is ScaleneTriangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Fruit.cs
@@ -72,11 +72,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Apple))
+                if (value.GetType() == typeof(Apple) || value is Apple)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Banana))
+                else if (value.GetType() == typeof(Banana) || value is Banana)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -81,11 +81,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(AppleReq))
+                if (value.GetType() == typeof(AppleReq) || value is AppleReq)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(BananaReq))
+                else if (value.GetType() == typeof(BananaReq) || value is BananaReq)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Mammal.cs
@@ -85,15 +85,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Pig))
+                if (value.GetType() == typeof(Pig) || value is Pig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Whale))
+                else if (value.GetType() == typeof(Whale) || value is Whale)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Zebra))
+                else if (value.GetType() == typeof(Zebra) || value is Zebra)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -108,23 +108,23 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(MixedSubId))
+                if (value.GetType() == typeof(MixedSubId) || value is MixedSubId)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(decimal))
+                else if (value.GetType() == typeof(decimal) || value is decimal)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(int))
+                else if (value.GetType() == typeof(int) || value is int)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -82,11 +82,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(string))
+                if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Pig.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(BasquePig))
+                if (value.GetType() == typeof(BasquePig) || value is BasquePig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(DanishPig))
+                else if (value.GetType() == typeof(DanishPig) || value is DanishPig)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -96,19 +96,19 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(List<string>))
+                if (value.GetType() == typeof(List<string>) || value is List<string>)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Object))
+                else if (value.GetType() == typeof(Object) || value is Object)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(ComplexQuadrilateral))
+                if (value.GetType() == typeof(ComplexQuadrilateral) || value is ComplexQuadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(SimpleQuadrilateral))
+                else if (value.GetType() == typeof(SimpleQuadrilateral) || value is SimpleQuadrilateral)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Shape.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -82,11 +82,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Triangle.cs
@@ -85,15 +85,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(EquilateralTriangle))
+                if (value.GetType() == typeof(EquilateralTriangle) || value is EquilateralTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(IsoscelesTriangle))
+                else if (value.GetType() == typeof(IsoscelesTriangle) || value is IsoscelesTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(ScaleneTriangle))
+                else if (value.GetType() == typeof(ScaleneTriangle) || value is ScaleneTriangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -72,11 +72,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Apple))
+                if (value.GetType() == typeof(Apple) || value is Apple)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Banana))
+                else if (value.GetType() == typeof(Banana) || value is Banana)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -81,11 +81,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(AppleReq))
+                if (value.GetType() == typeof(AppleReq) || value is AppleReq)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(BananaReq))
+                else if (value.GetType() == typeof(BananaReq) || value is BananaReq)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -85,15 +85,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Pig))
+                if (value.GetType() == typeof(Pig) || value is Pig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Whale))
+                else if (value.GetType() == typeof(Whale) || value is Whale)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Zebra))
+                else if (value.GetType() == typeof(Zebra) || value is Zebra)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -108,23 +108,23 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(MixedSubId))
+                if (value.GetType() == typeof(MixedSubId) || value is MixedSubId)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(decimal))
+                else if (value.GetType() == typeof(decimal) || value is decimal)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(int))
+                else if (value.GetType() == typeof(int) || value is int)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -82,11 +82,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(string))
+                if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(BasquePig))
+                if (value.GetType() == typeof(BasquePig) || value is BasquePig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(DanishPig))
+                else if (value.GetType() == typeof(DanishPig) || value is DanishPig)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -96,19 +96,19 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(List<string>))
+                if (value.GetType() == typeof(List<string>) || value is List<string>)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Object))
+                else if (value.GetType() == typeof(Object) || value is Object)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(ComplexQuadrilateral))
+                if (value.GetType() == typeof(ComplexQuadrilateral) || value is ComplexQuadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(SimpleQuadrilateral))
+                else if (value.GetType() == typeof(SimpleQuadrilateral) || value is SimpleQuadrilateral)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -82,11 +82,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -85,15 +85,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(EquilateralTriangle))
+                if (value.GetType() == typeof(EquilateralTriangle) || value is EquilateralTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(IsoscelesTriangle))
+                else if (value.GetType() == typeof(IsoscelesTriangle) || value is IsoscelesTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(ScaleneTriangle))
+                else if (value.GetType() == typeof(ScaleneTriangle) || value is ScaleneTriangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Fruit.cs
@@ -72,11 +72,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Apple))
+                if (value.GetType() == typeof(Apple) || value is Apple)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Banana))
+                else if (value.GetType() == typeof(Banana) || value is Banana)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -81,11 +81,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(AppleReq))
+                if (value.GetType() == typeof(AppleReq) || value is AppleReq)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(BananaReq))
+                else if (value.GetType() == typeof(BananaReq) || value is BananaReq)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Mammal.cs
@@ -85,15 +85,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Pig))
+                if (value.GetType() == typeof(Pig) || value is Pig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Whale))
+                else if (value.GetType() == typeof(Whale) || value is Whale)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Zebra))
+                else if (value.GetType() == typeof(Zebra) || value is Zebra)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -108,23 +108,23 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(MixedSubId))
+                if (value.GetType() == typeof(MixedSubId) || value is MixedSubId)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(decimal))
+                else if (value.GetType() == typeof(decimal) || value is decimal)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(int))
+                else if (value.GetType() == typeof(int) || value is int)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -82,11 +82,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(string))
+                if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Pig.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(BasquePig))
+                if (value.GetType() == typeof(BasquePig) || value is BasquePig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(DanishPig))
+                else if (value.GetType() == typeof(DanishPig) || value is DanishPig)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -96,19 +96,19 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(List<string>))
+                if (value.GetType() == typeof(List<string>) || value is List<string>)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Object))
+                else if (value.GetType() == typeof(Object) || value is Object)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(ComplexQuadrilateral))
+                if (value.GetType() == typeof(ComplexQuadrilateral) || value is ComplexQuadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(SimpleQuadrilateral))
+                else if (value.GetType() == typeof(SimpleQuadrilateral) || value is SimpleQuadrilateral)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Shape.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -82,11 +82,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Triangle.cs
@@ -85,15 +85,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(EquilateralTriangle))
+                if (value.GetType() == typeof(EquilateralTriangle) || value is EquilateralTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(IsoscelesTriangle))
+                else if (value.GetType() == typeof(IsoscelesTriangle) || value is IsoscelesTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(ScaleneTriangle))
+                else if (value.GetType() == typeof(ScaleneTriangle) || value is ScaleneTriangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -72,11 +72,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Apple))
+                if (value.GetType() == typeof(Apple) || value is Apple)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Banana))
+                else if (value.GetType() == typeof(Banana) || value is Banana)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -81,11 +81,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(AppleReq))
+                if (value.GetType() == typeof(AppleReq) || value is AppleReq)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(BananaReq))
+                else if (value.GetType() == typeof(BananaReq) || value is BananaReq)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -85,15 +85,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Pig))
+                if (value.GetType() == typeof(Pig) || value is Pig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Whale))
+                else if (value.GetType() == typeof(Whale) || value is Whale)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Zebra))
+                else if (value.GetType() == typeof(Zebra) || value is Zebra)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -108,23 +108,23 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(MixedSubId))
+                if (value.GetType() == typeof(MixedSubId) || value is MixedSubId)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(decimal))
+                else if (value.GetType() == typeof(decimal) || value is decimal)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(int))
+                else if (value.GetType() == typeof(int) || value is int)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -82,11 +82,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(string))
+                if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(BasquePig))
+                if (value.GetType() == typeof(BasquePig) || value is BasquePig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(DanishPig))
+                else if (value.GetType() == typeof(DanishPig) || value is DanishPig)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -96,19 +96,19 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(List<string>))
+                if (value.GetType() == typeof(List<string>) || value is List<string>)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Object))
+                else if (value.GetType() == typeof(Object) || value is Object)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(ComplexQuadrilateral))
+                if (value.GetType() == typeof(ComplexQuadrilateral) || value is ComplexQuadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(SimpleQuadrilateral))
+                else if (value.GetType() == typeof(SimpleQuadrilateral) || value is SimpleQuadrilateral)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -73,11 +73,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -82,11 +82,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -85,15 +85,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(EquilateralTriangle))
+                if (value.GetType() == typeof(EquilateralTriangle) || value is EquilateralTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(IsoscelesTriangle))
+                else if (value.GetType() == typeof(IsoscelesTriangle) || value is IsoscelesTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(ScaleneTriangle))
+                else if (value.GetType() == typeof(ScaleneTriangle) || value is ScaleneTriangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -70,11 +70,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Apple))
+                if (value.GetType() == typeof(Apple) || value is Apple)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Banana))
+                else if (value.GetType() == typeof(Banana) || value is Banana)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -79,11 +79,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(AppleReq))
+                if (value.GetType() == typeof(AppleReq) || value is AppleReq)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(BananaReq))
+                else if (value.GetType() == typeof(BananaReq) || value is BananaReq)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -82,15 +82,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Pig))
+                if (value.GetType() == typeof(Pig) || value is Pig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Whale))
+                else if (value.GetType() == typeof(Whale) || value is Whale)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Zebra))
+                else if (value.GetType() == typeof(Zebra) || value is Zebra)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -106,23 +106,23 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(MixedSubId))
+                if (value.GetType() == typeof(MixedSubId) || value is MixedSubId)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(decimal))
+                else if (value.GetType() == typeof(decimal) || value is decimal)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(int))
+                else if (value.GetType() == typeof(int) || value is int)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -79,11 +79,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(string))
+                if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -70,11 +70,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(BasquePig))
+                if (value.GetType() == typeof(BasquePig) || value is BasquePig)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(DanishPig))
+                else if (value.GetType() == typeof(DanishPig) || value is DanishPig)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -94,19 +94,19 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(List<string>))
+                if (value.GetType() == typeof(List<string>) || value is List<string>)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Object))
+                else if (value.GetType() == typeof(Object) || value is Object)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(bool))
+                else if (value.GetType() == typeof(bool) || value is bool)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(string))
+                else if (value.GetType() == typeof(string) || value is string)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -70,11 +70,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(ComplexQuadrilateral))
+                if (value.GetType() == typeof(ComplexQuadrilateral) || value is ComplexQuadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(SimpleQuadrilateral))
+                else if (value.GetType() == typeof(SimpleQuadrilateral) || value is SimpleQuadrilateral)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -70,11 +70,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -79,11 +79,11 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(Quadrilateral))
+                if (value.GetType() == typeof(Quadrilateral) || value is Quadrilateral)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(Triangle))
+                else if (value.GetType() == typeof(Triangle) || value is Triangle)
                 {
                     this._actualInstance = value;
                 }

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -82,15 +82,15 @@ namespace Org.OpenAPITools.Model
             }
             set
             {
-                if (value.GetType() == typeof(EquilateralTriangle))
+                if (value.GetType() == typeof(EquilateralTriangle) || value is EquilateralTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(IsoscelesTriangle))
+                else if (value.GetType() == typeof(IsoscelesTriangle) || value is IsoscelesTriangle)
                 {
                     this._actualInstance = value;
                 }
-                else if (value.GetType() == typeof(ScaleneTriangle))
+                else if (value.GetType() == typeof(ScaleneTriangle) || value is ScaleneTriangle)
                 {
                     this._actualInstance = value;
                 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
In the current C# generator, properties that have a oneOf relationship only handle the relationship for concrete types. However, if a schema in the oneOf clause is an abstract type, it should accept types derived from the abstract class. Unfortunately, this behavior is not possible in the current C# generator. I’ve implemented a fix to handle inheritance-based type checks using the is operator.

The current generator generate a code as below for oneOf schema

```code
public override Object ActualInstance
        {
            get
            {
                return _actualInstance;
            }
            set
            {
                if (value.GetType() == typeof(FabricAbstractInterfaceRole))
                {
                    this._actualInstance = value;
                }
                else if (value.GetType() == typeof(MoMoRef) )
                {
                    this._actualInstance = value;
                }
                else
                {
                    throw new ArgumentException("Invalid instance found. Must be the following types: FabricAbstractInterfaceRole, MoMoRef");
                }
            }
        }


```


Expected behaviour to accepts any type which are derived from abstract class

```code
public override Object ActualInstance
        {
            get
            {
                return _actualInstance;
            }
            set
            {
                if (value.GetType() == typeof(FabricAbstractInterfaceRole) || value is FabricAbstractInterfaceRole)
                {
                    this._actualInstance = value;
                }
                else if (value.GetType() == typeof(MoMoRef) || value is MoMoRef )
                {
                    this._actualInstance = value;
                }
                else
                {
                    throw new ArgumentException("Invalid instance found. Must be the following types: FabricAbstractInterfaceRole, MoMoRef");
                }
            }
        }


``` 




  
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@wing328 