### PR TITLE
[Typescript] Generate oneOf schemas as type unions

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -354,6 +354,16 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
                     }
                 }
             }
+            if (!cm.oneOf.isEmpty()) {
+                // For oneOfs only import $refs within the oneOf
+                TreeSet<String> oneOfRefs = new TreeSet<>();
+                for (String im : cm.imports) {
+                    if (cm.oneOf.contains(im)) {
+                        oneOfRefs.add(im);
+                    }
+                }
+                cm.imports = oneOfRefs;
+            }
         }
         for (ModelMap mo : models) {
             CodegenModel cm = mo.getModel();

--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -43,8 +43,7 @@ let typeMap: {[index: string]: any} = {
     {{#models}}
         {{#model}}
             {{^isEnum}}
-    "{{classname}}": {{classname}}{{#oneOf}}{{#-first}}Class{{/-first}}{{/oneOf}},{{#hasDiscriminatorWithNonEmptyMapping}}{{#discriminator.mappedModels}}
-    "{{mappingName}}": {{modelName}},{{/discriminator.mappedModels}}{{/hasDiscriminatorWithNonEmptyMapping}}
+    "{{classname}}": {{classname}}{{#oneOf}}{{#-first}}Class{{/-first}}{{/oneOf}},
             {{/isEnum}}
         {{/model}}
     {{/models}}
@@ -121,13 +120,14 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            if (discriminatorProperty == null) {
+            let mapping = typeMap[expectedType].mapping;
+            if (discriminatorProperty == null || mapping == undefined) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
-                        return discriminatorType; // use the type given in the discriminator
+                    if(mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -6,7 +6,7 @@ export * from '{{{ importPath }}}{{importFileExtension}}';
 
 {{#models}}
 {{#model}}
-import { {{classname}}{{#hasEnums}}{{#vars}}{{#isEnum}}, {{classname}}{{enumName}} {{/isEnum}} {{/vars}}{{/hasEnums}} } from '{{{ importPath }}}{{importFileExtension}}';
+import { {{classname}}{{#oneOf}}{{#-first}}Class{{/-first}}{{/oneOf}}{{^oneOf}}{{#hasEnums}}{{#vars}}{{#isEnum}}, {{classname}}{{enumName}} {{/isEnum}} {{/vars}}{{/hasEnums}}{{/oneOf}} } from '{{{ importPath }}}{{importFileExtension}}';
 {{/model}}
 {{/models}}
 
@@ -43,7 +43,8 @@ let typeMap: {[index: string]: any} = {
     {{#models}}
         {{#model}}
             {{^isEnum}}
-    "{{classname}}": {{classname}},
+    "{{classname}}": {{classname}}{{#oneOf}}{{#-first}}Class{{/-first}}{{/oneOf}},{{#hasDiscriminatorWithNonEmptyMapping}}{{#discriminator.mappedModels}}
+    "{{mappingName}}": {{modelName}},{{/discriminator.mappedModels}}{{/hasDiscriminatorWithNonEmptyMapping}}
             {{/isEnum}}
         {{/model}}
     {{/models}}

--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -120,14 +120,16 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            let mapping = typeMap[expectedType].mapping;
-            if (discriminatorProperty == null || mapping == undefined) {
+            if (discriminatorProperty == null) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(mapping[discriminatorType]) {
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
                         return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
+                        return discriminatorType;
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
@@ -11,10 +11,8 @@ import { HttpFile } from '../http/http{{importFileExtension}}';
 * {{{.}}}
 */
 {{/description}}
-{{#oneOf}}{{#-first}}{{>model/modelOneOf}}{{/-first}}{{/oneOf}}
-{{^oneOf}}
 {{^isEnum}}
-export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
+{{#oneOf}}{{#-first}}{{>model/modelOneOf}}{{/-first}}{{/oneOf}}{{^oneOf}}export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
 {{#vars}}
 {{#description}}
     /**
@@ -68,7 +66,7 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
         {{/discriminatorName}}
     }
 }
-
+{{/oneOf}}
 {{#hasEnums}}
 
 {{#vars}}
@@ -94,6 +92,5 @@ export enum {{classname}} {
     {{/allowableValues}}
 }
 {{/isEnum}}
-{{/oneOf}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
@@ -32,6 +32,18 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
     {{^discriminator}}
     static readonly discriminator: string | undefined = undefined;
     {{/discriminator}}
+    {{#hasDiscriminatorWithNonEmptyMapping}}
+
+    static readonly mapping: {[index: string]: any} | undefined = {
+    {{#discriminator.mappedModels}}
+        "{{mappingName}}": "{{modelName}}",
+    {{/discriminator.mappedModels}}
+    };
+    {{/hasDiscriminatorWithNonEmptyMapping}}
+    {{^hasDiscriminatorWithNonEmptyMapping}}
+
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    {{/hasDiscriminatorWithNonEmptyMapping}}
 
     {{^isArray}}
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [

--- a/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
@@ -12,7 +12,11 @@ import { HttpFile } from '../http/http{{importFileExtension}}';
 */
 {{/description}}
 {{^isEnum}}
-{{#oneOf}}{{#-first}}{{>model/modelOneOf}}{{/-first}}{{/oneOf}}{{^oneOf}}export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
+{{#oneOf}}
+{{#-first}}{{>model/modelOneOf}}{{/-first}}
+{{/oneOf}}
+{{^oneOf}}
+export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
 {{#vars}}
 {{#description}}
     /**

--- a/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
@@ -34,7 +34,7 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
     {{/discriminator}}
     {{#hasDiscriminatorWithNonEmptyMapping}}
 
-    static readonly mapping: {[index: string]: any} | undefined = {
+    static readonly mapping: {[index: string]: string} | undefined = {
     {{#discriminator.mappedModels}}
         "{{mappingName}}": "{{modelName}}",
     {{/discriminator.mappedModels}}
@@ -42,7 +42,7 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
     {{/hasDiscriminatorWithNonEmptyMapping}}
     {{^hasDiscriminatorWithNonEmptyMapping}}
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
     {{/hasDiscriminatorWithNonEmptyMapping}}
 
     {{^isArray}}

--- a/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
@@ -70,7 +70,6 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
         {{/discriminatorName}}
     }
 }
-{{/oneOf}}
 {{#hasEnums}}
 
 {{#vars}}
@@ -86,6 +85,7 @@ export enum {{classname}}{{enumName}} {
 {{/vars}}
 
 {{/hasEnums}}
+{{/oneOf}}
 {{/isEnum}}
 {{#isEnum}}
 export enum {{classname}} {

--- a/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
@@ -11,6 +11,8 @@ import { HttpFile } from '../http/http{{importFileExtension}}';
 * {{{.}}}
 */
 {{/description}}
+{{#oneOf}}{{#-first}}{{>model/modelOneOf}}{{/-first}}{{/oneOf}}
+{{^oneOf}}
 {{^isEnum}}
 export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
 {{#vars}}
@@ -92,5 +94,6 @@ export enum {{classname}} {
     {{/allowableValues}}
 }
 {{/isEnum}}
+{{/oneOf}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
@@ -27,7 +27,7 @@ export class {{classname}}Class {
     {{/discriminator}}
     {{#hasDiscriminatorWithNonEmptyMapping}}
 
-    static readonly mapping: {[index: string]: any} | undefined = {
+    static readonly mapping: {[index: string]: string} | undefined = {
     {{#discriminator.mappedModels}}
         "{{mappingName}}": "{{modelName}}",
     {{/discriminator.mappedModels}}
@@ -35,6 +35,6 @@ export class {{classname}}Class {
     {{/hasDiscriminatorWithNonEmptyMapping}}
     {{^hasDiscriminatorWithNonEmptyMapping}}
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
     {{/hasDiscriminatorWithNonEmptyMapping}}
 }

--- a/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
@@ -1,0 +1,14 @@
+{{#hasImports}}
+import {
+    {{#imports}}
+    {{{.}}}{{importFileExtension}},
+    {{/imports}}
+} from './';
+
+{{/hasImports}}
+/**
+ * @type {{classname}}{{#description}}
+ * {{{.}}}{{/description}}
+ * @export
+ */
+export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};

--- a/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
@@ -7,8 +7,22 @@ import {
 
 {{/hasImports}}
 /**
- * @type {{classname}}{{#description}}
- * {{{.}}}{{/description}}
+ * @type {{classname}}
+ * Type
  * @export
  */
 export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};
+
+/**
+* @type {{classname}}Class{{#description}}
+    * {{{.}}}{{/description}}
+* @export
+*/
+export class {{classname}}Class {
+    {{#discriminator}}
+        static readonly discriminator: string | undefined = "{{discriminatorName}}";
+    {{/discriminator}}
+    {{^discriminator}}
+        static readonly discriminator: string | undefined = undefined;
+    {{/discriminator}}
+}

--- a/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
@@ -20,9 +20,21 @@ export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};
 */
 export class {{classname}}Class {
     {{#discriminator}}
-        static readonly discriminator: string | undefined = "{{discriminatorName}}";
+    static readonly discriminator: string | undefined = "{{discriminatorName}}";
     {{/discriminator}}
     {{^discriminator}}
-        static readonly discriminator: string | undefined = undefined;
+    static readonly discriminator: string | undefined = undefined;
     {{/discriminator}}
+    {{#hasDiscriminatorWithNonEmptyMapping}}
+
+    static readonly mapping: {[index: string]: any} | undefined = {
+    {{#discriminator.mappedModels}}
+        "{{mappingName}}": "{{modelName}}",
+    {{/discriminator.mappedModels}}
+    };
+    {{/hasDiscriminatorWithNonEmptyMapping}}
+    {{^hasDiscriminatorWithNonEmptyMapping}}
+
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    {{/hasDiscriminatorWithNonEmptyMapping}}
 }

--- a/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
@@ -92,13 +92,14 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            if (discriminatorProperty == null) {
+            let mapping = typeMap[expectedType].mapping;
+            if (discriminatorProperty == null || mapping == undefined) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
-                        return discriminatorType; // use the type given in the discriminator
+                    if(mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
@@ -92,14 +92,16 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            let mapping = typeMap[expectedType].mapping;
-            if (discriminatorProperty == null || mapping == undefined) {
+            if (discriminatorProperty == null) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(mapping[discriminatorType]) {
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
                         return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
+                        return discriminatorType;
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/client/others/typescript/builds/with-unique-items/models/Response.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/models/Response.ts
@@ -39,4 +39,3 @@ export class Response {
     public constructor() {
     }
 }
-

--- a/samples/client/others/typescript/builds/with-unique-items/models/Response.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/models/Response.ts
@@ -18,7 +18,7 @@ export class Response {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/client/others/typescript/builds/with-unique-items/models/Response.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/models/Response.ts
@@ -18,6 +18,8 @@ export class Response {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "nonUniqueArray",

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/ApiResponse.ts
@@ -49,4 +49,3 @@ export class ApiResponse {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/ApiResponse.ts
@@ -22,6 +22,8 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "code",

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/ApiResponse.ts
@@ -22,7 +22,7 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Category.ts
@@ -21,6 +21,8 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Category.ts
@@ -21,7 +21,7 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Category.ts
@@ -42,4 +42,3 @@ export class Category {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
@@ -109,14 +109,16 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            let mapping = typeMap[expectedType].mapping;
-            if (discriminatorProperty == null || mapping == undefined) {
+            if (discriminatorProperty == null) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(mapping[discriminatorType]) {
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
                         return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
+                        return discriminatorType;
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
@@ -109,13 +109,14 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            if (discriminatorProperty == null) {
+            let mapping = typeMap[expectedType].mapping;
+            if (discriminatorProperty == null || mapping == undefined) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
-                        return discriminatorType; // use the type given in the discriminator
+                    if(mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Order.ts
@@ -74,7 +74,6 @@ export class Order {
     }
 }
 
-
 export enum OrderStatusEnum {
     Placed = 'placed',
     Approved = 'approved',

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Order.ts
@@ -28,7 +28,7 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Order.ts
@@ -28,6 +28,8 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Pet.ts
@@ -30,7 +30,7 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Pet.ts
@@ -30,6 +30,8 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Pet.ts
@@ -76,7 +76,6 @@ export class Pet {
     }
 }
 
-
 export enum PetStatusEnum {
     Available = 'available',
     Pending = 'pending',

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Tag.ts
@@ -42,4 +42,3 @@ export class Tag {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Tag.ts
@@ -21,7 +21,7 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Tag.ts
@@ -21,6 +21,8 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/User.ts
@@ -87,4 +87,3 @@ export class User {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/User.ts
@@ -30,7 +30,7 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/User.ts
@@ -30,6 +30,8 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Cat.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Cat.ts
@@ -39,4 +39,3 @@ export class Cat {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Cat.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Cat.ts
@@ -18,7 +18,7 @@ export class Cat {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Cat.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Cat.ts
@@ -18,6 +18,8 @@ export class Cat {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "hunts",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Dog.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Dog.ts
@@ -18,6 +18,8 @@ export class Dog {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "bark",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Dog.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Dog.ts
@@ -40,7 +40,6 @@ export class Dog {
     }
 }
 
-
 export enum DogBreedEnum {
     Dingo = 'Dingo',
     Husky = 'Husky',

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Dog.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Dog.ts
@@ -18,7 +18,7 @@ export class Dog {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/FilePostRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/FilePostRequest.ts
@@ -17,6 +17,8 @@ export class FilePostRequest {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "file",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/FilePostRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/FilePostRequest.ts
@@ -32,4 +32,3 @@ export class FilePostRequest {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/FilePostRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/FilePostRequest.ts
@@ -17,7 +17,7 @@ export class FilePostRequest {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
@@ -114,13 +114,14 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            if (discriminatorProperty == null) {
+            let mapping = typeMap[expectedType].mapping;
+            if (discriminatorProperty == null || mapping == undefined) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
-                        return discriminatorType; // use the type given in the discriminator
+                    if(mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
@@ -12,7 +12,7 @@ import { FilePostRequest } from '../models/FilePostRequest';
 import { PetByAge } from '../models/PetByAge';
 import { PetByType, PetByTypePetTypeEnum    } from '../models/PetByType';
 import { PetsFilteredPatchRequest  , PetsFilteredPatchRequestPetTypeEnum    } from '../models/PetsFilteredPatchRequest';
-import { PetsPatchRequest   , PetsPatchRequestBreedEnum   } from '../models/PetsPatchRequest';
+import { PetsPatchRequestClass } from '../models/PetsPatchRequest';
 
 /* tslint:disable:no-unused-variable */
 let primitives = [
@@ -40,7 +40,7 @@ let typeMap: {[index: string]: any} = {
     "PetByAge": PetByAge,
     "PetByType": PetByType,
     "PetsFilteredPatchRequest": PetsFilteredPatchRequest,
-    "PetsPatchRequest": PetsPatchRequest,
+    "PetsPatchRequest": PetsPatchRequestClass,
 }
 
 type MimeTypeDescriptor = {

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
@@ -114,14 +114,16 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            let mapping = typeMap[expectedType].mapping;
-            if (discriminatorProperty == null || mapping == undefined) {
+            if (discriminatorProperty == null) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(mapping[discriminatorType]) {
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
                         return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
+                        return discriminatorType;
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByAge.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByAge.ts
@@ -39,4 +39,3 @@ export class PetByAge {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByAge.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByAge.ts
@@ -18,6 +18,8 @@ export class PetByAge {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "age",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByAge.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByAge.ts
@@ -18,7 +18,7 @@ export class PetByAge {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByType.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByType.ts
@@ -40,7 +40,6 @@ export class PetByType {
     }
 }
 
-
 export enum PetByTypePetTypeEnum {
     Cat = 'Cat',
     Dog = 'Dog'

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByType.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByType.ts
@@ -18,6 +18,8 @@ export class PetByType {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "petType",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByType.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByType.ts
@@ -18,7 +18,7 @@ export class PetByType {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsFilteredPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsFilteredPatchRequest.ts
@@ -56,7 +56,6 @@ export class PetsFilteredPatchRequest {
     }
 }
 
-
 export enum PetsFilteredPatchRequestPetTypeEnum {
     Cat = 'Cat',
     Dog = 'Dog'

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsFilteredPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsFilteredPatchRequest.ts
@@ -22,6 +22,8 @@ export class PetsFilteredPatchRequest {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "age",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsFilteredPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsFilteredPatchRequest.ts
@@ -22,7 +22,7 @@ export class PetsFilteredPatchRequest {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
@@ -14,49 +14,11 @@ import { Cat } from '../models/Cat';
 import { Dog } from '../models/Dog';
 import { HttpFile } from '../http/http';
 
-export class PetsPatchRequest {
-    'hunts'?: boolean;
-    'age'?: number;
-    'bark'?: boolean;
-    'breed'?: PetsPatchRequestBreedEnum;
-
-    static readonly discriminator: string | undefined = "petType";
-
-    static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
-        {
-            "name": "hunts",
-            "baseName": "hunts",
-            "type": "boolean",
-            "format": ""
-        },
-        {
-            "name": "age",
-            "baseName": "age",
-            "type": "number",
-            "format": ""
-        },
-        {
-            "name": "bark",
-            "baseName": "bark",
-            "type": "boolean",
-            "format": ""
-        },
-        {
-            "name": "breed",
-            "baseName": "breed",
-            "type": "PetsPatchRequestBreedEnum",
-            "format": ""
-        }    ];
-
-    static getAttributeTypeMap() {
-        return PetsPatchRequest.attributeTypeMap;
-    }
-
-    public constructor() {
-        this.petType = "PetsPatchRequest";
-    }
-}
-
+/**
+ * @type PetsPatchRequest
+ * @export
+ */
+export type PetsPatchRequest = Cat | Dog;
 
 export enum PetsPatchRequestBreedEnum {
     Dingo = 'Dingo',

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
@@ -26,6 +26,8 @@ export type PetsPatchRequest = Cat | Dog;
 * @export
 */
 export class PetsPatchRequestClass {
-        static readonly discriminator: string | undefined = "petType";
+    static readonly discriminator: string | undefined = "petType";
+
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
 }
 

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
@@ -21,11 +21,3 @@ import { HttpFile } from '../http/http';
 export type PetsPatchRequest = Cat | Dog;
 
 
-
-export enum PetsPatchRequestBreedEnum {
-    Dingo = 'Dingo',
-    Husky = 'Husky',
-    Retriever = 'Retriever',
-    Shepherd = 'Shepherd'
-}
-

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
@@ -16,8 +16,16 @@ import { HttpFile } from '../http/http';
 
 /**
  * @type PetsPatchRequest
+ * Type
  * @export
  */
 export type PetsPatchRequest = Cat | Dog;
 
+/**
+* @type PetsPatchRequestClass
+* @export
+*/
+export class PetsPatchRequestClass {
+        static readonly discriminator: string | undefined = "petType";
+}
 

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
@@ -28,6 +28,6 @@ export type PetsPatchRequest = Cat | Dog;
 export class PetsPatchRequestClass {
     static readonly discriminator: string | undefined = "petType";
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 }
 

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
@@ -20,6 +20,8 @@ import { HttpFile } from '../http/http';
  */
 export type PetsPatchRequest = Cat | Dog;
 
+
+
 export enum PetsPatchRequestBreedEnum {
     Dingo = 'Dingo',
     Husky = 'Husky',

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ApiResponse.ts
@@ -49,4 +49,3 @@ export class ApiResponse {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ApiResponse.ts
@@ -22,6 +22,8 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "code",

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ApiResponse.ts
@@ -22,7 +22,7 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Category.ts
@@ -21,6 +21,8 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Category.ts
@@ -21,7 +21,7 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Category.ts
@@ -42,4 +42,3 @@ export class Category {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
@@ -109,14 +109,16 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            let mapping = typeMap[expectedType].mapping;
-            if (discriminatorProperty == null || mapping == undefined) {
+            if (discriminatorProperty == null) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(mapping[discriminatorType]) {
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
                         return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
+                        return discriminatorType;
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
@@ -109,13 +109,14 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            if (discriminatorProperty == null) {
+            let mapping = typeMap[expectedType].mapping;
+            if (discriminatorProperty == null || mapping == undefined) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
-                        return discriminatorType; // use the type given in the discriminator
+                    if(mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Order.ts
@@ -74,7 +74,6 @@ export class Order {
     }
 }
 
-
 export enum OrderStatusEnum {
     Placed = 'placed',
     Approved = 'approved',

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Order.ts
@@ -28,7 +28,7 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Order.ts
@@ -28,6 +28,8 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Pet.ts
@@ -30,7 +30,7 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Pet.ts
@@ -30,6 +30,8 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Pet.ts
@@ -76,7 +76,6 @@ export class Pet {
     }
 }
 
-
 export enum PetStatusEnum {
     Available = 'available',
     Pending = 'pending',

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Tag.ts
@@ -42,4 +42,3 @@ export class Tag {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Tag.ts
@@ -21,7 +21,7 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Tag.ts
@@ -21,6 +21,8 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/User.ts
@@ -87,4 +87,3 @@ export class User {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/User.ts
@@ -30,7 +30,7 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/User.ts
@@ -30,6 +30,8 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/ApiResponse.ts
@@ -49,4 +49,3 @@ export class ApiResponse {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/ApiResponse.ts
@@ -22,6 +22,8 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "code",

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/ApiResponse.ts
@@ -22,7 +22,7 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Category.ts
@@ -21,6 +21,8 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Category.ts
@@ -21,7 +21,7 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Category.ts
@@ -42,4 +42,3 @@ export class Category {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
@@ -109,14 +109,16 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            let mapping = typeMap[expectedType].mapping;
-            if (discriminatorProperty == null || mapping == undefined) {
+            if (discriminatorProperty == null) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(mapping[discriminatorType]) {
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
                         return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
+                        return discriminatorType;
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
@@ -109,13 +109,14 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            if (discriminatorProperty == null) {
+            let mapping = typeMap[expectedType].mapping;
+            if (discriminatorProperty == null || mapping == undefined) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
-                        return discriminatorType; // use the type given in the discriminator
+                    if(mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Order.ts
@@ -74,7 +74,6 @@ export class Order {
     }
 }
 
-
 export enum OrderStatusEnum {
     Placed = 'placed',
     Approved = 'approved',

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Order.ts
@@ -28,7 +28,7 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Order.ts
@@ -28,6 +28,8 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Pet.ts
@@ -30,7 +30,7 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Pet.ts
@@ -30,6 +30,8 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Pet.ts
@@ -76,7 +76,6 @@ export class Pet {
     }
 }
 
-
 export enum PetStatusEnum {
     Available = 'available',
     Pending = 'pending',

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Tag.ts
@@ -42,4 +42,3 @@ export class Tag {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Tag.ts
@@ -21,7 +21,7 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Tag.ts
@@ -21,6 +21,8 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/User.ts
@@ -87,4 +87,3 @@ export class User {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/User.ts
@@ -30,7 +30,7 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/User.ts
@@ -30,6 +30,8 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/ApiResponse.ts
@@ -49,4 +49,3 @@ export class ApiResponse {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/ApiResponse.ts
@@ -22,6 +22,8 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "code",

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/ApiResponse.ts
@@ -22,7 +22,7 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Category.ts
@@ -21,6 +21,8 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Category.ts
@@ -21,7 +21,7 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Category.ts
@@ -42,4 +42,3 @@ export class Category {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
@@ -109,14 +109,16 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            let mapping = typeMap[expectedType].mapping;
-            if (discriminatorProperty == null || mapping == undefined) {
+            if (discriminatorProperty == null) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(mapping[discriminatorType]) {
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
                         return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
+                        return discriminatorType;
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
@@ -109,13 +109,14 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            if (discriminatorProperty == null) {
+            let mapping = typeMap[expectedType].mapping;
+            if (discriminatorProperty == null || mapping == undefined) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
-                        return discriminatorType; // use the type given in the discriminator
+                    if(mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Order.ts
@@ -74,7 +74,6 @@ export class Order {
     }
 }
 
-
 export enum OrderStatusEnum {
     Placed = 'placed',
     Approved = 'approved',

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Order.ts
@@ -28,7 +28,7 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Order.ts
@@ -28,6 +28,8 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Pet.ts
@@ -30,7 +30,7 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Pet.ts
@@ -30,6 +30,8 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Pet.ts
@@ -76,7 +76,6 @@ export class Pet {
     }
 }
 
-
 export enum PetStatusEnum {
     Available = 'available',
     Pending = 'pending',

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Tag.ts
@@ -42,4 +42,3 @@ export class Tag {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Tag.ts
@@ -21,7 +21,7 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Tag.ts
@@ -21,6 +21,8 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/User.ts
@@ -87,4 +87,3 @@ export class User {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/User.ts
@@ -30,7 +30,7 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/User.ts
@@ -30,6 +30,8 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/ApiResponse.ts
@@ -49,4 +49,3 @@ export class ApiResponse {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/ApiResponse.ts
@@ -22,6 +22,8 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "code",

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/ApiResponse.ts
@@ -22,7 +22,7 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Category.ts
@@ -21,6 +21,8 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Category.ts
@@ -21,7 +21,7 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Category.ts
@@ -42,4 +42,3 @@ export class Category {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
@@ -109,14 +109,16 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            let mapping = typeMap[expectedType].mapping;
-            if (discriminatorProperty == null || mapping == undefined) {
+            if (discriminatorProperty == null) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(mapping[discriminatorType]) {
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
                         return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
+                        return discriminatorType;
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
@@ -109,13 +109,14 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            if (discriminatorProperty == null) {
+            let mapping = typeMap[expectedType].mapping;
+            if (discriminatorProperty == null || mapping == undefined) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
-                        return discriminatorType; // use the type given in the discriminator
+                    if(mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Order.ts
@@ -74,7 +74,6 @@ export class Order {
     }
 }
 
-
 export enum OrderStatusEnum {
     Placed = 'placed',
     Approved = 'approved',

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Order.ts
@@ -28,7 +28,7 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Order.ts
@@ -28,6 +28,8 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Pet.ts
@@ -30,7 +30,7 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Pet.ts
@@ -30,6 +30,8 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Pet.ts
@@ -76,7 +76,6 @@ export class Pet {
     }
 }
 
-
 export enum PetStatusEnum {
     Available = 'available',
     Pending = 'pending',

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Tag.ts
@@ -42,4 +42,3 @@ export class Tag {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Tag.ts
@@ -21,7 +21,7 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Tag.ts
@@ -21,6 +21,8 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/User.ts
@@ -87,4 +87,3 @@ export class User {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/User.ts
@@ -30,7 +30,7 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/User.ts
@@ -30,6 +30,8 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/ApiResponse.ts
@@ -49,4 +49,3 @@ export class ApiResponse {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/ApiResponse.ts
@@ -22,6 +22,8 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "code",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/ApiResponse.ts
@@ -22,7 +22,7 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Category.ts
@@ -21,6 +21,8 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Category.ts
@@ -21,7 +21,7 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Category.ts
@@ -42,4 +42,3 @@ export class Category {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
@@ -109,14 +109,16 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            let mapping = typeMap[expectedType].mapping;
-            if (discriminatorProperty == null || mapping == undefined) {
+            if (discriminatorProperty == null) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(mapping[discriminatorType]) {
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
                         return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
+                        return discriminatorType;
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
@@ -109,13 +109,14 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            if (discriminatorProperty == null) {
+            let mapping = typeMap[expectedType].mapping;
+            if (discriminatorProperty == null || mapping == undefined) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
-                        return discriminatorType; // use the type given in the discriminator
+                    if(mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type
                     }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Order.ts
@@ -74,7 +74,6 @@ export class Order {
     }
 }
 
-
 export enum OrderStatusEnum {
     Placed = 'placed',
     Approved = 'approved',

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Order.ts
@@ -28,7 +28,7 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Order.ts
@@ -28,6 +28,8 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Pet.ts
@@ -30,7 +30,7 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Pet.ts
@@ -30,6 +30,8 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Pet.ts
@@ -76,7 +76,6 @@ export class Pet {
     }
 }
 
-
 export enum PetStatusEnum {
     Available = 'available',
     Pending = 'pending',

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Tag.ts
@@ -42,4 +42,3 @@ export class Tag {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Tag.ts
@@ -21,7 +21,7 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Tag.ts
@@ -21,6 +21,8 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/User.ts
@@ -87,4 +87,3 @@ export class User {
     public constructor() {
     }
 }
-

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/User.ts
@@ -30,7 +30,7 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
-    static readonly mapping: {[index: string]: any} | undefined = undefined;
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/User.ts
@@ -30,6 +30,8 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: any} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",


### PR DESCRIPTION
### Description of the PR
I have implemented `oneOf` schemas as a type union and a `oneOf` class with a discriminator and mapping, similar to [PR 2617](https://github.com/OpenAPITools/openapi-generator/pull/2617) and [PR 2647](https://github.com/OpenAPITools/openapi-generator/pull/2647), but for the TypeScript generator.

The type union is used for methods like request/response types and for models as a type of parameters. The `oneOf` class is used for the deserialization process to determine the type of an object from the type union. It checks the discriminator in the mapping list, then in the list of all classes.

Before this PR, the TypeScript generator created a new model with all fields from all `oneOf` models. The created model is not described in the swagger files. There are the following problems:

- It doesn't work if `oneOf` models have fields with the same name but different types.
- It doesn't work if  `oneOf` models have enum fields with the same name but different values in the enum.
- It doesn't work if  `oneOf` has a mapping list.
- If  `oneOf` models contain required fields, a user has to set all required fields, even if they are not needed for the request.
example: 
Dog's required fields: 
https://github.com/OpenAPITools/openapi-generator/blob/daf52229e3b0e60ac5e41052f053cb4eba60d2f0/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Dog.ts#L15-L17 
Cat's required fields: 
https://github.com/OpenAPITools/openapi-generator/blob/daf52229e3b0e60ac5e41052f053cb4eba60d2f0/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Cat.ts#L15-L17
`oneOf` model required fields : 
https://github.com/OpenAPITools/openapi-generator/blob/daf52229e3b0e60ac5e41052f053cb4eba60d2f0/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts#L17-L21
if we sent Dog model we have to set all required fields to `PetsPatchRequest`(even cat's ones)
- It doesn't look like  `oneOf`. If generate docs by the swagger with "oneOf", it won’t match the generated docs.

The implementation "oneOf" schemas as a type union resolve all these problems, making the generated code accurate with the swagger specification.

Sample input:

```json
"inputFieldDependencies" : {
    "type" : "array",
    "items" : {
        "oneOf" : [ {
            "$ref" : "#/components/schemas/PublicSingleFieldDependency"
        }, {
            "$ref" : "#/components/schemas/PublicConditionalSingleFieldDependency"
        } ],
        "discriminator": {
            "propertyName": "dependencyType",
            "mapping": {
                "SINGLE_FIELD": "#/components/schemas/PublicSingleFieldDependency",
                "CONDITIONAL_SINGLE_FIELD": "#/components/schemas/PublicConditionalSingleFieldDependency"
            }
        }
    }
},
```

Sample output:
```Typescript
import { PublicConditionalSingleFieldDependency } from '../models/PublicConditionalSingleFieldDependency';
import { PublicSingleFieldDependency } from '../models/PublicSingleFieldDependency';

export type PublicActionDefinitionInputFieldDependenciesInner = PublicConditionalSingleFieldDependency | PublicSingleFieldDependency;

export class PublicActionDefinitionInputFieldDependenciesInnerClass {
    static readonly discriminator: string | undefined = "dependencyType";

    static readonly mapping: {[index: string]: string} | undefined = {
        "CONDITIONAL_SINGLE_FIELD": "PublicConditionalSingleFieldDependency",
        "SINGLE_FIELD": "PublicSingleFieldDependency",
    };
}
```

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

### Related issues: 

https://github.com/OpenAPITools/openapi-generator/issues/9305