### PR TITLE
Update Python versions used for unit tests

### DIFF
--- a/.github/workflows/samples-python-client-echo-api.yaml
+++ b/.github/workflows/samples-python-client-echo-api.yaml
@@ -18,11 +18,11 @@ jobs:
           - samples/client/echo_api/python
           - samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Python 3.7 is EOL, and Python 3.12 has been released.

See: https://devguide.python.org/versions/
