### PR TITLE
enable java-camel sample checks

### DIFF
--- a/.github/workflows/samples-java-server-jdk8.yaml
+++ b/.github/workflows/samples-java-server-jdk8.yaml
@@ -3,8 +3,6 @@ name: Samples Java Server
 on:
   push:
     paths:
-      # java-camel is tested locally for the time being
-      #- 'samples/server/petstore/java-camel/**'
       - 'samples/server/petstore/java-vertx-web/**'
       - 'samples/server/petstore/java-inflector/**'
       - 'samples/server/petstore/java-pkmst/**'
@@ -13,7 +11,6 @@ on:
       - 'samples/server/petstore/java-microprofile/**'
   pull_request:
     paths:
-      #- 'samples/server/petstore/java-camel/**'
       - 'samples/server/petstore/java-vertx-web/**'
       - 'samples/server/petstore/java-inflector/**'
       - 'samples/server/petstore/java-pkmst/**'
@@ -28,7 +25,6 @@ jobs:
       matrix:
         sample:
           # servers
-          #- samples/server/petstore/java-camel/
           - samples/server/petstore/java-vertx-web/
           - samples/server/petstore/java-inflector/
           - samples/server/petstore/java-pkmst/

--- a/.github/workflows/samples-jdk17.yaml
+++ b/.github/workflows/samples-jdk17.yaml
@@ -11,6 +11,7 @@ on:
       - samples/client/petstore/java/webclient-jakarta/**
       # servers
       - samples/openapi3/server/petstore/springboot-3/**
+      - samples/server/petstore/java-camel/**
       - samples/server/petstore/java-helidon-server/v3/mp/**
       - samples/server/petstore/java-helidon-server/v3/se/**
   pull_request:
@@ -24,6 +25,7 @@ on:
       - samples/client/petstore/java/webclient-jakarta/**
       # servers
       - samples/openapi3/server/petstore/springboot-3/**
+      - samples/server/petstore/java-camel/**
       - samples/server/petstore/java-helidon-server/v3/mp/**
       - samples/server/petstore/java-helidon-server/v3/se/**
 jobs:
@@ -43,6 +45,7 @@ jobs:
           - samples/client/petstore/java/webclient-jakarta
           # servers
           - samples/openapi3/server/petstore/springboot-3
+          - samples/server/petstore/java-camel/
           - samples/server/petstore/java-helidon-server/v3/mp/
           - samples/server/petstore/java-helidon-server/v3/se
           - samples/client/petstore/spring-http-interface-reactive


### PR DESCRIPTION
Enable checks for java-camel samples.

This is a follow-up to https://github.com/OpenAPITools/openapi-generator/pull/18690#issuecomment-2208338374, where a compilation error in java-camel samples wasn't caught by the current pipeline setup.

While testing my changes, I discovered that https://github.com/OpenAPITools/openapi-generator/pull/18870 recently broke the java-camel samples.

I also had to move the java-camel checks to JDK 17, because these samples now use an option that's not available in Java 8.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
  @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
