### PR TITLE
Update call to assertDictContainsSubset()

### DIFF
--- a/samples/client/echo_api/python/tests/test_manual.py
+++ b/samples/client/echo_api/python/tests/test_manual.py
@@ -66,7 +66,7 @@ class TestManual(unittest.TestCase):
             enum_nonref_string_header="success",
             enum_ref_string_header="failure",
         )
-        self.assertDictContainsSubset(expected_header, e.headers)
+        self.assertLessEqual(expected_header.items(), e.headers.items())
 
     def testEnumQueryParameters(self):
         api_instance = openapi_client.QueryApi()


### PR DESCRIPTION
`TestCase.assertDictContainsSubset()` was deprecated in Python 3.2,
which went EOL in 2016. Rewrite the assertion to target Python 3.8+.

See: https://docs.python.org/3.2/library/unittest.html#unittest.TestCase.assertDictContainsSubset

See: https://devguide.python.org/versions/