### PR TITLE
[Go] Set Default Values for Required Variables where only one value is possible

### DIFF
--- a/bin/configs/go-petstore.yaml
+++ b/bin/configs/go-petstore.yaml
@@ -15,6 +15,7 @@ additionalProperties:
   packageName: petstore
   disallowAdditionalPropertiesIfNotPresent: false
   generateInterfaces: true
+  useDefaultValuesForRequiredVars: true
 enumNameMappings:
   delivered: SHIPPED
 

--- a/bin/configs/go-petstore.yaml
+++ b/bin/configs/go-petstore.yaml
@@ -15,7 +15,7 @@ additionalProperties:
   packageName: petstore
   disallowAdditionalPropertiesIfNotPresent: false
   generateInterfaces: true
-  useDefaultValuesForRequiredVars: true
+  useDefaultValuesForRequiredVars: false
 enumNameMappings:
   delivered: SHIPPED
 

--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -168,6 +168,18 @@ func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
 {{/isNullable}}
 }
 
+{{#useDefaultValuesForRequiredVars}}
+{{^isReadOnly}}
+{{#defaultValue}}
+// GetDefault{{baseName}} function assigns the default value {{defaultValue}} to the {{name}} field
+// of the {{classname}} struct and returns the {{{defaultValue}}}.
+func (o *{{classname}}) GetDefault{{baseName}}() interface{}  { 
+	o.{{name}} = {{{defaultValue}}}
+	return {{{defaultValue}}}
+}
+{{/defaultValue}}
+{{/isReadOnly}}
+{{/useDefaultValuesForRequiredVars}}
 {{/required}}
 {{^required}}
 // Get{{name}} returns the {{name}} field value if set, zero value otherwise{{#isNullable}} (both if not set or set to explicit null){{/isNullable}}.
@@ -318,6 +330,15 @@ func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 	{{! if argument is not nullable, don't set it if it is nil}}
 	{{^isNullable}}
 	{{#required}}
+	{{#useDefaultValuesForRequiredVars}}
+	{{^isReadOnly}}
+	{{#defaultValue}}
+	if _, exists := toSerialize["{{{baseName}}}"]; !exists {
+		toSerialize["{{{baseName}}}"] = o.GetDefault{{baseName}}()
+	}
+	{{/defaultValue}}
+	{{/isReadOnly}}
+	{{/useDefaultValuesForRequiredVars}}
 	toSerialize["{{{baseName}}}"] = o.{{name}}
 	{{/required}}
 	{{^required}}
@@ -356,20 +377,42 @@ func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
 {{/requiredVars}}
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+{{#requiredVars}}
+{{#useDefaultValuesForRequiredVars}}
+{{^isReadOnly}}
+{{#defaultValue}}
+		"{{baseName}}": o.GetDefault{{baseName}},
+{{/defaultValue}}
+{{/isReadOnly}}
+{{/useDefaultValuesForRequiredVars}}
+{{/requiredVars}}
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 {{/hasRequired}}
 {{#isAdditionalPropertiesTrue}}
 {{#parent}}

--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -377,19 +377,19 @@ func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
 {{/requiredVars}}
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
 {{#requiredVars}}
 {{#useDefaultValuesForRequiredVars}}
+	defaultValueFuncMap := map[string]func() interface{} {
 {{^isReadOnly}}
 {{#defaultValue}}
 		"{{baseName}}": o.GetDefault{{baseName}},
 {{/defaultValue}}
 {{/isReadOnly}}
+	}
+	var defaultValueApplied bool
 {{/useDefaultValuesForRequiredVars}}
 {{/requiredVars}}
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -397,22 +397,26 @@ func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
 	}
 
 	for _, requiredProperty := range(requiredProperties){
+		{{#useDefaultValuesForRequiredVars}}
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
 				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
 				defaultValueApplied = true
 			}
 		}
+		{{/useDefaultValuesForRequiredVars}}
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
+	{{#useDefaultValuesForRequiredVars}}
 	if defaultValueApplied{
 		data, err = json.Marshal(allProperties)
 		if err != nil{
 			return err
 		}
 	}
+	{{/useDefaultValuesForRequiredVars}}
 {{/hasRequired}}
 {{#isAdditionalPropertiesTrue}}
 {{#parent}}

--- a/samples/client/echo_api/go-external-refs/model_pet.go
+++ b/samples/client/echo_api/go-external-refs/model_pet.go
@@ -264,10 +264,7 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 		"photoUrls",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -276,19 +273,7 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varPet := _Pet{}

--- a/samples/client/echo_api/go-external-refs/model_pet.go
+++ b/samples/client/echo_api/go-external-refs/model_pet.go
@@ -264,20 +264,33 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 		"photoUrls",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varPet := _Pet{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/echo_api/go/model_pet.go
+++ b/samples/client/echo_api/go/model_pet.go
@@ -264,10 +264,7 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 		"photoUrls",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -276,19 +273,7 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varPet := _Pet{}

--- a/samples/client/echo_api/go/model_pet.go
+++ b/samples/client/echo_api/go/model_pet.go
@@ -264,20 +264,33 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 		"photoUrls",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varPet := _Pet{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/others/go/allof_multiple_ref_and_discriminator/model_additional_data.go
+++ b/samples/client/others/go/allof_multiple_ref_and_discriminator/model_additional_data.go
@@ -174,20 +174,33 @@ func (o *AdditionalData) UnmarshalJSON(data []byte) (err error) {
 		"totalPrice",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varAdditionalData := _AdditionalData{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/others/go/allof_multiple_ref_and_discriminator/model_additional_data.go
+++ b/samples/client/others/go/allof_multiple_ref_and_discriminator/model_additional_data.go
@@ -174,10 +174,7 @@ func (o *AdditionalData) UnmarshalJSON(data []byte) (err error) {
 		"totalPrice",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -186,19 +183,7 @@ func (o *AdditionalData) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varAdditionalData := _AdditionalData{}

--- a/samples/client/others/go/allof_multiple_ref_and_discriminator/model_base_item.go
+++ b/samples/client/others/go/allof_multiple_ref_and_discriminator/model_base_item.go
@@ -118,20 +118,33 @@ func (o *BaseItem) UnmarshalJSON(data []byte) (err error) {
 		"type",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varBaseItem := _BaseItem{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/others/go/allof_multiple_ref_and_discriminator/model_base_item.go
+++ b/samples/client/others/go/allof_multiple_ref_and_discriminator/model_base_item.go
@@ -118,10 +118,7 @@ func (o *BaseItem) UnmarshalJSON(data []byte) (err error) {
 		"type",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -130,19 +127,7 @@ func (o *BaseItem) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varBaseItem := _BaseItem{}

--- a/samples/client/others/go/allof_multiple_ref_and_discriminator/model_final_item.go
+++ b/samples/client/others/go/allof_multiple_ref_and_discriminator/model_final_item.go
@@ -179,10 +179,7 @@ func (o *FinalItem) UnmarshalJSON(data []byte) (err error) {
 		"type",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -191,19 +188,7 @@ func (o *FinalItem) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varFinalItem := _FinalItem{}

--- a/samples/client/others/go/allof_multiple_ref_and_discriminator/model_final_item.go
+++ b/samples/client/others/go/allof_multiple_ref_and_discriminator/model_final_item.go
@@ -179,20 +179,33 @@ func (o *FinalItem) UnmarshalJSON(data []byte) (err error) {
 		"type",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varFinalItem := _FinalItem{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/others/go/oneof-anyof-required/model_nested_object1.go
+++ b/samples/client/others/go/oneof-anyof-required/model_nested_object1.go
@@ -91,20 +91,33 @@ func (o *NestedObject1) UnmarshalJSON(data []byte) (err error) {
 		"field1",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varNestedObject1 := _NestedObject1{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/others/go/oneof-anyof-required/model_nested_object1.go
+++ b/samples/client/others/go/oneof-anyof-required/model_nested_object1.go
@@ -91,10 +91,7 @@ func (o *NestedObject1) UnmarshalJSON(data []byte) (err error) {
 		"field1",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -103,19 +100,7 @@ func (o *NestedObject1) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varNestedObject1 := _NestedObject1{}

--- a/samples/client/others/go/oneof-anyof-required/model_nested_object2.go
+++ b/samples/client/others/go/oneof-anyof-required/model_nested_object2.go
@@ -91,20 +91,33 @@ func (o *NestedObject2) UnmarshalJSON(data []byte) (err error) {
 		"field2",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varNestedObject2 := _NestedObject2{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/others/go/oneof-anyof-required/model_nested_object2.go
+++ b/samples/client/others/go/oneof-anyof-required/model_nested_object2.go
@@ -91,10 +91,7 @@ func (o *NestedObject2) UnmarshalJSON(data []byte) (err error) {
 		"field2",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -103,19 +100,7 @@ func (o *NestedObject2) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varNestedObject2 := _NestedObject2{}

--- a/samples/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/client/petstore/go/go-petstore/model_animal.go
@@ -130,20 +130,33 @@ func (o *Animal) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varAnimal := _Animal{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/client/petstore/go/go-petstore/model_animal.go
@@ -130,10 +130,7 @@ func (o *Animal) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -142,19 +139,7 @@ func (o *Animal) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varAnimal := _Animal{}

--- a/samples/client/petstore/go/go-petstore/model_big_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_big_cat.go
@@ -111,20 +111,33 @@ func (o *BigCat) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varBigCat := _BigCat{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/petstore/go/go-petstore/model_big_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_big_cat.go
@@ -111,10 +111,7 @@ func (o *BigCat) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -123,19 +120,7 @@ func (o *BigCat) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varBigCat := _BigCat{}

--- a/samples/client/petstore/go/go-petstore/model_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_cat.go
@@ -111,10 +111,7 @@ func (o *Cat) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -123,19 +120,7 @@ func (o *Cat) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varCat := _Cat{}

--- a/samples/client/petstore/go/go-petstore/model_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_cat.go
@@ -111,20 +111,33 @@ func (o *Cat) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varCat := _Cat{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/petstore/go/go-petstore/model_category.go
+++ b/samples/client/petstore/go/go-petstore/model_category.go
@@ -128,10 +128,7 @@ func (o *Category) UnmarshalJSON(data []byte) (err error) {
 		"name",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -140,19 +137,7 @@ func (o *Category) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varCategory := _Category{}

--- a/samples/client/petstore/go/go-petstore/model_dog.go
+++ b/samples/client/petstore/go/go-petstore/model_dog.go
@@ -111,20 +111,33 @@ func (o *Dog) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varDog := _Dog{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/petstore/go/go-petstore/model_dog.go
+++ b/samples/client/petstore/go/go-petstore/model_dog.go
@@ -111,10 +111,7 @@ func (o *Dog) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -123,19 +120,7 @@ func (o *Dog) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varDog := _Dog{}

--- a/samples/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_test_.go
@@ -234,10 +234,7 @@ func (o *EnumTest) UnmarshalJSON(data []byte) (err error) {
 		"enum_string_required",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -246,19 +243,7 @@ func (o *EnumTest) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varEnumTest := _EnumTest{}

--- a/samples/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_test_.go
@@ -234,20 +234,33 @@ func (o *EnumTest) UnmarshalJSON(data []byte) (err error) {
 		"enum_string_required",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varEnumTest := _EnumTest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_format_test_.go
@@ -536,20 +536,33 @@ func (o *FormatTest) UnmarshalJSON(data []byte) (err error) {
 		"password",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varFormatTest := _FormatTest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_format_test_.go
@@ -536,10 +536,7 @@ func (o *FormatTest) UnmarshalJSON(data []byte) (err error) {
 		"password",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -548,19 +545,7 @@ func (o *FormatTest) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varFormatTest := _FormatTest{}

--- a/samples/client/petstore/go/go-petstore/model_name.go
+++ b/samples/client/petstore/go/go-petstore/model_name.go
@@ -198,20 +198,33 @@ func (o *Name) UnmarshalJSON(data []byte) (err error) {
 		"name",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varName := _Name{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/petstore/go/go-petstore/model_name.go
+++ b/samples/client/petstore/go/go-petstore/model_name.go
@@ -198,10 +198,7 @@ func (o *Name) UnmarshalJSON(data []byte) (err error) {
 		"name",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -210,19 +207,7 @@ func (o *Name) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varName := _Name{}

--- a/samples/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/client/petstore/go/go-petstore/model_pet.go
@@ -263,20 +263,33 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 		"photoUrls",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varPet := _Pet{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/client/petstore/go/go-petstore/model_pet.go
@@ -263,10 +263,7 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 		"photoUrls",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -275,19 +272,7 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varPet := _Pet{}

--- a/samples/client/petstore/go/go-petstore/model_type_holder_default.go
+++ b/samples/client/petstore/go/go-petstore/model_type_holder_default.go
@@ -206,10 +206,7 @@ func (o *TypeHolderDefault) UnmarshalJSON(data []byte) (err error) {
 		"array_item",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -218,19 +215,7 @@ func (o *TypeHolderDefault) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varTypeHolderDefault := _TypeHolderDefault{}

--- a/samples/client/petstore/go/go-petstore/model_type_holder_default.go
+++ b/samples/client/petstore/go/go-petstore/model_type_holder_default.go
@@ -206,20 +206,33 @@ func (o *TypeHolderDefault) UnmarshalJSON(data []byte) (err error) {
 		"array_item",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varTypeHolderDefault := _TypeHolderDefault{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/client/petstore/go/go-petstore/model_type_holder_example.go
+++ b/samples/client/petstore/go/go-petstore/model_type_holder_example.go
@@ -230,10 +230,7 @@ func (o *TypeHolderExample) UnmarshalJSON(data []byte) (err error) {
 		"array_item",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -242,19 +239,7 @@ func (o *TypeHolderExample) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varTypeHolderExample := _TypeHolderExample{}

--- a/samples/client/petstore/go/go-petstore/model_type_holder_example.go
+++ b/samples/client/petstore/go/go-petstore/model_type_holder_example.go
@@ -230,20 +230,33 @@ func (o *TypeHolderExample) UnmarshalJSON(data []byte) (err error) {
 		"array_item",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varTypeHolderExample := _TypeHolderExample{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))

--- a/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/model_pet.go
+++ b/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/model_pet.go
@@ -264,10 +264,7 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 		"photoUrls",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -276,19 +273,7 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varPet := _Pet{}

--- a/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/model_pet.go
+++ b/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/model_pet.go
@@ -264,20 +264,33 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 		"photoUrls",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varPet := _Pet{}
 
 	err = json.Unmarshal(data, &varPet)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
@@ -135,20 +135,33 @@ func (o *Animal) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varAnimal := _Animal{}
 
 	err = json.Unmarshal(data, &varAnimal)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
@@ -135,10 +135,7 @@ func (o *Animal) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -147,19 +144,7 @@ func (o *Animal) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varAnimal := _Animal{}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
@@ -131,20 +131,33 @@ func (o *AppleReq) UnmarshalJSON(data []byte) (err error) {
 		"cultivar",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varAppleReq := _AppleReq{}
 
 	err = json.Unmarshal(data, &varAppleReq)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
@@ -131,10 +131,7 @@ func (o *AppleReq) UnmarshalJSON(data []byte) (err error) {
 		"cultivar",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -143,19 +140,7 @@ func (o *AppleReq) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varAppleReq := _AppleReq{}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
@@ -131,10 +131,7 @@ func (o *BananaReq) UnmarshalJSON(data []byte) (err error) {
 		"lengthCm",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -143,19 +140,7 @@ func (o *BananaReq) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varBananaReq := _BananaReq{}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
@@ -131,20 +131,33 @@ func (o *BananaReq) UnmarshalJSON(data []byte) (err error) {
 		"lengthCm",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varBananaReq := _BananaReq{}
 
 	err = json.Unmarshal(data, &varBananaReq)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_cat.go
@@ -118,20 +118,33 @@ func (o *Cat) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	type CatWithoutEmbeddedStruct struct {
 		Declawed *bool `json:"declawed,omitempty"`
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_cat.go
@@ -118,10 +118,7 @@ func (o *Cat) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -130,19 +127,7 @@ func (o *Cat) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	type CatWithoutEmbeddedStruct struct {

--- a/samples/openapi3/client/petstore/go/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_category.go
@@ -103,6 +103,12 @@ func (o *Category) SetName(v string) {
 	o.Name = v
 }
 
+// GetDefaultname function assigns the default value &quot;default-name&quot; to the Name field
+// of the Category struct and returns the "default-name".
+func (o *Category) GetDefaultname() interface{}  { 
+	o.Name = "default-name"
+	return "default-name"
+}
 func (o Category) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -115,6 +121,9 @@ func (o Category) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
+	}
+	if _, exists := toSerialize["name"]; !exists {
+		toSerialize["name"] = o.GetDefaultname()
 	}
 	toSerialize["name"] = o.Name
 
@@ -133,20 +142,34 @@ func (o *Category) UnmarshalJSON(data []byte) (err error) {
 		"name",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+		"name": o.GetDefaultname,
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varCategory := _Category{}
 
 	err = json.Unmarshal(data, &varCategory)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_category.go
@@ -103,12 +103,6 @@ func (o *Category) SetName(v string) {
 	o.Name = v
 }
 
-// GetDefaultname function assigns the default value &quot;default-name&quot; to the Name field
-// of the Category struct and returns the "default-name".
-func (o *Category) GetDefaultname() interface{}  { 
-	o.Name = "default-name"
-	return "default-name"
-}
 func (o Category) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -121,9 +115,6 @@ func (o Category) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
-	}
-	if _, exists := toSerialize["name"]; !exists {
-		toSerialize["name"] = o.GetDefaultname()
 	}
 	toSerialize["name"] = o.Name
 
@@ -142,11 +133,7 @@ func (o *Category) UnmarshalJSON(data []byte) (err error) {
 		"name",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-		"name": o.GetDefaultname,
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -155,19 +142,7 @@ func (o *Category) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varCategory := _Category{}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_dog.go
@@ -118,20 +118,33 @@ func (o *Dog) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	type DogWithoutEmbeddedStruct struct {
 		Breed *string `json:"breed,omitempty"`
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_dog.go
@@ -118,10 +118,7 @@ func (o *Dog) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -130,19 +127,7 @@ func (o *Dog) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	type DogWithoutEmbeddedStruct struct {

--- a/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_parent.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_parent.go
@@ -96,20 +96,33 @@ func (o *DuplicatedPropParent) UnmarshalJSON(data []byte) (err error) {
 		"dup-prop",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varDuplicatedPropParent := _DuplicatedPropParent{}
 
 	err = json.Unmarshal(data, &varDuplicatedPropParent)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_parent.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_parent.go
@@ -96,10 +96,7 @@ func (o *DuplicatedPropParent) UnmarshalJSON(data []byte) (err error) {
 		"dup-prop",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -108,19 +105,7 @@ func (o *DuplicatedPropParent) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varDuplicatedPropParent := _DuplicatedPropParent{}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
@@ -365,10 +365,7 @@ func (o *EnumTest) UnmarshalJSON(data []byte) (err error) {
 		"enum_string_required",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -377,19 +374,7 @@ func (o *EnumTest) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varEnumTest := _EnumTest{}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
@@ -365,20 +365,33 @@ func (o *EnumTest) UnmarshalJSON(data []byte) (err error) {
 		"enum_string_required",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varEnumTest := _EnumTest{}
 
 	err = json.Unmarshal(data, &varEnumTest)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_foo.go
@@ -72,6 +72,12 @@ func (o *Foo) SetBar(v string) {
 	o.Bar = v
 }
 
+// GetDefaultbar function assigns the default value &quot;bar&quot; to the Bar field
+// of the Foo struct and returns the "bar".
+func (o *Foo) GetDefaultbar() interface{}  { 
+	o.Bar = "bar"
+	return "bar"
+}
 // GetMap returns the Map field value if set, zero value otherwise.
 func (o *Foo) GetMap() map[string][]time.Time {
 	if o == nil || IsNil(o.Map) {
@@ -114,6 +120,9 @@ func (o Foo) MarshalJSON() ([]byte, error) {
 
 func (o Foo) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if _, exists := toSerialize["bar"]; !exists {
+		toSerialize["bar"] = o.GetDefaultbar()
+	}
 	toSerialize["bar"] = o.Bar
 	if !IsNil(o.Map) {
 		toSerialize["map"] = o.Map
@@ -134,20 +143,34 @@ func (o *Foo) UnmarshalJSON(data []byte) (err error) {
 		"bar",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+		"bar": o.GetDefaultbar,
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varFoo := _Foo{}
 
 	err = json.Unmarshal(data, &varFoo)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_foo.go
@@ -72,12 +72,6 @@ func (o *Foo) SetBar(v string) {
 	o.Bar = v
 }
 
-// GetDefaultbar function assigns the default value &quot;bar&quot; to the Bar field
-// of the Foo struct and returns the "bar".
-func (o *Foo) GetDefaultbar() interface{}  { 
-	o.Bar = "bar"
-	return "bar"
-}
 // GetMap returns the Map field value if set, zero value otherwise.
 func (o *Foo) GetMap() map[string][]time.Time {
 	if o == nil || IsNil(o.Map) {
@@ -120,9 +114,6 @@ func (o Foo) MarshalJSON() ([]byte, error) {
 
 func (o Foo) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if _, exists := toSerialize["bar"]; !exists {
-		toSerialize["bar"] = o.GetDefaultbar()
-	}
 	toSerialize["bar"] = o.Bar
 	if !IsNil(o.Map) {
 		toSerialize["map"] = o.Map
@@ -143,11 +134,7 @@ func (o *Foo) UnmarshalJSON(data []byte) (err error) {
 		"bar",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-		"bar": o.GetDefaultbar,
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -156,19 +143,7 @@ func (o *Foo) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varFoo := _Foo{}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
@@ -579,20 +579,33 @@ func (o *FormatTest) UnmarshalJSON(data []byte) (err error) {
 		"password",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varFormatTest := _FormatTest{}
 
 	err = json.Unmarshal(data, &varFormatTest)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
@@ -579,10 +579,7 @@ func (o *FormatTest) UnmarshalJSON(data []byte) (err error) {
 		"password",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -591,19 +588,7 @@ func (o *FormatTest) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varFormatTest := _FormatTest{}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_name.go
@@ -203,10 +203,7 @@ func (o *Name) UnmarshalJSON(data []byte) (err error) {
 		"name",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -215,19 +212,7 @@ func (o *Name) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varName := _Name{}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_name.go
@@ -203,20 +203,33 @@ func (o *Name) UnmarshalJSON(data []byte) (err error) {
 		"name",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varName := _Name{}
 
 	err = json.Unmarshal(data, &varName)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
@@ -272,10 +272,7 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 		"photoUrls",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -284,19 +281,7 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varPet := _Pet{}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
@@ -272,20 +272,33 @@ func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 		"photoUrls",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varPet := _Pet{}
 
 	err = json.Unmarshal(data, &varPet)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
@@ -167,10 +167,7 @@ func (o *Whale) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -179,19 +176,7 @@ func (o *Whale) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varWhale := _Whale{}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
@@ -167,20 +167,33 @@ func (o *Whale) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varWhale := _Whale{}
 
 	err = json.Unmarshal(data, &varWhale)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
@@ -131,10 +131,7 @@ func (o *Zebra) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
-	defaultValueFuncMap := map[string]func() interface{} {
-	}
 	allProperties := make(map[string]interface{})
-	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
@@ -143,19 +140,7 @@ func (o *Zebra) UnmarshalJSON(data []byte) (err error) {
 
 	for _, requiredProperty := range(requiredProperties){
 		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
-			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
-				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
-				defaultValueApplied = true
-			}
-		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-	if defaultValueApplied{
-		data, err = json.Marshal(allProperties)
-		if err != nil{
-			return err
 		}
 	}
 	varZebra := _Zebra{}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
@@ -131,20 +131,33 @@ func (o *Zebra) UnmarshalJSON(data []byte) (err error) {
 		"className",
 	}
 
+	defaultValueFuncMap := map[string]func() interface{} {
+	}
 	allProperties := make(map[string]interface{})
-
+	var defaultValueApplied bool
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
+	for _, requiredProperty := range(requiredProperties){
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}
-
+	if defaultValueApplied{
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
 	varZebra := _Zebra{}
 
 	err = json.Unmarshal(data, &varZebra)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->


Fix [19107](https://github.com/OpenAPITools/openapi-generator/issues/19107)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
