### PR TITLE
[Ruby] Fix Content-Transfer-Encoding binary unpacking

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -117,35 +117,41 @@
       request.options.on_data = Proc.new do |chunk, overall_received_bytes|
         stream << chunk
       end
+
       stream
     end
 
     def deserialize_file(response, stream)
-      body = response.body
-      if @config.return_binary_data == true
-        # return byte stream
-        encoding = body.encoding
-        stream.join.force_encoding(encoding)
+      body     = response.body
+      encoding = body.encoding
+
+      # reconstruct content
+      content = stream.join
+      content = content.unpack('m').join if response.headers['Content-Transfer-Encoding'] == 'binary'
+      content = content.force_encoding(encoding)
+
+      # return byte stream
+      return content if @config.return_binary_data == true
+
+      # return file instead of binary data
+      content_disposition = response.headers['Content-Disposition']
+      if content_disposition && content_disposition =~ /filename=/i
+        filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
+        prefix = sanitize_filename(filename)
       else
-        # return file instead of binary data
-        content_disposition = response.headers['Content-Disposition']
-        if content_disposition && content_disposition =~ /filename=/i
-          filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
-          prefix = sanitize_filename(filename)
-        else
-          prefix = 'download-'
-        end
-        prefix = prefix + '-' unless prefix.end_with?('-')
-        encoding = body.encoding
-        tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
-        tempfile.write(stream.join.force_encoding(encoding))
-        tempfile.close
-        config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
-                            "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
-                            "will be deleted automatically with GC. It's also recommended to delete the temp file "\
-                            "explicitly with `tempfile.delete`"
-        tempfile
+        prefix = 'download-'
       end
+      prefix = prefix + '-' unless prefix.end_with?('-')
+
+      tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
+      tempfile.write(content)
+      tempfile.close
+
+      config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
+                          "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
+                          "will be deleted automatically with GC. It's also recommended to delete the temp file "\
+                          "explicitly with `tempfile.delete`"
+      tempfile
     end
 
     def connection(opts)

--- a/samples/client/echo_api/ruby-faraday/lib/openapi_client/api_client.rb
+++ b/samples/client/echo_api/ruby-faraday/lib/openapi_client/api_client.rb
@@ -164,35 +164,41 @@ module OpenapiClient
       request.options.on_data = Proc.new do |chunk, overall_received_bytes|
         stream << chunk
       end
+
       stream
     end
 
     def deserialize_file(response, stream)
-      body = response.body
-      if @config.return_binary_data == true
-        # return byte stream
-        encoding = body.encoding
-        stream.join.force_encoding(encoding)
+      body     = response.body
+      encoding = body.encoding
+
+      # reconstruct content
+      content = stream.join
+      content = content.unpack('m').join if response.headers['Content-Transfer-Encoding'] == 'binary'
+      content = content.force_encoding(encoding)
+
+      # return byte stream
+      return content if @config.return_binary_data == true
+
+      # return file instead of binary data
+      content_disposition = response.headers['Content-Disposition']
+      if content_disposition && content_disposition =~ /filename=/i
+        filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
+        prefix = sanitize_filename(filename)
       else
-        # return file instead of binary data
-        content_disposition = response.headers['Content-Disposition']
-        if content_disposition && content_disposition =~ /filename=/i
-          filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
-          prefix = sanitize_filename(filename)
-        else
-          prefix = 'download-'
-        end
-        prefix = prefix + '-' unless prefix.end_with?('-')
-        encoding = body.encoding
-        tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
-        tempfile.write(stream.join.force_encoding(encoding))
-        tempfile.close
-        config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
-                            "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
-                            "will be deleted automatically with GC. It's also recommended to delete the temp file "\
-                            "explicitly with `tempfile.delete`"
-        tempfile
+        prefix = 'download-'
       end
+      prefix = prefix + '-' unless prefix.end_with?('-')
+
+      tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
+      tempfile.write(content)
+      tempfile.close
+
+      config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
+                          "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
+                          "will be deleted automatically with GC. It's also recommended to delete the temp file "\
+                          "explicitly with `tempfile.delete`"
+      tempfile
     end
 
     def connection(opts)

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -164,35 +164,41 @@ module Petstore
       request.options.on_data = Proc.new do |chunk, overall_received_bytes|
         stream << chunk
       end
+
       stream
     end
 
     def deserialize_file(response, stream)
-      body = response.body
-      if @config.return_binary_data == true
-        # return byte stream
-        encoding = body.encoding
-        stream.join.force_encoding(encoding)
+      body     = response.body
+      encoding = body.encoding
+
+      # reconstruct content
+      content = stream.join
+      content = content.unpack('m').join if response.headers['Content-Transfer-Encoding'] == 'binary'
+      content = content.force_encoding(encoding)
+
+      # return byte stream
+      return content if @config.return_binary_data == true
+
+      # return file instead of binary data
+      content_disposition = response.headers['Content-Disposition']
+      if content_disposition && content_disposition =~ /filename=/i
+        filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
+        prefix = sanitize_filename(filename)
       else
-        # return file instead of binary data
-        content_disposition = response.headers['Content-Disposition']
-        if content_disposition && content_disposition =~ /filename=/i
-          filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
-          prefix = sanitize_filename(filename)
-        else
-          prefix = 'download-'
-        end
-        prefix = prefix + '-' unless prefix.end_with?('-')
-        encoding = body.encoding
-        tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
-        tempfile.write(stream.join.force_encoding(encoding))
-        tempfile.close
-        config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
-                            "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
-                            "will be deleted automatically with GC. It's also recommended to delete the temp file "\
-                            "explicitly with `tempfile.delete`"
-        tempfile
+        prefix = 'download-'
       end
+      prefix = prefix + '-' unless prefix.end_with?('-')
+
+      tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
+      tempfile.write(content)
+      tempfile.close
+
+      config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
+                          "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
+                          "will be deleted automatically with GC. It's also recommended to delete the temp file "\
+                          "explicitly with `tempfile.delete`"
+      tempfile
     end
 
     def connection(opts)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Based on my findings attempting to download PDFs with a downstream gem, I discovered that binary transferred data is never being unpacked into it's native format. This renders the results malformed. https://github.com/mxenabled/mx-platform-ruby/issues/90

This PR adds a patch that simplifies the flow control of the `deserialize` method, while updating it to properly deserialize content from binary transfer encoding.

I have a patch of this running downstream in production.

Ruby Committee: @cliffano @zlx @autopp

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
