### PR TITLE
[Dart] Make dependency on http, collection and meta packages less strict

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
@@ -15,10 +15,10 @@ publish_to: {{.}}
 environment:
   sdk: '>=2.12.0 <4.0.0'
 dependencies:
-  collection: '^1.17.0'
-  http: '>=0.13.0 <0.14.0'
+  collection: '>=1.17.0 <2.0.0'
+  http: '>=0.13.0 <2.0.0'
   intl: any
-  meta: '^1.1.8'
+  meta: '>=1.1.8 <2.0.0'
 dev_dependencies:
   test: '>=1.21.6 <1.22.0'
 {{#json_serializable}}

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
@@ -9,9 +9,9 @@ homepage: 'homepage'
 environment:
   sdk: '>=2.12.0 <4.0.0'
 dependencies:
-  collection: '^1.17.0'
-  http: '>=0.13.0 <0.14.0'
+  collection: '>=1.17.0 <2.0.0'
+  http: '>=0.13.0 <2.0.0'
   intl: any
-  meta: '^1.1.8'
+  meta: '>=1.1.8 <2.0.0'
 dev_dependencies:
   test: '>=1.21.6 <1.22.0'

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
@@ -9,9 +9,9 @@ homepage: 'homepage'
 environment:
   sdk: '>=2.12.0 <4.0.0'
 dependencies:
-  collection: '^1.17.0'
-  http: '>=0.13.0 <0.14.0'
+  collection: '>=1.17.0 <2.0.0'
+  http: '>=0.13.0 <2.0.0'
   intl: any
-  meta: '^1.1.8'
+  meta: '>=1.1.8 <2.0.0'
 dev_dependencies:
   test: '>=1.21.6 <1.22.0'


### PR DESCRIPTION
The hard reuirements of 
- `http: '>=0.13.0 <0.14.0'`
- `collection: '^1.17.0'`
- `meta: '^1.1.8'`
 
limit current and future update behavior.

Previous discussions with @aviadkam have been done in https://github.com/OpenAPITools/openapi-generator/pull/17862

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)
