### PR TITLE
Fix README by adding default entry for new `templateResourcePath` option in AsciiDoc

### DIFF
--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -176,6 +176,7 @@ apply plugin: 'org.openapi.generator'
 
 |templateResourcePath
 |String
+|None
 |Directory with mustache templates via resource path. This option will overwrite any option defined in `templateDir`
 
 |auth


### PR DESCRIPTION
#14909 added a new option `templateResourcePath`. However, the `README` was missing a default value for the AsciiDoc table, which caused all the properties after to be rendered wrongly (see the [`README.adoc`](https://github.com/OpenAPITools/openapi-generator/blob/819083b1ba2dfcd732abd3d9ed2ccd96e2e63992/modules/openapi-generator-gradle-plugin/README.adoc) and check the properties after `templateResourcePath` in the rendered Markdown).

This PR adds the `None` default (to match the existing properties).

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)

