### PR TITLE
[kotlin-server][javalin5] Add Javalin context to generated services

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/api.mustache
@@ -17,7 +17,7 @@ class {{classname}}(private val service: {{classname}}Service) {
      {{#allParams}}* @param {{paramName}} {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
      {{/allParams}}*/
     fun {{operationId}}(ctx: Context) {
-        ctx.status(200).json(service.{{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}}, {{/-last}}{{/allParams}}))
+        ctx.status(200).json(service.{{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}}, {{/-last}}{{/allParams}}{{#hasParams}}, {{/hasParams}}ctx))
     }
 
     {{/operation}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/service.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/service.mustache
@@ -2,6 +2,7 @@ package {{package}}
 
 {{#imports}}import {{import}}
 {{/imports}}
+import io.javalin.http.Context
 
 {{#operations}}
 interface {{classname}}Service {
@@ -16,6 +17,7 @@ interface {{classname}}Service {
     {{#allParams}}
      * @param {{{paramName}}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
     {{/allParams}}
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return {{#responses}}{{message}} (status code {{code}}){{^-last}}
      *         or {{/-last}}{{/responses}}
     {{#isDeprecated}}
@@ -27,7 +29,7 @@ interface {{classname}}Service {
     {{/externalDocs}}
      * @see {{classname}}#{{operationId}}
      */
-    {{#reactive}}{{^isArray}}suspend {{/isArray}}{{/reactive}}fun {{operationId}}({{#allParams}}{{{paramName}}}: {{^isBodyParam}}{{>optionalDataType}}{{/isBodyParam}}{{#isBodyParam}}{{^reactive}}{{>optionalDataType}}{{/reactive}}{{#reactive}}{{^isArray}}{{>optionalDataType}}{{/isArray}}{{#isArray}}Flow<{{{baseType}}}>{{/isArray}}{{/reactive}}{{/isBodyParam}}{{^-last}}, {{/-last}}{{/allParams}}): {{>returnTypes}}
+    {{#reactive}}{{^isArray}}suspend {{/isArray}}{{/reactive}}fun {{operationId}}({{#allParams}}{{{paramName}}}: {{^isBodyParam}}{{>optionalDataType}}{{/isBodyParam}}{{#isBodyParam}}{{^reactive}}{{>optionalDataType}}{{/reactive}}{{#reactive}}{{^isArray}}{{>optionalDataType}}{{/isArray}}{{#isArray}}Flow<{{{baseType}}}>{{/isArray}}{{/reactive}}{{/isBodyParam}}{{^-last}}, {{/-last}}{{/allParams}}{{#hasParams}}, {{/hasParams}}ctx: Context): {{>returnTypes}}
 {{/operation}}
 }
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/serviceImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/serviceImpl.mustache
@@ -2,6 +2,7 @@ package {{package}}
 
 {{#imports}}import {{import}}
 {{/imports}}
+import io.javalin.http.Context
 {{#reactive}}
 import kotlinx.coroutines.flow.Flow
 {{/reactive}}
@@ -10,7 +11,7 @@ import kotlinx.coroutines.flow.Flow
 class {{classname}}ServiceImpl : {{classname}}Service {
 {{#operation}}
 
-    override {{#reactive}}{{^isArray}}suspend {{/isArray}}{{/reactive}}fun {{operationId}}({{#allParams}}{{paramName}}: {{^isBodyParam}}{{>optionalDataType}}{{/isBodyParam}}{{#isBodyParam}}{{^reactive}}{{>optionalDataType}}{{/reactive}}{{#reactive}}{{^isArray}}{{>optionalDataType}}{{/isArray}}{{#isArray}}Flow<{{{baseType}}}>{{/isArray}}{{/reactive}}{{/isBodyParam}}{{^-last}}, {{/-last}}{{/allParams}}): {{>returnTypes}} {
+    override {{#reactive}}{{^isArray}}suspend {{/isArray}}{{/reactive}}fun {{operationId}}({{#allParams}}{{paramName}}: {{^isBodyParam}}{{>optionalDataType}}{{/isBodyParam}}{{#isBodyParam}}{{^reactive}}{{>optionalDataType}}{{/reactive}}{{#reactive}}{{^isArray}}{{>optionalDataType}}{{/isArray}}{{#isArray}}Flow<{{{baseType}}}>{{/isArray}}{{/reactive}}{{/isBodyParam}}{{^-last}}, {{/-last}}{{/allParams}}{{#hasParams}}, {{/hasParams}}ctx: Context): {{>returnTypes}} {
         TODO("Implement me")
     }
 {{/operation}}

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/PetApi.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/PetApi.kt
@@ -15,7 +15,7 @@ class PetApi(private val service: PetApiService) {
      * @param pet Pet object that needs to be added to the store 
      */
     fun addPet(ctx: Context) {
-        ctx.status(200).json(service.addPet(ctx.bodyAsClass<Pet>()))
+        ctx.status(200).json(service.addPet(ctx.bodyAsClass<Pet>(), ctx))
     }
 
     /**
@@ -25,7 +25,7 @@ class PetApi(private val service: PetApiService) {
      * @param apiKey  (optional)
      */
     fun deletePet(ctx: Context) {
-        ctx.status(200).json(service.deletePet(ctx.pathParamAsClass<kotlin.Long>("petId").get(), ctx.header("api_key")))
+        ctx.status(200).json(service.deletePet(ctx.pathParamAsClass<kotlin.Long>("petId").get(), ctx.header("api_key"), ctx))
     }
 
     /**
@@ -34,7 +34,7 @@ class PetApi(private val service: PetApiService) {
      * @param status Status values that need to be considered for filter 
      */
     fun findPetsByStatus(ctx: Context) {
-        ctx.status(200).json(service.findPetsByStatus(ctx.queryParams("status")))
+        ctx.status(200).json(service.findPetsByStatus(ctx.queryParams("status"), ctx))
     }
 
     /**
@@ -43,7 +43,7 @@ class PetApi(private val service: PetApiService) {
      * @param tags Tags to filter by 
      */
     fun findPetsByTags(ctx: Context) {
-        ctx.status(200).json(service.findPetsByTags(ctx.queryParams("tags")))
+        ctx.status(200).json(service.findPetsByTags(ctx.queryParams("tags"), ctx))
     }
 
     /**
@@ -52,7 +52,7 @@ class PetApi(private val service: PetApiService) {
      * @param petId ID of pet to return 
      */
     fun getPetById(ctx: Context) {
-        ctx.status(200).json(service.getPetById(ctx.pathParamAsClass<kotlin.Long>("petId").get()))
+        ctx.status(200).json(service.getPetById(ctx.pathParamAsClass<kotlin.Long>("petId").get(), ctx))
     }
 
     /**
@@ -61,7 +61,7 @@ class PetApi(private val service: PetApiService) {
      * @param pet Pet object that needs to be added to the store 
      */
     fun updatePet(ctx: Context) {
-        ctx.status(200).json(service.updatePet(ctx.bodyAsClass<Pet>()))
+        ctx.status(200).json(service.updatePet(ctx.bodyAsClass<Pet>(), ctx))
     }
 
     /**
@@ -72,7 +72,7 @@ class PetApi(private val service: PetApiService) {
      * @param status Updated status of the pet (optional)
      */
     fun updatePetWithForm(ctx: Context) {
-        ctx.status(200).json(service.updatePetWithForm(ctx.pathParamAsClass<kotlin.Long>("petId").get(), ctx.formParam("name"), ctx.formParam("status")))
+        ctx.status(200).json(service.updatePetWithForm(ctx.pathParamAsClass<kotlin.Long>("petId").get(), ctx.formParam("name"), ctx.formParam("status"), ctx))
     }
 
     /**
@@ -83,7 +83,7 @@ class PetApi(private val service: PetApiService) {
      * @param file file to upload (optional)
      */
     fun uploadFile(ctx: Context) {
-        ctx.status(200).json(service.uploadFile(ctx.pathParamAsClass<kotlin.Long>("petId").get(), ctx.formParam("additionalMetadata"), ctx.uploadedFile("file")))
+        ctx.status(200).json(service.uploadFile(ctx.pathParamAsClass<kotlin.Long>("petId").get(), ctx.formParam("additionalMetadata"), ctx.uploadedFile("file"), ctx))
     }
 
 }

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/PetApiService.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/PetApiService.kt
@@ -2,6 +2,7 @@ package org.openapitools.server.apis
 
 import org.openapitools.server.models.ModelApiResponse
 import org.openapitools.server.models.Pet
+import io.javalin.http.Context
 
 interface PetApiService {
 
@@ -10,11 +11,12 @@ interface PetApiService {
      * 
      *
      * @param pet Pet object that needs to be added to the store (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      *         or Invalid input (status code 405)
      * @see PetApi#addPet
      */
-    fun addPet(pet: Pet): Pet
+    fun addPet(pet: Pet, ctx: Context): Pet
 
     /**
      * DELETE /pet/{petId} : Deletes a pet
@@ -22,51 +24,56 @@ interface PetApiService {
      *
      * @param petId Pet id to delete (required)
      * @param apiKey  (optional)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return Invalid pet value (status code 400)
      * @see PetApi#deletePet
      */
-    fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?): Unit
+    fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?, ctx: Context): Unit
 
     /**
      * GET /pet/findByStatus : Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      *
      * @param status Status values that need to be considered for filter (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      *         or Invalid status value (status code 400)
      * @see PetApi#findPetsByStatus
      */
-    fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>): List<Pet>
+    fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>, ctx: Context): List<Pet>
 
     /**
      * GET /pet/findByTags : Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      *
      * @param tags Tags to filter by (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      *         or Invalid tag value (status code 400)
      * @deprecated
      * @see PetApi#findPetsByTags
      */
-    fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>): List<Pet>
+    fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>, ctx: Context): List<Pet>
 
     /**
      * GET /pet/{petId} : Find pet by ID
      * Returns a single pet
      *
      * @param petId ID of pet to return (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      *         or Invalid ID supplied (status code 400)
      *         or Pet not found (status code 404)
      * @see PetApi#getPetById
      */
-    fun getPetById(petId: kotlin.Long): Pet
+    fun getPetById(petId: kotlin.Long, ctx: Context): Pet
 
     /**
      * PUT /pet : Update an existing pet
      * 
      *
      * @param pet Pet object that needs to be added to the store (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      *         or Invalid ID supplied (status code 400)
      *         or Pet not found (status code 404)
@@ -75,7 +82,7 @@ interface PetApiService {
      * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      * @see PetApi#updatePet
      */
-    fun updatePet(pet: Pet): Pet
+    fun updatePet(pet: Pet, ctx: Context): Pet
 
     /**
      * POST /pet/{petId} : Updates a pet in the store with form data
@@ -84,10 +91,11 @@ interface PetApiService {
      * @param petId ID of pet that needs to be updated (required)
      * @param name Updated name of the pet (optional)
      * @param status Updated status of the pet (optional)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return Invalid input (status code 405)
      * @see PetApi#updatePetWithForm
      */
-    fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?): Unit
+    fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?, ctx: Context): Unit
 
     /**
      * POST /pet/{petId}/uploadImage : uploads an image
@@ -96,8 +104,9 @@ interface PetApiService {
      * @param petId ID of pet to update (required)
      * @param additionalMetadata Additional data to pass to server (optional)
      * @param file file to upload (optional)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      * @see PetApi#uploadFile
      */
-    fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: io.javalin.http.UploadedFile?): ModelApiResponse
+    fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: io.javalin.http.UploadedFile?, ctx: Context): ModelApiResponse
 }

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/PetApiServiceImpl.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/PetApiServiceImpl.kt
@@ -2,38 +2,39 @@ package org.openapitools.server.apis
 
 import org.openapitools.server.models.ModelApiResponse
 import org.openapitools.server.models.Pet
+import io.javalin.http.Context
 
 class PetApiServiceImpl : PetApiService {
 
-    override fun addPet(pet: Pet): Pet {
+    override fun addPet(pet: Pet, ctx: Context): Pet {
         TODO("Implement me")
     }
 
-    override fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?): Unit {
+    override fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?, ctx: Context): Unit {
         TODO("Implement me")
     }
 
-    override fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>): List<Pet> {
+    override fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>, ctx: Context): List<Pet> {
         TODO("Implement me")
     }
 
-    override fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>): List<Pet> {
+    override fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>, ctx: Context): List<Pet> {
         TODO("Implement me")
     }
 
-    override fun getPetById(petId: kotlin.Long): Pet {
+    override fun getPetById(petId: kotlin.Long, ctx: Context): Pet {
         TODO("Implement me")
     }
 
-    override fun updatePet(pet: Pet): Pet {
+    override fun updatePet(pet: Pet, ctx: Context): Pet {
         TODO("Implement me")
     }
 
-    override fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?): Unit {
+    override fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?, ctx: Context): Unit {
         TODO("Implement me")
     }
 
-    override fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: io.javalin.http.UploadedFile?): ModelApiResponse {
+    override fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: io.javalin.http.UploadedFile?, ctx: Context): ModelApiResponse {
         TODO("Implement me")
     }
 }

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/StoreApi.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/StoreApi.kt
@@ -14,7 +14,7 @@ class StoreApi(private val service: StoreApiService) {
      * @param orderId ID of the order that needs to be deleted 
      */
     fun deleteOrder(ctx: Context) {
-        ctx.status(200).json(service.deleteOrder(ctx.pathParamAsClass<kotlin.String>("orderId").get()))
+        ctx.status(200).json(service.deleteOrder(ctx.pathParamAsClass<kotlin.String>("orderId").get(), ctx))
     }
 
     /**
@@ -22,7 +22,7 @@ class StoreApi(private val service: StoreApiService) {
      * Returns a map of status codes to quantities
      */
     fun getInventory(ctx: Context) {
-        ctx.status(200).json(service.getInventory())
+        ctx.status(200).json(service.getInventory(ctx))
     }
 
     /**
@@ -31,7 +31,7 @@ class StoreApi(private val service: StoreApiService) {
      * @param orderId ID of pet that needs to be fetched 
      */
     fun getOrderById(ctx: Context) {
-        ctx.status(200).json(service.getOrderById(ctx.pathParamAsClass<kotlin.Long>("orderId").get()))
+        ctx.status(200).json(service.getOrderById(ctx.pathParamAsClass<kotlin.Long>("orderId").get(), ctx))
     }
 
     /**
@@ -40,7 +40,7 @@ class StoreApi(private val service: StoreApiService) {
      * @param order order placed for purchasing the pet 
      */
     fun placeOrder(ctx: Context) {
-        ctx.status(200).json(service.placeOrder(ctx.bodyAsClass<Order>()))
+        ctx.status(200).json(service.placeOrder(ctx.bodyAsClass<Order>(), ctx))
     }
 
 }

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/StoreApiService.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/StoreApiService.kt
@@ -1,6 +1,7 @@
 package org.openapitools.server.apis
 
 import org.openapitools.server.models.Order
+import io.javalin.http.Context
 
 interface StoreApiService {
 
@@ -9,41 +10,45 @@ interface StoreApiService {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      *
      * @param orderId ID of the order that needs to be deleted (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return Invalid ID supplied (status code 400)
      *         or Order not found (status code 404)
      * @see StoreApi#deleteOrder
      */
-    fun deleteOrder(orderId: kotlin.String): Unit
+    fun deleteOrder(orderId: kotlin.String, ctx: Context): Unit
 
     /**
      * GET /store/inventory : Returns pet inventories by status
      * Returns a map of status codes to quantities
      *
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      * @see StoreApi#getInventory
      */
-    fun getInventory(): Map<String, kotlin.Int>
+    fun getInventory(ctx: Context): Map<String, kotlin.Int>
 
     /**
      * GET /store/order/{orderId} : Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      *
      * @param orderId ID of pet that needs to be fetched (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      *         or Invalid ID supplied (status code 400)
      *         or Order not found (status code 404)
      * @see StoreApi#getOrderById
      */
-    fun getOrderById(orderId: kotlin.Long): Order
+    fun getOrderById(orderId: kotlin.Long, ctx: Context): Order
 
     /**
      * POST /store/order : Place an order for a pet
      * 
      *
      * @param order order placed for purchasing the pet (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      *         or Invalid Order (status code 400)
      * @see StoreApi#placeOrder
      */
-    fun placeOrder(order: Order): Order
+    fun placeOrder(order: Order, ctx: Context): Order
 }

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/StoreApiServiceImpl.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/StoreApiServiceImpl.kt
@@ -1,22 +1,23 @@
 package org.openapitools.server.apis
 
 import org.openapitools.server.models.Order
+import io.javalin.http.Context
 
 class StoreApiServiceImpl : StoreApiService {
 
-    override fun deleteOrder(orderId: kotlin.String): Unit {
+    override fun deleteOrder(orderId: kotlin.String, ctx: Context): Unit {
         TODO("Implement me")
     }
 
-    override fun getInventory(): Map<String, kotlin.Int> {
+    override fun getInventory(ctx: Context): Map<String, kotlin.Int> {
         TODO("Implement me")
     }
 
-    override fun getOrderById(orderId: kotlin.Long): Order {
+    override fun getOrderById(orderId: kotlin.Long, ctx: Context): Order {
         TODO("Implement me")
     }
 
-    override fun placeOrder(order: Order): Order {
+    override fun placeOrder(order: Order, ctx: Context): Order {
         TODO("Implement me")
     }
 }

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/UserApi.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/UserApi.kt
@@ -14,7 +14,7 @@ class UserApi(private val service: UserApiService) {
      * @param user Created user object 
      */
     fun createUser(ctx: Context) {
-        ctx.status(200).json(service.createUser(ctx.bodyAsClass<User>()))
+        ctx.status(200).json(service.createUser(ctx.bodyAsClass<User>(), ctx))
     }
 
     /**
@@ -23,7 +23,7 @@ class UserApi(private val service: UserApiService) {
      * @param user List of user object 
      */
     fun createUsersWithArrayInput(ctx: Context) {
-        ctx.status(200).json(service.createUsersWithArrayInput(ctx.bodyAsClass<List<User>>()))
+        ctx.status(200).json(service.createUsersWithArrayInput(ctx.bodyAsClass<List<User>>(), ctx))
     }
 
     /**
@@ -32,7 +32,7 @@ class UserApi(private val service: UserApiService) {
      * @param user List of user object 
      */
     fun createUsersWithListInput(ctx: Context) {
-        ctx.status(200).json(service.createUsersWithListInput(ctx.bodyAsClass<List<User>>()))
+        ctx.status(200).json(service.createUsersWithListInput(ctx.bodyAsClass<List<User>>(), ctx))
     }
 
     /**
@@ -41,7 +41,7 @@ class UserApi(private val service: UserApiService) {
      * @param username The name that needs to be deleted 
      */
     fun deleteUser(ctx: Context) {
-        ctx.status(200).json(service.deleteUser(ctx.pathParamAsClass<kotlin.String>("username").get()))
+        ctx.status(200).json(service.deleteUser(ctx.pathParamAsClass<kotlin.String>("username").get(), ctx))
     }
 
     /**
@@ -50,7 +50,7 @@ class UserApi(private val service: UserApiService) {
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
     fun getUserByName(ctx: Context) {
-        ctx.status(200).json(service.getUserByName(ctx.pathParamAsClass<kotlin.String>("username").get()))
+        ctx.status(200).json(service.getUserByName(ctx.pathParamAsClass<kotlin.String>("username").get(), ctx))
     }
 
     /**
@@ -60,7 +60,7 @@ class UserApi(private val service: UserApiService) {
      * @param password The password for login in clear text 
      */
     fun loginUser(ctx: Context) {
-        ctx.status(200).json(service.loginUser(ctx.queryParamAsClass<String>("username").get(), ctx.queryParamAsClass<String>("password").get()))
+        ctx.status(200).json(service.loginUser(ctx.queryParamAsClass<String>("username").get(), ctx.queryParamAsClass<String>("password").get(), ctx))
     }
 
     /**
@@ -68,7 +68,7 @@ class UserApi(private val service: UserApiService) {
      * 
      */
     fun logoutUser(ctx: Context) {
-        ctx.status(200).json(service.logoutUser())
+        ctx.status(200).json(service.logoutUser(ctx))
     }
 
     /**
@@ -78,7 +78,7 @@ class UserApi(private val service: UserApiService) {
      * @param user Updated user object 
      */
     fun updateUser(ctx: Context) {
-        ctx.status(200).json(service.updateUser(ctx.pathParamAsClass<kotlin.String>("username").get(), ctx.bodyAsClass<User>()))
+        ctx.status(200).json(service.updateUser(ctx.pathParamAsClass<kotlin.String>("username").get(), ctx.bodyAsClass<User>(), ctx))
     }
 
 }

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/UserApiService.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/UserApiService.kt
@@ -1,6 +1,7 @@
 package org.openapitools.server.apis
 
 import org.openapitools.server.models.User
+import io.javalin.http.Context
 
 interface UserApiService {
 
@@ -9,53 +10,58 @@ interface UserApiService {
      * This can only be done by the logged in user.
      *
      * @param user Created user object (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      * @see UserApi#createUser
      */
-    fun createUser(user: User): Unit
+    fun createUser(user: User, ctx: Context): Unit
 
     /**
      * POST /user/createWithArray : Creates list of users with given input array
      * 
      *
      * @param user List of user object (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      * @see UserApi#createUsersWithArrayInput
      */
-    fun createUsersWithArrayInput(user: kotlin.collections.List<User>): Unit
+    fun createUsersWithArrayInput(user: kotlin.collections.List<User>, ctx: Context): Unit
 
     /**
      * POST /user/createWithList : Creates list of users with given input array
      * 
      *
      * @param user List of user object (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      * @see UserApi#createUsersWithListInput
      */
-    fun createUsersWithListInput(user: kotlin.collections.List<User>): Unit
+    fun createUsersWithListInput(user: kotlin.collections.List<User>, ctx: Context): Unit
 
     /**
      * DELETE /user/{username} : Delete user
      * This can only be done by the logged in user.
      *
      * @param username The name that needs to be deleted (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return Invalid username supplied (status code 400)
      *         or User not found (status code 404)
      * @see UserApi#deleteUser
      */
-    fun deleteUser(username: kotlin.String): Unit
+    fun deleteUser(username: kotlin.String, ctx: Context): Unit
 
     /**
      * GET /user/{username} : Get user by user name
      * 
      *
      * @param username The name that needs to be fetched. Use user1 for testing. (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      *         or Invalid username supplied (status code 400)
      *         or User not found (status code 404)
      * @see UserApi#getUserByName
      */
-    fun getUserByName(username: kotlin.String): User
+    fun getUserByName(username: kotlin.String, ctx: Context): User
 
     /**
      * GET /user/login : Logs user into the system
@@ -63,20 +69,22 @@ interface UserApiService {
      *
      * @param username The user name for login (required)
      * @param password The password for login in clear text (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      *         or Invalid username/password supplied (status code 400)
      * @see UserApi#loginUser
      */
-    fun loginUser(username: kotlin.String, password: kotlin.String): kotlin.String
+    fun loginUser(username: kotlin.String, password: kotlin.String, ctx: Context): kotlin.String
 
     /**
      * GET /user/logout : Logs out current logged in user session
      * 
      *
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return successful operation (status code 200)
      * @see UserApi#logoutUser
      */
-    fun logoutUser(): Unit
+    fun logoutUser(ctx: Context): Unit
 
     /**
      * PUT /user/{username} : Updated user
@@ -84,9 +92,10 @@ interface UserApiService {
      *
      * @param username name that need to be deleted (required)
      * @param user Updated user object (required)
+     * @param ctx The Javalin context. Especially handy if you need to access things like authentication headers in your service. (required)
      * @return Invalid user supplied (status code 400)
      *         or User not found (status code 404)
      * @see UserApi#updateUser
      */
-    fun updateUser(username: kotlin.String, user: User): Unit
+    fun updateUser(username: kotlin.String, user: User, ctx: Context): Unit
 }

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/UserApiServiceImpl.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/apis/UserApiServiceImpl.kt
@@ -1,38 +1,39 @@
 package org.openapitools.server.apis
 
 import org.openapitools.server.models.User
+import io.javalin.http.Context
 
 class UserApiServiceImpl : UserApiService {
 
-    override fun createUser(user: User): Unit {
+    override fun createUser(user: User, ctx: Context): Unit {
         TODO("Implement me")
     }
 
-    override fun createUsersWithArrayInput(user: kotlin.collections.List<User>): Unit {
+    override fun createUsersWithArrayInput(user: kotlin.collections.List<User>, ctx: Context): Unit {
         TODO("Implement me")
     }
 
-    override fun createUsersWithListInput(user: kotlin.collections.List<User>): Unit {
+    override fun createUsersWithListInput(user: kotlin.collections.List<User>, ctx: Context): Unit {
         TODO("Implement me")
     }
 
-    override fun deleteUser(username: kotlin.String): Unit {
+    override fun deleteUser(username: kotlin.String, ctx: Context): Unit {
         TODO("Implement me")
     }
 
-    override fun getUserByName(username: kotlin.String): User {
+    override fun getUserByName(username: kotlin.String, ctx: Context): User {
         TODO("Implement me")
     }
 
-    override fun loginUser(username: kotlin.String, password: kotlin.String): kotlin.String {
+    override fun loginUser(username: kotlin.String, password: kotlin.String, ctx: Context): kotlin.String {
         TODO("Implement me")
     }
 
-    override fun logoutUser(): Unit {
+    override fun logoutUser(ctx: Context): Unit {
         TODO("Implement me")
     }
 
-    override fun updateUser(username: kotlin.String, user: User): Unit {
+    override fun updateUser(username: kotlin.String, user: User, ctx: Context): Unit {
         TODO("Implement me")
     }
 }


### PR DESCRIPTION
Sometimes, services need to access certain contexts that aren't explicitly passed as service parameters, like authentication. Since there is not one way to handle auth in Javalin, let's pass the Javalin Context to the service for flexibility. This also allows services to return custom status codes if they want.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Tagging the Kotlin technical committee: @jimschubert (2017/09) [❤️](https://www.patreon.com/jimschubert), @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
