### PR TITLE
Upgrade rust-hyper to use hyper 1.0

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
@@ -40,8 +40,9 @@ serde_json = "^1.0"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
 {{#hyper}}
-hyper = { version = "~0.14", features = ["full"] }
-hyper-tls = "~0.5"
+hyper = { version = "^1.3.1", features = ["full"] }
+hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util = { version = "0.1.2" }
 http = "~0.2"
 base64 = "~0.7.0"
 futures = "^0.3"

--- a/modules/openapi-generator/src/main/resources/rust/hyper/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/hyper/api.mustache
@@ -6,18 +6,19 @@ use std::pin::Pin;
 use std::option::Option;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use futures::Future;
 
 use crate::models;
 use super::{Error, configuration};
 use super::request as __internal_request;
 
-pub struct {{{classname}}}Client<C: hyper::client::connect::Connect>
+pub struct {{{classname}}}Client<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     configuration: Rc<configuration::Configuration<C>>,
 }
 
-impl<C: hyper::client::connect::Connect> {{{classname}}}Client<C>
+impl<C: Connect> {{{classname}}}Client<C>
     where C: Clone + std::marker::Send + Sync {
     pub fn new(configuration: Rc<configuration::Configuration<C>>) -> {{{classname}}}Client<C> {
         {{{classname}}}Client {
@@ -34,7 +35,7 @@ pub trait {{{classname}}} {
 {{/operations}}
 }
 
-impl<C: hyper::client::connect::Connect>{{{classname}}} for {{{classname}}}Client<C>
+impl<C: Connect>{{{classname}}} for {{{classname}}}Client<C>
     where C: Clone + std::marker::Send + Sync {
  {{#operations}}
  {{#operation}}

--- a/modules/openapi-generator/src/main/resources/rust/hyper/api_mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/hyper/api_mod.mustache
@@ -1,25 +1,38 @@
-use http;
+use std::fmt;
+use std::fmt::Debug;
+
 use hyper;
+use hyper::http;
+use hyper_util::client::legacy::connect::Connect;
 use serde_json;
 
 #[derive(Debug)]
 pub enum Error {
     Api(ApiError),
-    Header(hyper::http::header::InvalidHeaderValue),
+    Header(http::header::InvalidHeaderValue),
     Http(http::Error),
     Hyper(hyper::Error),
+    HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
     UriError(http::uri::InvalidUri),
 }
 
-#[derive(Debug)]
 pub struct ApiError {
     pub code: hyper::StatusCode,
-    pub body: hyper::body::Body,
+    pub body: hyper::body::Incoming,
 }
 
-impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
-    fn from(e: (hyper::StatusCode, hyper::body::Body)) -> Self {
+impl Debug for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApiError")
+         .field("code", &self.code)
+         .field("body", &"hyper::body::Incoming")
+         .finish()
+    }
+}
+
+impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
+    fn from(e: (hyper::StatusCode, hyper::body::Incoming)) -> Self {
         Error::Api(ApiError {
             code: e.0,
             body: e.1,
@@ -30,6 +43,12 @@ impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)
+    }
+}
+
+impl From<hyper_util::client::legacy::Error> for Error {
+    fn from(e: hyper_util::client::legacy::Error) -> Self {
+        Error::HyperClient(e)
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/rust/hyper/client.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/hyper/client.mustache
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use super::configuration::Configuration;
 
 pub struct APIClient {
@@ -18,7 +19,7 @@ pub struct APIClient {
 }
 
 impl APIClient {
-    pub fn new<C: hyper::client::connect::Connect>(configuration: Configuration<C>) -> APIClient
+    pub fn new<C: Connect>(configuration: Configuration<C>) -> APIClient
         where C: Clone + std::marker::Send + Sync + 'static {
         let rc = Rc::new(configuration);
 

--- a/modules/openapi-generator/src/main/resources/rust/hyper/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/hyper/configuration.mustache
@@ -1,11 +1,13 @@
 {{>partial_header}}
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::Client;
 
-pub struct Configuration<C: hyper::client::connect::Connect>
+pub struct Configuration<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub client: hyper::client::Client<C>,
+    pub client: Client<C, String>,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
@@ -19,9 +21,9 @@ pub struct ApiKey {
     pub key: String,
 }
 
-impl<C: hyper::client::connect::Connect> Configuration<C>
+impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: hyper::client::Client<C>) -> Configuration<C> {
+    pub fn new(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "{{{basePath}}}".to_owned(),
             user_agent: {{#httpUserAgent}}Some("{{{.}}}".to_owned()){{/httpUserAgent}}{{^httpUserAgent}}Some("OpenAPI-Generator/{{{version}}}/rust".to_owned()){{/httpUserAgent}},

--- a/modules/openapi-generator/src/main/resources/rust/hyper/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/hyper/configuration.mustache
@@ -1,9 +1,11 @@
 {{>partial_header}}
 use hyper;
-use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioExecutor;
 
-pub struct Configuration<C: Connect>
+pub struct Configuration<C: Connect = HttpConnector>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
@@ -21,9 +23,41 @@ pub struct ApiKey {
     pub key: String,
 }
 
+impl Configuration<HttpConnector> {
+    /// Construct a default [`Configuration`](Self) with a hyper client using a default
+    /// [`HttpConnector`](hyper_util::client::legacy::connect::HttpConnector).
+    ///
+    /// Use [`with_client`](Configuration<T>::with_client) to construct a Configuration with a
+    /// custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let api_config = {
+    ///   api_key: "my-api-key",
+    ///   ...Configuration::new()
+    /// }
+    /// ```
+    pub fn new() -> Configuration<HttpConnector> {
+        Configuration::default()
+    }
+}
+
 impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: Client<C, String>) -> Configuration<C> {
+
+    /// Construct a new Configuration with a custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let client = Client::builder(TokioExecutor::new())
+    ///   .pool_idle_timeout(Duration::from_secs(30))
+    ///   .build_http();
+    ///
+    /// let api_config = Configuration::with_client(client);
+    /// ```
+    pub fn with_client(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "{{{basePath}}}".to_owned(),
             user_agent: {{#httpUserAgent}}Some("{{{.}}}".to_owned()){{/httpUserAgent}}{{^httpUserAgent}}Some("OpenAPI-Generator/{{{version}}}/rust".to_owned()){{/httpUserAgent}},
@@ -32,5 +66,12 @@ impl<C: Connect> Configuration<C>
             oauth_access_token: None,
             api_key: None,
         }
+    }
+}
+
+impl Default for Configuration<HttpConnector> {
+    fn default() -> Self {
+        let client = Client::builder(TokioExecutor::new()).build_http();
+    	Configuration::with_client(client)
     }
 }

--- a/modules/openapi-generator/src/main/resources/rust/request.rs
+++ b/modules/openapi-generator/src/main/resources/rust/request.rs
@@ -4,7 +4,9 @@ use std::pin::Pin;
 use futures;
 use futures::Future;
 use futures::future::*;
+use http_body_util::BodyExt;
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use hyper::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, USER_AGENT};
 use serde;
 use serde_json;
@@ -109,7 +111,7 @@ impl Request {
         conf: &configuration::Configuration<C>,
     ) -> Pin<Box<dyn Future<Output=Result<U, Error>> + 'a>>
         where
-            C: hyper::client::connect::Connect + Clone + std::marker::Send + Sync,
+            C: Connect + Clone + std::marker::Send + Sync,
             U: Sized + std::marker::Send + 'a,
             for<'de> U: serde::Deserialize<'de>,
     {
@@ -203,13 +205,13 @@ impl Request {
             for (k, v) in self.form_params {
                 enc.append_pair(&k, &v);
             }
-            req_builder.body(hyper::Body::from(enc.finish()))
+            req_builder.body(enc.finish())
         } else if let Some(body) = self.serialized_body {
             req_headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
             req_headers.insert(CONTENT_LENGTH, body.len().into());
-            req_builder.body(hyper::Body::from(body))
+            req_builder.body(body)
         } else {
-            req_builder.body(hyper::Body::default())
+            req_builder.body(String::new())
         };
         let request = match request_result {
             Ok(request) => request,
@@ -233,9 +235,12 @@ impl Request {
                     // need to impl default for all models.
                     futures::future::ok::<U, Error>(serde_json::from_str("null").expect("serde null value")).boxed()
                 } else {
-                    hyper::body::to_bytes(response.into_body())
-                        .map(|bytes| serde_json::from_slice(&bytes.unwrap()))
-                        .map_err(|e| Error::from(e)).boxed()
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect.map(|collected| {
+                        collected.and_then(|collected| {
+                           serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
+                        })
+                    }).boxed()
                 }
             }))
     }

--- a/samples/client/others/rust/Cargo.lock
+++ b/samples/client/others/rust/Cargo.lock
@@ -23,11 +23,11 @@ version = "0.0.0"
 dependencies = [
  "base64 0.7.0",
  "futures",
- "http",
+ "http 0.2.11",
+ "http-body-util",
  "hyper",
- "hyper-tls",
+ "hyper-util",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
  "uuid",
@@ -39,11 +39,16 @@ version = "0.0.0"
 dependencies = [
  "reqwest",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
  "uuid",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -78,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -108,9 +113,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "5208975e568d83b6b05cc0a063c8e7e9acc2b43bee6da15616a5b73e109d7437"
 
 [[package]]
 name = "cfg-if"
@@ -124,11 +129,11 @@ version = "1.0.0"
 dependencies = [
  "base64 0.7.0",
  "futures",
- "http",
+ "http 0.2.11",
+ "http-body-util",
  "hyper",
- "hyper-tls",
+ "hyper-util",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
  "uuid",
@@ -140,7 +145,6 @@ version = "1.0.0"
 dependencies = [
  "reqwest",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
  "uuid",
@@ -168,11 +172,11 @@ version = "1.0.0"
 dependencies = [
  "base64 0.7.0",
  "futures",
- "http",
+ "http 0.2.11",
+ "http-body-util",
  "hyper",
- "hyper-tls",
+ "hyper-util",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
  "uuid",
@@ -184,7 +188,6 @@ version = "1.0.0"
 dependencies = [
  "reqwest",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
  "uuid",
@@ -258,9 +261,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -373,16 +376,16 @@ checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
- "http",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -414,13 +417,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "0.4.6"
+name = "http"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
- "http",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -438,46 +464,83 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 1.1.0",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -542,9 +605,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "linux-raw-sys"
@@ -619,16 +682,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,11 +702,11 @@ version = "0.0.1"
 dependencies = [
  "base64 0.7.0",
  "futures",
- "http",
+ "http 0.2.11",
+ "http-body-util",
  "hyper",
- "hyper-tls",
+ "hyper-util",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
  "uuid",
@@ -665,7 +718,6 @@ version = "0.0.1"
 dependencies = [
  "reqwest",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
  "uuid",
@@ -677,11 +729,11 @@ version = "0.0.1"
 dependencies = [
  "base64 0.7.0",
  "futures",
- "http",
+ "http 0.2.11",
+ "http-body-util",
  "hyper",
- "hyper-tls",
+ "hyper-util",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
  "uuid",
@@ -693,7 +745,6 @@ version = "0.0.1"
 dependencies = [
  "reqwest",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
  "uuid",
@@ -705,11 +756,11 @@ version = "1.0.0"
 dependencies = [
  "base64 0.7.0",
  "futures",
- "http",
+ "http 0.2.11",
+ "http-body-util",
  "hyper",
- "hyper-tls",
+ "hyper-util",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
  "uuid",
@@ -721,7 +772,6 @@ version = "1.0.0"
 dependencies = [
  "reqwest",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
  "uuid",
@@ -773,9 +823,29 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -828,7 +898,6 @@ version = "0.1.0"
 dependencies = [
  "reqwest",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
  "uuid",
@@ -836,20 +905,24 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 1.1.0",
  "http-body",
+ "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -876,6 +949,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,12 +984,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
- "base64 0.21.7",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -953,6 +1072,9 @@ name = "serde"
 version = "1.0.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91f70896d6720bc714a4a57d22fc91f1db634680e65c8efe13323f1fa38d53f"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -998,6 +1120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
 name = "socket2"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1134,18 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1020,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "system-configuration"
@@ -1083,7 +1223,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.48.0",
@@ -1100,6 +1239,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +1262,27 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -1175,10 +1346,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "url"
-version = "2.4.0"
+name = "untrusted"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1187,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
  "serde",
@@ -1332,6 +1509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,6 +1548,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1574,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1386,6 +1594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,6 +1610,18 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1410,6 +1636,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,6 +1652,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1434,6 +1672,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,11 +1690,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
+name = "windows_x86_64_msvc"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/samples/client/others/rust/hyper/api-with-ref-param/Cargo.toml
+++ b/samples/client/others/rust/hyper/api-with-ref-param/Cargo.toml
@@ -12,8 +12,9 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-hyper = { version = "~0.14", features = ["full"] }
-hyper-tls = "~0.5"
+hyper = { version = "^1.3.1", features = ["full"] }
+hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util = { version = "0.1.2" }
 http = "~0.2"
 base64 = "~0.7.0"
 futures = "^0.3"

--- a/samples/client/others/rust/hyper/api-with-ref-param/src/apis/client.rs
+++ b/samples/client/others/rust/hyper/api-with-ref-param/src/apis/client.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use super::configuration::Configuration;
 
 pub struct APIClient {
@@ -8,7 +9,7 @@ pub struct APIClient {
 }
 
 impl APIClient {
-    pub fn new<C: hyper::client::connect::Connect>(configuration: Configuration<C>) -> APIClient
+    pub fn new<C: Connect>(configuration: Configuration<C>) -> APIClient
         where C: Clone + std::marker::Send + Sync + 'static {
         let rc = Rc::new(configuration);
 

--- a/samples/client/others/rust/hyper/api-with-ref-param/src/apis/configuration.rs
+++ b/samples/client/others/rust/hyper/api-with-ref-param/src/apis/configuration.rs
@@ -9,12 +9,14 @@
  */
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::Client;
 
-pub struct Configuration<C: hyper::client::connect::Connect>
+pub struct Configuration<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub client: hyper::client::Client<C>,
+    pub client: Client<C, String>,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
@@ -28,9 +30,9 @@ pub struct ApiKey {
     pub key: String,
 }
 
-impl<C: hyper::client::connect::Connect> Configuration<C>
+impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: hyper::client::Client<C>) -> Configuration<C> {
+    pub fn new(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "http://localhost".to_owned(),
             user_agent: Some("OpenAPI-Generator/0.0.0/rust".to_owned()),

--- a/samples/client/others/rust/hyper/api-with-ref-param/src/apis/configuration.rs
+++ b/samples/client/others/rust/hyper/api-with-ref-param/src/apis/configuration.rs
@@ -9,10 +9,12 @@
  */
 
 use hyper;
-use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioExecutor;
 
-pub struct Configuration<C: Connect>
+pub struct Configuration<C: Connect = HttpConnector>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
@@ -30,9 +32,41 @@ pub struct ApiKey {
     pub key: String,
 }
 
+impl Configuration<HttpConnector> {
+    /// Construct a default [`Configuration`](Self) with a hyper client using a default
+    /// [`HttpConnector`](hyper_util::client::legacy::connect::HttpConnector).
+    ///
+    /// Use [`with_client`](Configuration<T>::with_client) to construct a Configuration with a
+    /// custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let api_config = {
+    ///   api_key: "my-api-key",
+    ///   ...Configuration::new()
+    /// }
+    /// ```
+    pub fn new() -> Configuration<HttpConnector> {
+        Configuration::default()
+    }
+}
+
 impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: Client<C, String>) -> Configuration<C> {
+
+    /// Construct a new Configuration with a custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let client = Client::builder(TokioExecutor::new())
+    ///   .pool_idle_timeout(Duration::from_secs(30))
+    ///   .build_http();
+    ///
+    /// let api_config = Configuration::with_client(client);
+    /// ```
+    pub fn with_client(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "http://localhost".to_owned(),
             user_agent: Some("OpenAPI-Generator/0.0.0/rust".to_owned()),
@@ -41,5 +75,12 @@ impl<C: Connect> Configuration<C>
             oauth_access_token: None,
             api_key: None,
         }
+    }
+}
+
+impl Default for Configuration<HttpConnector> {
+    fn default() -> Self {
+        let client = Client::builder(TokioExecutor::new()).build_http();
+    	Configuration::with_client(client)
     }
 }

--- a/samples/client/others/rust/hyper/api-with-ref-param/src/apis/default_api.rs
+++ b/samples/client/others/rust/hyper/api-with-ref-param/src/apis/default_api.rs
@@ -15,18 +15,19 @@ use std::pin::Pin;
 use std::option::Option;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use futures::Future;
 
 use crate::models;
 use super::{Error, configuration};
 use super::request as __internal_request;
 
-pub struct DefaultApiClient<C: hyper::client::connect::Connect>
+pub struct DefaultApiClient<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     configuration: Rc<configuration::Configuration<C>>,
 }
 
-impl<C: hyper::client::connect::Connect> DefaultApiClient<C>
+impl<C: Connect> DefaultApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     pub fn new(configuration: Rc<configuration::Configuration<C>>) -> DefaultApiClient<C> {
         DefaultApiClient {
@@ -39,7 +40,7 @@ pub trait DefaultApi {
     fn demo_color_get(&self, color: models::Color) -> Pin<Box<dyn Future<Output = Result<(), Error>>>>;
 }
 
-impl<C: hyper::client::connect::Connect>DefaultApi for DefaultApiClient<C>
+impl<C: Connect>DefaultApi for DefaultApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     #[allow(unused_mut)]
     fn demo_color_get(&self, color: models::Color) -> Pin<Box<dyn Future<Output = Result<(), Error>>>> {

--- a/samples/client/others/rust/hyper/api-with-ref-param/src/apis/mod.rs
+++ b/samples/client/others/rust/hyper/api-with-ref-param/src/apis/mod.rs
@@ -1,25 +1,38 @@
-use http;
+use std::fmt;
+use std::fmt::Debug;
+
 use hyper;
+use hyper::http;
+use hyper_util::client::legacy::connect::Connect;
 use serde_json;
 
 #[derive(Debug)]
 pub enum Error {
     Api(ApiError),
-    Header(hyper::http::header::InvalidHeaderValue),
+    Header(http::header::InvalidHeaderValue),
     Http(http::Error),
     Hyper(hyper::Error),
+    HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
     UriError(http::uri::InvalidUri),
 }
 
-#[derive(Debug)]
 pub struct ApiError {
     pub code: hyper::StatusCode,
-    pub body: hyper::body::Body,
+    pub body: hyper::body::Incoming,
 }
 
-impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
-    fn from(e: (hyper::StatusCode, hyper::body::Body)) -> Self {
+impl Debug for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApiError")
+         .field("code", &self.code)
+         .field("body", &"hyper::body::Incoming")
+         .finish()
+    }
+}
+
+impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
+    fn from(e: (hyper::StatusCode, hyper::body::Incoming)) -> Self {
         Error::Api(ApiError {
             code: e.0,
             body: e.1,
@@ -30,6 +43,12 @@ impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)
+    }
+}
+
+impl From<hyper_util::client::legacy::Error> for Error {
+    fn from(e: hyper_util::client::legacy::Error) -> Self {
+        Error::HyperClient(e)
     }
 }
 

--- a/samples/client/others/rust/hyper/api-with-ref-param/src/apis/request.rs
+++ b/samples/client/others/rust/hyper/api-with-ref-param/src/apis/request.rs
@@ -4,7 +4,9 @@ use std::pin::Pin;
 use futures;
 use futures::Future;
 use futures::future::*;
+use http_body_util::BodyExt;
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use hyper::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, USER_AGENT};
 use serde;
 use serde_json;
@@ -109,7 +111,7 @@ impl Request {
         conf: &configuration::Configuration<C>,
     ) -> Pin<Box<dyn Future<Output=Result<U, Error>> + 'a>>
         where
-            C: hyper::client::connect::Connect + Clone + std::marker::Send + Sync,
+            C: Connect + Clone + std::marker::Send + Sync,
             U: Sized + std::marker::Send + 'a,
             for<'de> U: serde::Deserialize<'de>,
     {
@@ -203,13 +205,13 @@ impl Request {
             for (k, v) in self.form_params {
                 enc.append_pair(&k, &v);
             }
-            req_builder.body(hyper::Body::from(enc.finish()))
+            req_builder.body(enc.finish())
         } else if let Some(body) = self.serialized_body {
             req_headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
             req_headers.insert(CONTENT_LENGTH, body.len().into());
-            req_builder.body(hyper::Body::from(body))
+            req_builder.body(body)
         } else {
-            req_builder.body(hyper::Body::default())
+            req_builder.body(String::new())
         };
         let request = match request_result {
             Ok(request) => request,
@@ -233,9 +235,12 @@ impl Request {
                     // need to impl default for all models.
                     futures::future::ok::<U, Error>(serde_json::from_str("null").expect("serde null value")).boxed()
                 } else {
-                    hyper::body::to_bytes(response.into_body())
-                        .map(|bytes| serde_json::from_slice(&bytes.unwrap()))
-                        .map_err(|e| Error::from(e)).boxed()
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect.map(|collected| {
+                        collected.and_then(|collected| {
+                           serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
+                        })
+                    }).boxed()
                 }
             }))
     }

--- a/samples/client/others/rust/hyper/composed-oneof/Cargo.toml
+++ b/samples/client/others/rust/hyper/composed-oneof/Cargo.toml
@@ -12,8 +12,9 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-hyper = { version = "~0.14", features = ["full"] }
-hyper-tls = "~0.5"
+hyper = { version = "^1.3.1", features = ["full"] }
+hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util = { version = "0.1.2" }
 http = "~0.2"
 base64 = "~0.7.0"
 futures = "^0.3"

--- a/samples/client/others/rust/hyper/composed-oneof/src/apis/client.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/apis/client.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use super::configuration::Configuration;
 
 pub struct APIClient {
@@ -8,7 +9,7 @@ pub struct APIClient {
 }
 
 impl APIClient {
-    pub fn new<C: hyper::client::connect::Connect>(configuration: Configuration<C>) -> APIClient
+    pub fn new<C: Connect>(configuration: Configuration<C>) -> APIClient
         where C: Clone + std::marker::Send + Sync + 'static {
         let rc = Rc::new(configuration);
 

--- a/samples/client/others/rust/hyper/composed-oneof/src/apis/configuration.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/apis/configuration.rs
@@ -9,12 +9,14 @@
  */
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::Client;
 
-pub struct Configuration<C: hyper::client::connect::Connect>
+pub struct Configuration<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub client: hyper::client::Client<C>,
+    pub client: Client<C, String>,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
@@ -28,9 +30,9 @@ pub struct ApiKey {
     pub key: String,
 }
 
-impl<C: hyper::client::connect::Connect> Configuration<C>
+impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: hyper::client::Client<C>) -> Configuration<C> {
+    pub fn new(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "http://localhost:8000".to_owned(),
             user_agent: Some("OpenAPI-Generator/1.0.0/rust".to_owned()),

--- a/samples/client/others/rust/hyper/composed-oneof/src/apis/configuration.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/apis/configuration.rs
@@ -9,10 +9,12 @@
  */
 
 use hyper;
-use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioExecutor;
 
-pub struct Configuration<C: Connect>
+pub struct Configuration<C: Connect = HttpConnector>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
@@ -30,9 +32,41 @@ pub struct ApiKey {
     pub key: String,
 }
 
+impl Configuration<HttpConnector> {
+    /// Construct a default [`Configuration`](Self) with a hyper client using a default
+    /// [`HttpConnector`](hyper_util::client::legacy::connect::HttpConnector).
+    ///
+    /// Use [`with_client`](Configuration<T>::with_client) to construct a Configuration with a
+    /// custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let api_config = {
+    ///   api_key: "my-api-key",
+    ///   ...Configuration::new()
+    /// }
+    /// ```
+    pub fn new() -> Configuration<HttpConnector> {
+        Configuration::default()
+    }
+}
+
 impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: Client<C, String>) -> Configuration<C> {
+
+    /// Construct a new Configuration with a custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let client = Client::builder(TokioExecutor::new())
+    ///   .pool_idle_timeout(Duration::from_secs(30))
+    ///   .build_http();
+    ///
+    /// let api_config = Configuration::with_client(client);
+    /// ```
+    pub fn with_client(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "http://localhost:8000".to_owned(),
             user_agent: Some("OpenAPI-Generator/1.0.0/rust".to_owned()),
@@ -41,5 +75,12 @@ impl<C: Connect> Configuration<C>
             oauth_access_token: None,
             api_key: None,
         }
+    }
+}
+
+impl Default for Configuration<HttpConnector> {
+    fn default() -> Self {
+        let client = Client::builder(TokioExecutor::new()).build_http();
+    	Configuration::with_client(client)
     }
 }

--- a/samples/client/others/rust/hyper/composed-oneof/src/apis/default_api.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/apis/default_api.rs
@@ -15,18 +15,19 @@ use std::pin::Pin;
 use std::option::Option;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use futures::Future;
 
 use crate::models;
 use super::{Error, configuration};
 use super::request as __internal_request;
 
-pub struct DefaultApiClient<C: hyper::client::connect::Connect>
+pub struct DefaultApiClient<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     configuration: Rc<configuration::Configuration<C>>,
 }
 
-impl<C: hyper::client::connect::Connect> DefaultApiClient<C>
+impl<C: Connect> DefaultApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     pub fn new(configuration: Rc<configuration::Configuration<C>>) -> DefaultApiClient<C> {
         DefaultApiClient {
@@ -40,7 +41,7 @@ pub trait DefaultApi {
     fn get_state(&self, ) -> Pin<Box<dyn Future<Output = Result<models::GetState200Response, Error>>>>;
 }
 
-impl<C: hyper::client::connect::Connect>DefaultApi for DefaultApiClient<C>
+impl<C: Connect>DefaultApi for DefaultApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     #[allow(unused_mut)]
     fn create_state(&self, create_state_request: models::CreateStateRequest) -> Pin<Box<dyn Future<Output = Result<(), Error>>>> {

--- a/samples/client/others/rust/hyper/composed-oneof/src/apis/mod.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/apis/mod.rs
@@ -1,25 +1,38 @@
-use http;
+use std::fmt;
+use std::fmt::Debug;
+
 use hyper;
+use hyper::http;
+use hyper_util::client::legacy::connect::Connect;
 use serde_json;
 
 #[derive(Debug)]
 pub enum Error {
     Api(ApiError),
-    Header(hyper::http::header::InvalidHeaderValue),
+    Header(http::header::InvalidHeaderValue),
     Http(http::Error),
     Hyper(hyper::Error),
+    HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
     UriError(http::uri::InvalidUri),
 }
 
-#[derive(Debug)]
 pub struct ApiError {
     pub code: hyper::StatusCode,
-    pub body: hyper::body::Body,
+    pub body: hyper::body::Incoming,
 }
 
-impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
-    fn from(e: (hyper::StatusCode, hyper::body::Body)) -> Self {
+impl Debug for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApiError")
+         .field("code", &self.code)
+         .field("body", &"hyper::body::Incoming")
+         .finish()
+    }
+}
+
+impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
+    fn from(e: (hyper::StatusCode, hyper::body::Incoming)) -> Self {
         Error::Api(ApiError {
             code: e.0,
             body: e.1,
@@ -30,6 +43,12 @@ impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)
+    }
+}
+
+impl From<hyper_util::client::legacy::Error> for Error {
+    fn from(e: hyper_util::client::legacy::Error) -> Self {
+        Error::HyperClient(e)
     }
 }
 

--- a/samples/client/others/rust/hyper/composed-oneof/src/apis/request.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/apis/request.rs
@@ -4,7 +4,9 @@ use std::pin::Pin;
 use futures;
 use futures::Future;
 use futures::future::*;
+use http_body_util::BodyExt;
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use hyper::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, USER_AGENT};
 use serde;
 use serde_json;
@@ -109,7 +111,7 @@ impl Request {
         conf: &configuration::Configuration<C>,
     ) -> Pin<Box<dyn Future<Output=Result<U, Error>> + 'a>>
         where
-            C: hyper::client::connect::Connect + Clone + std::marker::Send + Sync,
+            C: Connect + Clone + std::marker::Send + Sync,
             U: Sized + std::marker::Send + 'a,
             for<'de> U: serde::Deserialize<'de>,
     {
@@ -203,13 +205,13 @@ impl Request {
             for (k, v) in self.form_params {
                 enc.append_pair(&k, &v);
             }
-            req_builder.body(hyper::Body::from(enc.finish()))
+            req_builder.body(enc.finish())
         } else if let Some(body) = self.serialized_body {
             req_headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
             req_headers.insert(CONTENT_LENGTH, body.len().into());
-            req_builder.body(hyper::Body::from(body))
+            req_builder.body(body)
         } else {
-            req_builder.body(hyper::Body::default())
+            req_builder.body(String::new())
         };
         let request = match request_result {
             Ok(request) => request,
@@ -233,9 +235,12 @@ impl Request {
                     // need to impl default for all models.
                     futures::future::ok::<U, Error>(serde_json::from_str("null").expect("serde null value")).boxed()
                 } else {
-                    hyper::body::to_bytes(response.into_body())
-                        .map(|bytes| serde_json::from_slice(&bytes.unwrap()))
-                        .map_err(|e| Error::from(e)).boxed()
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect.map(|collected| {
+                        collected.and_then(|collected| {
+                           serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
+                        })
+                    }).boxed()
                 }
             }))
     }

--- a/samples/client/others/rust/hyper/emptyObject/Cargo.toml
+++ b/samples/client/others/rust/hyper/emptyObject/Cargo.toml
@@ -12,8 +12,9 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-hyper = { version = "~0.14", features = ["full"] }
-hyper-tls = "~0.5"
+hyper = { version = "^1.3.1", features = ["full"] }
+hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util = { version = "0.1.2" }
 http = "~0.2"
 base64 = "~0.7.0"
 futures = "^0.3"

--- a/samples/client/others/rust/hyper/emptyObject/src/apis/client.rs
+++ b/samples/client/others/rust/hyper/emptyObject/src/apis/client.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use super::configuration::Configuration;
 
 pub struct APIClient {
@@ -8,7 +9,7 @@ pub struct APIClient {
 }
 
 impl APIClient {
-    pub fn new<C: hyper::client::connect::Connect>(configuration: Configuration<C>) -> APIClient
+    pub fn new<C: Connect>(configuration: Configuration<C>) -> APIClient
         where C: Clone + std::marker::Send + Sync + 'static {
         let rc = Rc::new(configuration);
 

--- a/samples/client/others/rust/hyper/emptyObject/src/apis/configuration.rs
+++ b/samples/client/others/rust/hyper/emptyObject/src/apis/configuration.rs
@@ -9,12 +9,14 @@
  */
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::Client;
 
-pub struct Configuration<C: hyper::client::connect::Connect>
+pub struct Configuration<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub client: hyper::client::Client<C>,
+    pub client: Client<C, String>,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
@@ -28,9 +30,9 @@ pub struct ApiKey {
     pub key: String,
 }
 
-impl<C: hyper::client::connect::Connect> Configuration<C>
+impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: hyper::client::Client<C>) -> Configuration<C> {
+    pub fn new(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "http://localhost".to_owned(),
             user_agent: Some("OpenAPI-Generator/1.0.0/rust".to_owned()),

--- a/samples/client/others/rust/hyper/emptyObject/src/apis/configuration.rs
+++ b/samples/client/others/rust/hyper/emptyObject/src/apis/configuration.rs
@@ -9,10 +9,12 @@
  */
 
 use hyper;
-use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioExecutor;
 
-pub struct Configuration<C: Connect>
+pub struct Configuration<C: Connect = HttpConnector>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
@@ -30,9 +32,41 @@ pub struct ApiKey {
     pub key: String,
 }
 
+impl Configuration<HttpConnector> {
+    /// Construct a default [`Configuration`](Self) with a hyper client using a default
+    /// [`HttpConnector`](hyper_util::client::legacy::connect::HttpConnector).
+    ///
+    /// Use [`with_client`](Configuration<T>::with_client) to construct a Configuration with a
+    /// custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let api_config = {
+    ///   api_key: "my-api-key",
+    ///   ...Configuration::new()
+    /// }
+    /// ```
+    pub fn new() -> Configuration<HttpConnector> {
+        Configuration::default()
+    }
+}
+
 impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: Client<C, String>) -> Configuration<C> {
+
+    /// Construct a new Configuration with a custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let client = Client::builder(TokioExecutor::new())
+    ///   .pool_idle_timeout(Duration::from_secs(30))
+    ///   .build_http();
+    ///
+    /// let api_config = Configuration::with_client(client);
+    /// ```
+    pub fn with_client(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "http://localhost".to_owned(),
             user_agent: Some("OpenAPI-Generator/1.0.0/rust".to_owned()),
@@ -41,5 +75,12 @@ impl<C: Connect> Configuration<C>
             oauth_access_token: None,
             api_key: None,
         }
+    }
+}
+
+impl Default for Configuration<HttpConnector> {
+    fn default() -> Self {
+        let client = Client::builder(TokioExecutor::new()).build_http();
+    	Configuration::with_client(client)
     }
 }

--- a/samples/client/others/rust/hyper/emptyObject/src/apis/default_api.rs
+++ b/samples/client/others/rust/hyper/emptyObject/src/apis/default_api.rs
@@ -15,18 +15,19 @@ use std::pin::Pin;
 use std::option::Option;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use futures::Future;
 
 use crate::models;
 use super::{Error, configuration};
 use super::request as __internal_request;
 
-pub struct DefaultApiClient<C: hyper::client::connect::Connect>
+pub struct DefaultApiClient<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     configuration: Rc<configuration::Configuration<C>>,
 }
 
-impl<C: hyper::client::connect::Connect> DefaultApiClient<C>
+impl<C: Connect> DefaultApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     pub fn new(configuration: Rc<configuration::Configuration<C>>) -> DefaultApiClient<C> {
         DefaultApiClient {
@@ -39,7 +40,7 @@ pub trait DefaultApi {
     fn endpoint_get(&self, ) -> Pin<Box<dyn Future<Output = Result<models::EmptyObject, Error>>>>;
 }
 
-impl<C: hyper::client::connect::Connect>DefaultApi for DefaultApiClient<C>
+impl<C: Connect>DefaultApi for DefaultApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     #[allow(unused_mut)]
     fn endpoint_get(&self, ) -> Pin<Box<dyn Future<Output = Result<models::EmptyObject, Error>>>> {

--- a/samples/client/others/rust/hyper/emptyObject/src/apis/mod.rs
+++ b/samples/client/others/rust/hyper/emptyObject/src/apis/mod.rs
@@ -1,25 +1,38 @@
-use http;
+use std::fmt;
+use std::fmt::Debug;
+
 use hyper;
+use hyper::http;
+use hyper_util::client::legacy::connect::Connect;
 use serde_json;
 
 #[derive(Debug)]
 pub enum Error {
     Api(ApiError),
-    Header(hyper::http::header::InvalidHeaderValue),
+    Header(http::header::InvalidHeaderValue),
     Http(http::Error),
     Hyper(hyper::Error),
+    HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
     UriError(http::uri::InvalidUri),
 }
 
-#[derive(Debug)]
 pub struct ApiError {
     pub code: hyper::StatusCode,
-    pub body: hyper::body::Body,
+    pub body: hyper::body::Incoming,
 }
 
-impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
-    fn from(e: (hyper::StatusCode, hyper::body::Body)) -> Self {
+impl Debug for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApiError")
+         .field("code", &self.code)
+         .field("body", &"hyper::body::Incoming")
+         .finish()
+    }
+}
+
+impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
+    fn from(e: (hyper::StatusCode, hyper::body::Incoming)) -> Self {
         Error::Api(ApiError {
             code: e.0,
             body: e.1,
@@ -30,6 +43,12 @@ impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)
+    }
+}
+
+impl From<hyper_util::client::legacy::Error> for Error {
+    fn from(e: hyper_util::client::legacy::Error) -> Self {
+        Error::HyperClient(e)
     }
 }
 

--- a/samples/client/others/rust/hyper/emptyObject/src/apis/request.rs
+++ b/samples/client/others/rust/hyper/emptyObject/src/apis/request.rs
@@ -4,7 +4,9 @@ use std::pin::Pin;
 use futures;
 use futures::Future;
 use futures::future::*;
+use http_body_util::BodyExt;
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use hyper::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, USER_AGENT};
 use serde;
 use serde_json;
@@ -109,7 +111,7 @@ impl Request {
         conf: &configuration::Configuration<C>,
     ) -> Pin<Box<dyn Future<Output=Result<U, Error>> + 'a>>
         where
-            C: hyper::client::connect::Connect + Clone + std::marker::Send + Sync,
+            C: Connect + Clone + std::marker::Send + Sync,
             U: Sized + std::marker::Send + 'a,
             for<'de> U: serde::Deserialize<'de>,
     {
@@ -203,13 +205,13 @@ impl Request {
             for (k, v) in self.form_params {
                 enc.append_pair(&k, &v);
             }
-            req_builder.body(hyper::Body::from(enc.finish()))
+            req_builder.body(enc.finish())
         } else if let Some(body) = self.serialized_body {
             req_headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
             req_headers.insert(CONTENT_LENGTH, body.len().into());
-            req_builder.body(hyper::Body::from(body))
+            req_builder.body(body)
         } else {
-            req_builder.body(hyper::Body::default())
+            req_builder.body(String::new())
         };
         let request = match request_result {
             Ok(request) => request,
@@ -233,9 +235,12 @@ impl Request {
                     // need to impl default for all models.
                     futures::future::ok::<U, Error>(serde_json::from_str("null").expect("serde null value")).boxed()
                 } else {
-                    hyper::body::to_bytes(response.into_body())
-                        .map(|bytes| serde_json::from_slice(&bytes.unwrap()))
-                        .map_err(|e| Error::from(e)).boxed()
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect.map(|collected| {
+                        collected.and_then(|collected| {
+                           serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
+                        })
+                    }).boxed()
                 }
             }))
     }

--- a/samples/client/others/rust/hyper/oneOf-array-map/Cargo.toml
+++ b/samples/client/others/rust/hyper/oneOf-array-map/Cargo.toml
@@ -12,8 +12,9 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-hyper = { version = "~0.14", features = ["full"] }
-hyper-tls = "~0.5"
+hyper = { version = "^1.3.1", features = ["full"] }
+hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util = { version = "0.1.2" }
 http = "~0.2"
 base64 = "~0.7.0"
 futures = "^0.3"

--- a/samples/client/others/rust/hyper/oneOf-array-map/src/apis/client.rs
+++ b/samples/client/others/rust/hyper/oneOf-array-map/src/apis/client.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use super::configuration::Configuration;
 
 pub struct APIClient {
@@ -8,7 +9,7 @@ pub struct APIClient {
 }
 
 impl APIClient {
-    pub fn new<C: hyper::client::connect::Connect>(configuration: Configuration<C>) -> APIClient
+    pub fn new<C: Connect>(configuration: Configuration<C>) -> APIClient
         where C: Clone + std::marker::Send + Sync + 'static {
         let rc = Rc::new(configuration);
 

--- a/samples/client/others/rust/hyper/oneOf-array-map/src/apis/configuration.rs
+++ b/samples/client/others/rust/hyper/oneOf-array-map/src/apis/configuration.rs
@@ -9,12 +9,14 @@
  */
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::Client;
 
-pub struct Configuration<C: hyper::client::connect::Connect>
+pub struct Configuration<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub client: hyper::client::Client<C>,
+    pub client: Client<C, String>,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
@@ -28,9 +30,9 @@ pub struct ApiKey {
     pub key: String,
 }
 
-impl<C: hyper::client::connect::Connect> Configuration<C>
+impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: hyper::client::Client<C>) -> Configuration<C> {
+    pub fn new(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "http://localhost".to_owned(),
             user_agent: Some("OpenAPI-Generator/0.0.1/rust".to_owned()),

--- a/samples/client/others/rust/hyper/oneOf-array-map/src/apis/configuration.rs
+++ b/samples/client/others/rust/hyper/oneOf-array-map/src/apis/configuration.rs
@@ -9,10 +9,12 @@
  */
 
 use hyper;
-use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioExecutor;
 
-pub struct Configuration<C: Connect>
+pub struct Configuration<C: Connect = HttpConnector>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
@@ -30,9 +32,41 @@ pub struct ApiKey {
     pub key: String,
 }
 
+impl Configuration<HttpConnector> {
+    /// Construct a default [`Configuration`](Self) with a hyper client using a default
+    /// [`HttpConnector`](hyper_util::client::legacy::connect::HttpConnector).
+    ///
+    /// Use [`with_client`](Configuration<T>::with_client) to construct a Configuration with a
+    /// custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let api_config = {
+    ///   api_key: "my-api-key",
+    ///   ...Configuration::new()
+    /// }
+    /// ```
+    pub fn new() -> Configuration<HttpConnector> {
+        Configuration::default()
+    }
+}
+
 impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: Client<C, String>) -> Configuration<C> {
+
+    /// Construct a new Configuration with a custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let client = Client::builder(TokioExecutor::new())
+    ///   .pool_idle_timeout(Duration::from_secs(30))
+    ///   .build_http();
+    ///
+    /// let api_config = Configuration::with_client(client);
+    /// ```
+    pub fn with_client(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "http://localhost".to_owned(),
             user_agent: Some("OpenAPI-Generator/0.0.1/rust".to_owned()),
@@ -41,5 +75,12 @@ impl<C: Connect> Configuration<C>
             oauth_access_token: None,
             api_key: None,
         }
+    }
+}
+
+impl Default for Configuration<HttpConnector> {
+    fn default() -> Self {
+        let client = Client::builder(TokioExecutor::new()).build_http();
+    	Configuration::with_client(client)
     }
 }

--- a/samples/client/others/rust/hyper/oneOf-array-map/src/apis/default_api.rs
+++ b/samples/client/others/rust/hyper/oneOf-array-map/src/apis/default_api.rs
@@ -15,18 +15,19 @@ use std::pin::Pin;
 use std::option::Option;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use futures::Future;
 
 use crate::models;
 use super::{Error, configuration};
 use super::request as __internal_request;
 
-pub struct DefaultApiClient<C: hyper::client::connect::Connect>
+pub struct DefaultApiClient<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     configuration: Rc<configuration::Configuration<C>>,
 }
 
-impl<C: hyper::client::connect::Connect> DefaultApiClient<C>
+impl<C: Connect> DefaultApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     pub fn new(configuration: Rc<configuration::Configuration<C>>) -> DefaultApiClient<C> {
         DefaultApiClient {
@@ -40,7 +41,7 @@ pub trait DefaultApi {
     fn test(&self, body: Option<serde_json::Value>) -> Pin<Box<dyn Future<Output = Result<(), Error>>>>;
 }
 
-impl<C: hyper::client::connect::Connect>DefaultApi for DefaultApiClient<C>
+impl<C: Connect>DefaultApi for DefaultApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     #[allow(unused_mut)]
     fn root_get(&self, ) -> Pin<Box<dyn Future<Output = Result<models::Fruit, Error>>>> {

--- a/samples/client/others/rust/hyper/oneOf-array-map/src/apis/mod.rs
+++ b/samples/client/others/rust/hyper/oneOf-array-map/src/apis/mod.rs
@@ -1,25 +1,38 @@
-use http;
+use std::fmt;
+use std::fmt::Debug;
+
 use hyper;
+use hyper::http;
+use hyper_util::client::legacy::connect::Connect;
 use serde_json;
 
 #[derive(Debug)]
 pub enum Error {
     Api(ApiError),
-    Header(hyper::http::header::InvalidHeaderValue),
+    Header(http::header::InvalidHeaderValue),
     Http(http::Error),
     Hyper(hyper::Error),
+    HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
     UriError(http::uri::InvalidUri),
 }
 
-#[derive(Debug)]
 pub struct ApiError {
     pub code: hyper::StatusCode,
-    pub body: hyper::body::Body,
+    pub body: hyper::body::Incoming,
 }
 
-impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
-    fn from(e: (hyper::StatusCode, hyper::body::Body)) -> Self {
+impl Debug for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApiError")
+         .field("code", &self.code)
+         .field("body", &"hyper::body::Incoming")
+         .finish()
+    }
+}
+
+impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
+    fn from(e: (hyper::StatusCode, hyper::body::Incoming)) -> Self {
         Error::Api(ApiError {
             code: e.0,
             body: e.1,
@@ -30,6 +43,12 @@ impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)
+    }
+}
+
+impl From<hyper_util::client::legacy::Error> for Error {
+    fn from(e: hyper_util::client::legacy::Error) -> Self {
+        Error::HyperClient(e)
     }
 }
 

--- a/samples/client/others/rust/hyper/oneOf-array-map/src/apis/request.rs
+++ b/samples/client/others/rust/hyper/oneOf-array-map/src/apis/request.rs
@@ -4,7 +4,9 @@ use std::pin::Pin;
 use futures;
 use futures::Future;
 use futures::future::*;
+use http_body_util::BodyExt;
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use hyper::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, USER_AGENT};
 use serde;
 use serde_json;
@@ -109,7 +111,7 @@ impl Request {
         conf: &configuration::Configuration<C>,
     ) -> Pin<Box<dyn Future<Output=Result<U, Error>> + 'a>>
         where
-            C: hyper::client::connect::Connect + Clone + std::marker::Send + Sync,
+            C: Connect + Clone + std::marker::Send + Sync,
             U: Sized + std::marker::Send + 'a,
             for<'de> U: serde::Deserialize<'de>,
     {
@@ -203,13 +205,13 @@ impl Request {
             for (k, v) in self.form_params {
                 enc.append_pair(&k, &v);
             }
-            req_builder.body(hyper::Body::from(enc.finish()))
+            req_builder.body(enc.finish())
         } else if let Some(body) = self.serialized_body {
             req_headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
             req_headers.insert(CONTENT_LENGTH, body.len().into());
-            req_builder.body(hyper::Body::from(body))
+            req_builder.body(body)
         } else {
-            req_builder.body(hyper::Body::default())
+            req_builder.body(String::new())
         };
         let request = match request_result {
             Ok(request) => request,
@@ -233,9 +235,12 @@ impl Request {
                     // need to impl default for all models.
                     futures::future::ok::<U, Error>(serde_json::from_str("null").expect("serde null value")).boxed()
                 } else {
-                    hyper::body::to_bytes(response.into_body())
-                        .map(|bytes| serde_json::from_slice(&bytes.unwrap()))
-                        .map_err(|e| Error::from(e)).boxed()
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect.map(|collected| {
+                        collected.and_then(|collected| {
+                           serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
+                        })
+                    }).boxed()
                 }
             }))
     }

--- a/samples/client/others/rust/hyper/oneOf-reuseRef/Cargo.toml
+++ b/samples/client/others/rust/hyper/oneOf-reuseRef/Cargo.toml
@@ -11,8 +11,9 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-hyper = { version = "~0.14", features = ["full"] }
-hyper-tls = "~0.5"
+hyper = { version = "^1.3.1", features = ["full"] }
+hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util = { version = "0.1.2" }
 http = "~0.2"
 base64 = "~0.7.0"
 futures = "^0.3"

--- a/samples/client/others/rust/hyper/oneOf-reuseRef/src/apis/client.rs
+++ b/samples/client/others/rust/hyper/oneOf-reuseRef/src/apis/client.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use super::configuration::Configuration;
 
 pub struct APIClient {
@@ -8,7 +9,7 @@ pub struct APIClient {
 }
 
 impl APIClient {
-    pub fn new<C: hyper::client::connect::Connect>(configuration: Configuration<C>) -> APIClient
+    pub fn new<C: Connect>(configuration: Configuration<C>) -> APIClient
         where C: Clone + std::marker::Send + Sync + 'static {
         let rc = Rc::new(configuration);
 

--- a/samples/client/others/rust/hyper/oneOf-reuseRef/src/apis/configuration.rs
+++ b/samples/client/others/rust/hyper/oneOf-reuseRef/src/apis/configuration.rs
@@ -9,12 +9,14 @@
  */
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::Client;
 
-pub struct Configuration<C: hyper::client::connect::Connect>
+pub struct Configuration<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub client: hyper::client::Client<C>,
+    pub client: Client<C, String>,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
@@ -28,9 +30,9 @@ pub struct ApiKey {
     pub key: String,
 }
 
-impl<C: hyper::client::connect::Connect> Configuration<C>
+impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: hyper::client::Client<C>) -> Configuration<C> {
+    pub fn new(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "http://api.example.xyz/v1".to_owned(),
             user_agent: Some("OpenAPI-Generator/1.0.0/rust".to_owned()),

--- a/samples/client/others/rust/hyper/oneOf-reuseRef/src/apis/default_api.rs
+++ b/samples/client/others/rust/hyper/oneOf-reuseRef/src/apis/default_api.rs
@@ -15,18 +15,19 @@ use std::pin::Pin;
 use std::option::Option;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use futures::Future;
 
 use crate::models;
 use super::{Error, configuration};
 use super::request as __internal_request;
 
-pub struct DefaultApiClient<C: hyper::client::connect::Connect>
+pub struct DefaultApiClient<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     configuration: Rc<configuration::Configuration<C>>,
 }
 
-impl<C: hyper::client::connect::Connect> DefaultApiClient<C>
+impl<C: Connect> DefaultApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     pub fn new(configuration: Rc<configuration::Configuration<C>>) -> DefaultApiClient<C> {
         DefaultApiClient {
@@ -39,7 +40,7 @@ pub trait DefaultApi {
     fn get_fruit(&self, ) -> Pin<Box<dyn Future<Output = Result<models::Fruit, Error>>>>;
 }
 
-impl<C: hyper::client::connect::Connect>DefaultApi for DefaultApiClient<C>
+impl<C: Connect>DefaultApi for DefaultApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     #[allow(unused_mut)]
     fn get_fruit(&self, ) -> Pin<Box<dyn Future<Output = Result<models::Fruit, Error>>>> {

--- a/samples/client/others/rust/hyper/oneOf-reuseRef/src/apis/mod.rs
+++ b/samples/client/others/rust/hyper/oneOf-reuseRef/src/apis/mod.rs
@@ -1,25 +1,38 @@
-use http;
+use std::fmt;
+use std::fmt::Debug;
+
 use hyper;
+use hyper::http;
+use hyper_util::client::legacy::connect::Connect;
 use serde_json;
 
 #[derive(Debug)]
 pub enum Error {
     Api(ApiError),
-    Header(hyper::http::header::InvalidHeaderValue),
+    Header(http::header::InvalidHeaderValue),
     Http(http::Error),
     Hyper(hyper::Error),
+    HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
     UriError(http::uri::InvalidUri),
 }
 
-#[derive(Debug)]
 pub struct ApiError {
     pub code: hyper::StatusCode,
-    pub body: hyper::body::Body,
+    pub body: hyper::body::Incoming,
 }
 
-impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
-    fn from(e: (hyper::StatusCode, hyper::body::Body)) -> Self {
+impl Debug for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApiError")
+         .field("code", &self.code)
+         .field("body", &"hyper::body::Incoming")
+         .finish()
+    }
+}
+
+impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
+    fn from(e: (hyper::StatusCode, hyper::body::Incoming)) -> Self {
         Error::Api(ApiError {
             code: e.0,
             body: e.1,
@@ -30,6 +43,12 @@ impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)
+    }
+}
+
+impl From<hyper_util::client::legacy::Error> for Error {
+    fn from(e: hyper_util::client::legacy::Error) -> Self {
+        Error::HyperClient(e)
     }
 }
 

--- a/samples/client/others/rust/hyper/oneOf-reuseRef/src/apis/request.rs
+++ b/samples/client/others/rust/hyper/oneOf-reuseRef/src/apis/request.rs
@@ -4,7 +4,9 @@ use std::pin::Pin;
 use futures;
 use futures::Future;
 use futures::future::*;
+use http_body_util::BodyExt;
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use hyper::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, USER_AGENT};
 use serde;
 use serde_json;
@@ -109,7 +111,7 @@ impl Request {
         conf: &configuration::Configuration<C>,
     ) -> Pin<Box<dyn Future<Output=Result<U, Error>> + 'a>>
         where
-            C: hyper::client::connect::Connect + Clone + std::marker::Send + Sync,
+            C: Connect + Clone + std::marker::Send + Sync,
             U: Sized + std::marker::Send + 'a,
             for<'de> U: serde::Deserialize<'de>,
     {
@@ -203,13 +205,13 @@ impl Request {
             for (k, v) in self.form_params {
                 enc.append_pair(&k, &v);
             }
-            req_builder.body(hyper::Body::from(enc.finish()))
+            req_builder.body(enc.finish())
         } else if let Some(body) = self.serialized_body {
             req_headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
             req_headers.insert(CONTENT_LENGTH, body.len().into());
-            req_builder.body(hyper::Body::from(body))
+            req_builder.body(body)
         } else {
-            req_builder.body(hyper::Body::default())
+            req_builder.body(String::new())
         };
         let request = match request_result {
             Ok(request) => request,
@@ -233,9 +235,12 @@ impl Request {
                     // need to impl default for all models.
                     futures::future::ok::<U, Error>(serde_json::from_str("null").expect("serde null value")).boxed()
                 } else {
-                    hyper::body::to_bytes(response.into_body())
-                        .map(|bytes| serde_json::from_slice(&bytes.unwrap()))
-                        .map_err(|e| Error::from(e)).boxed()
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect.map(|collected| {
+                        collected.and_then(|collected| {
+                           serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
+                        })
+                    }).boxed()
                 }
             }))
     }

--- a/samples/client/others/rust/hyper/oneOf/Cargo.toml
+++ b/samples/client/others/rust/hyper/oneOf/Cargo.toml
@@ -12,8 +12,9 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-hyper = { version = "~0.14", features = ["full"] }
-hyper-tls = "~0.5"
+hyper = { version = "^1.3.1", features = ["full"] }
+hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util = { version = "0.1.2" }
 http = "~0.2"
 base64 = "~0.7.0"
 futures = "^0.3"

--- a/samples/client/others/rust/hyper/oneOf/src/apis/bar_api.rs
+++ b/samples/client/others/rust/hyper/oneOf/src/apis/bar_api.rs
@@ -15,18 +15,19 @@ use std::pin::Pin;
 use std::option::Option;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use futures::Future;
 
 use crate::models;
 use super::{Error, configuration};
 use super::request as __internal_request;
 
-pub struct BarApiClient<C: hyper::client::connect::Connect>
+pub struct BarApiClient<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     configuration: Rc<configuration::Configuration<C>>,
 }
 
-impl<C: hyper::client::connect::Connect> BarApiClient<C>
+impl<C: Connect> BarApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     pub fn new(configuration: Rc<configuration::Configuration<C>>) -> BarApiClient<C> {
         BarApiClient {
@@ -39,7 +40,7 @@ pub trait BarApi {
     fn create_bar(&self, bar_create: models::BarCreate) -> Pin<Box<dyn Future<Output = Result<models::Bar, Error>>>>;
 }
 
-impl<C: hyper::client::connect::Connect>BarApi for BarApiClient<C>
+impl<C: Connect>BarApi for BarApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     #[allow(unused_mut)]
     fn create_bar(&self, bar_create: models::BarCreate) -> Pin<Box<dyn Future<Output = Result<models::Bar, Error>>>> {

--- a/samples/client/others/rust/hyper/oneOf/src/apis/client.rs
+++ b/samples/client/others/rust/hyper/oneOf/src/apis/client.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use super::configuration::Configuration;
 
 pub struct APIClient {
@@ -9,7 +10,7 @@ pub struct APIClient {
 }
 
 impl APIClient {
-    pub fn new<C: hyper::client::connect::Connect>(configuration: Configuration<C>) -> APIClient
+    pub fn new<C: Connect>(configuration: Configuration<C>) -> APIClient
         where C: Clone + std::marker::Send + Sync + 'static {
         let rc = Rc::new(configuration);
 

--- a/samples/client/others/rust/hyper/oneOf/src/apis/configuration.rs
+++ b/samples/client/others/rust/hyper/oneOf/src/apis/configuration.rs
@@ -9,10 +9,12 @@
  */
 
 use hyper;
-use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioExecutor;
 
-pub struct Configuration<C: Connect>
+pub struct Configuration<C: Connect = HttpConnector>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
@@ -30,9 +32,41 @@ pub struct ApiKey {
     pub key: String,
 }
 
+impl Configuration<HttpConnector> {
+    /// Construct a default [`Configuration`](Self) with a hyper client using a default
+    /// [`HttpConnector`](hyper_util::client::legacy::connect::HttpConnector).
+    ///
+    /// Use [`with_client`](Configuration<T>::with_client) to construct a Configuration with a
+    /// custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let api_config = {
+    ///   api_key: "my-api-key",
+    ///   ...Configuration::new()
+    /// }
+    /// ```
+    pub fn new() -> Configuration<HttpConnector> {
+        Configuration::default()
+    }
+}
+
 impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: Client<C, String>) -> Configuration<C> {
+
+    /// Construct a new Configuration with a custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let client = Client::builder(TokioExecutor::new())
+    ///   .pool_idle_timeout(Duration::from_secs(30))
+    ///   .build_http();
+    ///
+    /// let api_config = Configuration::with_client(client);
+    /// ```
+    pub fn with_client(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "http://localhost:8080".to_owned(),
             user_agent: Some("OpenAPI-Generator/0.0.1/rust".to_owned()),
@@ -41,5 +75,12 @@ impl<C: Connect> Configuration<C>
             oauth_access_token: None,
             api_key: None,
         }
+    }
+}
+
+impl Default for Configuration<HttpConnector> {
+    fn default() -> Self {
+        let client = Client::builder(TokioExecutor::new()).build_http();
+    	Configuration::with_client(client)
     }
 }

--- a/samples/client/others/rust/hyper/oneOf/src/apis/configuration.rs
+++ b/samples/client/others/rust/hyper/oneOf/src/apis/configuration.rs
@@ -9,12 +9,14 @@
  */
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::Client;
 
-pub struct Configuration<C: hyper::client::connect::Connect>
+pub struct Configuration<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub client: hyper::client::Client<C>,
+    pub client: Client<C, String>,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
@@ -28,9 +30,9 @@ pub struct ApiKey {
     pub key: String,
 }
 
-impl<C: hyper::client::connect::Connect> Configuration<C>
+impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: hyper::client::Client<C>) -> Configuration<C> {
+    pub fn new(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "http://localhost:8080".to_owned(),
             user_agent: Some("OpenAPI-Generator/0.0.1/rust".to_owned()),

--- a/samples/client/others/rust/hyper/oneOf/src/apis/foo_api.rs
+++ b/samples/client/others/rust/hyper/oneOf/src/apis/foo_api.rs
@@ -15,18 +15,19 @@ use std::pin::Pin;
 use std::option::Option;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use futures::Future;
 
 use crate::models;
 use super::{Error, configuration};
 use super::request as __internal_request;
 
-pub struct FooApiClient<C: hyper::client::connect::Connect>
+pub struct FooApiClient<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     configuration: Rc<configuration::Configuration<C>>,
 }
 
-impl<C: hyper::client::connect::Connect> FooApiClient<C>
+impl<C: Connect> FooApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     pub fn new(configuration: Rc<configuration::Configuration<C>>) -> FooApiClient<C> {
         FooApiClient {
@@ -40,7 +41,7 @@ pub trait FooApi {
     fn get_all_foos(&self, ) -> Pin<Box<dyn Future<Output = Result<Vec<models::FooRefOrValue>, Error>>>>;
 }
 
-impl<C: hyper::client::connect::Connect>FooApi for FooApiClient<C>
+impl<C: Connect>FooApi for FooApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     #[allow(unused_mut)]
     fn create_foo(&self, foo: Option<models::Foo>) -> Pin<Box<dyn Future<Output = Result<models::FooRefOrValue, Error>>>> {

--- a/samples/client/others/rust/hyper/oneOf/src/apis/mod.rs
+++ b/samples/client/others/rust/hyper/oneOf/src/apis/mod.rs
@@ -1,25 +1,38 @@
-use http;
+use std::fmt;
+use std::fmt::Debug;
+
 use hyper;
+use hyper::http;
+use hyper_util::client::legacy::connect::Connect;
 use serde_json;
 
 #[derive(Debug)]
 pub enum Error {
     Api(ApiError),
-    Header(hyper::http::header::InvalidHeaderValue),
+    Header(http::header::InvalidHeaderValue),
     Http(http::Error),
     Hyper(hyper::Error),
+    HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
     UriError(http::uri::InvalidUri),
 }
 
-#[derive(Debug)]
 pub struct ApiError {
     pub code: hyper::StatusCode,
-    pub body: hyper::body::Body,
+    pub body: hyper::body::Incoming,
 }
 
-impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
-    fn from(e: (hyper::StatusCode, hyper::body::Body)) -> Self {
+impl Debug for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApiError")
+         .field("code", &self.code)
+         .field("body", &"hyper::body::Incoming")
+         .finish()
+    }
+}
+
+impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
+    fn from(e: (hyper::StatusCode, hyper::body::Incoming)) -> Self {
         Error::Api(ApiError {
             code: e.0,
             body: e.1,
@@ -30,6 +43,12 @@ impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)
+    }
+}
+
+impl From<hyper_util::client::legacy::Error> for Error {
+    fn from(e: hyper_util::client::legacy::Error) -> Self {
+        Error::HyperClient(e)
     }
 }
 

--- a/samples/client/others/rust/hyper/oneOf/src/apis/request.rs
+++ b/samples/client/others/rust/hyper/oneOf/src/apis/request.rs
@@ -4,7 +4,9 @@ use std::pin::Pin;
 use futures;
 use futures::Future;
 use futures::future::*;
+use http_body_util::BodyExt;
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use hyper::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, USER_AGENT};
 use serde;
 use serde_json;
@@ -109,7 +111,7 @@ impl Request {
         conf: &configuration::Configuration<C>,
     ) -> Pin<Box<dyn Future<Output=Result<U, Error>> + 'a>>
         where
-            C: hyper::client::connect::Connect + Clone + std::marker::Send + Sync,
+            C: Connect + Clone + std::marker::Send + Sync,
             U: Sized + std::marker::Send + 'a,
             for<'de> U: serde::Deserialize<'de>,
     {
@@ -203,13 +205,13 @@ impl Request {
             for (k, v) in self.form_params {
                 enc.append_pair(&k, &v);
             }
-            req_builder.body(hyper::Body::from(enc.finish()))
+            req_builder.body(enc.finish())
         } else if let Some(body) = self.serialized_body {
             req_headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
             req_headers.insert(CONTENT_LENGTH, body.len().into());
-            req_builder.body(hyper::Body::from(body))
+            req_builder.body(body)
         } else {
-            req_builder.body(hyper::Body::default())
+            req_builder.body(String::new())
         };
         let request = match request_result {
             Ok(request) => request,
@@ -233,9 +235,12 @@ impl Request {
                     // need to impl default for all models.
                     futures::future::ok::<U, Error>(serde_json::from_str("null").expect("serde null value")).boxed()
                 } else {
-                    hyper::body::to_bytes(response.into_body())
-                        .map(|bytes| serde_json::from_slice(&bytes.unwrap()))
-                        .map_err(|e| Error::from(e)).boxed()
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect.map(|collected| {
+                        collected.and_then(|collected| {
+                           serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
+                        })
+                    }).boxed()
                 }
             }))
     }

--- a/samples/client/petstore/rust/hyper/petstore/Cargo.toml
+++ b/samples/client/petstore/rust/hyper/petstore/Cargo.toml
@@ -12,8 +12,9 @@ serde_with = { version = "^3.8", default-features = false, features = ["base64",
 serde_json = "^1.0"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-hyper = { version = "~0.14", features = ["full"] }
-hyper-tls = "~0.5"
+hyper = { version = "^1.3.1", features = ["full"] }
+hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util = { version = "0.1.2" }
 http = "~0.2"
 base64 = "~0.7.0"
 futures = "^0.3"

--- a/samples/client/petstore/rust/hyper/petstore/src/apis/client.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/apis/client.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use super::configuration::Configuration;
 
 pub struct APIClient {
@@ -12,7 +13,7 @@ pub struct APIClient {
 }
 
 impl APIClient {
-    pub fn new<C: hyper::client::connect::Connect>(configuration: Configuration<C>) -> APIClient
+    pub fn new<C: Connect>(configuration: Configuration<C>) -> APIClient
         where C: Clone + std::marker::Send + Sync + 'static {
         let rc = Rc::new(configuration);
 

--- a/samples/client/petstore/rust/hyper/petstore/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/apis/configuration.rs
@@ -9,10 +9,12 @@
  */
 
 use hyper;
-use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioExecutor;
 
-pub struct Configuration<C: Connect>
+pub struct Configuration<C: Connect = HttpConnector>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
@@ -30,9 +32,41 @@ pub struct ApiKey {
     pub key: String,
 }
 
+impl Configuration<HttpConnector> {
+    /// Construct a default [`Configuration`](Self) with a hyper client using a default
+    /// [`HttpConnector`](hyper_util::client::legacy::connect::HttpConnector).
+    ///
+    /// Use [`with_client`](Configuration<T>::with_client) to construct a Configuration with a
+    /// custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let api_config = {
+    ///   api_key: "my-api-key",
+    ///   ...Configuration::new()
+    /// }
+    /// ```
+    pub fn new() -> Configuration<HttpConnector> {
+        Configuration::default()
+    }
+}
+
 impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: Client<C, String>) -> Configuration<C> {
+
+    /// Construct a new Configuration with a custom hyper client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let client = Client::builder(TokioExecutor::new())
+    ///   .pool_idle_timeout(Duration::from_secs(30))
+    ///   .build_http();
+    ///
+    /// let api_config = Configuration::with_client(client);
+    /// ```
+    pub fn with_client(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "http://petstore.swagger.io/v2".to_owned(),
             user_agent: Some("OpenAPI-Generator/1.0.0/rust".to_owned()),
@@ -41,5 +75,12 @@ impl<C: Connect> Configuration<C>
             oauth_access_token: None,
             api_key: None,
         }
+    }
+}
+
+impl Default for Configuration<HttpConnector> {
+    fn default() -> Self {
+        let client = Client::builder(TokioExecutor::new()).build_http();
+    	Configuration::with_client(client)
     }
 }

--- a/samples/client/petstore/rust/hyper/petstore/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/apis/configuration.rs
@@ -9,12 +9,14 @@
  */
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
+use hyper_util::client::legacy::Client;
 
-pub struct Configuration<C: hyper::client::connect::Connect>
+pub struct Configuration<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub client: hyper::client::Client<C>,
+    pub client: Client<C, String>,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
@@ -28,9 +30,9 @@ pub struct ApiKey {
     pub key: String,
 }
 
-impl<C: hyper::client::connect::Connect> Configuration<C>
+impl<C: Connect> Configuration<C>
     where C: Clone + std::marker::Send + Sync {
-    pub fn new(client: hyper::client::Client<C>) -> Configuration<C> {
+    pub fn new(client: Client<C, String>) -> Configuration<C> {
         Configuration {
             base_path: "http://petstore.swagger.io/v2".to_owned(),
             user_agent: Some("OpenAPI-Generator/1.0.0/rust".to_owned()),

--- a/samples/client/petstore/rust/hyper/petstore/src/apis/fake_api.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/apis/fake_api.rs
@@ -15,18 +15,19 @@ use std::pin::Pin;
 use std::option::Option;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use futures::Future;
 
 use crate::models;
 use super::{Error, configuration};
 use super::request as __internal_request;
 
-pub struct FakeApiClient<C: hyper::client::connect::Connect>
+pub struct FakeApiClient<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     configuration: Rc<configuration::Configuration<C>>,
 }
 
-impl<C: hyper::client::connect::Connect> FakeApiClient<C>
+impl<C: Connect> FakeApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     pub fn new(configuration: Rc<configuration::Configuration<C>>) -> FakeApiClient<C> {
         FakeApiClient {
@@ -39,7 +40,7 @@ pub trait FakeApi {
     fn test_nullable_required_param(&self, username: &str, dummy_required_nullable_param: Option<&str>, uppercase: Option<&str>) -> Pin<Box<dyn Future<Output = Result<(), Error>>>>;
 }
 
-impl<C: hyper::client::connect::Connect>FakeApi for FakeApiClient<C>
+impl<C: Connect>FakeApi for FakeApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     #[allow(unused_mut)]
     fn test_nullable_required_param(&self, username: &str, dummy_required_nullable_param: Option<&str>, uppercase: Option<&str>) -> Pin<Box<dyn Future<Output = Result<(), Error>>>> {

--- a/samples/client/petstore/rust/hyper/petstore/src/apis/mod.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/apis/mod.rs
@@ -1,25 +1,38 @@
-use http;
+use std::fmt;
+use std::fmt::Debug;
+
 use hyper;
+use hyper::http;
+use hyper_util::client::legacy::connect::Connect;
 use serde_json;
 
 #[derive(Debug)]
 pub enum Error {
     Api(ApiError),
-    Header(hyper::http::header::InvalidHeaderValue),
+    Header(http::header::InvalidHeaderValue),
     Http(http::Error),
     Hyper(hyper::Error),
+    HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
     UriError(http::uri::InvalidUri),
 }
 
-#[derive(Debug)]
 pub struct ApiError {
     pub code: hyper::StatusCode,
-    pub body: hyper::body::Body,
+    pub body: hyper::body::Incoming,
 }
 
-impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
-    fn from(e: (hyper::StatusCode, hyper::body::Body)) -> Self {
+impl Debug for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApiError")
+         .field("code", &self.code)
+         .field("body", &"hyper::body::Incoming")
+         .finish()
+    }
+}
+
+impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
+    fn from(e: (hyper::StatusCode, hyper::body::Incoming)) -> Self {
         Error::Api(ApiError {
             code: e.0,
             body: e.1,
@@ -30,6 +43,12 @@ impl From<(hyper::StatusCode, hyper::body::Body)> for Error {
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)
+    }
+}
+
+impl From<hyper_util::client::legacy::Error> for Error {
+    fn from(e: hyper_util::client::legacy::Error) -> Self {
+        Error::HyperClient(e)
     }
 }
 

--- a/samples/client/petstore/rust/hyper/petstore/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/apis/pet_api.rs
@@ -15,18 +15,19 @@ use std::pin::Pin;
 use std::option::Option;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use futures::Future;
 
 use crate::models;
 use super::{Error, configuration};
 use super::request as __internal_request;
 
-pub struct PetApiClient<C: hyper::client::connect::Connect>
+pub struct PetApiClient<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     configuration: Rc<configuration::Configuration<C>>,
 }
 
-impl<C: hyper::client::connect::Connect> PetApiClient<C>
+impl<C: Connect> PetApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     pub fn new(configuration: Rc<configuration::Configuration<C>>) -> PetApiClient<C> {
         PetApiClient {
@@ -46,7 +47,7 @@ pub trait PetApi {
     fn upload_file(&self, pet_id: i64, additional_metadata: Option<&str>, file: Option<std::path::PathBuf>) -> Pin<Box<dyn Future<Output = Result<models::ApiResponse, Error>>>>;
 }
 
-impl<C: hyper::client::connect::Connect>PetApi for PetApiClient<C>
+impl<C: Connect>PetApi for PetApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     #[allow(unused_mut)]
     fn add_pet(&self, pet: models::Pet) -> Pin<Box<dyn Future<Output = Result<models::Pet, Error>>>> {

--- a/samples/client/petstore/rust/hyper/petstore/src/apis/request.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/apis/request.rs
@@ -4,7 +4,9 @@ use std::pin::Pin;
 use futures;
 use futures::Future;
 use futures::future::*;
+use http_body_util::BodyExt;
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use hyper::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, USER_AGENT};
 use serde;
 use serde_json;
@@ -109,7 +111,7 @@ impl Request {
         conf: &configuration::Configuration<C>,
     ) -> Pin<Box<dyn Future<Output=Result<U, Error>> + 'a>>
         where
-            C: hyper::client::connect::Connect + Clone + std::marker::Send + Sync,
+            C: Connect + Clone + std::marker::Send + Sync,
             U: Sized + std::marker::Send + 'a,
             for<'de> U: serde::Deserialize<'de>,
     {
@@ -203,13 +205,13 @@ impl Request {
             for (k, v) in self.form_params {
                 enc.append_pair(&k, &v);
             }
-            req_builder.body(hyper::Body::from(enc.finish()))
+            req_builder.body(enc.finish())
         } else if let Some(body) = self.serialized_body {
             req_headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
             req_headers.insert(CONTENT_LENGTH, body.len().into());
-            req_builder.body(hyper::Body::from(body))
+            req_builder.body(body)
         } else {
-            req_builder.body(hyper::Body::default())
+            req_builder.body(String::new())
         };
         let request = match request_result {
             Ok(request) => request,
@@ -233,9 +235,12 @@ impl Request {
                     // need to impl default for all models.
                     futures::future::ok::<U, Error>(serde_json::from_str("null").expect("serde null value")).boxed()
                 } else {
-                    hyper::body::to_bytes(response.into_body())
-                        .map(|bytes| serde_json::from_slice(&bytes.unwrap()))
-                        .map_err(|e| Error::from(e)).boxed()
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect.map(|collected| {
+                        collected.and_then(|collected| {
+                           serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
+                        })
+                    }).boxed()
                 }
             }))
     }

--- a/samples/client/petstore/rust/hyper/petstore/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/apis/store_api.rs
@@ -15,18 +15,19 @@ use std::pin::Pin;
 use std::option::Option;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use futures::Future;
 
 use crate::models;
 use super::{Error, configuration};
 use super::request as __internal_request;
 
-pub struct StoreApiClient<C: hyper::client::connect::Connect>
+pub struct StoreApiClient<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     configuration: Rc<configuration::Configuration<C>>,
 }
 
-impl<C: hyper::client::connect::Connect> StoreApiClient<C>
+impl<C: Connect> StoreApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     pub fn new(configuration: Rc<configuration::Configuration<C>>) -> StoreApiClient<C> {
         StoreApiClient {
@@ -42,7 +43,7 @@ pub trait StoreApi {
     fn place_order(&self, order: models::Order) -> Pin<Box<dyn Future<Output = Result<models::Order, Error>>>>;
 }
 
-impl<C: hyper::client::connect::Connect>StoreApi for StoreApiClient<C>
+impl<C: Connect>StoreApi for StoreApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     #[allow(unused_mut)]
     fn delete_order(&self, order_id: &str) -> Pin<Box<dyn Future<Output = Result<(), Error>>>> {

--- a/samples/client/petstore/rust/hyper/petstore/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/apis/testing_api.rs
@@ -15,18 +15,19 @@ use std::pin::Pin;
 use std::option::Option;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use futures::Future;
 
 use crate::models;
 use super::{Error, configuration};
 use super::request as __internal_request;
 
-pub struct TestingApiClient<C: hyper::client::connect::Connect>
+pub struct TestingApiClient<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     configuration: Rc<configuration::Configuration<C>>,
 }
 
-impl<C: hyper::client::connect::Connect> TestingApiClient<C>
+impl<C: Connect> TestingApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     pub fn new(configuration: Rc<configuration::Configuration<C>>) -> TestingApiClient<C> {
         TestingApiClient {
@@ -40,7 +41,7 @@ pub trait TestingApi {
     fn tests_type_testing_get(&self, ) -> Pin<Box<dyn Future<Output = Result<models::TypeTesting, Error>>>>;
 }
 
-impl<C: hyper::client::connect::Connect>TestingApi for TestingApiClient<C>
+impl<C: Connect>TestingApi for TestingApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     #[allow(unused_mut)]
     fn tests_file_response_get(&self, ) -> Pin<Box<dyn Future<Output = Result<std::path::PathBuf, Error>>>> {

--- a/samples/client/petstore/rust/hyper/petstore/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/apis/user_api.rs
@@ -15,18 +15,19 @@ use std::pin::Pin;
 use std::option::Option;
 
 use hyper;
+use hyper_util::client::legacy::connect::Connect;
 use futures::Future;
 
 use crate::models;
 use super::{Error, configuration};
 use super::request as __internal_request;
 
-pub struct UserApiClient<C: hyper::client::connect::Connect>
+pub struct UserApiClient<C: Connect>
     where C: Clone + std::marker::Send + Sync + 'static {
     configuration: Rc<configuration::Configuration<C>>,
 }
 
-impl<C: hyper::client::connect::Connect> UserApiClient<C>
+impl<C: Connect> UserApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     pub fn new(configuration: Rc<configuration::Configuration<C>>) -> UserApiClient<C> {
         UserApiClient {
@@ -46,7 +47,7 @@ pub trait UserApi {
     fn update_user(&self, username: &str, user: models::User) -> Pin<Box<dyn Future<Output = Result<(), Error>>>>;
 }
 
-impl<C: hyper::client::connect::Connect>UserApi for UserApiClient<C>
+impl<C: Connect>UserApi for UserApiClient<C>
     where C: Clone + std::marker::Send + Sync {
     #[allow(unused_mut)]
     fn create_user(&self, user: models::User) -> Pin<Box<dyn Future<Output = Result<(), Error>>>> {


### PR DESCRIPTION
Upgrade rust-hyper to use hyper 1.0. Related issue: https://github.com/OpenAPITools/openapi-generator/issues/17876. And related documentation: [hyper upgrade guide](https://hyper.rs/guides/1/upgrading/).

The `Client` provided by hyper was moved to another module `hyper_util` as `hyper_util::client::legacy::Client`. It was not a simple drop in replacement. The biggest changes had to do with the fact that `Body` is modeled very differently in 1.0. I went with a simple `String` based body and that seems to work. As far as I could tell all requests come down to parsing fully fetched strings and all posts involved pushing fully serialized JSON strings.

In the linked issue @wing328 suggested the following:
> I think we can go with direct upgrade without fallback to v0.14 to start with. If there's a need (valid) later, we can create another library option (e.g. hyper-0.x)

`mvn verify -f samples/client/others/rust/hyper` works and I've been successfully using this update myself.

Pinging the rust technical committee members: @frol @farcaller @richardwhiuk @paladinzh @jacob-pro

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.