### PR TITLE
[Elixir] allow custom packageVersion

### DIFF
--- a/docs/generators/elixir.md
+++ b/docs/generators/elixir.md
@@ -26,6 +26,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |licenseHeader|The license header to prepend to the top of all source files.| |null|
 |packageName|Elixir package name (convention: lowercase).| |null|
+|packageVersion|Elixir package version.| |1.0.0|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -50,7 +50,7 @@ public class ElixirClientCodegen extends DefaultCodegen {
 
     private final Pattern simpleAtomPattern = Pattern.compile("\\A(?:(?:[_@\\p{Alpha}][_@\\p{Alnum}]*[?!]?)|-)\\z");
 
-    protected String apiVersion = "1.0.0";
+    @Setter protected String packageVersion = "1.0.0";
     @Setter protected String moduleName;
     protected static final String defaultModuleName = "OpenAPI.Client";
 
@@ -146,12 +146,6 @@ public class ElixirClientCodegen extends DefaultCodegen {
                         "__DIR__",
                         "__ENV__",
                         "__CALLER__"));
-
-        /**
-         * Additional Properties. These values can be passed to the templates and
-         * are available in models, apis, and supporting files
-         */
-        additionalProperties.put("apiVersion", apiVersion);
 
         /**
          * Supporting Files. You can write single files for the generator with the
@@ -301,6 +295,10 @@ public class ElixirClientCodegen extends DefaultCodegen {
         if (additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)) {
             setModuleName((String) additionalProperties.get(CodegenConstants.INVOKER_PACKAGE));
         }
+        if (additionalProperties.containsKey(CodegenConstants.PACKAGE_VERSION)) {
+            setPackageVersion((String) additionalProperties.get(CodegenConstants.PACKAGE_VERSION));
+        }
+        additionalProperties.put(CodegenConstants.PACKAGE_VERSION, packageVersion);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/elixir/README.md.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/README.md.mustache
@@ -18,7 +18,7 @@ your list of dependencies in `mix.exs`:
 
 ```elixir
 {{=<% %>=}}def deps do
-  [{<%#atom%><%#underscored%><%packageName%><%/underscored%><%/atom%>, "~> <%appVersion%>"}]
+  [{<%#atom%><%#underscored%><%packageName%><%/underscored%><%/atom%>, "~> <%packageVersion%>"}]
 end<%={{ }}=%>
 ```
 

--- a/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
@@ -225,7 +225,7 @@ defmodule {{moduleName}}.Connection do
         Keyword.get(
           tesla_options,
           :user_agent,
-          "openapi-generator - {{moduleName}} {{appVersion}} - elixir"
+          "openapi-generator - {{moduleName}} {{packageVersion}} - elixir"
         )
       )
 

--- a/modules/openapi-generator/src/main/resources/elixir/mix.exs.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/mix.exs.mustache
@@ -4,7 +4,7 @@ defmodule {{moduleName}}.Mixfile do
   def project do
     [
       app: {{#atom}}{{#underscored}}{{packageName}}{{/underscored}}{{/atom}},
-      version: "{{appVersion}}",
+      version: "{{packageVersion}}",
       elixir: "~> {{supportedElixirVersion}}",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Fix package version handling: remove unused hardcoded `apiVersion`, add `packageVersion` and use it everywhere.

@mrmstn 