### PR TITLE
[typescript-fetch] Fix API-generation of referenced enums for multipart/form-data

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -1120,6 +1120,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             this.isMap = cp.isMap;
             this.isFile = cp.isFile;
             this.isEnum = cp.isEnum;
+            this.isEnumRef = cp.isEnumRef;
             this._enum = cp._enum;
             this.allowableValues = cp.allowableValues;
             this.items = cp.items;
@@ -1280,6 +1281,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             this.isArray = cp.isArray;
             this.isMap = cp.isMap;
             this.isEnum = cp.isEnum;
+            this.isEnumRef = cp.isEnumRef;
             this.isReadOnly = cp.isReadOnly;
             this.isWriteOnly = cp.isWriteOnly;
             this.isNullable = cp.isNullable;

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -256,11 +256,16 @@ export class {{classname}} extends runtime.BaseAPI {
             formParams.append('{{baseName}}', requestParameters['{{paramName}}'] as any);
             {{/isPrimitiveType}}
             {{^isPrimitiveType}}
+            {{#isEnumRef}}
+            formParams.append('{{baseName}}', requestParameters['{{paramName}}'] as any);
+            {{/isEnumRef}}
+            {{^isEnumRef}}
             {{^withoutRuntimeChecks}}
             formParams.append('{{baseName}}', new Blob([JSON.stringify({{{dataType}}}ToJSON(requestParameters['{{paramName}}']))], { type: "application/json", }));
             {{/withoutRuntimeChecks}}{{#withoutRuntimeChecks}}
             formParams.append('{{baseName}}', new Blob([JSON.stringify(requestParameters['{{paramName}}'])], { type: "application/json", }));
             {{/withoutRuntimeChecks}}
+            {{/isEnumRef}}
             {{/isPrimitiveType}}
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
@@ -40,6 +40,8 @@ export interface AllOfWithSingleRef {
     singleRefType?: SingleRefType;
 }
 
+
+
 /**
  * Check if a given object implements the AllOfWithSingleRef interface.
  */

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
@@ -34,6 +34,8 @@ export interface OuterObjectWithEnumProperty {
     value: OuterEnumInteger;
 }
 
+
+
 /**
  * Check if a given object implements the OuterObjectWithEnumProperty interface.
  */

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -58,6 +58,8 @@ export interface EnumPatternObject {
     nullableNumberEnum?: NumberEnum | null;
 }
 
+
+
 /**
  * Check if a given object implements the EnumPatternObject interface.
  */

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
@@ -46,6 +46,8 @@ export interface GetBehaviorTypeResponse {
     data?: BehaviorType;
 }
 
+
+
 /**
  * Check if a given object implements the GetBehaviorTypeResponse interface.
  */

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
@@ -46,6 +46,8 @@ export interface GetPetPartTypeResponse {
     data?: PetPartType;
 }
 
+
+
 /**
  * Check if a given object implements the GetPetPartTypeResponse interface.
  */

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
@@ -40,6 +40,8 @@ export interface AllOfWithSingleRef {
     singleRefType?: SingleRefType;
 }
 
+
+
 /**
  * Check if a given object implements the AllOfWithSingleRef interface.
  */

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
@@ -34,6 +34,8 @@ export interface OuterObjectWithEnumProperty {
     value: OuterEnumInteger;
 }
 
+
+
 /**
  * Check if a given object implements the OuterObjectWithEnumProperty interface.
  */

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
@@ -58,6 +58,8 @@ export interface EnumPatternObject {
     nullableNumberEnum?: NumberEnum | null;
 }
 
+
+
 /**
  * Check if a given object implements the EnumPatternObject interface.
  */


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Adds isEnumRef to the condition because it does not match the isPrimitiveType condition if the enum definition is separated.
isEnumRef was also added to the typescript-fetch specific ExtendedCodegenParameter and ExtendedCodegenProperty so that it can be used in templates.

Fixes #11613 

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka 

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
