### PR TITLE
[Kotlin] update ApiClient to register all adapters for GsonBuilder

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -163,6 +163,7 @@ import {{packageName}}.infrastructure.ITransformForStorage
 {{/vars}}
 {{/hasEnums}}
 {{#generateOneOfAnyOfWrappers}}
+    {{#gson}}
 
     class CustomTypeAdapterFactory : TypeAdapterFactory {
         override fun <T> create(gson: Gson, type: TypeToken<T>): TypeAdapter<T>? {
@@ -249,24 +250,22 @@ import {{packageName}}.infrastructure.ITransformForStorage
               throw IllegalArgumentException(String.format("Expected the field `{{{baseName}}}` to be an array in the JSON string but got `%s`", jsonObj["{{{baseName}}}"].toString()))
             }
       
-            val jsonArray{{name}} = jsonObj.getAsJsonArray("{{{baseName}}}")
             // validate the required field `{{{baseName}}}` (array)
-            for (i in 0 until jsonArray{{name}}.size()) {
-              {{{items.dataType}}}.validateJsonElement(jsonArray{{name}}.get(i))
+            for (i in 0 until jsonObj.getAsJsonArray("{{{baseName}}}").size()) {
+              {{{items.dataType}}}.validateJsonElement(jsonObj.getAsJsonArray("{{{baseName}}}").get(i))
             }
             {{/required}}
             {{^required}}
             if (jsonObj["{{{baseName}}}"] != null && !jsonObj["{{{baseName}}}"].isJsonNull) {
-              val jsonArray{{name}} = jsonObj.getAsJsonArray("{{{baseName}}}")
-              if (jsonArray{{name}} != null) {
+              if (jsonObj.getAsJsonArray("{{{baseName}}}") != null) {
                 // ensure the json data is an array
                 require(jsonObj["{{{baseName}}}"].isJsonArray) {
                   String.format("Expected the field `{{{baseName}}}` to be an array in the JSON string but got `%s`", jsonObj["{{{baseName}}}"].toString())
                 }
       
                 // validate the optional field `{{{baseName}}}` (array)
-                for (i in 0 until jsonArray{{name}}.size()) {
-                  {{{items.dataType}}}.validateJsonElement(jsonArray{{name}}[i])
+                for (i in 0 until jsonObj.getAsJsonArray("{{{baseName}}}").size()) {
+                  {{{items.dataType}}}.validateJsonElement(jsonObj.getAsJsonArray("{{{baseName}}}").get(i))
                 }
               }
             }
@@ -356,6 +355,7 @@ import {{packageName}}.infrastructure.ITransformForStorage
             {{/discriminator}}
         }
     }
+    {{/gson}}
 {{/generateOneOfAnyOfWrappers}}
 
 {{#vendorExtensions.x-has-data-class-body}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
@@ -64,9 +64,9 @@ import okhttp3.MediaType.Companion.toMediaType
     private var baseUrl: String = defaultBasePath,
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     {{^kotlinx_serialization}}
-    private val serializerBuilder: {{#gson}}GsonBuilder{{/gson}}{{#moshi}}Moshi.Builder{{/moshi}}{{#jackson}}ObjectMapper{{/jackson}} = Serializer.{{#gson}}gsonBuilder{{/gson}}{{#moshi}}moshiBuilder{{/moshi}}{{#jackson}}jacksonObjectMapper{{/jackson}},
+    private val serializerBuilder: {{#gson}}GsonBuilder{{/gson}}{{#moshi}}Moshi.Builder{{/moshi}}{{#jackson}}ObjectMapper{{/jackson}} = {{#generateOneOfAnyOfWrappers}}registerTypeAdapterFactoryForAllModels({{/generateOneOfAnyOfWrappers}}Serializer.{{#gson}}gsonBuilder{{/gson}}{{#generateOneOfAnyOfWrappers}}){{/generateOneOfAnyOfWrappers}}{{#moshi}}moshiBuilder{{/moshi}}{{#jackson}}jacksonObjectMapper{{/jackson}},
     {{/kotlinx_serialization}}
-    private val callFactory : Call.Factory? = null,
+    private val callFactory: Call.Factory? = null,
     private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
         {{#useRxJava}}
         RxJavaCallAdapterFactory.create(),
@@ -148,7 +148,7 @@ import okhttp3.MediaType.Companion.toMediaType
                 addAuthorization(authName, auth)
             }
         }
-	{{#generateOneOfAnyOfWrappers}}
+        {{#generateOneOfAnyOfWrappers}}
         {{^kotlinx_serialization}}
         {{#gson}}
         {{#models}}
@@ -162,7 +162,7 @@ import okhttp3.MediaType.Companion.toMediaType
         {{/models}}
         {{/gson}}
         {{/kotlinx_serialization}}
-	{{/generateOneOfAnyOfWrappers}}
+        {{/generateOneOfAnyOfWrappers}}
     }
 
     {{#authMethods}}
@@ -177,21 +177,6 @@ import okhttp3.MediaType.Companion.toMediaType
         password: String
     ) : this(baseUrl, okHttpClientBuilder, {{^kotlinx_serialization}}serializerBuilder, {{/kotlinx_serialization}}arrayOf(authName)) {
         setCredentials(username, password)
-	{{#generateOneOfAnyOfWrappers}}
-        {{^kotlinx_serialization}}
-        {{#gson}}
-        {{#models}}
-        {{#model}}
-        {{^isEnum}}
-        {{^hasChildren}}
-        serializerBuilder.registerTypeAdapterFactory({{modelPackage}}.{{{classname}}}.CustomTypeAdapterFactory())
-        {{/hasChildren}}
-        {{/isEnum}}
-        {{/model}}
-        {{/models}}
-        {{/gson}}
-        {{/kotlinx_serialization}}
-	{{/generateOneOfAnyOfWrappers}}
     }
 
     {{/isBasicBasic}}
@@ -204,21 +189,6 @@ import okhttp3.MediaType.Companion.toMediaType
         bearerToken: String
     ) : this(baseUrl, okHttpClientBuilder, {{^kotlinx_serialization}}serializerBuilder, {{/kotlinx_serialization}}arrayOf(authName)) {
         setBearerToken(bearerToken)
-	{{#generateOneOfAnyOfWrappers}}
-        {{^kotlinx_serialization}}
-        {{#gson}}
-        {{#models}}
-        {{#model}}
-        {{^isEnum}}
-        {{^hasChildren}}
-        serializerBuilder.registerTypeAdapterFactory({{modelPackage}}.{{{classname}}}.CustomTypeAdapterFactory())
-        {{/hasChildren}}
-        {{/isEnum}}
-        {{/model}}
-        {{/models}}
-        {{/gson}}
-        {{/kotlinx_serialization}}
-	{{/generateOneOfAnyOfWrappers}}
     }
 
     {{/isBasicBearer}}
@@ -240,21 +210,6 @@ import okhttp3.MediaType.Companion.toMediaType
             ?.setClientSecret(secret)
             ?.setUsername(username)
             ?.setPassword(password)
-	{{#generateOneOfAnyOfWrappers}}
-        {{^kotlinx_serialization}}
-        {{#gson}}
-        {{#models}}
-        {{#model}}
-        {{^isEnum}}
-        {{^hasChildren}}
-        serializerBuilder.registerTypeAdapterFactory({{modelPackage}}.{{{classname}}}.CustomTypeAdapterFactory())
-        {{/hasChildren}}
-        {{/isEnum}}
-        {{/model}}
-        {{/models}}
-        {{/gson}}
-        {{/kotlinx_serialization}}
-	{{/generateOneOfAnyOfWrappers}}
     }
 
     {{/hasOAuthMethods}}
@@ -298,9 +253,9 @@ import okhttp3.MediaType.Companion.toMediaType
     {{/hasAuthMethods}}
     {{#hasOAuthMethods}}
     /**
-    * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Token request builder
-    */
+     * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Token request builder
+     */
     fun getTokenEndPoint(): TokenRequestBuilder? {
         var result: TokenRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -310,9 +265,9 @@ import okhttp3.MediaType.Companion.toMediaType
     }
 
     /**
-    * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Authentication request builder
-    */
+     * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Authentication request builder
+     */
     fun getAuthorizationEndPoint(): AuthenticationRequestBuilder? {
         var result: AuthenticationRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -322,10 +277,10 @@ import okhttp3.MediaType.Companion.toMediaType
     }
 
     /**
-    * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
-    * @param accessToken Access token
-    * @return ApiClient
-    */
+     * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
+     * @param accessToken Access token
+     * @return ApiClient
+     */
     fun setAccessToken(accessToken: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             setAccessToken(accessToken)
@@ -334,12 +289,12 @@ import okhttp3.MediaType.Companion.toMediaType
     }
 
     /**
-    * Helper method to configure the oauth accessCode/implicit flow parameters
-    * @param clientId Client ID
-    * @param clientSecret Client secret
-    * @param redirectURI Redirect URI
-    * @return ApiClient
-    */
+     * Helper method to configure the oauth accessCode/implicit flow parameters
+     * @param clientId Client ID
+     * @param clientSecret Client secret
+     * @param redirectURI Redirect URI
+     * @return ApiClient
+     */
     fun configureAuthorizationFlow(clientId: String, clientSecret: String, redirectURI: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             tokenRequestBuilder
@@ -354,10 +309,10 @@ import okhttp3.MediaType.Companion.toMediaType
     }
 
     /**
-    * Configures a listener which is notified when a new access token is received.
-    * @param accessTokenListener Access token listener
-    * @return ApiClient
-    */
+     * Configures a listener which is notified when a new access token is received.
+     * @param accessTokenListener Access token listener
+     * @return ApiClient
+     */
     fun registerAccessTokenListener(accessTokenListener: AccessTokenListener): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             registerAccessTokenListener(accessTokenListener)
@@ -391,6 +346,20 @@ import okhttp3.MediaType.Companion.toMediaType
         return retrofitBuilder.callFactory(usedCallFactory).build().create(serviceClass)
     }
 
+    {{#generateOneOfAnyOfWrappers}}
+    {{^kotlinx_serialization}}
+    {{#gson}}
+    /**
+     * Gets the serializer builder.
+     * @return serial builder
+     */
+    fun getSerializerBuilder(): GsonBuilder {
+        return serializerBuilder
+    }
+
+    {{/gson}}
+    {{/kotlinx_serialization}}
+    {{/generateOneOfAnyOfWrappers}}
     private fun normalizeBaseUrl() {
         if (!baseUrl.endsWith("/")) {
             baseUrl += "/"
@@ -399,7 +368,7 @@ import okhttp3.MediaType.Companion.toMediaType
 
     private inline fun <T, reified U> Iterable<T>.runOnFirst(callback: U.() -> Unit) {
         for (element in this) {
-            if (element is U)  {
+            if (element is U) {
                 callback.invoke(element)
                 break
             }
@@ -416,3 +385,28 @@ import okhttp3.MediaType.Companion.toMediaType
         }
     }
 }
+{{#generateOneOfAnyOfWrappers}}
+{{^kotlinx_serialization}}
+{{#gson}}
+
+/**
+ * Registers all models with the type adapter factory.
+ *
+ * @param gsonBuilder gson builder
+ * @return GSON builder
+ */
+fun registerTypeAdapterFactoryForAllModels(gsonBuilder: GsonBuilder): GsonBuilder {
+    {{#models}}
+    {{#model}}
+    {{^isEnum}}
+    {{^hasChildren}}
+    gsonBuilder.registerTypeAdapterFactory({{modelPackage}}.{{{classname}}}.CustomTypeAdapterFactory())
+    {{/hasChildren}}
+    {{/isEnum}}
+    {{/model}}
+    {{/models}}
+    return gsonBuilder
+}
+{{/gson}}
+{{/kotlinx_serialization}}
+{{/generateOneOfAnyOfWrappers}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
@@ -64,7 +64,7 @@ import okhttp3.MediaType.Companion.toMediaType
     private var baseUrl: String = defaultBasePath,
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     {{^kotlinx_serialization}}
-    private val serializerBuilder: {{#gson}}GsonBuilder{{/gson}}{{#moshi}}Moshi.Builder{{/moshi}}{{#jackson}}ObjectMapper{{/jackson}} = {{#generateOneOfAnyOfWrappers}}registerTypeAdapterFactoryForAllModels({{/generateOneOfAnyOfWrappers}}Serializer.{{#gson}}gsonBuilder{{/gson}}{{#generateOneOfAnyOfWrappers}}){{/generateOneOfAnyOfWrappers}}{{#moshi}}moshiBuilder{{/moshi}}{{#jackson}}jacksonObjectMapper{{/jackson}},
+    private val serializerBuilder: {{#gson}}GsonBuilder{{/gson}}{{#moshi}}Moshi.Builder{{/moshi}}{{#jackson}}ObjectMapper{{/jackson}} = {{#generateOneOfAnyOfWrappers}}{{#gson}}registerTypeAdapterFactoryForAllModels({{/gson}}{{/generateOneOfAnyOfWrappers}}Serializer.{{#gson}}gsonBuilder{{/gson}}{{#generateOneOfAnyOfWrappers}}{{#gson}}){{/gson}}{{/generateOneOfAnyOfWrappers}}{{#moshi}}moshiBuilder{{/moshi}}{{#jackson}}jacksonObjectMapper{{/jackson}},
     {{/kotlinx_serialization}}
     private val callFactory: Call.Factory? = null,
     private val callAdapterFactories: List<CallAdapter.Factory> = listOf(

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -20,7 +20,7 @@ class ApiClient(
     private var baseUrl: String = defaultBasePath,
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val serializerBuilder: GsonBuilder = Serializer.gsonBuilder,
-    private val callFactory : Call.Factory? = null,
+    private val callFactory: Call.Factory? = null,
     private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
     ),
     private val converterFactories: List<Converter.Factory> = listOf(
@@ -150,7 +150,7 @@ class ApiClient(
 
     private inline fun <T, reified U> Iterable<T>.runOnFirst(callback: U.() -> Unit) {
         for (element in this) {
-            if (element is U)  {
+            if (element is U) {
                 callback.invoke(element)
                 break
             }

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -17,7 +17,7 @@ class ApiClient(
     private var baseUrl: String = defaultBasePath,
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val serializerBuilder: Moshi.Builder = Serializer.moshiBuilder,
-    private val callFactory : Call.Factory? = null,
+    private val callFactory: Call.Factory? = null,
     private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
     ),
     private val converterFactories: List<Converter.Factory> = listOf(
@@ -92,7 +92,7 @@ class ApiClient(
 
     private inline fun <T, reified U> Iterable<T>.runOnFirst(callback: U.() -> Unit) {
         for (element in this) {
-            if (element is U)  {
+            if (element is U) {
                 callback.invoke(element)
                 break
             }

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -23,7 +23,7 @@ class ApiClient(
     private var baseUrl: String = defaultBasePath,
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val serializerBuilder: ObjectMapper = Serializer.jacksonObjectMapper,
-    private val callFactory : Call.Factory? = null,
+    private val callFactory: Call.Factory? = null,
     private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
     ),
     private val converterFactories: List<Converter.Factory> = listOf(
@@ -103,9 +103,9 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Token request builder
-    */
+     * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Token request builder
+     */
     fun getTokenEndPoint(): TokenRequestBuilder? {
         var result: TokenRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -115,9 +115,9 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Authentication request builder
-    */
+     * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Authentication request builder
+     */
     fun getAuthorizationEndPoint(): AuthenticationRequestBuilder? {
         var result: AuthenticationRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -127,10 +127,10 @@ class ApiClient(
     }
 
     /**
-    * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
-    * @param accessToken Access token
-    * @return ApiClient
-    */
+     * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
+     * @param accessToken Access token
+     * @return ApiClient
+     */
     fun setAccessToken(accessToken: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             setAccessToken(accessToken)
@@ -139,12 +139,12 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure the oauth accessCode/implicit flow parameters
-    * @param clientId Client ID
-    * @param clientSecret Client secret
-    * @param redirectURI Redirect URI
-    * @return ApiClient
-    */
+     * Helper method to configure the oauth accessCode/implicit flow parameters
+     * @param clientId Client ID
+     * @param clientSecret Client secret
+     * @param redirectURI Redirect URI
+     * @return ApiClient
+     */
     fun configureAuthorizationFlow(clientId: String, clientSecret: String, redirectURI: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             tokenRequestBuilder
@@ -159,10 +159,10 @@ class ApiClient(
     }
 
     /**
-    * Configures a listener which is notified when a new access token is received.
-    * @param accessTokenListener Access token listener
-    * @return ApiClient
-    */
+     * Configures a listener which is notified when a new access token is received.
+     * @param accessTokenListener Access token listener
+     * @return ApiClient
+     */
     fun registerAccessTokenListener(accessTokenListener: AccessTokenListener): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             registerAccessTokenListener(accessTokenListener)
@@ -203,7 +203,7 @@ class ApiClient(
 
     private inline fun <T, reified U> Iterable<T>.runOnFirst(callback: U.() -> Unit) {
         for (element in this) {
-            if (element is U)  {
+            if (element is U) {
                 callback.invoke(element)
                 break
             }

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -23,8 +23,8 @@ import retrofit2.converter.gson.GsonConverterFactory
 class ApiClient(
     private var baseUrl: String = defaultBasePath,
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
-    private val serializerBuilder: GsonBuilder = Serializer.gsonBuilder,
-    private val callFactory : Call.Factory? = null,
+    private val serializerBuilder: GsonBuilder = registerTypeAdapterFactoryForAllModels(Serializer.gsonBuilder),
+    private val callFactory: Call.Factory? = null,
     private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
     ),
     private val converterFactories: List<Converter.Factory> = listOf(
@@ -112,23 +112,12 @@ class ApiClient(
             ?.setClientSecret(secret)
             ?.setUsername(username)
             ?.setPassword(password)
-        serializerBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiAnnotation.CustomTypeAdapterFactory())
-        serializerBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiAnyOfUserOrPet.CustomTypeAdapterFactory())
-        serializerBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiAnyOfUserOrPetOrArrayString.CustomTypeAdapterFactory())
-        serializerBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiApiResponse.CustomTypeAdapterFactory())
-        serializerBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiCategory.CustomTypeAdapterFactory())
-        serializerBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiOrder.CustomTypeAdapterFactory())
-        serializerBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiPet.CustomTypeAdapterFactory())
-        serializerBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiTag.CustomTypeAdapterFactory())
-        serializerBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiUser.CustomTypeAdapterFactory())
-        serializerBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiUserOrPet.CustomTypeAdapterFactory())
-        serializerBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiUserOrPetOrArrayString.CustomTypeAdapterFactory())
     }
 
     /**
-    * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Token request builder
-    */
+     * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Token request builder
+     */
     fun getTokenEndPoint(): TokenRequestBuilder? {
         var result: TokenRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -138,9 +127,9 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Authentication request builder
-    */
+     * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Authentication request builder
+     */
     fun getAuthorizationEndPoint(): AuthenticationRequestBuilder? {
         var result: AuthenticationRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -150,10 +139,10 @@ class ApiClient(
     }
 
     /**
-    * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
-    * @param accessToken Access token
-    * @return ApiClient
-    */
+     * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
+     * @param accessToken Access token
+     * @return ApiClient
+     */
     fun setAccessToken(accessToken: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             setAccessToken(accessToken)
@@ -162,12 +151,12 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure the oauth accessCode/implicit flow parameters
-    * @param clientId Client ID
-    * @param clientSecret Client secret
-    * @param redirectURI Redirect URI
-    * @return ApiClient
-    */
+     * Helper method to configure the oauth accessCode/implicit flow parameters
+     * @param clientId Client ID
+     * @param clientSecret Client secret
+     * @param redirectURI Redirect URI
+     * @return ApiClient
+     */
     fun configureAuthorizationFlow(clientId: String, clientSecret: String, redirectURI: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             tokenRequestBuilder
@@ -182,10 +171,10 @@ class ApiClient(
     }
 
     /**
-    * Configures a listener which is notified when a new access token is received.
-    * @param accessTokenListener Access token listener
-    * @return ApiClient
-    */
+     * Configures a listener which is notified when a new access token is received.
+     * @param accessTokenListener Access token listener
+     * @return ApiClient
+     */
     fun registerAccessTokenListener(accessTokenListener: AccessTokenListener): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             registerAccessTokenListener(accessTokenListener)
@@ -218,6 +207,14 @@ class ApiClient(
         return retrofitBuilder.callFactory(usedCallFactory).build().create(serviceClass)
     }
 
+    /**
+     * Gets the serializer builder.
+     * @return serial builder
+     */
+    fun getSerializerBuilder(): GsonBuilder {
+        return serializerBuilder
+    }
+
     private fun normalizeBaseUrl() {
         if (!baseUrl.endsWith("/")) {
             baseUrl += "/"
@@ -226,7 +223,7 @@ class ApiClient(
 
     private inline fun <T, reified U> Iterable<T>.runOnFirst(callback: U.() -> Unit) {
         for (element in this) {
-            if (element is U)  {
+            if (element is U) {
                 callback.invoke(element)
                 break
             }
@@ -242,4 +239,25 @@ class ApiClient(
             System.getProperties().getProperty(baseUrlKey, "http://petstore.swagger.io/v2")
         }
     }
+}
+
+/**
+ * Registers all models with the type adapter factory.
+ *
+ * @param gsonBuilder gson builder
+ * @return GSON builder
+ */
+fun registerTypeAdapterFactoryForAllModels(gsonBuilder: GsonBuilder): GsonBuilder {
+    gsonBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiAnnotation.CustomTypeAdapterFactory())
+    gsonBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiAnyOfUserOrPet.CustomTypeAdapterFactory())
+    gsonBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiAnyOfUserOrPetOrArrayString.CustomTypeAdapterFactory())
+    gsonBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiApiResponse.CustomTypeAdapterFactory())
+    gsonBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiCategory.CustomTypeAdapterFactory())
+    gsonBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiOrder.CustomTypeAdapterFactory())
+    gsonBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiPet.CustomTypeAdapterFactory())
+    gsonBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiTag.CustomTypeAdapterFactory())
+    gsonBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiUser.CustomTypeAdapterFactory())
+    gsonBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiUserOrPet.CustomTypeAdapterFactory())
+    gsonBuilder.registerTypeAdapterFactory(org.openapitools.client.models.ApiUserOrPetOrArrayString.CustomTypeAdapterFactory())
+    return gsonBuilder
 }

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiPet.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiPet.kt
@@ -156,16 +156,15 @@ data class ApiPet (
               ApiCategory.validateJsonElement(jsonObj["category"])
             }
             if (jsonObj["tags"] != null && !jsonObj["tags"].isJsonNull) {
-              val jsonArraytags = jsonObj.getAsJsonArray("tags")
-              if (jsonArraytags != null) {
+              if (jsonObj.getAsJsonArray("tags") != null) {
                 // ensure the json data is an array
                 require(jsonObj["tags"].isJsonArray) {
                   String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj["tags"].toString())
                 }
       
                 // validate the optional field `tags` (array)
-                for (i in 0 until jsonArraytags.size()) {
-                  ApiTag.validateJsonElement(jsonArraytags[i])
+                for (i in 0 until jsonObj.getAsJsonArray("tags").size()) {
+                  ApiTag.validateJsonElement(jsonObj.getAsJsonArray("tags").get(i))
                 }
               }
             }

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/test/kotlin/org/openapitools/client/models/UserOrPetTest.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/test/kotlin/org/openapitools/client/models/UserOrPetTest.kt
@@ -27,6 +27,8 @@ import com.google.gson.GsonBuilder
 import io.kotlintest.matchers.types.shouldBeSameInstanceAs
 import io.kotlintest.shouldNotBe
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.registerTypeAdapterFactoryForAllModels
 import java.io.IOException
 import java.lang.RuntimeException
 
@@ -34,13 +36,7 @@ class ApiUserOrPetTest : ShouldSpec() {
     init {
 
         should("test custom type adapter") {
-            val gson = GsonBuilder()
-                    .registerTypeAdapterFactory(ApiUser.CustomTypeAdapterFactory())
-                    .registerTypeAdapterFactory(ApiCategory.CustomTypeAdapterFactory())
-                    .registerTypeAdapterFactory(ApiPet.CustomTypeAdapterFactory())
-                    .registerTypeAdapterFactory(ApiTag.CustomTypeAdapterFactory())
-                    .registerTypeAdapterFactory(ApiUserOrPet.CustomTypeAdapterFactory())
-                    .create()
+            val gson = ApiClient().getSerializerBuilder().create()
 
             // test Category
             val categoryJson = "{\"id\":123,\"name\":\"category\"}"

--- a/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -23,7 +23,7 @@ class ApiClient(
     private var baseUrl: String = defaultBasePath,
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val serializerBuilder: ObjectMapper = Serializer.jacksonObjectMapper,
-    private val callFactory : Call.Factory? = null,
+    private val callFactory: Call.Factory? = null,
     private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
     ),
     private val converterFactories: List<Converter.Factory> = listOf(
@@ -103,9 +103,9 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Token request builder
-    */
+     * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Token request builder
+     */
     fun getTokenEndPoint(): TokenRequestBuilder? {
         var result: TokenRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -115,9 +115,9 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Authentication request builder
-    */
+     * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Authentication request builder
+     */
     fun getAuthorizationEndPoint(): AuthenticationRequestBuilder? {
         var result: AuthenticationRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -127,10 +127,10 @@ class ApiClient(
     }
 
     /**
-    * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
-    * @param accessToken Access token
-    * @return ApiClient
-    */
+     * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
+     * @param accessToken Access token
+     * @return ApiClient
+     */
     fun setAccessToken(accessToken: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             setAccessToken(accessToken)
@@ -139,12 +139,12 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure the oauth accessCode/implicit flow parameters
-    * @param clientId Client ID
-    * @param clientSecret Client secret
-    * @param redirectURI Redirect URI
-    * @return ApiClient
-    */
+     * Helper method to configure the oauth accessCode/implicit flow parameters
+     * @param clientId Client ID
+     * @param clientSecret Client secret
+     * @param redirectURI Redirect URI
+     * @return ApiClient
+     */
     fun configureAuthorizationFlow(clientId: String, clientSecret: String, redirectURI: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             tokenRequestBuilder
@@ -159,10 +159,10 @@ class ApiClient(
     }
 
     /**
-    * Configures a listener which is notified when a new access token is received.
-    * @param accessTokenListener Access token listener
-    * @return ApiClient
-    */
+     * Configures a listener which is notified when a new access token is received.
+     * @param accessTokenListener Access token listener
+     * @return ApiClient
+     */
     fun registerAccessTokenListener(accessTokenListener: AccessTokenListener): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             registerAccessTokenListener(accessTokenListener)
@@ -203,7 +203,7 @@ class ApiClient(
 
     private inline fun <T, reified U> Iterable<T>.runOnFirst(callback: U.() -> Unit) {
         for (element in this) {
-            if (element is U)  {
+            if (element is U) {
                 callback.invoke(element)
                 break
             }

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -23,7 +23,7 @@ import okhttp3.MediaType.Companion.toMediaType
 class ApiClient(
     private var baseUrl: String = defaultBasePath,
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
-    private val callFactory : Call.Factory? = null,
+    private val callFactory: Call.Factory? = null,
     private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
     ),
     private val converterFactories: List<Converter.Factory> = listOf(
@@ -103,9 +103,9 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Token request builder
-    */
+     * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Token request builder
+     */
     fun getTokenEndPoint(): TokenRequestBuilder? {
         var result: TokenRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -115,9 +115,9 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Authentication request builder
-    */
+     * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Authentication request builder
+     */
     fun getAuthorizationEndPoint(): AuthenticationRequestBuilder? {
         var result: AuthenticationRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -127,10 +127,10 @@ class ApiClient(
     }
 
     /**
-    * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
-    * @param accessToken Access token
-    * @return ApiClient
-    */
+     * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
+     * @param accessToken Access token
+     * @return ApiClient
+     */
     fun setAccessToken(accessToken: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             setAccessToken(accessToken)
@@ -139,12 +139,12 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure the oauth accessCode/implicit flow parameters
-    * @param clientId Client ID
-    * @param clientSecret Client secret
-    * @param redirectURI Redirect URI
-    * @return ApiClient
-    */
+     * Helper method to configure the oauth accessCode/implicit flow parameters
+     * @param clientId Client ID
+     * @param clientSecret Client secret
+     * @param redirectURI Redirect URI
+     * @return ApiClient
+     */
     fun configureAuthorizationFlow(clientId: String, clientSecret: String, redirectURI: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             tokenRequestBuilder
@@ -159,10 +159,10 @@ class ApiClient(
     }
 
     /**
-    * Configures a listener which is notified when a new access token is received.
-    * @param accessTokenListener Access token listener
-    * @return ApiClient
-    */
+     * Configures a listener which is notified when a new access token is received.
+     * @param accessTokenListener Access token listener
+     * @return ApiClient
+     */
     fun registerAccessTokenListener(accessTokenListener: AccessTokenListener): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             registerAccessTokenListener(accessTokenListener)
@@ -203,7 +203,7 @@ class ApiClient(
 
     private inline fun <T, reified U> Iterable<T>.runOnFirst(callback: U.() -> Unit) {
         for (element in this) {
-            if (element is U)  {
+            if (element is U) {
                 callback.invoke(element)
                 break
             }

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -24,7 +24,7 @@ class ApiClient(
     private var baseUrl: String = defaultBasePath,
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val serializerBuilder: Moshi.Builder = Serializer.moshiBuilder,
-    private val callFactory : Call.Factory? = null,
+    private val callFactory: Call.Factory? = null,
     private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
         RxJava3CallAdapterFactory.create(),
     ),
@@ -105,9 +105,9 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Token request builder
-    */
+     * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Token request builder
+     */
     fun getTokenEndPoint(): TokenRequestBuilder? {
         var result: TokenRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -117,9 +117,9 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Authentication request builder
-    */
+     * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Authentication request builder
+     */
     fun getAuthorizationEndPoint(): AuthenticationRequestBuilder? {
         var result: AuthenticationRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -129,10 +129,10 @@ class ApiClient(
     }
 
     /**
-    * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
-    * @param accessToken Access token
-    * @return ApiClient
-    */
+     * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
+     * @param accessToken Access token
+     * @return ApiClient
+     */
     fun setAccessToken(accessToken: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             setAccessToken(accessToken)
@@ -141,12 +141,12 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure the oauth accessCode/implicit flow parameters
-    * @param clientId Client ID
-    * @param clientSecret Client secret
-    * @param redirectURI Redirect URI
-    * @return ApiClient
-    */
+     * Helper method to configure the oauth accessCode/implicit flow parameters
+     * @param clientId Client ID
+     * @param clientSecret Client secret
+     * @param redirectURI Redirect URI
+     * @return ApiClient
+     */
     fun configureAuthorizationFlow(clientId: String, clientSecret: String, redirectURI: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             tokenRequestBuilder
@@ -161,10 +161,10 @@ class ApiClient(
     }
 
     /**
-    * Configures a listener which is notified when a new access token is received.
-    * @param accessTokenListener Access token listener
-    * @return ApiClient
-    */
+     * Configures a listener which is notified when a new access token is received.
+     * @param accessTokenListener Access token listener
+     * @return ApiClient
+     */
     fun registerAccessTokenListener(accessTokenListener: AccessTokenListener): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             registerAccessTokenListener(accessTokenListener)
@@ -205,7 +205,7 @@ class ApiClient(
 
     private inline fun <T, reified U> Iterable<T>.runOnFirst(callback: U.() -> Unit) {
         for (element in this) {
-            if (element is U)  {
+            if (element is U) {
                 callback.invoke(element)
                 break
             }

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -23,7 +23,7 @@ class ApiClient(
     private var baseUrl: String = defaultBasePath,
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val serializerBuilder: Moshi.Builder = Serializer.moshiBuilder,
-    private val callFactory : Call.Factory? = null,
+    private val callFactory: Call.Factory? = null,
     private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
     ),
     private val converterFactories: List<Converter.Factory> = listOf(
@@ -103,9 +103,9 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Token request builder
-    */
+     * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Token request builder
+     */
     fun getTokenEndPoint(): TokenRequestBuilder? {
         var result: TokenRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -115,9 +115,9 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
-    * @return Authentication request builder
-    */
+     * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     * @return Authentication request builder
+     */
     fun getAuthorizationEndPoint(): AuthenticationRequestBuilder? {
         var result: AuthenticationRequestBuilder? = null
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
@@ -127,10 +127,10 @@ class ApiClient(
     }
 
     /**
-    * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
-    * @param accessToken Access token
-    * @return ApiClient
-    */
+     * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
+     * @param accessToken Access token
+     * @return ApiClient
+     */
     fun setAccessToken(accessToken: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             setAccessToken(accessToken)
@@ -139,12 +139,12 @@ class ApiClient(
     }
 
     /**
-    * Helper method to configure the oauth accessCode/implicit flow parameters
-    * @param clientId Client ID
-    * @param clientSecret Client secret
-    * @param redirectURI Redirect URI
-    * @return ApiClient
-    */
+     * Helper method to configure the oauth accessCode/implicit flow parameters
+     * @param clientId Client ID
+     * @param clientSecret Client secret
+     * @param redirectURI Redirect URI
+     * @return ApiClient
+     */
     fun configureAuthorizationFlow(clientId: String, clientSecret: String, redirectURI: String): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             tokenRequestBuilder
@@ -159,10 +159,10 @@ class ApiClient(
     }
 
     /**
-    * Configures a listener which is notified when a new access token is received.
-    * @param accessTokenListener Access token listener
-    * @return ApiClient
-    */
+     * Configures a listener which is notified when a new access token is received.
+     * @param accessTokenListener Access token listener
+     * @return ApiClient
+     */
     fun registerAccessTokenListener(accessTokenListener: AccessTokenListener): ApiClient {
         apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
             registerAccessTokenListener(accessTokenListener)
@@ -203,7 +203,7 @@ class ApiClient(
 
     private inline fun <T, reified U> Iterable<T>.runOnFirst(callback: U.() -> Unit) {
         for (element in this) {
-            if (element is U)  {
+            if (element is U) {
                 callback.invoke(element)
                 break
             }


### PR DESCRIPTION
- update ApiClient to register all adapters for GsonBuilder when constructing a new instance of ApiClient
- add tests
- also fix invalid json array variable name (to close https://github.com/OpenAPITools/openapi-generator/issues/18908)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


cc 
@jimschubert (2017/09) ❤️, @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06)
