### PR TITLE
Run unittest tests with unittest

### DIFF
--- a/.github/workflows/samples-python-client-echo-api.yaml
+++ b/.github/workflows/samples-python-client-echo-api.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Test
         working-directory: ${{ matrix.sample }}
-        run: python -m pytest
+        run: python -m unittest discover
 
       - name: mypy
         working-directory: ${{ matrix.sample }}


### PR DESCRIPTION
The unit tests in the following directories are written to unittest, not pytest:

* `samples/client/echo_api/python/`
* `samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/`

If pytest is told to execute these tests, it will log warnings about being unable to collect certain tests.
