### PR TITLE
[BUG] [Python] Fix autoset constants Python code for default query string value

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -176,7 +176,7 @@ class {{classname}}:
         {{#constantParams}}
         {{#isQueryParam}}
         # Set client side default value of Query Param "{{baseName}}".
-        _query_params['{{baseName}}'] = {{#_enum}}'{{{.}}}'{{/_enum}}
+        _query_params.append(('{{baseName}}', {{#_enum}}'{{{.}}}'{{/_enum}}))
         {{/isQueryParam}}
         {{#isHeaderParam}}
         # Set client side default value of Header Param "{{baseName}}".

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -528,5 +528,6 @@ public class PythonClientCodegenTest {
                 .get(Paths.get(output.getAbsolutePath(), "openapi_client", "api", "hello_example_api.py").toString());
         assertNotNull(apiFile);
         assertFileContains(apiFile.toPath(), "_header_params['X-CUSTOM_CONSTANT_HEADER'] = 'CONSTANT_VALUE'");
+        assertFileContains(apiFile.toPath(), "_query_params.append(('CONSTANT_QUERY_STRING_KEY', 'CONSTANT_QUERY_STRING_VALUE'))");
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/java/autoset_constant.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/java/autoset_constant.yaml
@@ -21,6 +21,13 @@ paths:
             type: string
             enum:
             - CONSTANT_VALUE
+        - name: CONSTANT_QUERY_STRING_KEY
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - CONSTANT_QUERY_STRING_VALUE
         - name: name
           in: path
           required: true


### PR DESCRIPTION
https://github.com/OpenAPITools/openapi-generator/pull/16761 introduced Python code to set default header or query string value when OpenAPI parameter is  required and has one enum value (have to use `--additional-properties autosetConstants=true` to activate functionality).

The Python mustache template tries to add parameter to `_query_params` dict, but `query_params` is a list:

```
_query_params: List[Tuple[str, str]] = []
...
# Set client side default value of Query Param "{{baseName}}".
_query_params['{{baseName}}'] = {{#_enum}}'{{{.}}}'{{/_enum}} # wrong
```
https://github.com/prashant-pant/openapi-generator/blob/21ee1101f5fb310904ae904018cee93d249b796d/modules/openapi-generator/src/main/resources/python/api.mustache#L196-L228

This PR updates mustache template to append query string tuple to `_query_string` list.

<!-- Please check the completed items below -->
### PR checklist
 
- [ x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
