### PR TITLE
Add Python 3.12 to test matrix

### DIFF
--- a/.github/workflows/samples-python-petstore.yaml
+++ b/.github/workflows/samples-python-petstore.yaml
@@ -19,6 +19,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         sample:
           - samples/openapi3/client/petstore/python-aiohttp
           - samples/openapi3/client/petstore/python


### PR DESCRIPTION
Python 3.12 has been released. Update the Python versions used in tests
accordingly.

See: https://devguide.python.org/versions/