### PR TITLE
php: Fix typedoc comment for headers in ApiException

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ApiException.mustache
@@ -39,7 +39,7 @@ class ApiException extends Exception
     /**
      * The HTTP header of the server response.
      *
-     * @var string[]|null
+     * @var string[][]|null
      */
     protected ?array $responseHeaders;
 
@@ -55,10 +55,10 @@ class ApiException extends Exception
      *
      * @param string                $message         Error message
      * @param int                   $code            HTTP status code
-     * @param string[]|null         $responseHeaders HTTP response header
-     * @param mixed $responseBody    HTTP decoded body of the server response either as stdClass or string
+     * @param string[][]|null       $responseHeaders HTTP response header
+     * @param stdClass|string|null  $responseBody    HTTP decoded body of the server response either as stdClass or string
      */
-    public function __construct(string $message = "", int $code = 0, ?array $responseHeaders = [], mixed $responseBody = null)
+    public function __construct(string $message = "", int $code = 0, ?array $responseHeaders = [], stdClass|string|null $responseBody = null)
     {
         parent::__construct($message, $code);
         $this->responseHeaders = $responseHeaders;
@@ -68,7 +68,7 @@ class ApiException extends Exception
     /**
      * Gets the HTTP response header
      *
-     * @return string[]|null HTTP response header
+     * @return string[][]|null HTTP response header
      */
     public function getResponseHeaders(): ?array
     {

--- a/modules/openapi-generator/src/main/resources/php/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ApiException.mustache
@@ -40,7 +40,7 @@ class ApiException extends Exception
     /**
      * The HTTP header of the server response.
      *
-     * @var string[]|null
+     * @var string[][]|null
      */
     protected $responseHeaders;
 
@@ -56,7 +56,7 @@ class ApiException extends Exception
      *
      * @param string                $message         Error message
      * @param int                   $code            HTTP status code
-     * @param string[]|null         $responseHeaders HTTP response header
+     * @param string[][]|null       $responseHeaders HTTP response header
      * @param \stdClass|string|null $responseBody    HTTP decoded body of the server response either as \stdClass or string
      */
     public function __construct($message = "", $code = 0, $responseHeaders = [], $responseBody = null)
@@ -69,7 +69,7 @@ class ApiException extends Exception
     /**
      * Gets the HTTP response header
      *
-     * @return string[]|null HTTP response header
+     * @return string[][]|null HTTP response header
      */
     public function getResponseHeaders()
     {

--- a/modules/openapi-generator/src/main/resources/php/libraries/psr-18/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/php/libraries/psr-18/ApiException.mustache
@@ -44,7 +44,7 @@ class ApiException extends RequestException
     /**
      * The HTTP header of the server response.
      *
-     * @var string[]|null
+     * @var string[][]|null
      */
     protected $responseHeaders;
 
@@ -72,7 +72,7 @@ class ApiException extends RequestException
     /**
      * Gets the HTTP response header
      *
-     * @return string[]|null HTTP response header
+     * @return string[][]|null HTTP response header
      */
     public function getResponseHeaders()
     {

--- a/samples/client/echo_api/php-nextgen/src/ApiException.php
+++ b/samples/client/echo_api/php-nextgen/src/ApiException.php
@@ -49,7 +49,7 @@ class ApiException extends Exception
     /**
      * The HTTP header of the server response.
      *
-     * @var string[]|null
+     * @var string[][]|null
      */
     protected ?array $responseHeaders;
 
@@ -65,10 +65,10 @@ class ApiException extends Exception
      *
      * @param string                $message         Error message
      * @param int                   $code            HTTP status code
-     * @param string[]|null         $responseHeaders HTTP response header
-     * @param mixed $responseBody    HTTP decoded body of the server response either as stdClass or string
+     * @param string[][]|null       $responseHeaders HTTP response header
+     * @param stdClass|string|null  $responseBody    HTTP decoded body of the server response either as stdClass or string
      */
-    public function __construct(string $message = "", int $code = 0, ?array $responseHeaders = [], mixed $responseBody = null)
+    public function __construct(string $message = "", int $code = 0, ?array $responseHeaders = [], stdClass|string|null $responseBody = null)
     {
         parent::__construct($message, $code);
         $this->responseHeaders = $responseHeaders;
@@ -78,7 +78,7 @@ class ApiException extends Exception
     /**
      * Gets the HTTP response header
      *
-     * @return string[]|null HTTP response header
+     * @return string[][]|null HTTP response header
      */
     public function getResponseHeaders(): ?array
     {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/lib/ApiException.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/lib/ApiException.php
@@ -49,7 +49,7 @@ class ApiException extends Exception
     /**
      * The HTTP header of the server response.
      *
-     * @var string[]|null
+     * @var string[][]|null
      */
     protected $responseHeaders;
 
@@ -65,7 +65,7 @@ class ApiException extends Exception
      *
      * @param string                $message         Error message
      * @param int                   $code            HTTP status code
-     * @param string[]|null         $responseHeaders HTTP response header
+     * @param string[][]|null       $responseHeaders HTTP response headerr
      * @param \stdClass|string|null $responseBody    HTTP decoded body of the server response either as \stdClass or string
      */
     public function __construct($message = "", $code = 0, $responseHeaders = [], $responseBody = null)

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ApiException.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ApiException.php
@@ -48,7 +48,7 @@ class ApiException extends Exception
     /**
      * The HTTP header of the server response.
      *
-     * @var string[]|null
+     * @var string[][]|null
      */
     protected ?array $responseHeaders;
 
@@ -64,10 +64,10 @@ class ApiException extends Exception
      *
      * @param string                $message         Error message
      * @param int                   $code            HTTP status code
-     * @param string[]|null         $responseHeaders HTTP response header
-     * @param mixed $responseBody    HTTP decoded body of the server response either as stdClass or string
+     * @param string[][]|null       $responseHeaders HTTP response header
+     * @param stdClass|string|null  $responseBody    HTTP decoded body of the server response either as stdClass or string
      */
-    public function __construct(string $message = "", int $code = 0, ?array $responseHeaders = [], mixed $responseBody = null)
+    public function __construct(string $message = "", int $code = 0, ?array $responseHeaders = [], stdClass|string|null $responseBody = null)
     {
         parent::__construct($message, $code);
         $this->responseHeaders = $responseHeaders;
@@ -77,7 +77,7 @@ class ApiException extends Exception
     /**
      * Gets the HTTP response header
      *
-     * @return string[]|null HTTP response header
+     * @return string[][]|null HTTP response header
      */
     public function getResponseHeaders(): ?array
     {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ApiException.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ApiException.php
@@ -49,7 +49,7 @@ class ApiException extends Exception
     /**
      * The HTTP header of the server response.
      *
-     * @var string[]|null
+     * @var string[][]|null
      */
     protected $responseHeaders;
 
@@ -65,7 +65,7 @@ class ApiException extends Exception
      *
      * @param string                $message         Error message
      * @param int                   $code            HTTP status code
-     * @param string[]|null         $responseHeaders HTTP response header
+     * @param string[][]|null       $responseHeaders HTTP response header
      * @param \stdClass|string|null $responseBody    HTTP decoded body of the server response either as \stdClass or string
      */
     public function __construct($message = "", $code = 0, $responseHeaders = [], $responseBody = null)
@@ -78,7 +78,7 @@ class ApiException extends Exception
     /**
      * Gets the HTTP response header
      *
-     * @return string[]|null HTTP response header
+     * @return string[][]|null HTTP response header
      */
     public function getResponseHeaders()
     {

--- a/samples/client/petstore/php/psr-18/lib/ApiException.php
+++ b/samples/client/petstore/php/psr-18/lib/ApiException.php
@@ -53,7 +53,7 @@ class ApiException extends RequestException
     /**
      * The HTTP header of the server response.
      *
-     * @var string[]|null
+     * @var string[][]|null
      */
     protected $responseHeaders;
 
@@ -81,7 +81,7 @@ class ApiException extends RequestException
     /**
      * Gets the HTTP response header
      *
-     * @return string[]|null HTTP response header
+     * @return string[][]|null HTTP response header
      */
     public function getResponseHeaders()
     {


### PR DESCRIPTION
This PR fixes some incorrect type docs in the ApiException class for the PHP generators.
Mainly that the type of the headers array is actually `string[][]`, not `string[]` as documented in [PSR-7](https://www.php-fig.org/psr/psr-7/#3-interfaces).

I also specified the type of the response body in the constructor parameter from mixed to stdClass|string|null.
This type was already used for the property the value is stored in, and passing any other value therefore already caused fatal PHP errors.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon