### PR TITLE
[BUG] PHP Client - ObjectSerializer::buildQuery flattens array params resulting invalid URL params (param=a&param=b vs param[]=a&param[]=b) #19233

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
@@ -258,6 +258,11 @@ class ObjectSerializer
 
         $value = $flattenArray($value, $paramName);
 
+        // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#style-values
+        if ($openApiType === 'array' && $style === 'deepObject' && $explode) {
+            return $value;
+        }
+
         if ($openApiType === 'object' && ($style === 'deepObject' || $explode)) {
             return $value;
         }

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -256,6 +256,11 @@ class ObjectSerializer
 
         $value = $flattenArray($value, $paramName);
 
+        // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#style-values
+        if ($openApiType === 'array' && $style === 'deepObject' && $explode) {
+            return $value;
+        }
+
         if ($openApiType === 'object' && ($style === 'deepObject' || $explode)) {
             return $value;
         }
@@ -463,7 +468,7 @@ class ObjectSerializer
             // determine file name
             if (
                 is_array($httpHeaders)
-                && array_key_exists('Content-Disposition', $httpHeaders) 
+                && array_key_exists('Content-Disposition', $httpHeaders)
                 && preg_match('/inline; filename=[\'"]?([^\'"\s]+)[\'"]?$/i', $httpHeaders['Content-Disposition'], $match)
             ) {
                 $filename = Configuration::getDefaultConfiguration()->getTempFolderPath() . DIRECTORY_SEPARATOR . self::sanitizeFilename($match[1]);

--- a/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
+++ b/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
@@ -268,6 +268,11 @@ class ObjectSerializer
 
         $value = $flattenArray($value, $paramName);
 
+        // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#style-values
+        if ($openApiType === 'array' && $style === 'deepObject' && $explode) {
+            return $value;
+        }
+
         if ($openApiType === 'object' && ($style === 'deepObject' || $explode)) {
             return $value;
         }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
@@ -267,6 +267,11 @@ class ObjectSerializer
 
         $value = $flattenArray($value, $paramName);
 
+        // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#style-values
+        if ($openApiType === 'array' && $style === 'deepObject' && $explode) {
+            return $value;
+        }
+
         if ($openApiType === 'object' && ($style === 'deepObject' || $explode)) {
             return $value;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -266,7 +266,7 @@ class ObjectSerializer
         $value = $flattenArray($value, $paramName);
 
         // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#style-values
-            if ($openApiType === 'array' && $style === 'deepObject' && $explode) {
+        if ($openApiType === 'array' && $style === 'deepObject' && $explode) {
             return $value;
         }
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -265,6 +265,11 @@ class ObjectSerializer
 
         $value = $flattenArray($value, $paramName);
 
+        // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#style-values
+            if ($openApiType === 'array' && $style === 'deepObject' && $explode) {
+            return $value;
+        }
+
         if ($openApiType === 'object' && ($style === 'deepObject' || $explode)) {
             return $value;
         }
@@ -472,7 +477,7 @@ class ObjectSerializer
             // determine file name
             if (
                 is_array($httpHeaders)
-                && array_key_exists('Content-Disposition', $httpHeaders) 
+                && array_key_exists('Content-Disposition', $httpHeaders)
                 && preg_match('/inline; filename=[\'"]?([^\'"\s]+)[\'"]?$/i', $httpHeaders['Content-Disposition'], $match)
             ) {
                 $filename = Configuration::getDefaultConfiguration()->getTempFolderPath() . DIRECTORY_SEPARATOR . self::sanitizeFilename($match[1]);

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -28,7 +28,7 @@ class ObjectSerializerTest extends TestCase
         $this->assertSame("sun.gif", ObjectSerializer::sanitizeFilename("../sun.gif"));
         $this->assertSame("sun.gif", ObjectSerializer::sanitizeFilename("/var/tmp/sun.gif"));
         $this->assertSame("sun.gif", ObjectSerializer::sanitizeFilename("./sun.gif"));
-        
+
         $this->assertSame("sun", ObjectSerializer::sanitizeFilename("sun"));
         $this->assertSame("sun.gif", ObjectSerializer::sanitizeFilename("..\sun.gif"));
         $this->assertSame("sun.gif", ObjectSerializer::sanitizeFilename("\var\tmp\sun.gif"));
@@ -62,7 +62,7 @@ class ObjectSerializerTest extends TestCase
      * File Streams Provider
      * @return array[]
      */
-    public function provideFileStreams(): array
+    public static function provideFileStreams(): array
     {
         return [
             'File stream without headers' => [
@@ -112,7 +112,7 @@ class ObjectSerializerTest extends TestCase
      *
      * @return string[][]
      */
-    public function provideTimestamps(): array
+    public static function provideTimestamps(): array
     {
         return [
             'String from #7942' => [
@@ -173,7 +173,7 @@ class ObjectSerializerTest extends TestCase
      *
      * @return array[]
      */
-    public function provideQueryParams(): array
+    public static function provideQueryParams(): array
     {
         $array = ['blue', 'black', 'brown'];
         $object = ['R' => 100, 'G' => 200, 'B' => 150];
@@ -300,10 +300,12 @@ class ObjectSerializerTest extends TestCase
             'deepObject array, explode off, required true' => [
                 $array, 'color', 'array', 'deepObject', false, true, 'color=blue%2Cblack%2Cbrown',
             ],
-            // color=blue&color=black&color=brown
+
+            // color[0]=blue&color[1]=black&color[2]=brown
             'deepObject array, explode on, required true' => [
-                $array, 'color', 'array', 'deepObject', true, true, 'color=blue&color=black&color=brown',
+                $array, 'color', 'array', 'deepObject', true, true, 'color%5B0%5D=blue&color%5B1%5D=black&color%5B2%5D=brown',
             ],
+
             // color[R]=100&color[G]=200&color[B]=150
             'deepObject object, explode off, required true' => [
                 $object, 'color', 'object', 'deepObject', false, true, 'color%5BR%5D=100&color%5BG%5D=200&color%5BB%5D=150',

--- a/samples/client/petstore/php/psr-18/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/psr-18/lib/ObjectSerializer.php
@@ -266,7 +266,7 @@ class ObjectSerializer
         $value = $flattenArray($value, $paramName);
 
         // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#style-values
-            if ($openApiType === 'array' && $style === 'deepObject' && $explode) {
+        if ($openApiType === 'array' && $style === 'deepObject' && $explode) {
             return $value;
         }
 

--- a/samples/client/petstore/php/psr-18/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/psr-18/lib/ObjectSerializer.php
@@ -265,6 +265,11 @@ class ObjectSerializer
 
         $value = $flattenArray($value, $paramName);
 
+        // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#style-values
+            if ($openApiType === 'array' && $style === 'deepObject' && $explode) {
+            return $value;
+        }
+
         if ($openApiType === 'object' && ($style === 'deepObject' || $explode)) {
             return $value;
         }
@@ -472,7 +477,7 @@ class ObjectSerializer
             // determine file name
             if (
                 is_array($httpHeaders)
-                && array_key_exists('Content-Disposition', $httpHeaders) 
+                && array_key_exists('Content-Disposition', $httpHeaders)
                 && preg_match('/inline; filename=[\'"]?([^\'"\s]+)[\'"]?$/i', $httpHeaders['Content-Disposition'], $match)
             ) {
                 $filename = Configuration::getDefaultConfiguration()->getTempFolderPath() . DIRECTORY_SEPARATOR . self::sanitizeFilename($match[1]);


### PR DESCRIPTION
Fix for https://github.com/OpenAPITools/openapi-generator/issues/19233