### PR TITLE
Close #19129: java jersey2 and jersey3: Always cast path parameters to string similarly to okhttp-gson

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -134,7 +134,7 @@ public class {{classname}} {
     {{#hasPathParams}}
     // Path parameters
     String localVarPath = "{{{path}}}"{{#pathParams}}
-            .replaceAll({{=% %=}}"\\{%baseName%}"%={{ }}=%, apiClient.escapeString({{{paramName}}}{{#isUuid}}.toString(){{/isUuid}}{{^isString}}.toString(){{/isString}})){{/pathParams}};
+            .replaceAll({{=% %=}}"\\{%baseName%}"%={{ }}=%, apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
 
     {{/hasPathParams}}
     {{#queryParams}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
@@ -134,7 +134,7 @@ public class {{classname}} {
     {{#hasPathParams}}
     // Path parameters
     String localVarPath = "{{{path}}}"{{#pathParams}}
-            .replaceAll({{=% %=}}"\\{%baseName%}"%={{ }}=%, apiClient.escapeString({{{paramName}}}{{#isUuid}}.toString(){{/isUuid}}{{^isString}}.toString(){{/isString}})){{/pathParams}};
+            .replaceAll({{=% %=}}"\\{%baseName%}"%={{ }}=%, apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
 
     {{/hasPathParams}}
     {{#queryParams}}

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -83,7 +83,7 @@ public class StoreApi {
 
     // Path parameters
     String localVarPath = "/store/order/{order_id}"
-            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/UserApi.java
@@ -201,7 +201,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -249,7 +249,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -386,7 +386,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -83,7 +83,7 @@ public class StoreApi {
 
     // Path parameters
     String localVarPath = "/store/order/{order_id}"
-            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -201,7 +201,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -249,7 +249,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -386,7 +386,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -86,7 +86,7 @@ public class StoreApi {
 
     // Path parameters
     String localVarPath = "/store/order/{order_id}"
-            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/UserApi.java
@@ -204,7 +204,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -252,7 +252,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -389,7 +389,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType("application/json");

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -83,7 +83,7 @@ public class StoreApi {
 
     // Path parameters
     String localVarPath = "/store/order/{orderId}"
-            .replaceAll("\\{orderId}", apiClient.escapeString(orderId));
+            .replaceAll("\\{orderId}", apiClient.escapeString(orderId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/UserApi.java
@@ -204,7 +204,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -253,7 +253,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -391,7 +391,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType("application/json");

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -83,7 +83,7 @@ public class StoreApi {
 
     // Path parameters
     String localVarPath = "/store/order/{orderId}"
-            .replaceAll("\\{orderId}", apiClient.escapeString(orderId));
+            .replaceAll("\\{orderId}", apiClient.escapeString(orderId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/src/main/java/org/openapitools/client/api/UserApi.java
@@ -204,7 +204,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -253,7 +253,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -391,7 +391,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType("application/json");

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -83,7 +83,7 @@ public class StoreApi {
 
     // Path parameters
     String localVarPath = "/store/order/{order_id}"
-            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -201,7 +201,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -249,7 +249,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -386,7 +386,7 @@ public class UserApi {
 
     // Path parameters
     String localVarPath = "/user/{username}"
-            .replaceAll("\\{username}", apiClient.escapeString(username));
+            .replaceAll("\\{username}", apiClient.escapeString(username.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept();
     String localVarContentType = apiClient.selectHeaderContentType("application/json");


### PR DESCRIPTION
This PR fixes the case of a parameter with format URI in the path as seen in #19129. 
The `.toString()` casting were added only in two cases: `isUuid` or `^isString`. However this is not sufficient to catch the case of URI. Instead of adding another exception, I changed the code to always call `.toString()`, similarly to what is done for `okhttp-gson` template.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)