### PR TITLE
[python-fastapi] return 500 if not implemented, added some unittests

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-fastapi/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/api.mustache
@@ -14,6 +14,7 @@ from fastapi import (  # noqa: F401
     Depends,
     Form,
     Header,
+    HTTPException,
     Path,
     Query,
     Response,
@@ -65,7 +66,9 @@ async def {{operationId}}(
     {{/hasAuthMethods}}
 ) -> {{returnType}}{{^returnType}}None{{/returnType}}:
     {{#notes}}"""{{.}}"""
-    {{/notes}}return await Base{{classname}}.subclasses[0]().{{operationId}}({{#allParams}}{{>impl_argument}}{{^-last}}, {{/-last}}{{/allParams}})
+    {{/notes}}if not Base{{classname}}.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
+    return await Base{{classname}}.subclasses[0]().{{operationId}}({{#allParams}}{{>impl_argument}}{{^-last}}, {{/-last}}{{/allParams}})
 {{^-last}}
 
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFastapiCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFastapiCodegenTest.java
@@ -1,0 +1,56 @@
+package org.openapitools.codegen.python;
+
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.testng.annotations.Test;
+import org.openapitools.codegen.CodegenConstants;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class PythonFastapiCodegenTest {
+    @Test
+    public void testAdditionalPropertiesPutForConfigValues() throws Exception {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final String IMPL_PKG = "impl_package";
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("python-fastapi")
+                .setPackageName("nodesc")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"))
+                .setInputSpec("src/test/resources/3_1/nodesc.yaml")
+                .addAdditionalProperty(CodegenConstants.FASTAPI_IMPLEMENTATION_PACKAGE, IMPL_PKG);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileExists(Paths.get(output.getAbsolutePath(), "/src", IMPL_PKG, "__init__.py"));
+    }
+
+    @Test
+    public void testEndpointSpecsWithoutDescription() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("python-fastapi")
+                .setPackageName("nodesc")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"))
+                .setInputSpec("src/test/resources/3_1/nodesc.yaml");
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileContains(Paths.get(output + "/src/nodesc/apis/nodesc_api.py"),
+                "return await BaseNodescApi.subclasses[0]().nodesc()\n");
+        TestUtils.assertFileContains(Paths.get(output + "/src/nodesc/apis/desc_api.py"),
+                "return await BaseDescApi.subclasses[0]().desc()\n");
+    }
+}

--- a/modules/openapi-generator/src/test/resources/3_1/nodesc.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/nodesc.yaml
@@ -1,0 +1,35 @@
+openapi: 3.1.0
+info:
+  description: >-
+    Yet another example.
+  version: 1.0.0
+  title: OpenAPI example
+tags:
+  - name: nodesc
+    description: Endpoints have no description
+  - name: desc
+    description: Endpoints have description
+paths:
+  /nodesc:
+    post:
+      tags:
+        - nodesc
+      summary: dummy operation
+      operationId: nodesc
+      responses:
+        '200':
+          description: successful operation
+        '405':
+          description: Invalid input
+  /desc:
+    post:
+      tags:
+        - desc
+      summary: dummy operation
+      description: 'Description'
+      operationId: desc
+      responses:
+        '200':
+          description: successful operation
+        '405':
+          description: Invalid input

--- a/samples/server/petstore/python-fastapi/src/openapi_server/apis/fake_api.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/apis/fake_api.py
@@ -14,6 +14,7 @@ from fastapi import (  # noqa: F401
     Depends,
     Form,
     Header,
+    HTTPException,
     Path,
     Query,
     Response,
@@ -46,4 +47,6 @@ async def fake_query_param_default(
     no_default: str = Query(None, description="no default value", alias="noDefault"),
 ) -> None:
     """"""
+    if not BaseFakeApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BaseFakeApi.subclasses[0]().fake_query_param_default(has_default, no_default)

--- a/samples/server/petstore/python-fastapi/src/openapi_server/apis/pet_api.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/apis/pet_api.py
@@ -14,6 +14,7 @@ from fastapi import (  # noqa: F401
     Depends,
     Form,
     Header,
+    HTTPException,
     Path,
     Query,
     Response,
@@ -50,6 +51,8 @@ async def add_pet(
     ),
 ) -> Pet:
     """"""
+    if not BasePetApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BasePetApi.subclasses[0]().add_pet(pet)
 
 
@@ -70,6 +73,8 @@ async def delete_pet(
     ),
 ) -> None:
     """"""
+    if not BasePetApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BasePetApi.subclasses[0]().delete_pet(petId, api_key)
 
 
@@ -90,6 +95,8 @@ async def find_pets_by_status(
     ),
 ) -> List[Pet]:
     """Multiple status values can be provided with comma separated strings"""
+    if not BasePetApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BasePetApi.subclasses[0]().find_pets_by_status(status)
 
 
@@ -110,6 +117,8 @@ async def find_pets_by_tags(
     ),
 ) -> List[Pet]:
     """Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing."""
+    if not BasePetApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BasePetApi.subclasses[0]().find_pets_by_tags(tags)
 
 
@@ -131,6 +140,8 @@ async def get_pet_by_id(
     ),
 ) -> Pet:
     """Returns a single pet"""
+    if not BasePetApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BasePetApi.subclasses[0]().get_pet_by_id(petId)
 
 
@@ -153,6 +164,8 @@ async def update_pet(
     ),
 ) -> Pet:
     """"""
+    if not BasePetApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BasePetApi.subclasses[0]().update_pet(pet)
 
 
@@ -174,6 +187,8 @@ async def update_pet_with_form(
     ),
 ) -> None:
     """"""
+    if not BasePetApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BasePetApi.subclasses[0]().update_pet_with_form(petId, name, status)
 
 
@@ -195,4 +210,6 @@ async def upload_file(
     ),
 ) -> ApiResponse:
     """"""
+    if not BasePetApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BasePetApi.subclasses[0]().upload_file(petId, additional_metadata, file)

--- a/samples/server/petstore/python-fastapi/src/openapi_server/apis/store_api.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/apis/store_api.py
@@ -14,6 +14,7 @@ from fastapi import (  # noqa: F401
     Depends,
     Form,
     Header,
+    HTTPException,
     Path,
     Query,
     Response,
@@ -46,6 +47,8 @@ async def delete_order(
     orderId: str = Path(..., description="ID of the order that needs to be deleted"),
 ) -> None:
     """For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors"""
+    if not BaseStoreApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BaseStoreApi.subclasses[0]().delete_order(orderId)
 
 
@@ -64,6 +67,8 @@ async def get_inventory(
     ),
 ) -> Dict[str, int]:
     """Returns a map of status codes to quantities"""
+    if not BaseStoreApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BaseStoreApi.subclasses[0]().get_inventory()
 
 
@@ -82,6 +87,8 @@ async def get_order_by_id(
     orderId: int = Path(..., description="ID of pet that needs to be fetched", ge=1, le=5),
 ) -> Order:
     """For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions"""
+    if not BaseStoreApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BaseStoreApi.subclasses[0]().get_order_by_id(orderId)
 
 
@@ -99,4 +106,6 @@ async def place_order(
     order: Order = Body(None, description="order placed for purchasing the pet"),
 ) -> Order:
     """"""
+    if not BaseStoreApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BaseStoreApi.subclasses[0]().place_order(order)

--- a/samples/server/petstore/python-fastapi/src/openapi_server/apis/user_api.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/apis/user_api.py
@@ -14,6 +14,7 @@ from fastapi import (  # noqa: F401
     Depends,
     Form,
     Header,
+    HTTPException,
     Path,
     Query,
     Response,
@@ -48,6 +49,8 @@ async def create_user(
     ),
 ) -> None:
     """This can only be done by the logged in user."""
+    if not BaseUserApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BaseUserApi.subclasses[0]().create_user(user)
 
 
@@ -67,6 +70,8 @@ async def create_users_with_array_input(
     ),
 ) -> None:
     """"""
+    if not BaseUserApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BaseUserApi.subclasses[0]().create_users_with_array_input(user)
 
 
@@ -86,6 +91,8 @@ async def create_users_with_list_input(
     ),
 ) -> None:
     """"""
+    if not BaseUserApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BaseUserApi.subclasses[0]().create_users_with_list_input(user)
 
 
@@ -106,6 +113,8 @@ async def delete_user(
     ),
 ) -> None:
     """This can only be done by the logged in user."""
+    if not BaseUserApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BaseUserApi.subclasses[0]().delete_user(username)
 
 
@@ -124,6 +133,8 @@ async def get_user_by_name(
     username: str = Path(..., description="The name that needs to be fetched. Use user1 for testing."),
 ) -> User:
     """"""
+    if not BaseUserApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BaseUserApi.subclasses[0]().get_user_by_name(username)
 
 
@@ -142,6 +153,8 @@ async def login_user(
     password: str = Query(None, description="The password for login in clear text", alias="password"),
 ) -> str:
     """"""
+    if not BaseUserApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BaseUserApi.subclasses[0]().login_user(username, password)
 
 
@@ -160,6 +173,8 @@ async def logout_user(
     ),
 ) -> None:
     """"""
+    if not BaseUserApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BaseUserApi.subclasses[0]().logout_user()
 
 
@@ -181,4 +196,6 @@ async def update_user(
     ),
 ) -> None:
     """This can only be done by the logged in user."""
+    if not BaseUserApi.subclasses:
+        raise HTTPException(status_code=500, detail="Not implemented")
     return await BaseUserApi.subclasses[0]().update_user(username, user)


### PR DESCRIPTION
- return 500 if not implemented
- added some unittests

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc: @cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10) @multani (2023/10)