### PR TITLE
Kotlin-Spring request mapping mode

### DIFF
--- a/bin/configs/kotlin-spring-boot-3.yaml
+++ b/bin/configs/kotlin-spring-boot-3.yaml
@@ -11,3 +11,4 @@ additionalProperties:
   serializableModel: "true"
   beanValidations: "true"
   useSpringBoot3: "true"
+  requestMappingMode: api_interface

--- a/bin/configs/kotlin-spring-boot-delegate.yaml
+++ b/bin/configs/kotlin-spring-boot-delegate.yaml
@@ -9,3 +9,4 @@ additionalProperties:
   useSwaggerUI: "true"
   delegatePattern: "true"
   beanValidations: "true"
+  requestMappingMode: none

--- a/bin/configs/kotlin-spring-boot.yaml
+++ b/bin/configs/kotlin-spring-boot.yaml
@@ -10,3 +10,4 @@ additionalProperties:
   serviceImplementation: "true"
   serializableModel: "true"
   beanValidations: "true"
+  requestMappingMode: controller

--- a/docs/generators/kotlin-spring.md
+++ b/docs/generators/kotlin-spring.md
@@ -41,6 +41,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |packageName|Generated artifact package name.| |org.openapitools|
 |parcelizeModels|toggle &quot;@Parcelize&quot; for generated models| |null|
 |reactive|use coroutines for reactive behavior| |false|
+|requestMappingMode|Where to generate the class level @RequestMapping annotation.|<dl><dt>**api_interface**</dt><dd>Generate the @RequestMapping annotation on the generated Api Interface.</dd><dt>**controller**</dt><dd>Generate the @RequestMapping annotation on the generated Api Controller Implementation.</dd><dt>**none**</dt><dd>Do not add a class level @RequestMapping annotation.</dd></dl>|controller|
 |serializableModel|boolean - toggle &quot;implements Serializable&quot; for generated models| |null|
 |serverPort|configuration the port in which the sever is to run on| |8080|
 |serviceImplementation|generate stub service implementations that extends service interfaces. If this is set to true service interfaces will also be generated| |false|

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
@@ -57,9 +57,11 @@ import kotlin.collections.Map
 {{#swagger1AnnotationLibrary}}
 @Api(value = "{{{baseName}}}", description = "The {{{baseName}}} API")
 {{/swagger1AnnotationLibrary}}
+{{#useRequestMappingOnController}}
 {{=<% %>=}}
 @RequestMapping("\${api.base-path:<%contextPath%>}")
 <%={{ }}=%>
+{{/useRequestMappingOnController}}
 {{#operations}}
 class {{classname}}Controller({{#serviceInterface}}@Autowired(required = true) val service: {{classname}}Service{{/serviceInterface}}) {
 {{#operation}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiController.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiController.mustache
@@ -6,9 +6,11 @@ import java.util.Optional
 
 {{>generatedAnnotation}}
 @Controller{{#beanQualifiers}}("{{package}}.{{classname}}Controller"){{/beanQualifiers}}
+{{#useRequestMappingOnController}}
 {{=<% %>=}}
 @RequestMapping("\${openapi.<%title%>.base-path:<%>defaultBasePath%>}")
 <%={{ }}=%>
+{{/useRequestMappingOnController}}
 {{#operations}}
 class {{classname}}Controller(
         @org.springframework.beans.factory.annotation.Autowired(required = false) delegate: {{classname}}Delegate?

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
@@ -61,11 +61,11 @@ import kotlin.collections.Map
 {{#swagger1AnnotationLibrary}}
 @Api(value = "{{{baseName}}}", description = "The {{{baseName}}} API")
 {{/swagger1AnnotationLibrary}}
-{{^useFeignClient}}
+{{#useRequestMappingOnInterface}}
 {{=<% %>=}}
 @RequestMapping("\${api.base-path:<%contextPath%>}")
 <%={{ }}=%>
-{{/useFeignClient}}
+{{/useRequestMappingOnInterface}}
 {{#operations}}
 interface {{classname}} {
 {{#isDelegate}}

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -26,7 +26,6 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 class PetApiController(@Autowired(required = true) val service: PetApiService) {
 
 

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -25,7 +25,6 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 class StoreApiController(@Autowired(required = true) val service: StoreApiService) {
 
 

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -25,7 +25,6 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 class UserApiController(@Autowired(required = true) val service: UserApiService) {
 
 

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -35,7 +35,6 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 interface PetApi {
 
     fun getDelegate(): PetApiDelegate = object: PetApiDelegate {}

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -6,7 +6,6 @@ import java.util.Optional
 
 @javax.annotation.Generated(value = ["org.openapitools.codegen.languages.KotlinSpringServerCodegen"], comments = "Generator version: 7.7.0-SNAPSHOT")
 @Controller
-@RequestMapping("\${openapi.openAPIPetstore.base-path:/v2}")
 class PetApiController(
         @org.springframework.beans.factory.annotation.Autowired(required = false) delegate: PetApiDelegate?
 ) : PetApi {

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/StoreApi.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/StoreApi.kt
@@ -34,7 +34,6 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 interface StoreApi {
 
     fun getDelegate(): StoreApiDelegate = object: StoreApiDelegate {}

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -6,7 +6,6 @@ import java.util.Optional
 
 @javax.annotation.Generated(value = ["org.openapitools.codegen.languages.KotlinSpringServerCodegen"], comments = "Generator version: 7.7.0-SNAPSHOT")
 @Controller
-@RequestMapping("\${openapi.openAPIPetstore.base-path:/v2}")
 class StoreApiController(
         @org.springframework.beans.factory.annotation.Autowired(required = false) delegate: StoreApiDelegate?
 ) : StoreApi {

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApi.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApi.kt
@@ -34,7 +34,6 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 interface UserApi {
 
     fun getDelegate(): UserApiDelegate = object: UserApiDelegate {}

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -6,7 +6,6 @@ import java.util.Optional
 
 @javax.annotation.Generated(value = ["org.openapitools.codegen.languages.KotlinSpringServerCodegen"], comments = "Generator version: 7.7.0-SNAPSHOT")
 @Controller
-@RequestMapping("\${openapi.openAPIPetstore.base-path:/v2}")
 class UserApiController(
         @org.springframework.beans.factory.annotation.Autowired(required = false) delegate: UserApiDelegate?
 ) : UserApi {

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/api/FakeApi.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/api/FakeApi.kt
@@ -35,7 +35,6 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 interface FakeApi {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/api/FakeClassnameTestApi.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/api/FakeClassnameTestApi.kt
@@ -35,7 +35,6 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 interface FakeClassnameTestApi {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/api/FooApi.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/api/FooApi.kt
@@ -35,7 +35,6 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 interface FooApi {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -36,7 +36,6 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 interface PetApi {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/api/StoreApi.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/api/StoreApi.kt
@@ -35,7 +35,6 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 interface StoreApi {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/api/UserApi.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/api/UserApi.kt
@@ -35,7 +35,6 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 interface UserApi {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -36,7 +36,6 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 interface PetApi {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/api/StoreApi.kt
+++ b/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/api/StoreApi.kt
@@ -35,7 +35,6 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 interface StoreApi {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/api/UserApi.kt
+++ b/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/api/UserApi.kt
@@ -35,7 +35,6 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @Validated
-@RequestMapping("\${api.base-path:/v2}")
 interface UserApi {
 
     @Operation(


### PR DESCRIPTION
RequestMappingMode: Explicit configuration to control the location of the generated class level RequestMapping annotation-

Based on #13838 but for the kotlin-spring generator.

Fixes #18884

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @jimschubert, @dr4ke616, @karismann, @Zomzog, @andrewemery, @4brunu, @yutaka0m, @stefankoppier
