### PR TITLE
[PowerShell] Support ApiKeyPrefix

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/api.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/api.mustache
@@ -177,15 +177,20 @@ function {{{vendorExtensions.x-powershell-method-name}}} {
         {{/bodyParam}}
         {{#authMethods}}
         {{#isApiKey}}
+        if ($Configuration["ApiKeyPrefix"] -and $Configuration["ApiKeyPrefix"]["{{{keyParamName}}}"]) {
+            $apiKeyPrefix = $Configuration["ApiKeyPrefix"]["{{{keyParamName}}}"]
+        } else {
+            $apiKeyPrefix = ""
+        }
         {{#isKeyInHeader}}
         if ($Configuration["ApiKey"] -and $Configuration["ApiKey"]["{{{keyParamName}}}"]) {
-            $LocalVarHeaderParameters['{{{keyParamName}}}'] = $Configuration["ApiKey"]["{{{keyParamName}}}"]
+            $LocalVarHeaderParameters['{{{keyParamName}}}'] = $apiKeyPrefix + $Configuration["ApiKey"]["{{{keyParamName}}}"]
             Write-Verbose ("Using API key '{{{keyParamName}}}' in the header for authentication in {0}" -f $MyInvocation.MyCommand)
         }
         {{/isKeyInHeader}}
         {{#isKeyInQuery}}
         if ($Configuration["ApiKey"] -and $Configuration["ApiKey"]["{{{keyParamName}}}"]) {
-            $LocalVarQueryParameters['{{{keyParamName}}}'] = $Configuration["ApiKey"]["{{{keyParamName}}}"]
+            $LocalVarQueryParameters['{{{keyParamName}}}'] = $apiKeyPrefix + $Configuration["ApiKey"]["{{{keyParamName}}}"]
             Write-Verbose ("Using API key `{{{keyParamName}}}` in the URL query for authentication in {0}" -f $MyInvocation.MyCommand)
         }
         {{/isKeyInQuery}}

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSFakeClassnameTags123Api.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSFakeClassnameTags123Api.ps1
@@ -63,8 +63,13 @@ function Test-PSClassname {
 
         $LocalVarBodyParameter = $Client | ConvertTo-Json -Depth 100
 
+        if ($Configuration["ApiKeyPrefix"] -and $Configuration["ApiKeyPrefix"]["api_key_query_name"]) {
+            $apiKeyPrefix = $Configuration["ApiKeyPrefix"]["api_key_query_name"]
+        } else {
+            $apiKeyPrefix = ""
+        }
         if ($Configuration["ApiKey"] -and $Configuration["ApiKey"]["api_key_query_name"]) {
-            $LocalVarQueryParameters['api_key_query_name'] = $Configuration["ApiKey"]["api_key_query_name"]
+            $LocalVarQueryParameters['api_key_query_name'] = $apiKeyPrefix + $Configuration["ApiKey"]["api_key_query_name"]
             Write-Verbose ("Using API key `api_key_query_name` in the URL query for authentication in {0}" -f $MyInvocation.MyCommand)
         }
 

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSPetApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSPetApi.ps1
@@ -405,8 +405,13 @@ function Get-PSPetById {
         }
         $LocalVarUri = $LocalVarUri.replace('{petId}', [System.Web.HTTPUtility]::UrlEncode($PetId))
 
+        if ($Configuration["ApiKeyPrefix"] -and $Configuration["ApiKeyPrefix"]["api_key_name"]) {
+            $apiKeyPrefix = $Configuration["ApiKeyPrefix"]["api_key_name"]
+        } else {
+            $apiKeyPrefix = ""
+        }
         if ($Configuration["ApiKey"] -and $Configuration["ApiKey"]["api_key_name"]) {
-            $LocalVarHeaderParameters['api_key_name'] = $Configuration["ApiKey"]["api_key_name"]
+            $LocalVarHeaderParameters['api_key_name'] = $apiKeyPrefix + $Configuration["ApiKey"]["api_key_name"]
             Write-Verbose ("Using API key 'api_key_name' in the header for authentication in {0}" -f $MyInvocation.MyCommand)
         }
 

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSStoreApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSStoreApi.ps1
@@ -118,8 +118,13 @@ function Get-PSInventory {
 
         $LocalVarUri = '/store/inventory'
 
+        if ($Configuration["ApiKeyPrefix"] -and $Configuration["ApiKeyPrefix"]["api_key_name"]) {
+            $apiKeyPrefix = $Configuration["ApiKeyPrefix"]["api_key_name"]
+        } else {
+            $apiKeyPrefix = ""
+        }
         if ($Configuration["ApiKey"] -and $Configuration["ApiKey"]["api_key_name"]) {
-            $LocalVarHeaderParameters['api_key_name'] = $Configuration["ApiKey"]["api_key_name"]
+            $LocalVarHeaderParameters['api_key_name'] = $apiKeyPrefix + $Configuration["ApiKey"]["api_key_name"]
             Write-Verbose ("Using API key 'api_key_name' in the header for authentication in {0}" -f $MyInvocation.MyCommand)
         }
 


### PR DESCRIPTION
This PR contains a small change to support ApiKeyPrefix, i.e. an extra string that may be required in the `Authorization:` header (or in the URL parameter) before the ApiKey. ApiKeyPrefix is already supported in the Configuration, but never used in the API code. Likely, when required the prefix was added to the key as a workaround.

The prefix string is directly concatenated to the ApiKey. Any space separators that may be required must be added to the ApiKeyPrefix.

The change has been tested on a client API requiring such a prefix in the header.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328