### PR TITLE
[java] [resttemplate] Add support for a bearer token supplier to OAuth based RestTemplate clients

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -331,9 +331,18 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
      * @param accessToken Access token
      */
     public void setAccessToken(String accessToken) {
+        setAccessToken(() -> accessToken);
+    }
+
+    /**
+     * Helper method to set the supplier of access tokens for OAuth2 authentication.
+     *
+     * @param tokenSupplier The supplier of bearer tokens
+     */
+    public void setAccessToken(Supplier<String> tokenSupplier) {
         for (Authentication auth : authentications.values()) {
             if (auth instanceof OAuth) {
-                ((OAuth) auth).setAccessToken(accessToken);
+                ((OAuth) auth).setAccessToken(tokenSupplier);
                 return;
             }
         }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/auth/OAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/auth/OAuth.mustache
@@ -1,24 +1,48 @@
 package {{invokerPackage}}.auth;
 
+import java.util.Optional;
+import java.util.function.Supplier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 
+/**
+ * Provides support for RFC 6750 - Bearer Token usage for OAUTH 2.0 Authorization.
+ */
 {{>generatedAnnotation}}
 public class OAuth implements Authentication {
-    private String accessToken;
+    private Supplier<String> tokenSupplier;
 
+    /**
+     * Returns the bearer token used for Authorization.
+     *
+     * @return The bearer token
+     */
     public String getAccessToken() {
-        return accessToken;
+        return tokenSupplier.get();
     }
 
+    /**
+     * Sets the bearer access token used for Authorization.
+     *
+     * @param bearerToken The bearer token to send in the Authorization header
+     */
     public void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
+        setAccessToken(() -> accessToken);
+    }
+
+    /**
+     * Sets the supplier of bearer tokens used for Authorization.
+     *
+     * @param tokenSupplier The supplier of bearer tokens to send in the Authorization header
+     */
+    public void setAccessToken(Supplier<String> tokenSupplier) {
+        this.tokenSupplier = tokenSupplier;
     }
 
     @Override
     public void applyToParams(MultiValueMap<String, String> queryParams, HttpHeaders headerParams, MultiValueMap<String, String> cookieParams) {
-        if (accessToken != null) {
-            headerParams.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-        }
+        Optional.ofNullable(tokenSupplier).map(Supplier::get).ifPresent(accessToken ->
+            headerParams.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        );
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/java/oauth.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/java/oauth.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+
+info:
+  title: Test OAuth code generation
+  description: Tests OAuth code generation
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:8080
+
+paths:
+  /api/something:
+    get:
+      responses:
+        204:
+          description: Success!
+
+components:
+  securitySchemes:
+    oAuth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: ''
+          scopes: {}
+
+security:
+  - oAuth: []

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -240,9 +240,18 @@ public class ApiClient extends JavaTimeFormatter {
      * @param accessToken Access token
      */
     public void setAccessToken(String accessToken) {
+        setAccessToken(() -> accessToken);
+    }
+
+    /**
+     * Helper method to set the supplier of access tokens for OAuth2 authentication.
+     *
+     * @param tokenSupplier The supplier of bearer tokens
+     */
+    public void setAccessToken(Supplier<String> tokenSupplier) {
         for (Authentication auth : authentications.values()) {
             if (auth instanceof OAuth) {
-                ((OAuth) auth).setAccessToken(accessToken);
+                ((OAuth) auth).setAccessToken(tokenSupplier);
                 return;
             }
         }

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -1,24 +1,48 @@
 package org.openapitools.client.auth;
 
+import java.util.Optional;
+import java.util.function.Supplier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 
+/**
+ * Provides support for RFC 6750 - Bearer Token usage for OAUTH 2.0 Authorization.
+ */
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0-SNAPSHOT")
 public class OAuth implements Authentication {
-    private String accessToken;
+    private Supplier<String> tokenSupplier;
 
+    /**
+     * Returns the bearer token used for Authorization.
+     *
+     * @return The bearer token
+     */
     public String getAccessToken() {
-        return accessToken;
+        return tokenSupplier.get();
     }
 
+    /**
+     * Sets the bearer access token used for Authorization.
+     *
+     * @param bearerToken The bearer token to send in the Authorization header
+     */
     public void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
+        setAccessToken(() -> accessToken);
+    }
+
+    /**
+     * Sets the supplier of bearer tokens used for Authorization.
+     *
+     * @param tokenSupplier The supplier of bearer tokens to send in the Authorization header
+     */
+    public void setAccessToken(Supplier<String> tokenSupplier) {
+        this.tokenSupplier = tokenSupplier;
     }
 
     @Override
     public void applyToParams(MultiValueMap<String, String> queryParams, HttpHeaders headerParams, MultiValueMap<String, String> cookieParams) {
-        if (accessToken != null) {
-            headerParams.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-        }
+        Optional.ofNullable(tokenSupplier).map(Supplier::get).ifPresent(accessToken ->
+            headerParams.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        );
     }
 }

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -240,9 +240,18 @@ public class ApiClient extends JavaTimeFormatter {
      * @param accessToken Access token
      */
     public void setAccessToken(String accessToken) {
+        setAccessToken(() -> accessToken);
+    }
+
+    /**
+     * Helper method to set the supplier of access tokens for OAuth2 authentication.
+     *
+     * @param tokenSupplier The supplier of bearer tokens
+     */
+    public void setAccessToken(Supplier<String> tokenSupplier) {
         for (Authentication auth : authentications.values()) {
             if (auth instanceof OAuth) {
-                ((OAuth) auth).setAccessToken(accessToken);
+                ((OAuth) auth).setAccessToken(tokenSupplier);
                 return;
             }
         }

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -1,24 +1,48 @@
 package org.openapitools.client.auth;
 
+import java.util.Optional;
+import java.util.function.Supplier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 
+/**
+ * Provides support for RFC 6750 - Bearer Token usage for OAUTH 2.0 Authorization.
+ */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0-SNAPSHOT")
 public class OAuth implements Authentication {
-    private String accessToken;
+    private Supplier<String> tokenSupplier;
 
+    /**
+     * Returns the bearer token used for Authorization.
+     *
+     * @return The bearer token
+     */
     public String getAccessToken() {
-        return accessToken;
+        return tokenSupplier.get();
     }
 
+    /**
+     * Sets the bearer access token used for Authorization.
+     *
+     * @param bearerToken The bearer token to send in the Authorization header
+     */
     public void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
+        setAccessToken(() -> accessToken);
+    }
+
+    /**
+     * Sets the supplier of bearer tokens used for Authorization.
+     *
+     * @param tokenSupplier The supplier of bearer tokens to send in the Authorization header
+     */
+    public void setAccessToken(Supplier<String> tokenSupplier) {
+        this.tokenSupplier = tokenSupplier;
     }
 
     @Override
     public void applyToParams(MultiValueMap<String, String> queryParams, HttpHeaders headerParams, MultiValueMap<String, String> cookieParams) {
-        if (accessToken != null) {
-            headerParams.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-        }
+        Optional.ofNullable(tokenSupplier).map(Supplier::get).ifPresent(accessToken ->
+            headerParams.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        );
     }
 }

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -240,9 +240,18 @@ public class ApiClient extends JavaTimeFormatter {
      * @param accessToken Access token
      */
     public void setAccessToken(String accessToken) {
+        setAccessToken(() -> accessToken);
+    }
+
+    /**
+     * Helper method to set the supplier of access tokens for OAuth2 authentication.
+     *
+     * @param tokenSupplier The supplier of bearer tokens
+     */
+    public void setAccessToken(Supplier<String> tokenSupplier) {
         for (Authentication auth : authentications.values()) {
             if (auth instanceof OAuth) {
-                ((OAuth) auth).setAccessToken(accessToken);
+                ((OAuth) auth).setAccessToken(tokenSupplier);
                 return;
             }
         }

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -1,24 +1,48 @@
 package org.openapitools.client.auth;
 
+import java.util.Optional;
+import java.util.function.Supplier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 
+/**
+ * Provides support for RFC 6750 - Bearer Token usage for OAUTH 2.0 Authorization.
+ */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0-SNAPSHOT")
 public class OAuth implements Authentication {
-    private String accessToken;
+    private Supplier<String> tokenSupplier;
 
+    /**
+     * Returns the bearer token used for Authorization.
+     *
+     * @return The bearer token
+     */
     public String getAccessToken() {
-        return accessToken;
+        return tokenSupplier.get();
     }
 
+    /**
+     * Sets the bearer access token used for Authorization.
+     *
+     * @param bearerToken The bearer token to send in the Authorization header
+     */
     public void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
+        setAccessToken(() -> accessToken);
+    }
+
+    /**
+     * Sets the supplier of bearer tokens used for Authorization.
+     *
+     * @param tokenSupplier The supplier of bearer tokens to send in the Authorization header
+     */
+    public void setAccessToken(Supplier<String> tokenSupplier) {
+        this.tokenSupplier = tokenSupplier;
     }
 
     @Override
     public void applyToParams(MultiValueMap<String, String> queryParams, HttpHeaders headerParams, MultiValueMap<String, String> cookieParams) {
-        if (accessToken != null) {
-            headerParams.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-        }
+        Optional.ofNullable(tokenSupplier).map(Supplier::get).ifPresent(accessToken ->
+            headerParams.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        );
     }
 }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -303,9 +303,18 @@ public class ApiClient extends JavaTimeFormatter {
      * @param accessToken Access token
      */
     public void setAccessToken(String accessToken) {
+        setAccessToken(() -> accessToken);
+    }
+
+    /**
+     * Helper method to set the supplier of access tokens for OAuth2 authentication.
+     *
+     * @param tokenSupplier The supplier of bearer tokens
+     */
+    public void setAccessToken(Supplier<String> tokenSupplier) {
         for (Authentication auth : authentications.values()) {
             if (auth instanceof OAuth) {
-                ((OAuth) auth).setAccessToken(accessToken);
+                ((OAuth) auth).setAccessToken(tokenSupplier);
                 return;
             }
         }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -1,24 +1,48 @@
 package org.openapitools.client.auth;
 
+import java.util.Optional;
+import java.util.function.Supplier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 
+/**
+ * Provides support for RFC 6750 - Bearer Token usage for OAUTH 2.0 Authorization.
+ */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0-SNAPSHOT")
 public class OAuth implements Authentication {
-    private String accessToken;
+    private Supplier<String> tokenSupplier;
 
+    /**
+     * Returns the bearer token used for Authorization.
+     *
+     * @return The bearer token
+     */
     public String getAccessToken() {
-        return accessToken;
+        return tokenSupplier.get();
     }
 
+    /**
+     * Sets the bearer access token used for Authorization.
+     *
+     * @param bearerToken The bearer token to send in the Authorization header
+     */
     public void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
+        setAccessToken(() -> accessToken);
+    }
+
+    /**
+     * Sets the supplier of bearer tokens used for Authorization.
+     *
+     * @param tokenSupplier The supplier of bearer tokens to send in the Authorization header
+     */
+    public void setAccessToken(Supplier<String> tokenSupplier) {
+        this.tokenSupplier = tokenSupplier;
     }
 
     @Override
     public void applyToParams(MultiValueMap<String, String> queryParams, HttpHeaders headerParams, MultiValueMap<String, String> cookieParams) {
-        if (accessToken != null) {
-            headerParams.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-        }
+        Optional.ofNullable(tokenSupplier).map(Supplier::get).ifPresent(accessToken ->
+            headerParams.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        );
     }
 }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -298,9 +298,18 @@ public class ApiClient extends JavaTimeFormatter {
      * @param accessToken Access token
      */
     public void setAccessToken(String accessToken) {
+        setAccessToken(() -> accessToken);
+    }
+
+    /**
+     * Helper method to set the supplier of access tokens for OAuth2 authentication.
+     *
+     * @param tokenSupplier The supplier of bearer tokens
+     */
+    public void setAccessToken(Supplier<String> tokenSupplier) {
         for (Authentication auth : authentications.values()) {
             if (auth instanceof OAuth) {
-                ((OAuth) auth).setAccessToken(accessToken);
+                ((OAuth) auth).setAccessToken(tokenSupplier);
                 return;
             }
         }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -1,24 +1,48 @@
 package org.openapitools.client.auth;
 
+import java.util.Optional;
+import java.util.function.Supplier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 
+/**
+ * Provides support for RFC 6750 - Bearer Token usage for OAUTH 2.0 Authorization.
+ */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0-SNAPSHOT")
 public class OAuth implements Authentication {
-    private String accessToken;
+    private Supplier<String> tokenSupplier;
 
+    /**
+     * Returns the bearer token used for Authorization.
+     *
+     * @return The bearer token
+     */
     public String getAccessToken() {
-        return accessToken;
+        return tokenSupplier.get();
     }
 
+    /**
+     * Sets the bearer access token used for Authorization.
+     *
+     * @param bearerToken The bearer token to send in the Authorization header
+     */
     public void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
+        setAccessToken(() -> accessToken);
+    }
+
+    /**
+     * Sets the supplier of bearer tokens used for Authorization.
+     *
+     * @param tokenSupplier The supplier of bearer tokens to send in the Authorization header
+     */
+    public void setAccessToken(Supplier<String> tokenSupplier) {
+        this.tokenSupplier = tokenSupplier;
     }
 
     @Override
     public void applyToParams(MultiValueMap<String, String> queryParams, HttpHeaders headerParams, MultiValueMap<String, String> cookieParams) {
-        if (accessToken != null) {
-            headerParams.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-        }
+        Optional.ofNullable(tokenSupplier).map(Supplier::get).ifPresent(accessToken ->
+            headerParams.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        );
     }
 }


### PR DESCRIPTION
Fixes #19000

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Add support for a bearer token supplier to OAuth based RestTemplate clients

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
