### PR TITLE
Remove bean validation for uuid

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/beanValidationCore.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/beanValidationCore.mustache
@@ -1,4 +1,4 @@
-{{#pattern}}{{^isByteArray}}@Pattern(regexp = "{{{pattern}}}"{{#vendorExtensions.x-pattern-message}}, message="{{vendorExtensions.x-pattern-message}}"{{/vendorExtensions.x-pattern-message}}) {{/isByteArray}}{{/pattern}}{{!
+{{^isUuid}}{{#pattern}}{{^isByteArray}}@Pattern(regexp = "{{{pattern}}}"{{#vendorExtensions.x-pattern-message}}, message="{{vendorExtensions.x-pattern-message}}"{{/vendorExtensions.x-pattern-message}}) {{/isByteArray}}{{/pattern}}{{!
 minLength && maxLength set
 }}{{#minLength}}{{#maxLength}}@Size(min = {{minLength}}, max = {{maxLength}}) {{/maxLength}}{{/minLength}}{{!
 minLength set, maxLength not
@@ -21,4 +21,4 @@ isInteger set
 isLong set
 }}{{#isLong}}{{#minimum}}@Min({{.}}L) {{/minimum}}{{#maximum}}@Max({{.}}L) {{/maximum}}{{/isLong}}{{!
 Not Integer, not Long => we have a decimal value!
-}}{{^isInteger}}{{^isLong}}{{#minimum}}@DecimalMin({{#exclusiveMinimum}}value = {{/exclusiveMinimum}}"{{minimum}}"{{#exclusiveMinimum}}, inclusive = false{{/exclusiveMinimum}}) {{/minimum}}{{#maximum}}@DecimalMax({{#exclusiveMaximum}}value = {{/exclusiveMaximum}}"{{maximum}}"{{#exclusiveMaximum}}, inclusive = false{{/exclusiveMaximum}}) {{/maximum}}{{/isLong}}{{/isInteger}}
+}}{{^isInteger}}{{^isLong}}{{#minimum}}@DecimalMin({{#exclusiveMinimum}}value = {{/exclusiveMinimum}}"{{minimum}}"{{#exclusiveMinimum}}, inclusive = false{{/exclusiveMinimum}}) {{/minimum}}{{#maximum}}@DecimalMax({{#exclusiveMaximum}}value = {{/exclusiveMaximum}}"{{maximum}}"{{#exclusiveMaximum}}, inclusive = false{{/exclusiveMaximum}}) {{/maximum}}{{/isLong}}{{/isInteger}}{{/isUuid}}

--- a/modules/openapi-generator/src/test/resources/3_0/spring/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1454,6 +1454,7 @@ components:
         uuid:
           type: string
           format: uuid
+          maxLength: 36
           example: 72f98069-206d-4f12-9f12-3d1e525a8e84
         password:
           type: string

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
@@ -1609,6 +1609,7 @@ components:
         uuid:
           example: 72f98069-206d-4f12-9f12-3d1e525a8e84
           format: uuid
+          maxLength: 36
           type: string
         password:
           format: password

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
@@ -1609,6 +1609,7 @@ components:
         uuid:
           example: 72f98069-206d-4f12-9f12-3d1e525a8e84
           format: uuid
+          maxLength: 36
           type: string
         password:
           format: password

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/resources/openapi.yaml
@@ -1609,6 +1609,7 @@ components:
         uuid:
           example: 72f98069-206d-4f12-9f12-3d1e525a8e84
           format: uuid
+          maxLength: 36
           type: string
         password:
           format: password

--- a/samples/server/petstore/springboot-beanvalidation/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/resources/openapi.yaml
@@ -1609,6 +1609,7 @@ components:
         uuid:
           example: 72f98069-206d-4f12-9f12-3d1e525a8e84
           format: uuid
+          maxLength: 36
           type: string
         password:
           format: password

--- a/samples/server/petstore/springboot-delegate-j8/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/resources/openapi.yaml
@@ -1609,6 +1609,7 @@ components:
         uuid:
           example: 72f98069-206d-4f12-9f12-3d1e525a8e84
           format: uuid
+          maxLength: 36
           type: string
         password:
           format: password

--- a/samples/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
@@ -1609,6 +1609,7 @@ components:
         uuid:
           example: 72f98069-206d-4f12-9f12-3d1e525a8e84
           format: uuid
+          maxLength: 36
           type: string
         password:
           format: password

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
@@ -1609,6 +1609,7 @@ components:
         uuid:
           example: 72f98069-206d-4f12-9f12-3d1e525a8e84
           format: uuid
+          maxLength: 36
           type: string
         password:
           format: password

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/resources/openapi.yaml
@@ -1609,6 +1609,7 @@ components:
         uuid:
           example: 72f98069-206d-4f12-9f12-3d1e525a8e84
           format: uuid
+          maxLength: 36
           type: string
         password:
           format: password

--- a/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
@@ -1609,6 +1609,7 @@ components:
         uuid:
           example: 72f98069-206d-4f12-9f12-3d1e525a8e84
           format: uuid
+          maxLength: 36
           type: string
         password:
           format: password

--- a/samples/server/petstore/springboot-useoptional/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-useoptional/src/main/resources/openapi.yaml
@@ -1609,6 +1609,7 @@ components:
         uuid:
           example: 72f98069-206d-4f12-9f12-3d1e525a8e84
           format: uuid
+          maxLength: 36
           type: string
         password:
           format: password

--- a/samples/server/petstore/springboot-virtualan/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-virtualan/src/main/resources/openapi.yaml
@@ -1609,6 +1609,7 @@ components:
         uuid:
           example: 72f98069-206d-4f12-9f12-3d1e525a8e84
           format: uuid
+          maxLength: 36
           type: string
         password:
           format: password

--- a/samples/server/petstore/springboot/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot/src/main/resources/openapi.yaml
@@ -1609,6 +1609,7 @@ components:
         uuid:
           example: 72f98069-206d-4f12-9f12-3d1e525a8e84
           format: uuid
+          maxLength: 36
           type: string
         password:
           format: password


### PR DESCRIPTION
Remove bean validation for uuid, because it's not necessary and breaks the java code

#18095

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against master
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08)