### PR TITLE
feat(typescript-angular): add support for Angular V18.1

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -294,7 +294,9 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 
         // Set the typescript version compatible to the Angular version
         // based on https://angular.io/guide/versions#actively-supported-versions
-        if (ngVersion.atLeast("18.0.0")) {
+        if (ngVersion.atLeast("18.1.0")) {
+            additionalProperties.put("tsVersion", ">=5.4.0 <5.6.0");
+        } else if (ngVersion.atLeast("18.0.0")) {
             additionalProperties.put("tsVersion", ">=5.4.0 <5.5.0");
         } else if (ngVersion.atLeast("17.0.0")) {
             additionalProperties.put("tsVersion", ">=4.9.3 <5.3.0");
@@ -342,7 +344,11 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         supportingFiles.add(new SupportingFile("ng-package.mustache", getIndexDirectory(), "ng-package.json"));
 
         // Specific ng-packagr configuration
-        if (ngVersion.atLeast("18.0.0")) {
+        if (ngVersion.atLeast("18.1.0")) {
+            additionalProperties.put("ngPackagrVersion", "18.1.0");
+            // tsTickle is not required and there is no available version compatible with
+            // versions of TypeScript compatible with Angular 18.
+        } else if (ngVersion.atLeast("18.0.0")) {
             additionalProperties.put("ngPackagrVersion", "18.0.0");
             // tsTickle is not required and there is no available version compatible with
             // versions of TypeScript compatible with Angular 18.


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Our project using angular 18.1.X ran into some issues in combination with the generated openapi specs. The issue is that the generated definition files contain a line like `/// <reference path="xxxx.ngtypecheck.d.ts" />`
Also seen here: https://github.com/angular/angular/issues/56945
Upgrading typescript and ng-packagr seem to solve the issue.

I mostly looked at https://github.com/OpenAPITools/openapi-generator/pull/18916 to see what needed to be changed, hope I didn't miss anything :)

### Technical committee
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
