### PR TITLE
[rust-axum] Support for response status code ranges

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-axum/server-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/server-operation.mustache
@@ -45,7 +45,7 @@ async fn {{#vendorExtensions}}{{{x-operation-id}}}{{/vendorExtensions}}<I, A>(
 {{/x-consumes-multipart-related}}
 {{/vendorExtensions}}
 ) -> Result<Response, StatusCode>
-where 
+where
     I: AsRef<A> + Send + Sync,
     A: apis::{{classFilename}}::{{classnamePascalCase}},
 {
@@ -94,21 +94,21 @@ where
        }
   };
 
-  {{/-last}} 
+  {{/-last}}
 {{/headerParams}}
 
   {{^disableValidator}}
     {{^allowBlockingValidator}}
       #[allow(clippy::redundant_closure)]
-      let validation = tokio::task::spawn_blocking(move || 
-    {{/allowBlockingValidator}} 
+      let validation = tokio::task::spawn_blocking(move ||
+    {{/allowBlockingValidator}}
     {{#allowBlockingValidator}}
       let validation =
     {{/allowBlockingValidator}}
     {{#vendorExtensions}}{{{x-operation-id}}}_validation{{/vendorExtensions}}(
       {{#headerParams.size}}
         header_params,
-      {{/headerParams.size}} 
+      {{/headerParams.size}}
       {{#pathParams.size}}
         path_params,
       {{/pathParams.size}}
@@ -120,7 +120,7 @@ where
         {{#bodyParam}}
           body,
         {{/bodyParam}}
-      {{/x-consumes-multipart}} 
+      {{/x-consumes-multipart}}
       {{/x-consumes-multipart-related}}
     )
   {{^allowBlockingValidator}}).await.unwrap(){{/allowBlockingValidator}};
@@ -128,7 +128,7 @@ where
   let Ok((
   {{#headerParams.size}}
     header_params,
-  {{/headerParams.size}} 
+  {{/headerParams.size}}
   {{#pathParams.size}}
     path_params,
   {{/pathParams.size}}
@@ -140,13 +140,13 @@ where
     {{#bodyParam}}
       body,
     {{/bodyParam}}
-  {{/x-consumes-multipart}}  
+  {{/x-consumes-multipart}}
   {{/x-consumes-multipart-related}}
   )) = validation else {
     return Response::builder()
             .status(StatusCode::BAD_REQUEST)
             .body(Body::from(validation.unwrap_err().to_string()))
-            .map_err(|_| StatusCode::BAD_REQUEST); 
+            .map_err(|_| StatusCode::BAD_REQUEST);
   };
   {{/disableValidator}}
 
@@ -228,7 +228,7 @@ where
                                                         }
                                                     };
 
-                                                    
+
                                                     {
                                                       let mut response_headers = response.headers_mut().unwrap();
                                                       response_headers.insert(
@@ -240,8 +240,12 @@ where
                                                     }
   {{/required}}
 {{/headers}}
-
+{{#range}}
+                                                  response.status::<u16>(body.code.parse().unwrap());  // {{{code}}}
+{{/range}}
+{{^range}}
                                                   let mut response = response.status({{{code}}});
+{{/range}}
 {{#produces}}
 {{#-first}}
 {{#dataType}}
@@ -264,7 +268,7 @@ where
                                                   let body_content =  tokio::task::spawn_blocking(move ||
   {{/allowBlockingResponseSerialize}}
   {{#allowBlockingResponseSerialize}}
-                                                  let body_content = 
+                                                  let body_content =
   {{/allowBlockingResponseSerialize}}
                                                       serde_json::to_vec(&body).map_err(|e| {
                                                         error!(error = ?e);
@@ -276,7 +280,7 @@ where
                                                   let body_content =  tokio::task::spawn_blocking(move ||
   {{/allowBlockingResponseSerialize}}
   {{#allowBlockingResponseSerialize}}
-                                                  let body_content = 
+                                                  let body_content =
   {{/allowBlockingResponseSerialize}}
                                                       serde_urlencoded::to_string(body).map_err(|e| {
                                                         error!(error = ?e);


### PR DESCRIPTION
This PR adds support for response ranges in rust-axum server, as defined in section 4.8.16.2 of the spec.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@frol @farcaller @richardwhiuk @paladinzh @jacob-pro
