### PR TITLE
[Ruby] Allow Overriding Accept Header

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -188,7 +188,7 @@ module {{moduleName}}
       header_params = opts[:header_params] || {}
       {{#hasProduces}}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept([{{#produces}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/produces}}])
+      header_params['Accept'] = @api_client.select_header_accept([{{#produces}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/produces}}]) unless header_params['Accept']
       {{/hasProduces}}
       {{#hasConsumes}}
       # HTTP header 'Content-Type'

--- a/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/auth_api.rb
+++ b/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/auth_api.rb
@@ -45,7 +45,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -102,7 +102,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/body_api.rb
+++ b/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/body_api.rb
@@ -45,7 +45,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['image/gif'])
+      header_params['Accept'] = @api_client.select_header_accept(['image/gif']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -104,7 +104,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/octet-stream'])
       if !content_type.nil?
@@ -172,7 +172,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?
@@ -237,7 +237,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?
@@ -302,7 +302,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -366,7 +366,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -430,7 +430,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -494,7 +494,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -558,7 +558,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -622,7 +622,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/form_api.rb
+++ b/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/form_api.rb
@@ -51,7 +51,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
       if !content_type.nil?
@@ -122,7 +122,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?
@@ -197,7 +197,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
       if !content_type.nil?

--- a/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/header_api.rb
+++ b/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/header_api.rb
@@ -59,7 +59,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       header_params['integer_header'] = opts[:'integer_header'] if !opts[:'integer_header'].nil?
       header_params['boolean_header'] = opts[:'boolean_header'] if !opts[:'boolean_header'].nil?
       header_params['string_header'] = opts[:'string_header'] if !opts[:'string_header'].nil?

--- a/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/path_api.rb
+++ b/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/path_api.rb
@@ -74,7 +74,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/query_api.rb
+++ b/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/query_api.rb
@@ -55,7 +55,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -121,7 +121,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -187,7 +187,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -247,7 +247,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -307,7 +307,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -367,7 +367,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -427,7 +427,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -487,7 +487,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -547,7 +547,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -607,7 +607,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/auth_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/auth_api.rb
@@ -45,7 +45,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -102,7 +102,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/body_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/body_api.rb
@@ -45,7 +45,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['image/gif'])
+      header_params['Accept'] = @api_client.select_header_accept(['image/gif']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -104,7 +104,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/octet-stream'])
       if !content_type.nil?
@@ -172,7 +172,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?
@@ -237,7 +237,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?
@@ -302,7 +302,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -366,7 +366,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -430,7 +430,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -494,7 +494,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -558,7 +558,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -622,7 +622,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/form_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/form_api.rb
@@ -51,7 +51,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
       if !content_type.nil?
@@ -122,7 +122,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?
@@ -197,7 +197,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
       if !content_type.nil?

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/header_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/header_api.rb
@@ -59,7 +59,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       header_params['integer_header'] = opts[:'integer_header'] if !opts[:'integer_header'].nil?
       header_params['boolean_header'] = opts[:'boolean_header'] if !opts[:'boolean_header'].nil?
       header_params['string_header'] = opts[:'string_header'] if !opts[:'string_header'].nil?

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/path_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/path_api.rb
@@ -74,7 +74,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/query_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/query_api.rb
@@ -55,7 +55,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -121,7 +121,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -187,7 +187,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -247,7 +247,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -307,7 +307,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -367,7 +367,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -427,7 +427,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -487,7 +487,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -547,7 +547,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -607,7 +607,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/auth_api.rb
+++ b/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/auth_api.rb
@@ -45,7 +45,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -102,7 +102,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/body_api.rb
+++ b/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/body_api.rb
@@ -45,7 +45,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['image/gif'])
+      header_params['Accept'] = @api_client.select_header_accept(['image/gif']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -104,7 +104,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/octet-stream'])
       if !content_type.nil?
@@ -172,7 +172,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?
@@ -237,7 +237,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?
@@ -302,7 +302,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -366,7 +366,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -430,7 +430,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -494,7 +494,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -558,7 +558,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -622,7 +622,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/form_api.rb
+++ b/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/form_api.rb
@@ -51,7 +51,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
       if !content_type.nil?
@@ -122,7 +122,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?
@@ -197,7 +197,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
       if !content_type.nil?

--- a/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/header_api.rb
+++ b/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/header_api.rb
@@ -59,7 +59,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
       header_params['integer_header'] = opts[:'integer_header'] if !opts[:'integer_header'].nil?
       header_params['boolean_header'] = opts[:'boolean_header'] if !opts[:'boolean_header'].nil?
       header_params['string_header'] = opts[:'string_header'] if !opts[:'string_header'].nil?

--- a/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/path_api.rb
+++ b/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/path_api.rb
@@ -74,7 +74,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/query_api.rb
+++ b/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/query_api.rb
@@ -55,7 +55,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -121,7 +121,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -187,7 +187,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -247,7 +247,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -307,7 +307,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -367,7 +367,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -427,7 +427,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -487,7 +487,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -547,7 +547,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -607,7 +607,7 @@ module OpenapiClient
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['text/plain'])
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/petstore/ruby-autoload/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/api/another_fake_api.rb
@@ -51,7 +51,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-autoload/lib/petstore/api/default_api.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/api/default_api.rb
@@ -41,7 +41,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/petstore/ruby-autoload/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/api/fake_api.rb
@@ -43,7 +43,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -98,7 +98,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -225,7 +225,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -287,7 +287,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -349,7 +349,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -411,7 +411,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -477,7 +477,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -804,7 +804,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-autoload/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/api/fake_classname_tags123_api.rb
@@ -51,7 +51,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-autoload/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/api/pet_api.rb
@@ -182,7 +182,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -246,7 +246,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -309,7 +309,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -514,7 +514,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?
@@ -592,7 +592,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-autoload/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/api/store_api.rb
@@ -106,7 +106,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -177,7 +177,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -240,7 +240,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-autoload/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/api/user_api.rb
@@ -310,7 +310,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -381,7 +381,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/another_fake_api.rb
@@ -51,7 +51,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/default_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/default_api.rb
@@ -41,7 +41,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
@@ -43,7 +43,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -98,7 +98,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -225,7 +225,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -287,7 +287,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -349,7 +349,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -411,7 +411,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -477,7 +477,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -804,7 +804,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_classname_tags123_api.rb
@@ -51,7 +51,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/pet_api.rb
@@ -182,7 +182,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -246,7 +246,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -309,7 +309,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -514,7 +514,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?
@@ -592,7 +592,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/store_api.rb
@@ -106,7 +106,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -177,7 +177,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -240,7 +240,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/user_api.rb
@@ -310,7 +310,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -381,7 +381,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/petstore/ruby-httpx/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/api/another_fake_api.rb
@@ -51,7 +51,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-httpx/lib/petstore/api/default_api.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/api/default_api.rb
@@ -41,7 +41,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/petstore/ruby-httpx/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/api/fake_api.rb
@@ -43,7 +43,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -98,7 +98,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -225,7 +225,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -287,7 +287,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -349,7 +349,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -411,7 +411,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -477,7 +477,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -885,7 +885,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-httpx/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/api/fake_classname_tags123_api.rb
@@ -51,7 +51,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-httpx/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/api/pet_api.rb
@@ -182,7 +182,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -246,7 +246,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -309,7 +309,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -514,7 +514,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?
@@ -592,7 +592,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-httpx/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/api/store_api.rb
@@ -106,7 +106,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -177,7 +177,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -240,7 +240,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby-httpx/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/api/user_api.rb
@@ -310,7 +310,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -381,7 +381,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -51,7 +51,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby/lib/petstore/api/default_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/default_api.rb
@@ -41,7 +41,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -43,7 +43,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -98,7 +98,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -225,7 +225,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -287,7 +287,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -349,7 +349,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -411,7 +411,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -477,7 +477,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['*/*'])
+      header_params['Accept'] = @api_client.select_header_accept(['*/*']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -885,7 +885,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -51,7 +51,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -182,7 +182,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -246,7 +246,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -309,7 +309,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -514,7 +514,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?
@@ -592,7 +592,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['multipart/form-data'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -106,7 +106,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -177,7 +177,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -240,7 +240,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -310,7 +310,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -381,7 +381,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api/usage_api.rb
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api/usage_api.rb
@@ -45,7 +45,7 @@ module XAuthIDAlias
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -102,7 +102,7 @@ module XAuthIDAlias
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -159,7 +159,7 @@ module XAuthIDAlias
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -216,7 +216,7 @@ module XAuthIDAlias
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api/usage_api.rb
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api/usage_api.rb
@@ -45,7 +45,7 @@ module DynamicServers
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -102,7 +102,7 @@ module DynamicServers
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api/usage_api.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api/usage_api.rb
@@ -47,7 +47,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -111,7 +111,7 @@ module Petstore
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?


### PR DESCRIPTION
The Ruby SDK currently does not allow for overriding the Accept header at runtime. The header can be set using the `header_params` argument when calling an operation method, but this gets overwritten by the `select_header_accept` method called when the data is serialized to a request. This PR adds a conditional that skips the calling of the `select_header_accept` method if an Accept header has been provided by the user.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)