### PR TITLE
[Python] Add Flag to Allow Ignoring Operation Servers

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -232,7 +232,7 @@ class ApiClient:
             body = self.sanitize_for_serialization(body)
 
         # request url
-        if _host is None:
+        if _host is None or self.configuration.ignore_operation_servers:
             url = self.configuration.host + resource_path
         else:
             # use server/host defined in path or operation instead

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -24,6 +24,9 @@ class Configuration:
     """This class contains various settings of the API client.
 
     :param host: Base url.
+    :param ignore_operation_servers
+      Boolean to ignore operation servers for the API client.
+      Config will use `host` as the base url regardless of the operation servers.
     :param api_key: Dict to store API key(s).
       Each entry in the dict specifies an API key.
       The dict key is the name of the security scheme in the OAS specification.
@@ -148,6 +151,7 @@ conf = {{{packageName}}}.Configuration(
 {{/hasHttpSignatureMethods}}
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ignore_operation_servers=False,
                  ssl_ca_cert=None,
                  retries=None,
                  ) -> None:
@@ -163,6 +167,9 @@ conf = {{{packageName}}}.Configuration(
         self.server_variables = server_variables or {}
         self.server_operation_variables = server_operation_variables or {}
         """Default server variables
+        """
+        self.ignore_operation_servers = ignore_operation_servers
+        """Ignore operation servers
         """
         self.temp_folder_path = None
         """Temp file folder for downloading files

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -228,7 +228,7 @@ class ApiClient:
             body = self.sanitize_for_serialization(body)
 
         # request url
-        if _host is None:
+        if _host is None or self.configuration.ignore_operation_servers:
             url = self.configuration.host + resource_path
         else:
             # use server/host defined in path or operation instead

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
@@ -33,6 +33,9 @@ class Configuration:
     """This class contains various settings of the API client.
 
     :param host: Base url.
+    :param ignore_operation_servers
+      Boolean to ignore operation servers for the API client.
+      Config will use `host` as the base url regardless of the operation servers.
     :param api_key: Dict to store API key(s).
       Each entry in the dict specifies an API key.
       The dict key is the name of the security scheme in the OAS specification.
@@ -84,6 +87,7 @@ conf = openapi_client.Configuration(
                  access_token=None,
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ignore_operation_servers=False,
                  ssl_ca_cert=None,
                  retries=None,
                  ) -> None:
@@ -99,6 +103,9 @@ conf = openapi_client.Configuration(
         self.server_variables = server_variables or {}
         self.server_operation_variables = server_operation_variables or {}
         """Default server variables
+        """
+        self.ignore_operation_servers = ignore_operation_servers
+        """Ignore operation servers
         """
         self.temp_folder_path = None
         """Temp file folder for downloading files

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -228,7 +228,7 @@ class ApiClient:
             body = self.sanitize_for_serialization(body)
 
         # request url
-        if _host is None:
+        if _host is None or self.configuration.ignore_operation_servers:
             url = self.configuration.host + resource_path
         else:
             # use server/host defined in path or operation instead

--- a/samples/client/echo_api/python/openapi_client/configuration.py
+++ b/samples/client/echo_api/python/openapi_client/configuration.py
@@ -33,6 +33,9 @@ class Configuration:
     """This class contains various settings of the API client.
 
     :param host: Base url.
+    :param ignore_operation_servers
+      Boolean to ignore operation servers for the API client.
+      Config will use `host` as the base url regardless of the operation servers.
     :param api_key: Dict to store API key(s).
       Each entry in the dict specifies an API key.
       The dict key is the name of the security scheme in the OAS specification.
@@ -84,6 +87,7 @@ conf = openapi_client.Configuration(
                  access_token=None,
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ignore_operation_servers=False,
                  ssl_ca_cert=None,
                  retries=None,
                  ) -> None:
@@ -99,6 +103,9 @@ conf = openapi_client.Configuration(
         self.server_variables = server_variables or {}
         self.server_operation_variables = server_operation_variables or {}
         """Default server variables
+        """
+        self.ignore_operation_servers = ignore_operation_servers
+        """Ignore operation servers
         """
         self.temp_folder_path = None
         """Temp file folder for downloading files

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -230,7 +230,7 @@ class ApiClient:
             body = self.sanitize_for_serialization(body)
 
         # request url
-        if _host is None:
+        if _host is None or self.configuration.ignore_operation_servers:
             url = self.configuration.host + resource_path
         else:
             # use server/host defined in path or operation instead

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
@@ -31,6 +31,9 @@ class Configuration:
     """This class contains various settings of the API client.
 
     :param host: Base url.
+    :param ignore_operation_servers
+      Boolean to ignore operation servers for the API client.
+      Config will use `host` as the base url regardless of the operation servers.
     :param api_key: Dict to store API key(s).
       Each entry in the dict specifies an API key.
       The dict key is the name of the security scheme in the OAS specification.
@@ -143,6 +146,7 @@ conf = petstore_api.Configuration(
                  signing_info=None,
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ignore_operation_servers=False,
                  ssl_ca_cert=None,
                  retries=None,
                  ) -> None:
@@ -158,6 +162,9 @@ conf = petstore_api.Configuration(
         self.server_variables = server_variables or {}
         self.server_operation_variables = server_operation_variables or {}
         """Default server variables
+        """
+        self.ignore_operation_servers = ignore_operation_servers
+        """Ignore operation servers
         """
         self.temp_folder_path = None
         """Temp file folder for downloading files

--- a/samples/openapi3/client/petstore/python-aiohttp/tests/test_api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/tests/test_api_client.py
@@ -8,6 +8,7 @@ import weakref
 from tests.util import async_test
 import petstore_api
 
+HOST = 'http://localhost/v2'
 
 class TestApiClient(unittest.TestCase):
 
@@ -20,3 +21,31 @@ class TestApiClient(unittest.TestCase):
             rest_pool_ref = client.rest_client.pool_manager
 
         self.assertTrue(rest_pool_ref.closed)
+
+    @async_test
+    async def test_ignore_operation_servers(self):
+        config = petstore_api.Configuration(host=HOST)
+        client = petstore_api.ApiClient(config)
+        user_api_instance = petstore_api.api.user_api.UserApi(client)
+
+        config_ignore = petstore_api.Configuration(host=HOST, ignore_operation_servers=True)
+        client_ignore = petstore_api.ApiClient(config_ignore)
+        user_api_instance_ignore = petstore_api.api.user_api.UserApi(client_ignore)
+
+        params_to_serialize = {
+            'user': petstore_api.User(id=1, username='test'),
+            '_request_auth': None,
+            '_content_type': 'application/json',
+            '_headers': None,
+            '_host_index': 0
+        }
+
+        # operation servers should be used
+        _, url, *_ = user_api_instance._create_user_serialize(**params_to_serialize)
+        self.assertEqual(client.configuration.host, HOST)
+        self.assertEqual(url, 'http://petstore.swagger.io/v2/user')
+
+        # operation servers should be ignored
+        _, url_ignore, *_ = user_api_instance_ignore._create_user_serialize(**params_to_serialize)
+        self.assertEqual(client.configuration.host, HOST)
+        self.assertEqual(url_ignore, HOST + '/user')

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -227,7 +227,7 @@ class ApiClient:
             body = self.sanitize_for_serialization(body)
 
         # request url
-        if _host is None:
+        if _host is None or self.configuration.ignore_operation_servers:
             url = self.configuration.host + resource_path
         else:
             # use server/host defined in path or operation instead

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -32,6 +32,9 @@ class Configuration:
     """This class contains various settings of the API client.
 
     :param host: Base url.
+    :param ignore_operation_servers
+      Boolean to ignore operation servers for the API client.
+      Config will use `host` as the base url regardless of the operation servers.
     :param api_key: Dict to store API key(s).
       Each entry in the dict specifies an API key.
       The dict key is the name of the security scheme in the OAS specification.
@@ -144,6 +147,7 @@ conf = petstore_api.Configuration(
                  signing_info=None,
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ignore_operation_servers=False,
                  ssl_ca_cert=None,
                  retries=None,
                  ) -> None:
@@ -159,6 +163,9 @@ conf = petstore_api.Configuration(
         self.server_variables = server_variables or {}
         self.server_operation_variables = server_operation_variables or {}
         """Default server variables
+        """
+        self.ignore_operation_servers = ignore_operation_servers
+        """Ignore operation servers
         """
         self.temp_folder_path = None
         """Temp file folder for downloading files

--- a/samples/openapi3/client/petstore/python/tests/test_api_client.py
+++ b/samples/openapi3/client/petstore/python/tests/test_api_client.py
@@ -56,6 +56,33 @@ class ApiClientTests(unittest.TestCase):
         self.assertEqual('test_username', client.configuration.username)
         self.assertEqual('test_password', client.configuration.password)
 
+    def test_ignore_operation_servers(self):
+        config = petstore_api.Configuration(host=HOST)
+        client = petstore_api.ApiClient(config)
+        user_api_instance = petstore_api.api.user_api.UserApi(client)
+
+        config_ignore = petstore_api.Configuration(host=HOST, ignore_operation_servers=True)
+        client_ignore = petstore_api.ApiClient(config_ignore)
+        user_api_instance_ignore = petstore_api.api.user_api.UserApi(client_ignore)
+
+        params_to_serialize = {
+            'user': petstore_api.User(id=1, username='test'),
+            '_request_auth': None,
+            '_content_type': 'application/json',
+            '_headers': None,
+            '_host_index': 0
+        }
+
+        # operation servers should be used
+        _, url, *_ = user_api_instance._create_user_serialize(**params_to_serialize)
+        self.assertEqual(client.configuration.host, HOST)
+        self.assertEqual(url, 'http://petstore.swagger.io/v2/user')
+
+        # operation servers should be ignored
+        _, url_ignore, *_ = user_api_instance_ignore._create_user_serialize(**params_to_serialize)
+        self.assertEqual(client.configuration.host, HOST)
+        self.assertEqual(url_ignore, HOST + '/user')
+
     def test_select_header_accept(self):
         accepts = ['APPLICATION/JSON', 'APPLICATION/XML']
         accept = self.api_client.select_header_accept(accepts)

--- a/samples/openapi3/client/petstore/python/tests/test_configuration.py
+++ b/samples/openapi3/client/petstore/python/tests/test_configuration.py
@@ -58,6 +58,18 @@ class TestConfiguration(unittest.TestCase):
         c1 = petstore_api.Configuration(access_token="12345")
         self.assertEqual(c1.access_token, "12345")
 
+    def test_ignore_operation_servers(self):
+        self.config.ignore_operation_servers = True
+        self.assertTrue(self.config.ignore_operation_servers)
+        self.config.ignore_operation_servers = False
+        self.assertFalse(self.config.ignore_operation_servers)
+
+        c1 = petstore_api.Configuration(ignore_operation_servers=True)
+        self.assertTrue(c1.ignore_operation_servers)
+
+        c2 = petstore_api.Configuration()
+        self.assertFalse(c2.ignore_operation_servers)
+
     def test_get_host_settings(self):
         host_settings = self.config.get_host_settings()
 


### PR DESCRIPTION
Similar to #18934.

This change adds a flag to the configuration object to allow for ignoring operation servers. Currently, if operation level server objects are defined, there is no way to ignore these or use a different base path at the SDK level, which many other languages support. The new ignore_operation_servers flag allows the user to ignore any operation servers defined and instead use the currently defined `host`. This will default to the top level base path defined in the OpenAPI file, but can be configured to be any url by setting the `host` for the configuration object.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10) @multani (2023/10)
