### PR TITLE
Don't drop null fields from request bodies

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -371,19 +371,12 @@ class ApiClient:
             )
         elif isinstance(obj, (datetime.datetime, datetime.date)):
             return obj.isoformat()
-
         elif isinstance(obj, dict):
             obj_dict = obj
+        elif hasattr(obj, "model_dump") and callable(obj.model_dump):
+            obj_dict = obj.model_dump(by_alias=True, exclude_unset=True)
         else:
-            # Convert model obj to dict except
-            # attributes `openapi_types`, `attribute_map`
-            # and attributes which value is not None.
-            # Convert attribute name to json key in
-            # model definition for request.
-            if hasattr(obj, 'to_dict') and callable(getattr(obj, 'to_dict')):
-                obj_dict = obj.to_dict()
-            else:
-                obj_dict = obj.__dict__
+            raise TypeError(f"Can't serialize obj: {obj}")
 
         return {
             key: self.sanitize_for_serialization(val)

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -364,19 +364,12 @@ class ApiClient:
             )
         elif isinstance(obj, (datetime.datetime, datetime.date)):
             return obj.isoformat()
-
         elif isinstance(obj, dict):
             obj_dict = obj
+        elif hasattr(obj, "model_dump") and callable(obj.model_dump):
+            obj_dict = obj.model_dump(by_alias=True, exclude_unset=True)
         else:
-            # Convert model obj to dict except
-            # attributes `openapi_types`, `attribute_map`
-            # and attributes which value is not None.
-            # Convert attribute name to json key in
-            # model definition for request.
-            if hasattr(obj, 'to_dict') and callable(getattr(obj, 'to_dict')):
-                obj_dict = obj.to_dict()
-            else:
-                obj_dict = obj.__dict__
+            raise TypeError(f"Can't serialize obj: {obj}")
 
         return {
             key: self.sanitize_for_serialization(val)

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -364,19 +364,12 @@ class ApiClient:
             )
         elif isinstance(obj, (datetime.datetime, datetime.date)):
             return obj.isoformat()
-
         elif isinstance(obj, dict):
             obj_dict = obj
+        elif hasattr(obj, "model_dump") and callable(obj.model_dump):
+            obj_dict = obj.model_dump(by_alias=True, exclude_unset=True)
         else:
-            # Convert model obj to dict except
-            # attributes `openapi_types`, `attribute_map`
-            # and attributes which value is not None.
-            # Convert attribute name to json key in
-            # model definition for request.
-            if hasattr(obj, 'to_dict') and callable(getattr(obj, 'to_dict')):
-                obj_dict = obj.to_dict()
-            else:
-                obj_dict = obj.__dict__
+            raise TypeError(f"Can't serialize obj: {obj}")
 
         return {
             key: self.sanitize_for_serialization(val)

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -366,19 +366,12 @@ class ApiClient:
             )
         elif isinstance(obj, (datetime.datetime, datetime.date)):
             return obj.isoformat()
-
         elif isinstance(obj, dict):
             obj_dict = obj
+        elif hasattr(obj, "model_dump") and callable(obj.model_dump):
+            obj_dict = obj.model_dump(by_alias=True, exclude_unset=True)
         else:
-            # Convert model obj to dict except
-            # attributes `openapi_types`, `attribute_map`
-            # and attributes which value is not None.
-            # Convert attribute name to json key in
-            # model definition for request.
-            if hasattr(obj, 'to_dict') and callable(getattr(obj, 'to_dict')):
-                obj_dict = obj.to_dict()
-            else:
-                obj_dict = obj.__dict__
+            raise TypeError(f"Can't serialize obj: {obj}")
 
         return {
             key: self.sanitize_for_serialization(val)

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -363,19 +363,12 @@ class ApiClient:
             )
         elif isinstance(obj, (datetime.datetime, datetime.date)):
             return obj.isoformat()
-
         elif isinstance(obj, dict):
             obj_dict = obj
+        elif hasattr(obj, "model_dump") and callable(obj.model_dump):
+            obj_dict = obj.model_dump(by_alias=True, exclude_unset=True)
         else:
-            # Convert model obj to dict except
-            # attributes `openapi_types`, `attribute_map`
-            # and attributes which value is not None.
-            # Convert attribute name to json key in
-            # model definition for request.
-            if hasattr(obj, 'to_dict') and callable(getattr(obj, 'to_dict')):
-                obj_dict = obj.to_dict()
-            else:
-                obj_dict = obj.__dict__
+            raise TypeError(f"Can't serialize obj: {obj}")
 
         return {
             key: self.sanitize_for_serialization(val)


### PR DESCRIPTION
The python API bindings drop null request field from HTTP request
bodies. This is especially problematic for HTTP PUT and PATCH requests,
where null values are semantically important.

Change the behavior of the bindings:

```python
# before
model_dump(by_alias=True, exclude=excluded_fields, exclude_none=True)

# after
model_dump(by_alias=True, exclude_unset=True)
```

The effect of this change is to make the API send data to the remote
server that hews more closely to the original model. This is important
when making HTTP PUT and PATCH requests:

```python
# model describing a movie you've watched
class LogEntry(BaseModel):
    name: str
    rating: int | None = None

# create log entry
log_entry = LogEntry(name="Blade", rating=5)
api_client.put_log_entry(1, log_entry)

# clear rating; PUT {"name": "Blade", "rating": null}
log_entry = LogEntry(name="Blade", rating=None)
api_client.put_log_entry(1, log_entry)

# clear rating; PATCH {"rating": null}
log_entry = LogEntry.model_construct(rating=None)
api_client.patch_log_entry(1, log_entry)
```

Before this change, the API client would omit `"rating": null` from
request bodies.

Fix: https://github.com/OpenAPITools/openapi-generator/issues/19067
