### PR TITLE
Tries to fix #18975 by changing how the deserializer interacts with its parent class

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
@@ -57,7 +57,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
             Object deserialized = null;
             {{#discriminator}}
-            Class<?> cls = JSON.getClassForElement(tree, {{classname}}.class);
+            Class<?> cls = JSON.getClassForElement(tree, new {{classname}}().getClass());
             if (cls != null) {
                 // When the OAS schema includes a discriminator, use the discriminator value to
                 // discriminate the anyOf schemas.

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/anyof_model.mustache
@@ -57,7 +57,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
             Object deserialized = null;
             {{#discriminator}}
-            Class<?> cls = JSON.getClassForElement(tree, {{classname}}.class);
+            Class<?> cls = JSON.getClassForElement(tree, new {{classname}}().getClass());
             if (cls != null) {
                 // When the OAS schema includes a discriminator, use the discriminator value to
                 // discriminate the anyOf schemas.

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/anyof_model.mustache
@@ -54,7 +54,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
             Object deserialized = null;
             {{#discriminator}}
-            Class<?> cls = JSON.getClassForElement(tree, {{classname}}.class);
+            Class<?> cls = JSON.getClassForElement(tree, new {{classname}}().getClass());
             if (cls != null) {
                 // When the OAS schema includes a discriminator, use the discriminator value to
                 // discriminate the anyOf schemas.

--- a/modules/openapi-generator/src/test/resources/bugs/issue_18975.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_18975.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.1
+info:
+  title: sample issue 18975
+  description: sample issue 18975
+  version: "1.0"
+paths:
+  /sample:
+    get:
+      summary: sample
+      operationId: getSample
+      responses:
+        "200":
+          description: Found vehicle.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DifficultType'
+components:
+  schemas:
+    SubA:
+      required:
+        - type
+      type: object
+      properties:
+        type:
+          type: string
+        sim:
+          type: string
+    SubB:
+      required:
+        - type
+      type: object
+      properties:
+        type:
+          type: string
+        system:
+          type: string
+    DifficultType:
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          "typeA": '#/components/schemas/SubA'
+          "typeB": '#/components/schemas/SubB'
+      anyOf:
+        - $ref: '#/components/schemas/SubA'
+        - $ref: '#/components/schemas/SubB'


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Changes how an `StdDeserializer<A>` of a specific type `A` deserializes into an `A`. We noticed the static block filling the `mappings` passed to the `JSON.registerDiscriminator(A.class, "type", mappings)` was only called _after_ the first call to the deserializer, causing the first result to have an `setActualInstance` call of the wrong subtype of `A`. This is because the static block is part of `A`, while the `StdDeserializer<A>` is a static subclass of `A`. Changing the reference to `A.class` into an actual instance of `A` by the `new A().getClass()` causes the static block to be called on time.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)