### PR TITLE
Draft: probe content type of files using different strategy (i.e. inspect first bytes)

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -1643,21 +1643,25 @@ public class ApiClient {
      * @return The guessed Content-Type
      */
     public String guessContentTypeFromFile(File file) {
-        String contentType = URLConnection.guessContentTypeFromName(file.getName());
-        if (contentType == null) {
+        try {
+            String contentType = Files.probeContentType(file.toPath());
+            if (contentType == null) {
+               return "application/octet-stream";
+            } else {
+                return contentType;
+            }
+        } catch(IOException error) {
             return "application/octet-stream";
-        } else {
-            return contentType;
         }
     }
 
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
-     * @param mpBuilder MultipartBody.Builder 
+     * @param mpBuilder MultipartBody.Builder
      * @param key The key of the Header element
      * @param file The file to add to the Header
-     */ 
+     */
     private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
@@ -1383,21 +1383,25 @@ public class ApiClient {
      * @return The guessed Content-Type
      */
     public String guessContentTypeFromFile(File file) {
-        String contentType = URLConnection.guessContentTypeFromName(file.getName());
-        if (contentType == null) {
+        try {
+            String contentType = Files.probeContentType(file.toPath());
+            if (contentType == null) {
+               return "application/octet-stream";
+            } else {
+                return contentType;
+            }
+        } catch(IOException error) {
             return "application/octet-stream";
-        } else {
-            return contentType;
         }
     }
 
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
-     * @param mpBuilder MultipartBody.Builder 
+     * @param mpBuilder MultipartBody.Builder
      * @param key The key of the Header element
      * @param file The file to add to the Header
-     */ 
+     */
     private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiClient.java
@@ -1406,21 +1406,25 @@ public class ApiClient {
      * @return The guessed Content-Type
      */
     public String guessContentTypeFromFile(File file) {
-        String contentType = URLConnection.guessContentTypeFromName(file.getName());
-        if (contentType == null) {
+        try {
+            String contentType = Files.probeContentType(file.toPath());
+            if (contentType == null) {
+               return "application/octet-stream";
+            } else {
+                return contentType;
+            }
+        } catch(IOException error) {
             return "application/octet-stream";
-        } else {
-            return contentType;
         }
     }
 
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
-     * @param mpBuilder MultipartBody.Builder 
+     * @param mpBuilder MultipartBody.Builder
      * @param key The key of the Header element
      * @param file The file to add to the Header
-     */ 
+     */
     private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/ApiClient.java
@@ -1491,21 +1491,25 @@ public class ApiClient {
      * @return The guessed Content-Type
      */
     public String guessContentTypeFromFile(File file) {
-        String contentType = URLConnection.guessContentTypeFromName(file.getName());
-        if (contentType == null) {
+        try {
+            String contentType = Files.probeContentType(file.toPath());
+            if (contentType == null) {
+               return "application/octet-stream";
+            } else {
+                return contentType;
+            }
+        } catch(IOException error) {
             return "application/octet-stream";
-        } else {
-            return contentType;
         }
     }
 
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
-     * @param mpBuilder MultipartBody.Builder 
+     * @param mpBuilder MultipartBody.Builder
      * @param key The key of the Header element
      * @param file The file to add to the Header
-     */ 
+     */
     private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiClient.java
@@ -1484,21 +1484,25 @@ public class ApiClient {
      * @return The guessed Content-Type
      */
     public String guessContentTypeFromFile(File file) {
-        String contentType = URLConnection.guessContentTypeFromName(file.getName());
-        if (contentType == null) {
+        try {
+            String contentType = Files.probeContentType(file.toPath());
+            if (contentType == null) {
+               return "application/octet-stream";
+            } else {
+                return contentType;
+            }
+        } catch(IOException error) {
             return "application/octet-stream";
-        } else {
-            return contentType;
         }
     }
 
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
-     * @param mpBuilder MultipartBody.Builder 
+     * @param mpBuilder MultipartBody.Builder
      * @param key The key of the Header element
      * @param file The file to add to the Header
-     */ 
+     */
     private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/ApiClient.java
@@ -1479,21 +1479,25 @@ public class ApiClient {
      * @return The guessed Content-Type
      */
     public String guessContentTypeFromFile(File file) {
-        String contentType = URLConnection.guessContentTypeFromName(file.getName());
-        if (contentType == null) {
+        try {
+            String contentType = Files.probeContentType(file.toPath());
+            if (contentType == null) {
+               return "application/octet-stream";
+            } else {
+                return contentType;
+            }
+        } catch(IOException error) {
             return "application/octet-stream";
-        } else {
-            return contentType;
         }
     }
 
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
-     * @param mpBuilder MultipartBody.Builder 
+     * @param mpBuilder MultipartBody.Builder
      * @param key The key of the Header element
      * @param file The file to add to the Header
-     */ 
+     */
     private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/ApiClient.java
@@ -1482,21 +1482,25 @@ public class ApiClient {
      * @return The guessed Content-Type
      */
     public String guessContentTypeFromFile(File file) {
-        String contentType = URLConnection.guessContentTypeFromName(file.getName());
-        if (contentType == null) {
+        try {
+            String contentType = Files.probeContentType(file.toPath());
+            if (contentType == null) {
+               return "application/octet-stream";
+            } else {
+                return contentType;
+            }
+        } catch(IOException error) {
             return "application/octet-stream";
-        } else {
-            return contentType;
         }
     }
 
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
-     * @param mpBuilder MultipartBody.Builder 
+     * @param mpBuilder MultipartBody.Builder
      * @param key The key of the Header element
      * @param file The file to add to the Header
-     */ 
+     */
     private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
@@ -1485,21 +1485,25 @@ public class ApiClient {
      * @return The guessed Content-Type
      */
     public String guessContentTypeFromFile(File file) {
-        String contentType = URLConnection.guessContentTypeFromName(file.getName());
-        if (contentType == null) {
+        try {
+            String contentType = Files.probeContentType(file.toPath());
+            if (contentType == null) {
+               return "application/octet-stream";
+            } else {
+                return contentType;
+            }
+        } catch(IOException error) {
             return "application/octet-stream";
-        } else {
-            return contentType;
         }
     }
 
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
-     * @param mpBuilder MultipartBody.Builder 
+     * @param mpBuilder MultipartBody.Builder
      * @param key The key of the Header element
      * @param file The file to add to the Header
-     */ 
+     */
     private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -1479,21 +1479,25 @@ public class ApiClient {
      * @return The guessed Content-Type
      */
     public String guessContentTypeFromFile(File file) {
-        String contentType = URLConnection.guessContentTypeFromName(file.getName());
-        if (contentType == null) {
+        try {
+            String contentType = Files.probeContentType(file.toPath());
+            if (contentType == null) {
+               return "application/octet-stream";
+            } else {
+                return contentType;
+            }
+        } catch(IOException error) {
             return "application/octet-stream";
-        } else {
-            return contentType;
         }
     }
 
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
-     * @param mpBuilder MultipartBody.Builder 
+     * @param mpBuilder MultipartBody.Builder
      * @param key The key of the Header element
      * @param file The file to add to the Header
-     */ 
+     */
     private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -1479,21 +1479,25 @@ public class ApiClient {
      * @return The guessed Content-Type
      */
     public String guessContentTypeFromFile(File file) {
-        String contentType = URLConnection.guessContentTypeFromName(file.getName());
-        if (contentType == null) {
+        try {
+            String contentType = Files.probeContentType(file.toPath());
+            if (contentType == null) {
+               return "application/octet-stream";
+            } else {
+                return contentType;
+            }
+        } catch(IOException error) {
             return "application/octet-stream";
-        } else {
-            return contentType;
         }
     }
 
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
-     * @param mpBuilder MultipartBody.Builder 
+     * @param mpBuilder MultipartBody.Builder
      * @param key The key of the Header element
      * @param file The file to add to the Header
-     */ 
+     */
     private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
@@ -1544,21 +1544,25 @@ public class ApiClient {
      * @return The guessed Content-Type
      */
     public String guessContentTypeFromFile(File file) {
-        String contentType = URLConnection.guessContentTypeFromName(file.getName());
-        if (contentType == null) {
+        try {
+            String contentType = Files.probeContentType(file.toPath());
+            if (contentType == null) {
+               return "application/octet-stream";
+            } else {
+                return contentType;
+            }
+        } catch(IOException error) {
             return "application/octet-stream";
-        } else {
-            return contentType;
         }
     }
 
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
-     * @param mpBuilder MultipartBody.Builder 
+     * @param mpBuilder MultipartBody.Builder
      * @param key The key of the Header element
      * @param file The file to add to the Header
-     */ 
+     */
     private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/ApiClientTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/ApiClientTest.java
@@ -3,6 +3,9 @@ package org.openapitools.client;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
+import java.io.IOException;
+import java.io.File;
+import java.nio.file.Files;
 
 import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.*;
@@ -79,6 +82,30 @@ public class ApiClientTest {
 
         contentTypes = new String[]{};
         assertNull(apiClient.selectHeaderContentType(contentTypes));
+    }
+
+    @Test
+    public void testguessContentTypeFromFile() throws IOException {
+        byte[] b = {
+            //ccurve.png
+            -119, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82,
+            0, 0, 0, 15, 0, 0, 0, 15, 8, 6, 0, 0, 0, 59, -42, -107,
+            74, 0, 0, 0, 64, 73, 68, 65, 84, 120, -38, 99, 96, -64, 14, -2,
+            99, -63, 68, 1, 100, -59, -1, -79, -120, 17, -44, -8, 31, -121, 28, 81,
+            26, -1, -29, 113, 13, 78, -51, 100, -125, -1, -108, 24, 64, 86, -24, -30,
+            11, 101, -6, -37, 76, -106, -97, 25, 104, 17, 96, -76, 77, 97, 20, -89,
+            109, -110, 114, 21, 0, -82, -127, 56, -56, 56, 76, -17, -42, 0, 0, 0,
+            0, 73, 69, 78, 68, -82, 66, 96, -126
+        };
+
+        File jpegFile = File.createTempFile("image", ".png");
+        jpegFile.deleteOnExit();
+        Files.write(jpegFile.toPath(), b);
+        assertEquals("image/png", apiClient.guessContentTypeFromFile(jpegFile));
+        // File otherFile = File.createTempFile("image", ".txt");
+        // otherFile.deleteOnExit();
+        // Files.write(otherFile.toPath(), b);
+        // assertEquals("image/png", apiClient.guessContentTypeFromFile(otherFile));
     }
 
     @Test


### PR DESCRIPTION
current implementations are relying on file name/extension, which is prone to errors (.mp4, is it a video or a picture?) and spoofing. This change allows customers to use or opt into mechanisms which inspect the first bytes of a file's payload.

I'd like to do the same change for other http clients we use, but I'd like to feedback to validate the viability of this approach first.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
