### PR TITLE
[Kotlin][Spring] fix flag appendRequestToHandler with delegatePattern

### DIFF
--- a/bin/configs/kotlin-spring-boot-delegate.yaml
+++ b/bin/configs/kotlin-spring-boot-delegate.yaml
@@ -8,5 +8,6 @@ additionalProperties:
   annotationLibrary: swagger2
   useSwaggerUI: "true"
   delegatePattern: "true"
+  appendRequestToHandler: "true"
   beanValidations: "true"
   requestMappingMode: none

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -875,7 +875,7 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
                 final List<CodegenParameter> allParams = operation.allParams;
                 if (allParams != null) {
                     if (this.isAppendRequestToHandler()) {
-                        allParams.add(new RequestCodegenParameter(true));
+                        allParams.add(new RequestCodegenParameter());
                     }
                     allParams.forEach(param ->
                             // This is necessary in case 'modelMutable' is enabled,
@@ -972,7 +972,16 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
     @Data
     @EqualsAndHashCode(callSuper = true)
     static class RequestCodegenParameter extends CodegenParameter {
-        boolean isRequestObject;
+
+        boolean isRequestObject = true;
+
+        public RequestCodegenParameter() {
+            this.isOptional = false;
+            this.required = true;
+            this.paramName = "serverHttpRequest";
+            this.dataType = "ServerHttpRequest";
+        }
+
     }
 
     public RequestMappingMode getRequestMappingMode() {

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiDelegate.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiDelegate.mustache
@@ -7,6 +7,9 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.core.io.Resource
+{{#appendRequestToHandler}}
+import org.springframework.http.server.reactive.ServerHttpRequest
+{{/appendRequestToHandler}}
 {{#reactive}}
 import kotlinx.coroutines.flow.Flow
 {{/reactive}}

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.security.*
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.http.server.reactive.ServerHttpRequest
 
 import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
@@ -57,8 +58,8 @@ interface PetApi {
             produces = ["application/xml", "application/json"],
             consumes = ["application/json", "application/xml"]
     )
-    fun addPet(@Parameter(description = "Pet object that needs to be added to the store", required = true) @Valid @RequestBody pet: Pet): ResponseEntity<Pet> {
-        return getDelegate().addPet(pet)
+    fun addPet(@Parameter(description = "Pet object that needs to be added to the store", required = true) @Valid @RequestBody pet: Pet,serverHttpRequest: ServerHttpRequest): ResponseEntity<Pet> {
+        return getDelegate().addPet(pet, serverHttpRequest)
     }
 
     @Operation(
@@ -75,8 +76,8 @@ interface PetApi {
             method = [RequestMethod.DELETE],
             value = ["/pet/{petId}"]
     )
-    fun deletePet(@Parameter(description = "Pet id to delete", required = true) @PathVariable("petId") petId: kotlin.Long,@Parameter(description = "", `in` = ParameterIn.HEADER) @RequestHeader(value = "api_key", required = false) apiKey: kotlin.String?): ResponseEntity<Unit> {
-        return getDelegate().deletePet(petId, apiKey)
+    fun deletePet(@Parameter(description = "Pet id to delete", required = true) @PathVariable("petId") petId: kotlin.Long,@Parameter(description = "", `in` = ParameterIn.HEADER) @RequestHeader(value = "api_key", required = false) apiKey: kotlin.String?,serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
+        return getDelegate().deletePet(petId, apiKey, serverHttpRequest)
     }
 
     @Operation(
@@ -95,8 +96,8 @@ interface PetApi {
             value = ["/pet/findByStatus"],
             produces = ["application/xml", "application/json"]
     )
-    fun findPetsByStatus(@NotNull @Parameter(description = "Status values that need to be considered for filter", required = true, schema = Schema(allowableValues = ["available", "pending", "sold"])) @Valid @RequestParam(value = "status", required = true) status: kotlin.collections.List<kotlin.String>): ResponseEntity<List<Pet>> {
-        return getDelegate().findPetsByStatus(status)
+    fun findPetsByStatus(@NotNull @Parameter(description = "Status values that need to be considered for filter", required = true, schema = Schema(allowableValues = ["available", "pending", "sold"])) @Valid @RequestParam(value = "status", required = true) status: kotlin.collections.List<kotlin.String>,serverHttpRequest: ServerHttpRequest): ResponseEntity<List<Pet>> {
+        return getDelegate().findPetsByStatus(status, serverHttpRequest)
     }
 
     @Operation(
@@ -115,8 +116,8 @@ interface PetApi {
             value = ["/pet/findByTags"],
             produces = ["application/xml", "application/json"]
     )
-    fun findPetsByTags(@NotNull @Parameter(description = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) tags: kotlin.collections.List<kotlin.String>): ResponseEntity<List<Pet>> {
-        return getDelegate().findPetsByTags(tags)
+    fun findPetsByTags(@NotNull @Parameter(description = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) tags: kotlin.collections.List<kotlin.String>,serverHttpRequest: ServerHttpRequest): ResponseEntity<List<Pet>> {
+        return getDelegate().findPetsByTags(tags, serverHttpRequest)
     }
 
     @Operation(
@@ -136,8 +137,8 @@ interface PetApi {
             value = ["/pet/{petId}"],
             produces = ["application/xml", "application/json"]
     )
-    fun getPetById(@Parameter(description = "ID of pet to return", required = true) @PathVariable("petId") petId: kotlin.Long): ResponseEntity<Pet> {
-        return getDelegate().getPetById(petId)
+    fun getPetById(@Parameter(description = "ID of pet to return", required = true) @PathVariable("petId") petId: kotlin.Long,serverHttpRequest: ServerHttpRequest): ResponseEntity<Pet> {
+        return getDelegate().getPetById(petId, serverHttpRequest)
     }
 
     @Operation(
@@ -159,8 +160,8 @@ interface PetApi {
             produces = ["application/xml", "application/json"],
             consumes = ["application/json", "application/xml"]
     )
-    fun updatePet(@Parameter(description = "Pet object that needs to be added to the store", required = true) @Valid @RequestBody pet: Pet): ResponseEntity<Pet> {
-        return getDelegate().updatePet(pet)
+    fun updatePet(@Parameter(description = "Pet object that needs to be added to the store", required = true) @Valid @RequestBody pet: Pet,serverHttpRequest: ServerHttpRequest): ResponseEntity<Pet> {
+        return getDelegate().updatePet(pet, serverHttpRequest)
     }
 
     @Operation(
@@ -178,8 +179,8 @@ interface PetApi {
             value = ["/pet/{petId}"],
             consumes = ["application/x-www-form-urlencoded"]
     )
-    fun updatePetWithForm(@Parameter(description = "ID of pet that needs to be updated", required = true) @PathVariable("petId") petId: kotlin.Long,@Parameter(description = "Updated name of the pet") @RequestParam(value = "name", required = false) name: kotlin.String? ,@Parameter(description = "Updated status of the pet") @RequestParam(value = "status", required = false) status: kotlin.String? ): ResponseEntity<Unit> {
-        return getDelegate().updatePetWithForm(petId, name, status)
+    fun updatePetWithForm(@Parameter(description = "ID of pet that needs to be updated", required = true) @PathVariable("petId") petId: kotlin.Long,@Parameter(description = "Updated name of the pet") @RequestParam(value = "name", required = false) name: kotlin.String? ,@Parameter(description = "Updated status of the pet") @RequestParam(value = "status", required = false) status: kotlin.String? ,serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
+        return getDelegate().updatePetWithForm(petId, name, status, serverHttpRequest)
     }
 
     @Operation(
@@ -198,7 +199,7 @@ interface PetApi {
             produces = ["application/json"],
             consumes = ["multipart/form-data"]
     )
-    fun uploadFile(@Parameter(description = "ID of pet to update", required = true) @PathVariable("petId") petId: kotlin.Long,@Parameter(description = "Additional data to pass to server") @RequestParam(value = "additionalMetadata", required = false) additionalMetadata: kotlin.String? ,@Parameter(description = "file to upload") @Valid @RequestPart("file", required = false) file: org.springframework.core.io.Resource?): ResponseEntity<ModelApiResponse> {
-        return getDelegate().uploadFile(petId, additionalMetadata, file)
+    fun uploadFile(@Parameter(description = "ID of pet to update", required = true) @PathVariable("petId") petId: kotlin.Long,@Parameter(description = "Additional data to pass to server") @RequestParam(value = "additionalMetadata", required = false) additionalMetadata: kotlin.String? ,@Parameter(description = "file to upload") @Valid @RequestPart("file", required = false) file: org.springframework.core.io.Resource?,serverHttpRequest: ServerHttpRequest): ResponseEntity<ModelApiResponse> {
+        return getDelegate().uploadFile(petId, additionalMetadata, file, serverHttpRequest)
     }
 }

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApiDelegate.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApiDelegate.kt
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.core.io.Resource
+import org.springframework.http.server.reactive.ServerHttpRequest
 
 import java.util.Optional
 
@@ -22,7 +23,8 @@ interface PetApiDelegate {
     /**
      * @see PetApi#addPet
      */
-    fun addPet(pet: Pet): ResponseEntity<Pet> {
+    fun addPet(pet: Pet,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<Pet> {
         getRequest().ifPresent { request ->
             for (mediaType in MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -44,7 +46,8 @@ interface PetApiDelegate {
      * @see PetApi#deletePet
      */
     fun deletePet(petId: kotlin.Long,
-        apiKey: kotlin.String?): ResponseEntity<Unit> {
+        apiKey: kotlin.String?,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
     }
@@ -53,7 +56,8 @@ interface PetApiDelegate {
     /**
      * @see PetApi#findPetsByStatus
      */
-    fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>): ResponseEntity<List<Pet>> {
+    fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<List<Pet>> {
         getRequest().ifPresent { request ->
             for (mediaType in MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -74,7 +78,8 @@ interface PetApiDelegate {
     /**
      * @see PetApi#findPetsByTags
      */
-    fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>): ResponseEntity<List<Pet>> {
+    fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<List<Pet>> {
         getRequest().ifPresent { request ->
             for (mediaType in MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -95,7 +100,8 @@ interface PetApiDelegate {
     /**
      * @see PetApi#getPetById
      */
-    fun getPetById(petId: kotlin.Long): ResponseEntity<Pet> {
+    fun getPetById(petId: kotlin.Long,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<Pet> {
         getRequest().ifPresent { request ->
             for (mediaType in MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -116,7 +122,8 @@ interface PetApiDelegate {
     /**
      * @see PetApi#updatePet
      */
-    fun updatePet(pet: Pet): ResponseEntity<Pet> {
+    fun updatePet(pet: Pet,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<Pet> {
         getRequest().ifPresent { request ->
             for (mediaType in MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -139,7 +146,8 @@ interface PetApiDelegate {
      */
     fun updatePetWithForm(petId: kotlin.Long,
         name: kotlin.String?,
-        status: kotlin.String?): ResponseEntity<Unit> {
+        status: kotlin.String?,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
     }
@@ -150,7 +158,8 @@ interface PetApiDelegate {
      */
     fun uploadFile(petId: kotlin.Long,
         additionalMetadata: kotlin.String?,
-        file: Resource?): ResponseEntity<ModelApiResponse> {
+        file: Resource?,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<ModelApiResponse> {
         getRequest().ifPresent { request ->
             for (mediaType in MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/StoreApi.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/StoreApi.kt
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.security.*
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.http.server.reactive.ServerHttpRequest
 
 import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
@@ -53,8 +54,8 @@ interface StoreApi {
             method = [RequestMethod.DELETE],
             value = ["/store/order/{orderId}"]
     )
-    fun deleteOrder(@Parameter(description = "ID of the order that needs to be deleted", required = true) @PathVariable("orderId") orderId: kotlin.String): ResponseEntity<Unit> {
-        return getDelegate().deleteOrder(orderId)
+    fun deleteOrder(@Parameter(description = "ID of the order that needs to be deleted", required = true) @PathVariable("orderId") orderId: kotlin.String,serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
+        return getDelegate().deleteOrder(orderId, serverHttpRequest)
     }
 
     @Operation(
@@ -72,8 +73,8 @@ interface StoreApi {
             value = ["/store/inventory"],
             produces = ["application/json"]
     )
-    fun getInventory(): ResponseEntity<Map<String, kotlin.Int>> {
-        return getDelegate().getInventory()
+    fun getInventory(serverHttpRequest: ServerHttpRequest): ResponseEntity<Map<String, kotlin.Int>> {
+        return getDelegate().getInventory(serverHttpRequest)
     }
 
     @Operation(
@@ -92,8 +93,8 @@ interface StoreApi {
             value = ["/store/order/{orderId}"],
             produces = ["application/xml", "application/json"]
     )
-    fun getOrderById(@Min(1L) @Max(5L) @Parameter(description = "ID of pet that needs to be fetched", required = true) @PathVariable("orderId") orderId: kotlin.Long): ResponseEntity<Order> {
-        return getDelegate().getOrderById(orderId)
+    fun getOrderById(@Min(1L) @Max(5L) @Parameter(description = "ID of pet that needs to be fetched", required = true) @PathVariable("orderId") orderId: kotlin.Long,serverHttpRequest: ServerHttpRequest): ResponseEntity<Order> {
+        return getDelegate().getOrderById(orderId, serverHttpRequest)
     }
 
     @Operation(
@@ -112,7 +113,7 @@ interface StoreApi {
             produces = ["application/xml", "application/json"],
             consumes = ["application/json"]
     )
-    fun placeOrder(@Parameter(description = "order placed for purchasing the pet", required = true) @Valid @RequestBody order: Order): ResponseEntity<Order> {
-        return getDelegate().placeOrder(order)
+    fun placeOrder(@Parameter(description = "order placed for purchasing the pet", required = true) @Valid @RequestBody order: Order,serverHttpRequest: ServerHttpRequest): ResponseEntity<Order> {
+        return getDelegate().placeOrder(order, serverHttpRequest)
     }
 }

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/StoreApiDelegate.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/StoreApiDelegate.kt
@@ -6,6 +6,7 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.core.io.Resource
+import org.springframework.http.server.reactive.ServerHttpRequest
 
 import java.util.Optional
 
@@ -21,7 +22,8 @@ interface StoreApiDelegate {
     /**
      * @see StoreApi#deleteOrder
      */
-    fun deleteOrder(orderId: kotlin.String): ResponseEntity<Unit> {
+    fun deleteOrder(orderId: kotlin.String,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
     }
@@ -30,7 +32,7 @@ interface StoreApiDelegate {
     /**
      * @see StoreApi#getInventory
      */
-    fun getInventory(): ResponseEntity<Map<String, kotlin.Int>> {
+    fun getInventory(serverHttpRequest: ServerHttpRequest): ResponseEntity<Map<String, kotlin.Int>> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
     }
@@ -39,7 +41,8 @@ interface StoreApiDelegate {
     /**
      * @see StoreApi#getOrderById
      */
-    fun getOrderById(orderId: kotlin.Long): ResponseEntity<Order> {
+    fun getOrderById(orderId: kotlin.Long,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<Order> {
         getRequest().ifPresent { request ->
             for (mediaType in MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -60,7 +63,8 @@ interface StoreApiDelegate {
     /**
      * @see StoreApi#placeOrder
      */
-    fun placeOrder(order: Order): ResponseEntity<Order> {
+    fun placeOrder(order: Order,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<Order> {
         getRequest().ifPresent { request ->
             for (mediaType in MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApi.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApi.kt
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.security.*
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.http.server.reactive.ServerHttpRequest
 
 import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
@@ -54,8 +55,8 @@ interface UserApi {
             value = ["/user"],
             consumes = ["application/json"]
     )
-    fun createUser(@Parameter(description = "Created user object", required = true) @Valid @RequestBody user: User): ResponseEntity<Unit> {
-        return getDelegate().createUser(user)
+    fun createUser(@Parameter(description = "Created user object", required = true) @Valid @RequestBody user: User,serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
+        return getDelegate().createUser(user, serverHttpRequest)
     }
 
     @Operation(
@@ -73,8 +74,8 @@ interface UserApi {
             value = ["/user/createWithArray"],
             consumes = ["application/json"]
     )
-    fun createUsersWithArrayInput(@Parameter(description = "List of user object", required = true) @Valid @RequestBody user: kotlin.collections.List<User>): ResponseEntity<Unit> {
-        return getDelegate().createUsersWithArrayInput(user)
+    fun createUsersWithArrayInput(@Parameter(description = "List of user object", required = true) @Valid @RequestBody user: kotlin.collections.List<User>,serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
+        return getDelegate().createUsersWithArrayInput(user, serverHttpRequest)
     }
 
     @Operation(
@@ -92,8 +93,8 @@ interface UserApi {
             value = ["/user/createWithList"],
             consumes = ["application/json"]
     )
-    fun createUsersWithListInput(@Parameter(description = "List of user object", required = true) @Valid @RequestBody user: kotlin.collections.List<User>): ResponseEntity<Unit> {
-        return getDelegate().createUsersWithListInput(user)
+    fun createUsersWithListInput(@Parameter(description = "List of user object", required = true) @Valid @RequestBody user: kotlin.collections.List<User>,serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
+        return getDelegate().createUsersWithListInput(user, serverHttpRequest)
     }
 
     @Operation(
@@ -111,8 +112,8 @@ interface UserApi {
             method = [RequestMethod.DELETE],
             value = ["/user/{username}"]
     )
-    fun deleteUser(@Parameter(description = "The name that needs to be deleted", required = true) @PathVariable("username") username: kotlin.String): ResponseEntity<Unit> {
-        return getDelegate().deleteUser(username)
+    fun deleteUser(@Parameter(description = "The name that needs to be deleted", required = true) @PathVariable("username") username: kotlin.String,serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
+        return getDelegate().deleteUser(username, serverHttpRequest)
     }
 
     @Operation(
@@ -131,8 +132,8 @@ interface UserApi {
             value = ["/user/{username}"],
             produces = ["application/xml", "application/json"]
     )
-    fun getUserByName(@Parameter(description = "The name that needs to be fetched. Use user1 for testing.", required = true) @PathVariable("username") username: kotlin.String): ResponseEntity<User> {
-        return getDelegate().getUserByName(username)
+    fun getUserByName(@Parameter(description = "The name that needs to be fetched. Use user1 for testing.", required = true) @PathVariable("username") username: kotlin.String,serverHttpRequest: ServerHttpRequest): ResponseEntity<User> {
+        return getDelegate().getUserByName(username, serverHttpRequest)
     }
 
     @Operation(
@@ -150,8 +151,8 @@ interface UserApi {
             value = ["/user/login"],
             produces = ["application/xml", "application/json"]
     )
-    fun loginUser(@NotNull @Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$") @Parameter(description = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) username: kotlin.String,@NotNull @Parameter(description = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) password: kotlin.String): ResponseEntity<kotlin.String> {
-        return getDelegate().loginUser(username, password)
+    fun loginUser(@NotNull @Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$") @Parameter(description = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) username: kotlin.String,@NotNull @Parameter(description = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) password: kotlin.String,serverHttpRequest: ServerHttpRequest): ResponseEntity<kotlin.String> {
+        return getDelegate().loginUser(username, password, serverHttpRequest)
     }
 
     @Operation(
@@ -168,8 +169,8 @@ interface UserApi {
             method = [RequestMethod.GET],
             value = ["/user/logout"]
     )
-    fun logoutUser(): ResponseEntity<Unit> {
-        return getDelegate().logoutUser()
+    fun logoutUser(serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
+        return getDelegate().logoutUser(serverHttpRequest)
     }
 
     @Operation(
@@ -188,7 +189,7 @@ interface UserApi {
             value = ["/user/{username}"],
             consumes = ["application/json"]
     )
-    fun updateUser(@Parameter(description = "name that need to be deleted", required = true) @PathVariable("username") username: kotlin.String,@Parameter(description = "Updated user object", required = true) @Valid @RequestBody user: User): ResponseEntity<Unit> {
-        return getDelegate().updateUser(username, user)
+    fun updateUser(@Parameter(description = "name that need to be deleted", required = true) @PathVariable("username") username: kotlin.String,@Parameter(description = "Updated user object", required = true) @Valid @RequestBody user: User,serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
+        return getDelegate().updateUser(username, user, serverHttpRequest)
     }
 }

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApiDelegate.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApiDelegate.kt
@@ -6,6 +6,7 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.core.io.Resource
+import org.springframework.http.server.reactive.ServerHttpRequest
 
 import java.util.Optional
 
@@ -21,7 +22,8 @@ interface UserApiDelegate {
     /**
      * @see UserApi#createUser
      */
-    fun createUser(user: User): ResponseEntity<Unit> {
+    fun createUser(user: User,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
     }
@@ -30,7 +32,8 @@ interface UserApiDelegate {
     /**
      * @see UserApi#createUsersWithArrayInput
      */
-    fun createUsersWithArrayInput(user: kotlin.collections.List<User>): ResponseEntity<Unit> {
+    fun createUsersWithArrayInput(user: kotlin.collections.List<User>,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
     }
@@ -39,7 +42,8 @@ interface UserApiDelegate {
     /**
      * @see UserApi#createUsersWithListInput
      */
-    fun createUsersWithListInput(user: kotlin.collections.List<User>): ResponseEntity<Unit> {
+    fun createUsersWithListInput(user: kotlin.collections.List<User>,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
     }
@@ -48,7 +52,8 @@ interface UserApiDelegate {
     /**
      * @see UserApi#deleteUser
      */
-    fun deleteUser(username: kotlin.String): ResponseEntity<Unit> {
+    fun deleteUser(username: kotlin.String,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
     }
@@ -57,7 +62,8 @@ interface UserApiDelegate {
     /**
      * @see UserApi#getUserByName
      */
-    fun getUserByName(username: kotlin.String): ResponseEntity<User> {
+    fun getUserByName(username: kotlin.String,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<User> {
         getRequest().ifPresent { request ->
             for (mediaType in MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -79,7 +85,8 @@ interface UserApiDelegate {
      * @see UserApi#loginUser
      */
     fun loginUser(username: kotlin.String,
-        password: kotlin.String): ResponseEntity<kotlin.String> {
+        password: kotlin.String,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<kotlin.String> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
     }
@@ -88,7 +95,7 @@ interface UserApiDelegate {
     /**
      * @see UserApi#logoutUser
      */
-    fun logoutUser(): ResponseEntity<Unit> {
+    fun logoutUser(serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
     }
@@ -98,7 +105,8 @@ interface UserApiDelegate {
      * @see UserApi#updateUser
      */
     fun updateUser(username: kotlin.String,
-        user: User): ResponseEntity<Unit> {
+        user: User,
+        serverHttpRequest: ServerHttpRequest): ResponseEntity<Unit> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
     }


### PR DESCRIPTION
fix #18555 kotlin-spring generator flag appendRequestToHandler generates broken code when used with flag delegatePattern

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @jimschubert, @dr4ke616, @karismann, @Zomzog, @andrewemery, @4brunu, @yutaka0m, @stefankoppier

