### PR TITLE
Fix duplicate import javax.valid.Valid in resteasy generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/pojo.mustache
@@ -1,5 +1,4 @@
 import io.swagger.annotations.*;
-{{#useBeanValidation}}import javax.validation.Valid;{{/useBeanValidation}}
 
 {{#description}}@ApiModel(description="{{{.}}}"){{/description}}{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 {{#vendorExtensions.x-class-extra-annotation}}

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Category.java
@@ -9,7 +9,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="A category for a pet")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class Category   {

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -10,7 +10,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="Describes the result of uploading an image resource")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class ModelApiResponse   {

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Order.java
@@ -11,7 +11,6 @@ import java.util.Date;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="An order for a pets from the pet store")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class Order   {

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Pet.java
@@ -15,7 +15,6 @@ import org.openapitools.model.Tag;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="A pet for sale in the pet store")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class Pet   {

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Tag.java
@@ -9,7 +9,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="A tag for a pet")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class Tag   {

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/User.java
@@ -9,7 +9,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="A User who is purchasing from the pet store")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class User   {

--- a/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/model/Category.java
@@ -9,7 +9,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="A category for a pet")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class Category   {

--- a/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -10,7 +10,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="Describes the result of uploading an image resource")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class ModelApiResponse   {

--- a/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/model/Order.java
@@ -11,7 +11,6 @@ import java.time.OffsetDateTime;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="An order for a pets from the pet store")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class Order   {

--- a/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/model/Pet.java
@@ -15,7 +15,6 @@ import org.openapitools.model.Tag;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="A pet for sale in the pet store")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class Pet   {

--- a/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/model/Tag.java
@@ -9,7 +9,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="A tag for a pet")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class Tag   {

--- a/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/model/User.java
@@ -9,7 +9,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="A User who is purchasing from the pet store")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class User   {

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Category.java
@@ -9,7 +9,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="A category for a pet")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class Category   {

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -10,7 +10,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="Describes the result of uploading an image resource")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class ModelApiResponse   {

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Order.java
@@ -11,7 +11,6 @@ import org.joda.time.DateTime;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="An order for a pets from the pet store")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class Order   {

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Pet.java
@@ -15,7 +15,6 @@ import org.openapitools.model.Tag;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="A pet for sale in the pet store")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class Pet   {

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Tag.java
@@ -9,7 +9,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="A tag for a pet")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class Tag   {

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/User.java
@@ -9,7 +9,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 import io.swagger.annotations.*;
-import javax.validation.Valid;
 
 @ApiModel(description="A User who is purchasing from the pet store")@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", comments = "Generator version: 7.8.0-SNAPSHOT")
 public class User   {


### PR DESCRIPTION
Fixes https://github.com/OpenAPITools/openapi-generator/issues/17069

The resteasy generator generates

> import javax.validation.Valid;

twice when useBeanValidation is enabled.
It is already added here https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/model.mustache#L12

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
