### PR TITLE
Fix x-www-form-urlencoded date-time string parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -252,6 +252,10 @@ export class {{classname}} extends runtime.BaseAPI {
         {{/isArray}}
         {{^isArray}}
         if (requestParameters['{{paramName}}'] != null) {
+            {{#isDateTimeType}}
+            formParams.append('{{baseName}}', (requestParameters['{{paramName}}'] as any).toISOString());
+            {{/isDateTimeType}}
+            {{^isDateTimeType}}
             {{#isPrimitiveType}}
             formParams.append('{{baseName}}', requestParameters['{{paramName}}'] as any);
             {{/isPrimitiveType}}
@@ -262,6 +266,7 @@ export class {{classname}} extends runtime.BaseAPI {
             formParams.append('{{baseName}}', new Blob([JSON.stringify(requestParameters['{{paramName}}'])], { type: "application/json", }));
             {{/withoutRuntimeChecks}}
             {{/isPrimitiveType}}
+            {{/isDateTimeType}}
         }
 
         {{/isArray}}

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -722,7 +722,7 @@ export class FakeApi extends runtime.BaseAPI {
         }
 
         if (requestParameters['dateTime'] != null) {
-            formParams.append('dateTime', requestParameters['dateTime'] as any);
+            formParams.append('dateTime', (requestParameters['dateTime'] as any).toISOString());
         }
 
         if (requestParameters['password'] != null) {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
@@ -663,7 +663,7 @@ export class FakeApi extends runtime.BaseAPI {
         }
 
         if (requestParameters['dateTime'] != null) {
-            formParams.append('dateTime', requestParameters['dateTime'] as any);
+            formParams.append('dateTime', (requestParameters['dateTime'] as any).toISOString());
         }
 
         if (requestParameters['password'] != null) {


### PR DESCRIPTION
As mentioned in #13841, date-time parameters in request bodies are not ISO formatted, which breaks with certain webservers. This commit invokes `toISOString()` for date-time body parameters like it is done for queryParameters.

Fixes #13841.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

