### PR TITLE
Update okhttp3 to 4.12.0 for Maven projects

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -417,7 +417,7 @@
         {{#swagger2AnnotationLibrary}}
         <swagger-annotations-version>2.2.15</swagger-annotations-version>
         {{/swagger2AnnotationLibrary}}
-        <okhttp-version>4.11.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.14.0</commons-lang3-version>
         {{#openApiNullable}}

--- a/samples/client/echo_api/java/okhttp-gson-user-defined-templates/pom.xml
+++ b/samples/client/echo_api/java/okhttp-gson-user-defined-templates/pom.xml
@@ -334,7 +334,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.9.0</gson-fire-version>
-        <okhttp-version>4.11.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>

--- a/samples/client/echo_api/java/okhttp-gson/pom.xml
+++ b/samples/client/echo_api/java/okhttp-gson/pom.xml
@@ -329,7 +329,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.9.0</gson-fire-version>
-        <okhttp-version>4.11.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>

--- a/samples/client/others/java/okhttp-gson-oneOf/pom.xml
+++ b/samples/client/others/java/okhttp-gson-oneOf/pom.xml
@@ -329,7 +329,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.9.0</gson-fire-version>
-        <okhttp-version>4.11.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>

--- a/samples/client/others/java/okhttp-gson-streaming/pom.xml
+++ b/samples/client/others/java/okhttp-gson-streaming/pom.xml
@@ -329,7 +329,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.9.0</gson-fire-version>
-        <okhttp-version>4.11.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/okhttp-gson-3.1/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-3.1/pom.xml
@@ -334,7 +334,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.9.0</gson-fire-version>
-        <okhttp-version>4.11.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/pom.xml
@@ -339,7 +339,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.9.0</gson-fire-version>
-        <okhttp-version>4.11.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/pom.xml
@@ -339,7 +339,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.9.0</gson-fire-version>
-        <okhttp-version>4.11.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/pom.xml
@@ -334,7 +334,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.9.0</gson-fire-version>
-        <okhttp-version>4.11.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/pom.xml
@@ -334,7 +334,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.9.0</gson-fire-version>
-        <okhttp-version>4.11.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
@@ -341,7 +341,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.9.0</gson-fire-version>
-        <okhttp-version>4.11.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/okhttp-gson-swagger1/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/pom.xml
@@ -340,7 +340,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.9.0</gson-fire-version>
         <swagger-annotations-version>1.6.6</swagger-annotations-version>
-        <okhttp-version>4.11.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/okhttp-gson-swagger2/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/pom.xml
@@ -340,7 +340,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.9.0</gson-fire-version>
         <swagger-annotations-version>2.2.15</swagger-annotations-version>
-        <okhttp-version>4.11.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR is a follow up to #18235, that did not update okhttp in pom.xml files (was still 4.11.0).

This is a proper fix for CVE-2023-3635.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
