### PR TITLE
[Kotlin-Client][JVM-OkHttp] Override parameter enum's toString()

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
@@ -68,20 +68,20 @@ import {{packageName}}.infrastructure.toMultiValue
      {{#enumVars}}
          {{^multiplatform}}
          {{#moshi}}
-         @Json(name = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}
+         @Json(name = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
          {{/moshi}}
          {{#gson}}
-         @SerializedName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}
+         @SerializedName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
          {{/gson}}
          {{#jackson}}
-         @JsonProperty(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}
+         @JsonProperty(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
          {{/jackson}}
          {{#kotlinx_serialization}}
-         @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}
+         @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
          {{/kotlinx_serialization}}
          {{/multiplatform}}
          {{#multiplatform}}
-         @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}
+         @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
          {{/multiplatform}}
      {{/enumVars}}
      {{/allowableValues}}
@@ -89,28 +89,35 @@ import {{packageName}}.infrastructure.toMultiValue
      {{#enumUnknownDefaultCase}}
      {{#allowableValues}}
      {{#enumVars}}
-     {{^-last}}
          {{^multiplatform}}
          {{#moshi}}
-         @Json(name = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}),
+         @Json(name = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
          {{/moshi}}
          {{#gson}}
-         @SerializedName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}),
+         @SerializedName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
          {{/gson}}
          {{#jackson}}
-         @JsonProperty(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}),
+         @JsonProperty(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
          {{/jackson}}
          {{#kotlinx_serialization}}
-         @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}),
+         @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
          {{/kotlinx_serialization}}
          {{/multiplatform}}
          {{#multiplatform}}
-         @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}),
+         @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
          {{/multiplatform}}
-     {{/-last}}
      {{/enumVars}}
      {{/allowableValues}}
      {{/enumUnknownDefaultCase}}
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     {{/isEnum}}

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -50,7 +50,16 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient
      enum class QueryDefaultEnumFindPetsByStatus(val value: kotlin.String) {
          @Json(name = "A") A("A"),
          @Json(name = "B") B("B"),
-         @Json(name = "C") C("C")
+         @Json(name = "C") C("C");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**
@@ -59,7 +68,16 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient
      enum class HeaderDefaultEnumFindPetsByStatus(val value: kotlin.String) {
          @Json(name = "A") A("A"),
          @Json(name = "B") B("B"),
-         @Json(name = "C") C("C")
+         @Json(name = "C") C("C");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**
@@ -68,7 +86,16 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient
      enum class CookieDefaultEnumFindPetsByStatus(val value: kotlin.String) {
          @Json(name = "A") A("A"),
          @Json(name = "B") B("B"),
-         @Json(name = "C") C("C")
+         @Json(name = "C") C("C");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -193,7 +193,16 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient = A
      enum class StatusFindPetsByStatus(val value: kotlin.String) {
          @SerializedName(value = "available") available("available"),
          @SerializedName(value = "pending") pending("pending"),
-         @SerializedName(value = "sold") sold("sold")
+         @SerializedName(value = "sold") sold("sold");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -194,6 +194,16 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient = A
          @JsonProperty(value = "available") AVAILABLE("available"),
          @JsonProperty(value = "pending") PENDING("pending"),
          @JsonProperty(value = "sold") SOLD("sold"),
+         @JsonProperty(value = "unknown_default_open_api") UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -195,7 +195,16 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient = A
      enum class StatusFindPetsByStatus(val value: kotlin.String) {
          @SerializedName(value = "available") available("available"),
          @SerializedName(value = "pending") pending("pending"),
-         @SerializedName(value = "sold") sold("sold")
+         @SerializedName(value = "sold") sold("sold");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -193,7 +193,16 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient = A
      enum class StatusFindPetsByStatus(val value: kotlin.String) {
          @Json(name = "available") available("available"),
          @Json(name = "pending") pending("pending"),
-         @Json(name = "sold") sold("sold")
+         @Json(name = "sold") sold("sold");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -193,7 +193,16 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient = A
      enum class StatusFindPetsByStatus(val value: kotlin.String) {
          @Json(name = "available") available("available"),
          @Json(name = "pending") pending("pending"),
-         @Json(name = "sold") sold("sold")
+         @Json(name = "sold") sold("sold");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -193,7 +193,16 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient = A
      enum class StatusFindPetsByStatus(val value: kotlin.String) {
          @Json(name = "available") available("available"),
          @Json(name = "pending") pending("pending"),
-         @Json(name = "sold") sold("sold")
+         @Json(name = "sold") sold("sold");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -193,7 +193,16 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: OkHttpC
      internal enum class StatusFindPetsByStatus(val value: kotlin.String) {
          @Json(name = "available") available("available"),
          @Json(name = "pending") pending("pending"),
-         @Json(name = "sold") sold("sold")
+         @Json(name = "sold") sold("sold");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -193,7 +193,16 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient = A
      enum class StatusFindPetsByStatus(val value: kotlin.String) {
          @Json(name = "available") available("available"),
          @Json(name = "pending") pending("pending"),
-         @Json(name = "sold") sold("sold")
+         @Json(name = "sold") sold("sold");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -193,7 +193,16 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient = A
      enum class StatusFindPetsByStatus(val value: kotlin.String) {
          @Json(name = "available") available("available"),
          @Json(name = "pending") pending("pending"),
-         @Json(name = "sold") sold("sold")
+         @Json(name = "sold") sold("sold");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -193,7 +193,16 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient = A
      enum class StatusFindPetsByStatus(val value: kotlin.String) {
          @Json(name = "available") available("available"),
          @Json(name = "pending") pending("pending"),
-         @Json(name = "sold") sold("sold")
+         @Json(name = "sold") sold("sold");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -193,7 +193,16 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient = A
      enum class StatusFindPetsByStatus(val value: kotlin.String) {
          @Json(name = "available") available("available"),
          @Json(name = "pending") pending("pending"),
-         @Json(name = "sold") sold("sold")
+         @Json(name = "sold") sold("sold");
+
+        /**
+         * Override [toString()] to avoid using the enum variable name as the value, and instead use
+         * the actual value defined in the API spec file.
+         *
+         * This solves a problem when the variable name and its value are different, and ensures that
+         * the client sends the correct enum values to the server always.
+         */
+        override fun toString(): kotlin.String = "$value"
      }
 
     /**


### PR DESCRIPTION
## Override parameter enum's toString() method to use its value
### Problem
When using the JVM implementation of OkHttp with a Kotlin client, you may encounter issues with the toString() method of enum parameters. By default, the toString() method of an enum returns the name of the enum value, not its value. So currently for 

```yaml
paths
  /some/path:
    get:
      parameters:
        - in: query
          name: someEnum
          schema:
            type: array
            items:
              type: string
              enum: ["first.value", "second.value"]
              example: "first.value"
```
will generate a such enum for OkHttp Client (Moshi library just for an example)
```Kotlin
    /**
     * enum for parameter
     */
     enum class SomeEnum(val value: kotlin.String) {
         @Json(name = "first.value") firstPeriodValue("first.value"),
         @Json(name = "second.value") secondPeriodValue("second.value"),
      }
```
later in the client there is a mapping by (`ApiAbstractions.kt`)
```Kotlin
val defaultMultiValueConverter: (item: Any?) -> String = { item -> "$item" }
```
which at the end will create a such query:
`some/path?someParam=firstPeriodValue&someParam=secondPeriodValue`
instead of
`some/path?someParam=first.value&someParam=second.value` 

### Fix 
To fix this issue, we can override the `toString()` method of our enum to return its `value` instead of its name:
```Kotlin
    /**
     * enum for parameter
     */
     enum class SomeEnum(val value: kotlin.String) {
         @Json(name = "first.value") firstPeriodValue("first.value"),
         @Json(name = "second.value") secondPeriodValue("second.value");

        /**
         * Override [toString()] to avoid using the enum variable name as the value, and instead use
         * the actual value defined in the API spec file.
         *
         * This solves a problem when the variable name and its value are different, and ensures that
         * the client sends the correct enum values to the server always.
         */
        override fun toString(): kotlin.String = "$value"
     }
```


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
