### PR TITLE
[typescript-fetch] Don't encode query parameter names for array type

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -310,8 +310,8 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
     if (value instanceof Array) {
         const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
+            .join(`&${fullKey}=`);
+        return `${fullKey}=${multiValue}`;
     }
     if (value instanceof Set) {
         const valueAsArray = Array.from(value);


### PR DESCRIPTION
It makes sense to encode query parameter values, but query parameter names that are arrays need to remain unchanged otherwise `include[]` becomes this `include%5B%5D`.