### PR TITLE
[Kotlin] use @get:JsonProperty instead of @field:JsonProperty for Kotlin data classes properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class_opt_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class_opt_var.mustache
@@ -9,7 +9,7 @@
     @SerializedName("{{{vendorExtensions.x-base-name-literal}}}")
     {{/gson}}
     {{#jackson}}
-    @field:JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
+    @get:JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
     {{/jackson}}
     {{#kotlinx_serialization}}
     {{^isEnum}}{{^isArray}}{{^isPrimitiveType}}{{^isModel}}@Contextual {{/isModel}}{{/isPrimitiveType}}{{/isArray}}{{/isEnum}}@SerialName(value = "{{{vendorExtensions.x-base-name-literal}}}")

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class_req_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class_req_var.mustache
@@ -9,7 +9,7 @@
     @SerializedName("{{{vendorExtensions.x-base-name-literal}}}")
     {{/gson}}
     {{#jackson}}
-    @field:JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
+    @get:JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
     {{/jackson}}
     {{#kotlinx_serialization}}
     {{^isEnum}}{{^isArray}}{{^isPrimitiveType}}{{^isModel}}@Contextual {{/isModel}}{{/isPrimitiveType}}{{/isArray}}{{/isEnum}}@SerialName(value = "{{{vendorExtensions.x-base-name-literal}}}")

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Bird.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Bird.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Bird (
 
-    @field:JsonProperty("size")
+    @get:JsonProperty("size")
     val propertySize: kotlin.String? = null,
 
-    @field:JsonProperty("color")
+    @get:JsonProperty("color")
     val color: kotlin.String? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Category (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/DefaultValue.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/DefaultValue.kt
@@ -36,28 +36,28 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class DefaultValue (
 
-    @field:JsonProperty("array_string_enum_ref_default")
+    @get:JsonProperty("array_string_enum_ref_default")
     val arrayStringEnumRefDefault: kotlin.collections.List<StringEnumRef>? = null,
 
-    @field:JsonProperty("array_string_enum_default")
+    @get:JsonProperty("array_string_enum_default")
     val arrayStringEnumDefault: kotlin.collections.List<DefaultValue.ArrayStringEnumDefault>? = null,
 
-    @field:JsonProperty("array_string_default")
+    @get:JsonProperty("array_string_default")
     val arrayStringDefault: kotlin.collections.List<kotlin.String>? = arrayListOf("failure","skipped"),
 
-    @field:JsonProperty("array_integer_default")
+    @get:JsonProperty("array_integer_default")
     val arrayIntegerDefault: kotlin.collections.List<kotlin.Int>? = arrayListOf(1,3),
 
-    @field:JsonProperty("array_string")
+    @get:JsonProperty("array_string")
     val arrayString: kotlin.collections.List<kotlin.String>? = null,
 
-    @field:JsonProperty("array_string_nullable")
+    @get:JsonProperty("array_string_nullable")
     val arrayStringNullable: kotlin.collections.List<kotlin.String>? = null,
 
-    @field:JsonProperty("array_string_extension_nullable")
+    @get:JsonProperty("array_string_extension_nullable")
     val arrayStringExtensionNullable: kotlin.collections.List<kotlin.String>? = null,
 
-    @field:JsonProperty("string_nullable")
+    @get:JsonProperty("string_nullable")
     val stringNullable: kotlin.String? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/NumberPropertiesOnly.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/NumberPropertiesOnly.kt
@@ -30,13 +30,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class NumberPropertiesOnly (
 
-    @field:JsonProperty("number")
+    @get:JsonProperty("number")
     val number: java.math.BigDecimal? = null,
 
-    @field:JsonProperty("float")
+    @get:JsonProperty("float")
     val float: kotlin.Float? = null,
 
-    @field:JsonProperty("double")
+    @get:JsonProperty("double")
     val double: kotlin.Double? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -35,23 +35,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Pet (
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String,
 
-    @field:JsonProperty("photoUrls")
+    @get:JsonProperty("photoUrls")
     val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("category")
+    @get:JsonProperty("category")
     val category: Category? = null,
 
-    @field:JsonProperty("tags")
+    @get:JsonProperty("tags")
     val tags: kotlin.collections.List<Tag>? = null,
 
     /* pet status in the store */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     val status: Pet.Status? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Query.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Query.kt
@@ -30,10 +30,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 data class Query (
 
     /* Query */
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("outcomes")
+    @get:JsonProperty("outcomes")
     val outcomes: kotlin.collections.List<Query.Outcomes>? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Tag (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.kt
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter (
 
-    @field:JsonProperty("values")
+    @get:JsonProperty("values")
     val propertyValues: kotlin.collections.List<kotlin.String>? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Bird.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Bird.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Bird (
 
-    @field:JsonProperty("size")
+    @get:JsonProperty("size")
     val propertySize: kotlin.String? = null,
 
-    @field:JsonProperty("color")
+    @get:JsonProperty("color")
     val color: kotlin.String? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Category (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/DefaultValue.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/DefaultValue.kt
@@ -36,28 +36,28 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class DefaultValue (
 
-    @field:JsonProperty("array_string_enum_ref_default")
+    @get:JsonProperty("array_string_enum_ref_default")
     val arrayStringEnumRefDefault: kotlin.collections.List<StringEnumRef>? = null,
 
-    @field:JsonProperty("array_string_enum_default")
+    @get:JsonProperty("array_string_enum_default")
     val arrayStringEnumDefault: kotlin.collections.List<DefaultValue.ArrayStringEnumDefault>? = null,
 
-    @field:JsonProperty("array_string_default")
+    @get:JsonProperty("array_string_default")
     val arrayStringDefault: kotlin.collections.List<kotlin.String>? = arrayListOf("failure","skipped"),
 
-    @field:JsonProperty("array_integer_default")
+    @get:JsonProperty("array_integer_default")
     val arrayIntegerDefault: kotlin.collections.List<kotlin.Int>? = arrayListOf(1,3),
 
-    @field:JsonProperty("array_string")
+    @get:JsonProperty("array_string")
     val arrayString: kotlin.collections.List<kotlin.String>? = null,
 
-    @field:JsonProperty("array_string_nullable")
+    @get:JsonProperty("array_string_nullable")
     val arrayStringNullable: kotlin.collections.List<kotlin.String>? = null,
 
-    @field:JsonProperty("array_string_extension_nullable")
+    @get:JsonProperty("array_string_extension_nullable")
     val arrayStringExtensionNullable: kotlin.collections.List<kotlin.String>? = null,
 
-    @field:JsonProperty("string_nullable")
+    @get:JsonProperty("string_nullable")
     val stringNullable: kotlin.String? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/NumberPropertiesOnly.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/NumberPropertiesOnly.kt
@@ -30,13 +30,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class NumberPropertiesOnly (
 
-    @field:JsonProperty("number")
+    @get:JsonProperty("number")
     val number: java.math.BigDecimal? = null,
 
-    @field:JsonProperty("float")
+    @get:JsonProperty("float")
     val float: kotlin.Float? = null,
 
-    @field:JsonProperty("double")
+    @get:JsonProperty("double")
     val double: kotlin.Double? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -35,23 +35,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Pet (
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String,
 
-    @field:JsonProperty("photoUrls")
+    @get:JsonProperty("photoUrls")
     val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("category")
+    @get:JsonProperty("category")
     val category: Category? = null,
 
-    @field:JsonProperty("tags")
+    @get:JsonProperty("tags")
     val tags: kotlin.collections.List<Tag>? = null,
 
     /* pet status in the store */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     val status: Pet.Status? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Query.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Query.kt
@@ -30,10 +30,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 data class Query (
 
     /* Query */
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("outcomes")
+    @get:JsonProperty("outcomes")
     val outcomes: kotlin.collections.List<Query.Outcomes>? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Tag (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.kt
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter (
 
-    @field:JsonProperty("values")
+    @get:JsonProperty("values")
     val propertyValues: kotlin.collections.List<kotlin.String>? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Category (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
@@ -30,13 +30,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class ModelApiResponse (
 
-    @field:JsonProperty("code")
+    @get:JsonProperty("code")
     val code: kotlin.Int? = null,
 
-    @field:JsonProperty("type")
+    @get:JsonProperty("type")
     val type: kotlin.String? = null,
 
-    @field:JsonProperty("message")
+    @get:JsonProperty("message")
     val message: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -33,23 +33,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Order (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("petId")
+    @get:JsonProperty("petId")
     val petId: kotlin.Long? = null,
 
-    @field:JsonProperty("quantity")
+    @get:JsonProperty("quantity")
     val quantity: kotlin.Int? = null,
 
-    @field:JsonProperty("shipDate")
+    @get:JsonProperty("shipDate")
     val shipDate: java.time.OffsetDateTime? = null,
 
     /* Order Status */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     val status: Order.Status? = null,
 
-    @field:JsonProperty("complete")
+    @get:JsonProperty("complete")
     val complete: kotlin.Boolean? = false
 
 ) {

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -35,23 +35,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Pet (
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String,
 
-    @field:JsonProperty("photoUrls")
+    @get:JsonProperty("photoUrls")
     val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("category")
+    @get:JsonProperty("category")
     val category: Category? = null,
 
-    @field:JsonProperty("tags")
+    @get:JsonProperty("tags")
     val tags: kotlin.collections.List<Tag>? = null,
 
     /* pet status in the store */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     val status: Pet.Status? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Tag (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -35,29 +35,29 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class User (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("username")
+    @get:JsonProperty("username")
     val username: kotlin.String? = null,
 
-    @field:JsonProperty("firstName")
+    @get:JsonProperty("firstName")
     val firstName: kotlin.String? = null,
 
-    @field:JsonProperty("lastName")
+    @get:JsonProperty("lastName")
     val lastName: kotlin.String? = null,
 
-    @field:JsonProperty("email")
+    @get:JsonProperty("email")
     val email: kotlin.String? = null,
 
-    @field:JsonProperty("password")
+    @get:JsonProperty("password")
     val password: kotlin.String? = null,
 
-    @field:JsonProperty("phone")
+    @get:JsonProperty("phone")
     val phone: kotlin.String? = null,
 
     /* User Status */
-    @field:JsonProperty("userStatus")
+    @get:JsonProperty("userStatus")
     val userStatus: kotlin.Int? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Category (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
@@ -30,13 +30,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class ModelApiResponse (
 
-    @field:JsonProperty("code")
+    @get:JsonProperty("code")
     val code: kotlin.Int? = null,
 
-    @field:JsonProperty("type")
+    @get:JsonProperty("type")
     val type: kotlin.String? = null,
 
-    @field:JsonProperty("message")
+    @get:JsonProperty("message")
     val message: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -33,23 +33,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Order (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("petId")
+    @get:JsonProperty("petId")
     val petId: kotlin.Long? = null,
 
-    @field:JsonProperty("quantity")
+    @get:JsonProperty("quantity")
     val quantity: kotlin.Int? = null,
 
-    @field:JsonProperty("shipDate")
+    @get:JsonProperty("shipDate")
     val shipDate: java.time.OffsetDateTime? = null,
 
     /* Order Status */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     val status: Order.Status? = null,
 
-    @field:JsonProperty("complete")
+    @get:JsonProperty("complete")
     val complete: kotlin.Boolean? = false
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -35,23 +35,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Pet (
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String,
 
-    @field:JsonProperty("photoUrls")
+    @get:JsonProperty("photoUrls")
     val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("category")
+    @get:JsonProperty("category")
     val category: Category? = null,
 
-    @field:JsonProperty("tags")
+    @get:JsonProperty("tags")
     val tags: kotlin.collections.List<Tag>? = null,
 
     /* pet status in the store */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     @Deprecated(message = "This property is deprecated.")
     val status: Pet.Status? = null
 

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Tag (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -35,29 +35,29 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class User (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("username")
+    @get:JsonProperty("username")
     val username: kotlin.String? = null,
 
-    @field:JsonProperty("firstName")
+    @get:JsonProperty("firstName")
     val firstName: kotlin.String? = null,
 
-    @field:JsonProperty("lastName")
+    @get:JsonProperty("lastName")
     val lastName: kotlin.String? = null,
 
-    @field:JsonProperty("email")
+    @get:JsonProperty("email")
     val email: kotlin.String? = null,
 
-    @field:JsonProperty("password")
+    @get:JsonProperty("password")
     val password: kotlin.String? = null,
 
-    @field:JsonProperty("phone")
+    @get:JsonProperty("phone")
     val phone: kotlin.String? = null,
 
     /* User Status */
-    @field:JsonProperty("userStatus")
+    @get:JsonProperty("userStatus")
     val userStatus: kotlin.Int? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Category (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
@@ -30,13 +30,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class ModelApiResponse (
 
-    @field:JsonProperty("code")
+    @get:JsonProperty("code")
     val code: kotlin.Int? = null,
 
-    @field:JsonProperty("type")
+    @get:JsonProperty("type")
     val type: kotlin.String? = null,
 
-    @field:JsonProperty("message")
+    @get:JsonProperty("message")
     val message: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -33,23 +33,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Order (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("petId")
+    @get:JsonProperty("petId")
     val petId: kotlin.Long? = null,
 
-    @field:JsonProperty("quantity")
+    @get:JsonProperty("quantity")
     val quantity: kotlin.Int? = null,
 
-    @field:JsonProperty("shipDate")
+    @get:JsonProperty("shipDate")
     val shipDate: java.time.OffsetDateTime? = null,
 
     /* Order Status */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     val status: Order.Status? = null,
 
-    @field:JsonProperty("complete")
+    @get:JsonProperty("complete")
     val complete: kotlin.Boolean? = false
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -35,23 +35,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Pet (
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String,
 
-    @field:JsonProperty("photoUrls")
+    @get:JsonProperty("photoUrls")
     val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("category")
+    @get:JsonProperty("category")
     val category: Category? = null,
 
-    @field:JsonProperty("tags")
+    @get:JsonProperty("tags")
     val tags: kotlin.collections.List<Tag>? = null,
 
     /* pet status in the store */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     val status: Pet.Status? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Tag (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -35,29 +35,29 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class User (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("username")
+    @get:JsonProperty("username")
     val username: kotlin.String? = null,
 
-    @field:JsonProperty("firstName")
+    @get:JsonProperty("firstName")
     val firstName: kotlin.String? = null,
 
-    @field:JsonProperty("lastName")
+    @get:JsonProperty("lastName")
     val lastName: kotlin.String? = null,
 
-    @field:JsonProperty("email")
+    @get:JsonProperty("email")
     val email: kotlin.String? = null,
 
-    @field:JsonProperty("password")
+    @get:JsonProperty("password")
     val password: kotlin.String? = null,
 
-    @field:JsonProperty("phone")
+    @get:JsonProperty("phone")
     val phone: kotlin.String? = null,
 
     /* User Status */
-    @field:JsonProperty("userStatus")
+    @get:JsonProperty("userStatus")
     val userStatus: kotlin.Int? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Category (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
@@ -30,13 +30,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class ModelApiResponse (
 
-    @field:JsonProperty("code")
+    @get:JsonProperty("code")
     val code: kotlin.Int? = null,
 
-    @field:JsonProperty("type")
+    @get:JsonProperty("type")
     val type: kotlin.String? = null,
 
-    @field:JsonProperty("message")
+    @get:JsonProperty("message")
     val message: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -33,23 +33,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Order (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("petId")
+    @get:JsonProperty("petId")
     val petId: kotlin.Long? = null,
 
-    @field:JsonProperty("quantity")
+    @get:JsonProperty("quantity")
     val quantity: kotlin.Int? = null,
 
-    @field:JsonProperty("shipDate")
+    @get:JsonProperty("shipDate")
     val shipDate: java.time.OffsetDateTime? = null,
 
     /* Order Status */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     val status: Order.Status? = null,
 
-    @field:JsonProperty("complete")
+    @get:JsonProperty("complete")
     val complete: kotlin.Boolean? = false
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -35,23 +35,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Pet (
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String,
 
-    @field:JsonProperty("photoUrls")
+    @get:JsonProperty("photoUrls")
     val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("category")
+    @get:JsonProperty("category")
     val category: Category? = null,
 
-    @field:JsonProperty("tags")
+    @get:JsonProperty("tags")
     val tags: kotlin.collections.List<Tag>? = null,
 
     /* pet status in the store */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     @Deprecated(message = "This property is deprecated.")
     val status: Pet.Status? = null
 

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Tag (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -35,29 +35,29 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class User (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("username")
+    @get:JsonProperty("username")
     val username: kotlin.String? = null,
 
-    @field:JsonProperty("firstName")
+    @get:JsonProperty("firstName")
     val firstName: kotlin.String? = null,
 
-    @field:JsonProperty("lastName")
+    @get:JsonProperty("lastName")
     val lastName: kotlin.String? = null,
 
-    @field:JsonProperty("email")
+    @get:JsonProperty("email")
     val email: kotlin.String? = null,
 
-    @field:JsonProperty("password")
+    @get:JsonProperty("password")
     val password: kotlin.String? = null,
 
-    @field:JsonProperty("phone")
+    @get:JsonProperty("phone")
     val phone: kotlin.String? = null,
 
     /* User Status */
-    @field:JsonProperty("userStatus")
+    @get:JsonProperty("userStatus")
     val userStatus: kotlin.Int? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Category (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
@@ -30,13 +30,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class ModelApiResponse (
 
-    @field:JsonProperty("code")
+    @get:JsonProperty("code")
     val code: kotlin.Int? = null,
 
-    @field:JsonProperty("type")
+    @get:JsonProperty("type")
     val type: kotlin.String? = null,
 
-    @field:JsonProperty("message")
+    @get:JsonProperty("message")
     val message: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -33,23 +33,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Order (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("petId")
+    @get:JsonProperty("petId")
     val petId: kotlin.Long? = null,
 
-    @field:JsonProperty("quantity")
+    @get:JsonProperty("quantity")
     val quantity: kotlin.Int? = null,
 
-    @field:JsonProperty("shipDate")
+    @get:JsonProperty("shipDate")
     val shipDate: java.time.OffsetDateTime? = null,
 
     /* Order Status */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     val status: Order.Status? = null,
 
-    @field:JsonProperty("complete")
+    @get:JsonProperty("complete")
     val complete: kotlin.Boolean? = false
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -35,23 +35,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Pet (
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String,
 
-    @field:JsonProperty("photoUrls")
+    @get:JsonProperty("photoUrls")
     val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("category")
+    @get:JsonProperty("category")
     val category: Category? = null,
 
-    @field:JsonProperty("tags")
+    @get:JsonProperty("tags")
     val tags: kotlin.collections.List<Tag>? = null,
 
     /* pet status in the store */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     @Deprecated(message = "This property is deprecated.")
     val status: Pet.Status? = null
 

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Tag (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -35,29 +35,29 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class User (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("username")
+    @get:JsonProperty("username")
     val username: kotlin.String? = null,
 
-    @field:JsonProperty("firstName")
+    @get:JsonProperty("firstName")
     val firstName: kotlin.String? = null,
 
-    @field:JsonProperty("lastName")
+    @get:JsonProperty("lastName")
     val lastName: kotlin.String? = null,
 
-    @field:JsonProperty("email")
+    @get:JsonProperty("email")
     val email: kotlin.String? = null,
 
-    @field:JsonProperty("password")
+    @get:JsonProperty("password")
     val password: kotlin.String? = null,
 
-    @field:JsonProperty("phone")
+    @get:JsonProperty("phone")
     val phone: kotlin.String? = null,
 
     /* User Status */
-    @field:JsonProperty("userStatus")
+    @get:JsonProperty("userStatus")
     val userStatus: kotlin.Int? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Category (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
@@ -30,13 +30,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class ModelApiResponse (
 
-    @field:JsonProperty("code")
+    @get:JsonProperty("code")
     val code: kotlin.Int? = null,
 
-    @field:JsonProperty("type")
+    @get:JsonProperty("type")
     val type: kotlin.String? = null,
 
-    @field:JsonProperty("message")
+    @get:JsonProperty("message")
     val message: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -33,23 +33,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Order (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("petId")
+    @get:JsonProperty("petId")
     val petId: kotlin.Long? = null,
 
-    @field:JsonProperty("quantity")
+    @get:JsonProperty("quantity")
     val quantity: kotlin.Int? = null,
 
-    @field:JsonProperty("shipDate")
+    @get:JsonProperty("shipDate")
     val shipDate: java.time.OffsetDateTime? = null,
 
     /* Order Status */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     val status: Order.Status? = null,
 
-    @field:JsonProperty("complete")
+    @get:JsonProperty("complete")
     val complete: kotlin.Boolean? = false
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -35,23 +35,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Pet (
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String,
 
-    @field:JsonProperty("photoUrls")
+    @get:JsonProperty("photoUrls")
     val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("category")
+    @get:JsonProperty("category")
     val category: Category? = null,
 
-    @field:JsonProperty("tags")
+    @get:JsonProperty("tags")
     val tags: kotlin.collections.List<Tag>? = null,
 
     /* pet status in the store */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     @Deprecated(message = "This property is deprecated.")
     val status: Pet.Status? = null
 

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Tag (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -35,29 +35,29 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class User (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("username")
+    @get:JsonProperty("username")
     val username: kotlin.String? = null,
 
-    @field:JsonProperty("firstName")
+    @get:JsonProperty("firstName")
     val firstName: kotlin.String? = null,
 
-    @field:JsonProperty("lastName")
+    @get:JsonProperty("lastName")
     val lastName: kotlin.String? = null,
 
-    @field:JsonProperty("email")
+    @get:JsonProperty("email")
     val email: kotlin.String? = null,
 
-    @field:JsonProperty("password")
+    @get:JsonProperty("password")
     val password: kotlin.String? = null,
 
-    @field:JsonProperty("phone")
+    @get:JsonProperty("phone")
     val phone: kotlin.String? = null,
 
     /* User Status */
-    @field:JsonProperty("userStatus")
+    @get:JsonProperty("userStatus")
     val userStatus: kotlin.Int? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -28,10 +28,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Category (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
@@ -29,13 +29,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class ModelApiResponse (
 
-    @field:JsonProperty("code")
+    @get:JsonProperty("code")
     val code: kotlin.Int? = null,
 
-    @field:JsonProperty("type")
+    @get:JsonProperty("type")
     val type: kotlin.String? = null,
 
-    @field:JsonProperty("message")
+    @get:JsonProperty("message")
     val message: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -32,23 +32,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Order (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("petId")
+    @get:JsonProperty("petId")
     val petId: kotlin.Long? = null,
 
-    @field:JsonProperty("quantity")
+    @get:JsonProperty("quantity")
     val quantity: kotlin.Int? = null,
 
-    @field:JsonProperty("shipDate")
+    @get:JsonProperty("shipDate")
     val shipDate: java.time.OffsetDateTime? = null,
 
     /* Order Status */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     val status: Order.Status? = null,
 
-    @field:JsonProperty("complete")
+    @get:JsonProperty("complete")
     val complete: kotlin.Boolean? = false
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -34,23 +34,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Pet (
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String,
 
-    @field:JsonProperty("photoUrls")
+    @get:JsonProperty("photoUrls")
     val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("category")
+    @get:JsonProperty("category")
     val category: Category? = null,
 
-    @field:JsonProperty("tags")
+    @get:JsonProperty("tags")
     val tags: kotlin.collections.List<Tag>? = null,
 
     /* pet status in the store */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     @Deprecated(message = "This property is deprecated.")
     val status: Pet.Status? = null
 

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -28,10 +28,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Tag (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -34,29 +34,29 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class User (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("username")
+    @get:JsonProperty("username")
     val username: kotlin.String? = null,
 
-    @field:JsonProperty("firstName")
+    @get:JsonProperty("firstName")
     val firstName: kotlin.String? = null,
 
-    @field:JsonProperty("lastName")
+    @get:JsonProperty("lastName")
     val lastName: kotlin.String? = null,
 
-    @field:JsonProperty("email")
+    @get:JsonProperty("email")
     val email: kotlin.String? = null,
 
-    @field:JsonProperty("password")
+    @get:JsonProperty("password")
     val password: kotlin.String? = null,
 
-    @field:JsonProperty("phone")
+    @get:JsonProperty("phone")
     val phone: kotlin.String? = null,
 
     /* User Status */
-    @field:JsonProperty("userStatus")
+    @get:JsonProperty("userStatus")
     val userStatus: kotlin.Int? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -28,10 +28,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Category (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
@@ -29,13 +29,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class ModelApiResponse (
 
-    @field:JsonProperty("code")
+    @get:JsonProperty("code")
     val code: kotlin.Int? = null,
 
-    @field:JsonProperty("type")
+    @get:JsonProperty("type")
     val type: kotlin.String? = null,
 
-    @field:JsonProperty("message")
+    @get:JsonProperty("message")
     val message: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -32,23 +32,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Order (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("petId")
+    @get:JsonProperty("petId")
     val petId: kotlin.Long? = null,
 
-    @field:JsonProperty("quantity")
+    @get:JsonProperty("quantity")
     val quantity: kotlin.Int? = null,
 
-    @field:JsonProperty("shipDate")
+    @get:JsonProperty("shipDate")
     val shipDate: java.time.OffsetDateTime? = null,
 
     /* Order Status */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     val status: Order.Status? = null,
 
-    @field:JsonProperty("complete")
+    @get:JsonProperty("complete")
     val complete: kotlin.Boolean? = false
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -34,23 +34,23 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Pet (
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String,
 
-    @field:JsonProperty("photoUrls")
+    @get:JsonProperty("photoUrls")
     val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("category")
+    @get:JsonProperty("category")
     val category: Category? = null,
 
-    @field:JsonProperty("tags")
+    @get:JsonProperty("tags")
     val tags: kotlin.collections.List<Tag>? = null,
 
     /* pet status in the store */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     @Deprecated(message = "This property is deprecated.")
     val status: Pet.Status? = null
 

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -28,10 +28,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Tag (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) {

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -34,29 +34,29 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class User (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("username")
+    @get:JsonProperty("username")
     val username: kotlin.String? = null,
 
-    @field:JsonProperty("firstName")
+    @get:JsonProperty("firstName")
     val firstName: kotlin.String? = null,
 
-    @field:JsonProperty("lastName")
+    @get:JsonProperty("lastName")
     val lastName: kotlin.String? = null,
 
-    @field:JsonProperty("email")
+    @get:JsonProperty("email")
     val email: kotlin.String? = null,
 
-    @field:JsonProperty("password")
+    @get:JsonProperty("password")
     val password: kotlin.String? = null,
 
-    @field:JsonProperty("phone")
+    @get:JsonProperty("phone")
     val phone: kotlin.String? = null,
 
     /* User Status */
-    @field:JsonProperty("userStatus")
+    @get:JsonProperty("userStatus")
     val userStatus: kotlin.Int? = null
 
 ) {

--- a/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -29,10 +29,10 @@ import java.io.Serializable
 
 data class Category (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) : Serializable {

--- a/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/ModelApiResponse.kt
@@ -30,13 +30,13 @@ import java.io.Serializable
 
 data class ModelApiResponse (
 
-    @field:JsonProperty("code")
+    @get:JsonProperty("code")
     val code: kotlin.Int? = null,
 
-    @field:JsonProperty("type")
+    @get:JsonProperty("type")
     val type: kotlin.String? = null,
 
-    @field:JsonProperty("message")
+    @get:JsonProperty("message")
     val message: kotlin.String? = null
 
 ) : Serializable {

--- a/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -33,23 +33,23 @@ import java.io.Serializable
 
 data class Order (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("petId")
+    @get:JsonProperty("petId")
     val petId: kotlin.Long? = null,
 
-    @field:JsonProperty("quantity")
+    @get:JsonProperty("quantity")
     val quantity: kotlin.Int? = null,
 
-    @field:JsonProperty("shipDate")
+    @get:JsonProperty("shipDate")
     val shipDate: java.time.OffsetDateTime? = null,
 
     /* Order Status */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     val status: Order.Status? = null,
 
-    @field:JsonProperty("complete")
+    @get:JsonProperty("complete")
     val complete: kotlin.Boolean? = false
 
 ) : Serializable {

--- a/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -35,23 +35,23 @@ import java.io.Serializable
 
 data class Pet (
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String,
 
-    @field:JsonProperty("photoUrls")
+    @get:JsonProperty("photoUrls")
     val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("category")
+    @get:JsonProperty("category")
     val category: Category? = null,
 
-    @field:JsonProperty("tags")
+    @get:JsonProperty("tags")
     val tags: kotlin.collections.List<Tag>? = null,
 
     /* pet status in the store */
-    @field:JsonProperty("status")
+    @get:JsonProperty("status")
     @Deprecated(message = "This property is deprecated.")
     val status: Pet.Status? = null
 

--- a/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -29,10 +29,10 @@ import java.io.Serializable
 
 data class Tag (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("name")
+    @get:JsonProperty("name")
     val name: kotlin.String? = null
 
 ) : Serializable {

--- a/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -35,29 +35,29 @@ import java.io.Serializable
 
 data class User (
 
-    @field:JsonProperty("id")
+    @get:JsonProperty("id")
     val id: kotlin.Long? = null,
 
-    @field:JsonProperty("username")
+    @get:JsonProperty("username")
     val username: kotlin.String? = null,
 
-    @field:JsonProperty("firstName")
+    @get:JsonProperty("firstName")
     val firstName: kotlin.String? = null,
 
-    @field:JsonProperty("lastName")
+    @get:JsonProperty("lastName")
     val lastName: kotlin.String? = null,
 
-    @field:JsonProperty("email")
+    @get:JsonProperty("email")
     val email: kotlin.String? = null,
 
-    @field:JsonProperty("password")
+    @get:JsonProperty("password")
     val password: kotlin.String? = null,
 
-    @field:JsonProperty("phone")
+    @get:JsonProperty("phone")
     val phone: kotlin.String? = null,
 
     /* User Status */
-    @field:JsonProperty("userStatus")
+    @get:JsonProperty("userStatus")
     val userStatus: kotlin.Int? = null
 
 ) : Serializable {


### PR DESCRIPTION
fix #11353 use `@get:JsonProperty` instead of `@field:JsonProperty`

For Kotlin data classes and Jackson serialization the `JsonProperty` annotation needs to be prefixed with `@get:` instead of `@field`. Otherwise Jackson does it's own derivation from the getter name to the property and serializes the field twice if it starts with only one lower case character.

The same solution was used in the Kotlin Spring generator as you can see here: https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassOptVar.mustache#L5 and here https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassReqVar.mustache#L4.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jimschubert, @dr4ke616, @karismann, @Zomzog, @andrewemery, @4brunu, @yutaka0m, @stefankoppier