### PR TITLE
[csharp] #19176 fix Task.Result directly blocks thread

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -449,10 +449,9 @@ namespace {{packageName}}.Client
         /// <param name="configuration">A per-request configuration object.
         /// It is assumed that any merge with GlobalConfiguration has been done before calling this method.</param>
         /// <returns>A new ApiResponse instance.</returns>
-        private ApiResponse<T> ExecClient<T>(Func<RestClient, RestResponse<T>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
+        private async Task<ApiResponse<T>> ExecClientAsync<T>(Func<RestClient, Task<RestResponse<T>>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
-
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
@@ -485,7 +484,7 @@ namespace {{packageName}}.Client
             {
                 InterceptRequest(request);
 
-                RestResponse<T> response = getResponse(client);
+                RestResponse<T> response = await getResponse(client);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -581,21 +580,21 @@ namespace {{packageName}}.Client
                 clientOptions.CookieContainer = cookies;
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = (client) =>
             {
                 if (RetryConfiguration.RetryPolicy != null)
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
                 }
                 else
                 {
-                    return client.Execute<T>(request);
+                    return Task.FromResult(client.Execute<T>(request));
                 }
             };
 
-            return ExecClient(getResponse, setOptions, request, options, configuration);
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration).GetAwaiter().GetResult();
         }
 
         {{#supportsAsync}}
@@ -606,29 +605,25 @@ namespace {{packageName}}.Client
                 //no extra options
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = async (client) =>
             {
-                Func<Task<RestResponse<T>>> action = async () =>
+                {{#supportsRetry}}
+                if (RetryConfiguration.AsyncRetryPolicy != null)
                 {
-                    {{#supportsRetry}}
-                    if (RetryConfiguration.AsyncRetryPolicy != null)
-                    {
-                        var policy = RetryConfiguration.AsyncRetryPolicy;
-                        var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                        return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
-                    }
-                    else
-                    {
-                    {{/supportsRetry}}
-                        return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
-                    {{#supportsRetry}}
-                    }
-                    {{/supportsRetry}}
-                };
-                return action().Result;
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
+                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                }
+                else
+                {
+                {{/supportsRetry}}
+                    return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+                {{#supportsRetry}}
+                }
+                {{/supportsRetry}}
             };
 
-            return Task.FromResult<ApiResponse<T>>(ExecClient(getResponse, setOptions, request, options, configuration));
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration);
         }
 
         #region IAsynchronousClient

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -449,10 +449,9 @@ namespace Org.OpenAPITools.Client
         /// <param name="configuration">A per-request configuration object.
         /// It is assumed that any merge with GlobalConfiguration has been done before calling this method.</param>
         /// <returns>A new ApiResponse instance.</returns>
-        private ApiResponse<T> ExecClient<T>(Func<RestClient, RestResponse<T>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
+        private async Task<ApiResponse<T>> ExecClientAsync<T>(Func<RestClient, Task<RestResponse<T>>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
-
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
@@ -469,7 +468,7 @@ namespace Org.OpenAPITools.Client
             {
                 InterceptRequest(request);
 
-                RestResponse<T> response = getResponse(client);
+                RestResponse<T> response = await getResponse(client);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -565,21 +564,21 @@ namespace Org.OpenAPITools.Client
                 clientOptions.CookieContainer = cookies;
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = (client) =>
             {
                 if (RetryConfiguration.RetryPolicy != null)
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
                 }
                 else
                 {
-                    return client.Execute<T>(request);
+                    return Task.FromResult(client.Execute<T>(request));
                 }
             };
 
-            return ExecClient(getResponse, setOptions, request, options, configuration);
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration).GetAwaiter().GetResult();
         }
 
         private Task<ApiResponse<T>> ExecAsync<T>(RestRequest request, RequestOptions options, IReadableConfiguration configuration, CancellationToken cancellationToken = default(CancellationToken))
@@ -589,25 +588,21 @@ namespace Org.OpenAPITools.Client
                 //no extra options
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = async (client) =>
             {
-                Func<Task<RestResponse<T>>> action = async () =>
+                if (RetryConfiguration.AsyncRetryPolicy != null)
                 {
-                    if (RetryConfiguration.AsyncRetryPolicy != null)
-                    {
-                        var policy = RetryConfiguration.AsyncRetryPolicy;
-                        var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                        return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
-                    }
-                    else
-                    {
-                        return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
-                    }
-                };
-                return action().Result;
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
+                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                }
+                else
+                {
+                    return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+                }
             };
 
-            return Task.FromResult<ApiResponse<T>>(ExecClient(getResponse, setOptions, request, options, configuration));
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration);
         }
 
         #region IAsynchronousClient

--- a/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -449,10 +449,9 @@ namespace Org.OpenAPITools.Client
         /// <param name="configuration">A per-request configuration object.
         /// It is assumed that any merge with GlobalConfiguration has been done before calling this method.</param>
         /// <returns>A new ApiResponse instance.</returns>
-        private ApiResponse<T> ExecClient<T>(Func<RestClient, RestResponse<T>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
+        private async Task<ApiResponse<T>> ExecClientAsync<T>(Func<RestClient, Task<RestResponse<T>>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
-
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
@@ -469,7 +468,7 @@ namespace Org.OpenAPITools.Client
             {
                 InterceptRequest(request);
 
-                RestResponse<T> response = getResponse(client);
+                RestResponse<T> response = await getResponse(client);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -565,21 +564,21 @@ namespace Org.OpenAPITools.Client
                 clientOptions.CookieContainer = cookies;
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = (client) =>
             {
                 if (RetryConfiguration.RetryPolicy != null)
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
                 }
                 else
                 {
-                    return client.Execute<T>(request);
+                    return Task.FromResult(client.Execute<T>(request));
                 }
             };
 
-            return ExecClient(getResponse, setOptions, request, options, configuration);
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration).GetAwaiter().GetResult();
         }
 
         private Task<ApiResponse<T>> ExecAsync<T>(RestRequest request, RequestOptions options, IReadableConfiguration configuration, CancellationToken cancellationToken = default(CancellationToken))
@@ -589,25 +588,21 @@ namespace Org.OpenAPITools.Client
                 //no extra options
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = async (client) =>
             {
-                Func<Task<RestResponse<T>>> action = async () =>
+                if (RetryConfiguration.AsyncRetryPolicy != null)
                 {
-                    if (RetryConfiguration.AsyncRetryPolicy != null)
-                    {
-                        var policy = RetryConfiguration.AsyncRetryPolicy;
-                        var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                        return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
-                    }
-                    else
-                    {
-                        return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
-                    }
-                };
-                return action().Result;
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
+                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                }
+                else
+                {
+                    return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+                }
             };
 
-            return Task.FromResult<ApiResponse<T>>(ExecClient(getResponse, setOptions, request, options, configuration));
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration);
         }
 
         #region IAsynchronousClient

--- a/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -450,10 +450,9 @@ namespace Org.OpenAPITools.Client
         /// <param name="configuration">A per-request configuration object.
         /// It is assumed that any merge with GlobalConfiguration has been done before calling this method.</param>
         /// <returns>A new ApiResponse instance.</returns>
-        private ApiResponse<T> ExecClient<T>(Func<RestClient, RestResponse<T>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
+        private async Task<ApiResponse<T>> ExecClientAsync<T>(Func<RestClient, Task<RestResponse<T>>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
-
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
@@ -484,7 +483,7 @@ namespace Org.OpenAPITools.Client
             {
                 InterceptRequest(request);
 
-                RestResponse<T> response = getResponse(client);
+                RestResponse<T> response = await getResponse(client);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -580,21 +579,21 @@ namespace Org.OpenAPITools.Client
                 clientOptions.CookieContainer = cookies;
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = (client) =>
             {
                 if (RetryConfiguration.RetryPolicy != null)
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
                 }
                 else
                 {
-                    return client.Execute<T>(request);
+                    return Task.FromResult(client.Execute<T>(request));
                 }
             };
 
-            return ExecClient(getResponse, setOptions, request, options, configuration);
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration).GetAwaiter().GetResult();
         }
 
         private Task<ApiResponse<T>> ExecAsync<T>(RestRequest request, RequestOptions options, IReadableConfiguration configuration, CancellationToken cancellationToken = default(CancellationToken))
@@ -604,25 +603,21 @@ namespace Org.OpenAPITools.Client
                 //no extra options
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = async (client) =>
             {
-                Func<Task<RestResponse<T>>> action = async () =>
+                if (RetryConfiguration.AsyncRetryPolicy != null)
                 {
-                    if (RetryConfiguration.AsyncRetryPolicy != null)
-                    {
-                        var policy = RetryConfiguration.AsyncRetryPolicy;
-                        var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                        return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
-                    }
-                    else
-                    {
-                        return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
-                    }
-                };
-                return action().Result;
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
+                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                }
+                else
+                {
+                    return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+                }
             };
 
-            return Task.FromResult<ApiResponse<T>>(ExecClient(getResponse, setOptions, request, options, configuration));
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration);
         }
 
         #region IAsynchronousClient

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -450,10 +450,9 @@ namespace Org.OpenAPITools.Client
         /// <param name="configuration">A per-request configuration object.
         /// It is assumed that any merge with GlobalConfiguration has been done before calling this method.</param>
         /// <returns>A new ApiResponse instance.</returns>
-        private ApiResponse<T> ExecClient<T>(Func<RestClient, RestResponse<T>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
+        private async Task<ApiResponse<T>> ExecClientAsync<T>(Func<RestClient, Task<RestResponse<T>>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
-
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
@@ -484,7 +483,7 @@ namespace Org.OpenAPITools.Client
             {
                 InterceptRequest(request);
 
-                RestResponse<T> response = getResponse(client);
+                RestResponse<T> response = await getResponse(client);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -580,21 +579,21 @@ namespace Org.OpenAPITools.Client
                 clientOptions.CookieContainer = cookies;
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = (client) =>
             {
                 if (RetryConfiguration.RetryPolicy != null)
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
                 }
                 else
                 {
-                    return client.Execute<T>(request);
+                    return Task.FromResult(client.Execute<T>(request));
                 }
             };
 
-            return ExecClient(getResponse, setOptions, request, options, configuration);
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration).GetAwaiter().GetResult();
         }
 
         private Task<ApiResponse<T>> ExecAsync<T>(RestRequest request, RequestOptions options, IReadableConfiguration configuration, CancellationToken cancellationToken = default(CancellationToken))
@@ -604,25 +603,21 @@ namespace Org.OpenAPITools.Client
                 //no extra options
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = async (client) =>
             {
-                Func<Task<RestResponse<T>>> action = async () =>
+                if (RetryConfiguration.AsyncRetryPolicy != null)
                 {
-                    if (RetryConfiguration.AsyncRetryPolicy != null)
-                    {
-                        var policy = RetryConfiguration.AsyncRetryPolicy;
-                        var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                        return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
-                    }
-                    else
-                    {
-                        return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
-                    }
-                };
-                return action().Result;
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
+                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                }
+                else
+                {
+                    return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+                }
             };
 
-            return Task.FromResult<ApiResponse<T>>(ExecClient(getResponse, setOptions, request, options, configuration));
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration);
         }
 
         #region IAsynchronousClient

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -450,10 +450,9 @@ namespace Org.OpenAPITools.Client
         /// <param name="configuration">A per-request configuration object.
         /// It is assumed that any merge with GlobalConfiguration has been done before calling this method.</param>
         /// <returns>A new ApiResponse instance.</returns>
-        private ApiResponse<T> ExecClient<T>(Func<RestClient, RestResponse<T>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
+        private async Task<ApiResponse<T>> ExecClientAsync<T>(Func<RestClient, Task<RestResponse<T>>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
-
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
@@ -484,7 +483,7 @@ namespace Org.OpenAPITools.Client
             {
                 InterceptRequest(request);
 
-                RestResponse<T> response = getResponse(client);
+                RestResponse<T> response = await getResponse(client);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -580,21 +579,21 @@ namespace Org.OpenAPITools.Client
                 clientOptions.CookieContainer = cookies;
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = (client) =>
             {
                 if (RetryConfiguration.RetryPolicy != null)
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
                 }
                 else
                 {
-                    return client.Execute<T>(request);
+                    return Task.FromResult(client.Execute<T>(request));
                 }
             };
 
-            return ExecClient(getResponse, setOptions, request, options, configuration);
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration).GetAwaiter().GetResult();
         }
 
         private Task<ApiResponse<T>> ExecAsync<T>(RestRequest request, RequestOptions options, IReadableConfiguration configuration, CancellationToken cancellationToken = default(CancellationToken))
@@ -604,25 +603,21 @@ namespace Org.OpenAPITools.Client
                 //no extra options
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = async (client) =>
             {
-                Func<Task<RestResponse<T>>> action = async () =>
+                if (RetryConfiguration.AsyncRetryPolicy != null)
                 {
-                    if (RetryConfiguration.AsyncRetryPolicy != null)
-                    {
-                        var policy = RetryConfiguration.AsyncRetryPolicy;
-                        var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                        return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
-                    }
-                    else
-                    {
-                        return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
-                    }
-                };
-                return action().Result;
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
+                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                }
+                else
+                {
+                    return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+                }
             };
 
-            return Task.FromResult<ApiResponse<T>>(ExecClient(getResponse, setOptions, request, options, configuration));
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration);
         }
 
         #region IAsynchronousClient

--- a/samples/client/petstore/csharp/restsharp/net6/ParameterMappings/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net6/ParameterMappings/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -448,10 +448,9 @@ namespace Org.OpenAPITools.Client
         /// <param name="configuration">A per-request configuration object.
         /// It is assumed that any merge with GlobalConfiguration has been done before calling this method.</param>
         /// <returns>A new ApiResponse instance.</returns>
-        private ApiResponse<T> ExecClient<T>(Func<RestClient, RestResponse<T>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
+        private async Task<ApiResponse<T>> ExecClientAsync<T>(Func<RestClient, Task<RestResponse<T>>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
-
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
@@ -468,7 +467,7 @@ namespace Org.OpenAPITools.Client
             {
                 InterceptRequest(request);
 
-                RestResponse<T> response = getResponse(client);
+                RestResponse<T> response = await getResponse(client);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -564,21 +563,21 @@ namespace Org.OpenAPITools.Client
                 clientOptions.CookieContainer = cookies;
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = (client) =>
             {
                 if (RetryConfiguration.RetryPolicy != null)
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
                 }
                 else
                 {
-                    return client.Execute<T>(request);
+                    return Task.FromResult(client.Execute<T>(request));
                 }
             };
 
-            return ExecClient(getResponse, setOptions, request, options, configuration);
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration).GetAwaiter().GetResult();
         }
 
         private Task<ApiResponse<T>> ExecAsync<T>(RestRequest request, RequestOptions options, IReadableConfiguration configuration, CancellationToken cancellationToken = default(CancellationToken))
@@ -588,25 +587,21 @@ namespace Org.OpenAPITools.Client
                 //no extra options
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = async (client) =>
             {
-                Func<Task<RestResponse<T>>> action = async () =>
+                if (RetryConfiguration.AsyncRetryPolicy != null)
                 {
-                    if (RetryConfiguration.AsyncRetryPolicy != null)
-                    {
-                        var policy = RetryConfiguration.AsyncRetryPolicy;
-                        var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                        return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
-                    }
-                    else
-                    {
-                        return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
-                    }
-                };
-                return action().Result;
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
+                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                }
+                else
+                {
+                    return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+                }
             };
 
-            return Task.FromResult<ApiResponse<T>>(ExecClient(getResponse, setOptions, request, options, configuration));
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration);
         }
 
         #region IAsynchronousClient

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -449,10 +449,9 @@ namespace Org.OpenAPITools.Client
         /// <param name="configuration">A per-request configuration object.
         /// It is assumed that any merge with GlobalConfiguration has been done before calling this method.</param>
         /// <returns>A new ApiResponse instance.</returns>
-        private ApiResponse<T> ExecClient<T>(Func<RestClient, RestResponse<T>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
+        private async Task<ApiResponse<T>> ExecClientAsync<T>(Func<RestClient, Task<RestResponse<T>>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
-
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
@@ -483,7 +482,7 @@ namespace Org.OpenAPITools.Client
             {
                 InterceptRequest(request);
 
-                RestResponse<T> response = getResponse(client);
+                RestResponse<T> response = await getResponse(client);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -579,21 +578,21 @@ namespace Org.OpenAPITools.Client
                 clientOptions.CookieContainer = cookies;
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = (client) =>
             {
                 if (RetryConfiguration.RetryPolicy != null)
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
                 }
                 else
                 {
-                    return client.Execute<T>(request);
+                    return Task.FromResult(client.Execute<T>(request));
                 }
             };
 
-            return ExecClient(getResponse, setOptions, request, options, configuration);
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration).GetAwaiter().GetResult();
         }
 
         private Task<ApiResponse<T>> ExecAsync<T>(RestRequest request, RequestOptions options, IReadableConfiguration configuration, CancellationToken cancellationToken = default(CancellationToken))
@@ -603,25 +602,21 @@ namespace Org.OpenAPITools.Client
                 //no extra options
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = async (client) =>
             {
-                Func<Task<RestResponse<T>>> action = async () =>
+                if (RetryConfiguration.AsyncRetryPolicy != null)
                 {
-                    if (RetryConfiguration.AsyncRetryPolicy != null)
-                    {
-                        var policy = RetryConfiguration.AsyncRetryPolicy;
-                        var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                        return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
-                    }
-                    else
-                    {
-                        return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
-                    }
-                };
-                return action().Result;
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
+                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                }
+                else
+                {
+                    return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+                }
             };
 
-            return Task.FromResult<ApiResponse<T>>(ExecClient(getResponse, setOptions, request, options, configuration));
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration);
         }
 
         #region IAsynchronousClient

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -449,10 +449,9 @@ namespace Org.OpenAPITools.Client
         /// <param name="configuration">A per-request configuration object.
         /// It is assumed that any merge with GlobalConfiguration has been done before calling this method.</param>
         /// <returns>A new ApiResponse instance.</returns>
-        private ApiResponse<T> ExecClient<T>(Func<RestClient, RestResponse<T>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
+        private async Task<ApiResponse<T>> ExecClientAsync<T>(Func<RestClient, Task<RestResponse<T>>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
-
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
@@ -483,7 +482,7 @@ namespace Org.OpenAPITools.Client
             {
                 InterceptRequest(request);
 
-                RestResponse<T> response = getResponse(client);
+                RestResponse<T> response = await getResponse(client);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -579,21 +578,21 @@ namespace Org.OpenAPITools.Client
                 clientOptions.CookieContainer = cookies;
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = (client) =>
             {
                 if (RetryConfiguration.RetryPolicy != null)
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
                 }
                 else
                 {
-                    return client.Execute<T>(request);
+                    return Task.FromResult(client.Execute<T>(request));
                 }
             };
 
-            return ExecClient(getResponse, setOptions, request, options, configuration);
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration).GetAwaiter().GetResult();
         }
 
         private Task<ApiResponse<T>> ExecAsync<T>(RestRequest request, RequestOptions options, IReadableConfiguration configuration, CancellationToken cancellationToken = default(CancellationToken))
@@ -603,25 +602,21 @@ namespace Org.OpenAPITools.Client
                 //no extra options
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = async (client) =>
             {
-                Func<Task<RestResponse<T>>> action = async () =>
+                if (RetryConfiguration.AsyncRetryPolicy != null)
                 {
-                    if (RetryConfiguration.AsyncRetryPolicy != null)
-                    {
-                        var policy = RetryConfiguration.AsyncRetryPolicy;
-                        var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                        return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
-                    }
-                    else
-                    {
-                        return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
-                    }
-                };
-                return action().Result;
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
+                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                }
+                else
+                {
+                    return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+                }
             };
 
-            return Task.FromResult<ApiResponse<T>>(ExecClient(getResponse, setOptions, request, options, configuration));
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration);
         }
 
         #region IAsynchronousClient

--- a/samples/client/petstore/csharp/restsharp/net7/UseDateTimeForDate/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/UseDateTimeForDate/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -448,10 +448,9 @@ namespace Org.OpenAPITools.Client
         /// <param name="configuration">A per-request configuration object.
         /// It is assumed that any merge with GlobalConfiguration has been done before calling this method.</param>
         /// <returns>A new ApiResponse instance.</returns>
-        private ApiResponse<T> ExecClient<T>(Func<RestClient, RestResponse<T>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
+        private async Task<ApiResponse<T>> ExecClientAsync<T>(Func<RestClient, Task<RestResponse<T>>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
-
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
@@ -468,7 +467,7 @@ namespace Org.OpenAPITools.Client
             {
                 InterceptRequest(request);
 
-                RestResponse<T> response = getResponse(client);
+                RestResponse<T> response = await getResponse(client);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -564,21 +563,21 @@ namespace Org.OpenAPITools.Client
                 clientOptions.CookieContainer = cookies;
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = (client) =>
             {
                 if (RetryConfiguration.RetryPolicy != null)
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
                 }
                 else
                 {
-                    return client.Execute<T>(request);
+                    return Task.FromResult(client.Execute<T>(request));
                 }
             };
 
-            return ExecClient(getResponse, setOptions, request, options, configuration);
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration).GetAwaiter().GetResult();
         }
 
         private Task<ApiResponse<T>> ExecAsync<T>(RestRequest request, RequestOptions options, IReadableConfiguration configuration, CancellationToken cancellationToken = default(CancellationToken))
@@ -588,25 +587,21 @@ namespace Org.OpenAPITools.Client
                 //no extra options
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = async (client) =>
             {
-                Func<Task<RestResponse<T>>> action = async () =>
+                if (RetryConfiguration.AsyncRetryPolicy != null)
                 {
-                    if (RetryConfiguration.AsyncRetryPolicy != null)
-                    {
-                        var policy = RetryConfiguration.AsyncRetryPolicy;
-                        var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                        return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
-                    }
-                    else
-                    {
-                        return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
-                    }
-                };
-                return action().Result;
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
+                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                }
+                else
+                {
+                    return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+                }
             };
 
-            return Task.FromResult<ApiResponse<T>>(ExecClient(getResponse, setOptions, request, options, configuration));
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration);
         }
 
         #region IAsynchronousClient

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -450,10 +450,9 @@ namespace Org.OpenAPITools.Client
         /// <param name="configuration">A per-request configuration object.
         /// It is assumed that any merge with GlobalConfiguration has been done before calling this method.</param>
         /// <returns>A new ApiResponse instance.</returns>
-        private ApiResponse<T> ExecClient<T>(Func<RestClient, RestResponse<T>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
+        private async Task<ApiResponse<T>> ExecClientAsync<T>(Func<RestClient, Task<RestResponse<T>>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
-
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
@@ -484,7 +483,7 @@ namespace Org.OpenAPITools.Client
             {
                 InterceptRequest(request);
 
-                RestResponse<T> response = getResponse(client);
+                RestResponse<T> response = await getResponse(client);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -580,21 +579,21 @@ namespace Org.OpenAPITools.Client
                 clientOptions.CookieContainer = cookies;
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = (client) =>
             {
                 if (RetryConfiguration.RetryPolicy != null)
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
                 }
                 else
                 {
-                    return client.Execute<T>(request);
+                    return Task.FromResult(client.Execute<T>(request));
                 }
             };
 
-            return ExecClient(getResponse, setOptions, request, options, configuration);
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration).GetAwaiter().GetResult();
         }
 
         private Task<ApiResponse<T>> ExecAsync<T>(RestRequest request, RequestOptions options, IReadableConfiguration configuration, CancellationToken cancellationToken = default(CancellationToken))
@@ -604,25 +603,21 @@ namespace Org.OpenAPITools.Client
                 //no extra options
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = async (client) =>
             {
-                Func<Task<RestResponse<T>>> action = async () =>
+                if (RetryConfiguration.AsyncRetryPolicy != null)
                 {
-                    if (RetryConfiguration.AsyncRetryPolicy != null)
-                    {
-                        var policy = RetryConfiguration.AsyncRetryPolicy;
-                        var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                        return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
-                    }
-                    else
-                    {
-                        return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
-                    }
-                };
-                return action().Result;
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
+                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                }
+                else
+                {
+                    return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+                }
             };
 
-            return Task.FromResult<ApiResponse<T>>(ExecClient(getResponse, setOptions, request, options, configuration));
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration);
         }
 
         #region IAsynchronousClient

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -450,10 +450,9 @@ namespace Org.OpenAPITools.Client
         /// <param name="configuration">A per-request configuration object.
         /// It is assumed that any merge with GlobalConfiguration has been done before calling this method.</param>
         /// <returns>A new ApiResponse instance.</returns>
-        private ApiResponse<T> ExecClient<T>(Func<RestClient, RestResponse<T>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
+        private async Task<ApiResponse<T>> ExecClientAsync<T>(Func<RestClient, Task<RestResponse<T>>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
-
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
@@ -484,7 +483,7 @@ namespace Org.OpenAPITools.Client
             {
                 InterceptRequest(request);
 
-                RestResponse<T> response = getResponse(client);
+                RestResponse<T> response = await getResponse(client);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -580,21 +579,21 @@ namespace Org.OpenAPITools.Client
                 clientOptions.CookieContainer = cookies;
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = (client) =>
             {
                 if (RetryConfiguration.RetryPolicy != null)
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
                 }
                 else
                 {
-                    return client.Execute<T>(request);
+                    return Task.FromResult(client.Execute<T>(request));
                 }
             };
 
-            return ExecClient(getResponse, setOptions, request, options, configuration);
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration).GetAwaiter().GetResult();
         }
 
         private Task<ApiResponse<T>> ExecAsync<T>(RestRequest request, RequestOptions options, IReadableConfiguration configuration, CancellationToken cancellationToken = default(CancellationToken))
@@ -604,25 +603,21 @@ namespace Org.OpenAPITools.Client
                 //no extra options
             };
 
-            Func<RestClient, RestResponse<T>> getResponse = (client) =>
+            Func<RestClient, Task<RestResponse<T>>> getResponse = async (client) =>
             {
-                Func<Task<RestResponse<T>>> action = async () =>
+                if (RetryConfiguration.AsyncRetryPolicy != null)
                 {
-                    if (RetryConfiguration.AsyncRetryPolicy != null)
-                    {
-                        var policy = RetryConfiguration.AsyncRetryPolicy;
-                        var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                        return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
-                    }
-                    else
-                    {
-                        return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
-                    }
-                };
-                return action().Result;
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
+                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                }
+                else
+                {
+                    return await client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+                }
             };
 
-            return Task.FromResult<ApiResponse<T>>(ExecClient(getResponse, setOptions, request, options, configuration));
+            return ExecClientAsync(getResponse, setOptions, request, options, configuration);
         }
 
         #region IAsynchronousClient


### PR DESCRIPTION
 - async should never be blocked on the ApiClient To fix we invert the logic and use Task as base and keep consistency, we expect and wait result only on synchronous calls.
 - Fixes #19176 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
     
@mandrean @shibayan @Blackclaws @lucamazzanti @iBicha @wing328 