### PR TITLE
[Kotlin][Spring] fix build.gradle.kts and pom.xml for SpringBoot 2.x

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradleKts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradleKts.mustache
@@ -57,9 +57,8 @@ dependencies {
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin")
 {{#useBeanValidation}}
-    compile("jakarta.validation:jakarta.validation-api"){{/useBeanValidation}}
-    compile("jakarta.annotation:jakarta.annotation-api:2.1.0")
-
+    compile("javax.validation:validation-api"){{/useBeanValidation}}
+    compile("javax.annotation:javax.annotation-api:1.3.2")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit5")
     testCompile("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "junit")

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom.mustache
@@ -13,7 +13,7 @@
         <swagger-annotations.version>1.6.6</swagger-annotations.version>{{/swagger1AnnotationLibrary}}{{#swagger2AnnotationLibrary}}
         <swagger-annotations.version>2.2.0</swagger-annotations.version>{{/swagger2AnnotationLibrary}}{{/springDocDocumentationProvider}}{{/springFoxDocumentationProvider}}
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jakarta-annotation.version>2.1.0</jakarta-annotation.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
         <kotlin-test-junit5.version>1.6.21</kotlin-test-junit5.version>
 
         <kotlin.version>1.6.21</kotlin.version>
@@ -168,13 +168,13 @@
 {{#useBeanValidation}}
         <!-- Bean Validation API support -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>{{/useBeanValidation}}
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation.version}</version>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradleKts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradleKts.mustache
@@ -69,7 +69,7 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-oauth2:2.2.5.RELEASE"){{/hasAuthMethods}}
 
 {{#useBeanValidation}}
-    implementation("jakarta.validation:jakarta.validation-api"){{/useBeanValidation}}
-    implementation("jakarta.annotation:jakarta.annotation-api:2.1.0")
+    implementation("javax.validation:validation-api"){{/useBeanValidation}}
+    implementation("javax.annotation:javax.annotation-api:1.3.2")
 
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom.mustache
@@ -13,7 +13,7 @@
         <swagger-annotations.version>1.6.6</swagger-annotations.version>{{/swagger1AnnotationLibrary}}{{#swagger2AnnotationLibrary}}
         <swagger-annotations.version>2.2.0</swagger-annotations.version>{{/swagger2AnnotationLibrary}}{{/springDocDocumentationProvider}}{{/springFoxDocumentationProvider}}
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jakarta-annotation.version>2.1.0</jakarta-annotation.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
         <kotlin-test-junit5.version>1.6.21</kotlin-test-junit5.version>
 
         <kotlin.version>1.6.21</kotlin.version>
@@ -191,13 +191,13 @@
 {{#useBeanValidation}}
         <!-- Bean Validation API support -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>{{/useBeanValidation}}
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation.version}</version>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/samples/server/petstore/kotlin-spring-cloud/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-cloud/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
     implementation("org.springframework.cloud:spring-cloud-starter-oauth2:2.2.5.RELEASE")
 
-    implementation("jakarta.validation:jakarta.validation-api")
-    implementation("jakarta.annotation:jakarta.annotation-api:2.1.0")
+    implementation("javax.validation:validation-api")
+    implementation("javax.annotation:javax.annotation-api:1.3.2")
 
 }

--- a/samples/server/petstore/kotlin-spring-cloud/pom.xml
+++ b/samples/server/petstore/kotlin-spring-cloud/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0.0</version>
     <properties>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jakarta-annotation.version>2.1.0</jakarta-annotation.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
         <kotlin-test-junit5.version>1.6.21</kotlin-test-junit5.version>
 
         <kotlin.version>1.6.21</kotlin.version>
@@ -119,13 +119,13 @@
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation.version}</version>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/samples/server/petstore/kotlin-spring-default/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-default/build.gradle.kts
@@ -40,9 +40,8 @@ dependencies {
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin")
-    compile("jakarta.validation:jakarta.validation-api")
-    compile("jakarta.annotation:jakarta.annotation-api:2.1.0")
-
+    compile("javax.validation:validation-api")
+    compile("javax.annotation:javax.annotation-api:1.3.2")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit5")
     testCompile("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "junit")

--- a/samples/server/petstore/kotlin-spring-default/pom.xml
+++ b/samples/server/petstore/kotlin-spring-default/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jakarta-annotation.version>2.1.0</jakarta-annotation.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
         <kotlin-test-junit5.version>1.6.21</kotlin-test-junit5.version>
 
         <kotlin.version>1.6.21</kotlin.version>
@@ -117,13 +117,13 @@
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation.version}</version>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/samples/server/petstore/kotlin-springboot-bigdecimal-default/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-bigdecimal-default/build.gradle.kts
@@ -40,9 +40,8 @@ dependencies {
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin")
-    compile("jakarta.validation:jakarta.validation-api")
-    compile("jakarta.annotation:jakarta.annotation-api:2.1.0")
-
+    compile("javax.validation:validation-api")
+    compile("javax.annotation:javax.annotation-api:1.3.2")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit5")
     testCompile("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "junit")

--- a/samples/server/petstore/kotlin-springboot-bigdecimal-default/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-bigdecimal-default/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jakarta-annotation.version>2.1.0</jakarta-annotation.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
         <kotlin-test-junit5.version>1.6.21</kotlin-test-junit5.version>
 
         <kotlin.version>1.6.21</kotlin.version>
@@ -117,13 +117,13 @@
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation.version}</version>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/samples/server/petstore/kotlin-springboot-delegate/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-delegate/build.gradle.kts
@@ -40,9 +40,8 @@ dependencies {
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin")
-    compile("jakarta.validation:jakarta.validation-api")
-    compile("jakarta.annotation:jakarta.annotation-api:2.1.0")
-
+    compile("javax.validation:validation-api")
+    compile("javax.annotation:javax.annotation-api:1.3.2")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit5")
     testCompile("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "junit")

--- a/samples/server/petstore/kotlin-springboot-delegate/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-delegate/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jakarta-annotation.version>2.1.0</jakarta-annotation.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
         <kotlin-test-junit5.version>1.6.21</kotlin-test-junit5.version>
 
         <kotlin.version>1.6.21</kotlin.version>
@@ -117,13 +117,13 @@
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation.version}</version>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/samples/server/petstore/kotlin-springboot-modelMutable/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/build.gradle.kts
@@ -40,9 +40,8 @@ dependencies {
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin")
-    compile("jakarta.validation:jakarta.validation-api")
-    compile("jakarta.annotation:jakarta.annotation-api:2.1.0")
-
+    compile("javax.validation:validation-api")
+    compile("javax.annotation:javax.annotation-api:1.3.2")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit5")
     testCompile("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "junit")

--- a/samples/server/petstore/kotlin-springboot-modelMutable/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jakarta-annotation.version>2.1.0</jakarta-annotation.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
         <kotlin-test-junit5.version>1.6.21</kotlin-test-junit5.version>
 
         <kotlin.version>1.6.21</kotlin.version>
@@ -117,13 +117,13 @@
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation.version}</version>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/samples/server/petstore/kotlin-springboot-multipart-request-model/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-multipart-request-model/build.gradle.kts
@@ -40,9 +40,8 @@ dependencies {
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin")
-    compile("jakarta.validation:jakarta.validation-api")
-    compile("jakarta.annotation:jakarta.annotation-api:2.1.0")
-
+    compile("javax.validation:validation-api")
+    compile("javax.annotation:javax.annotation-api:1.3.2")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit5")
     testCompile("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "junit")

--- a/samples/server/petstore/kotlin-springboot-multipart-request-model/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-multipart-request-model/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jakarta-annotation.version>2.1.0</jakarta-annotation.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
         <kotlin-test-junit5.version>1.6.21</kotlin-test-junit5.version>
 
         <kotlin.version>1.6.21</kotlin.version>
@@ -117,13 +117,13 @@
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation.version}</version>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/samples/server/petstore/kotlin-springboot-reactive/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-reactive/build.gradle.kts
@@ -43,9 +43,8 @@ dependencies {
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin")
-    compile("jakarta.validation:jakarta.validation-api")
-    compile("jakarta.annotation:jakarta.annotation-api:2.1.0")
-
+    compile("javax.validation:validation-api")
+    compile("javax.annotation:javax.annotation-api:1.3.2")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit5")
     testCompile("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "junit")

--- a/samples/server/petstore/kotlin-springboot-reactive/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-reactive/pom.xml
@@ -9,7 +9,7 @@
         <kotlinx-coroutines.version>1.6.1</kotlinx-coroutines.version>
         <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jakarta-annotation.version>2.1.0</jakarta-annotation.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
         <kotlin-test-junit5.version>1.6.21</kotlin-test-junit5.version>
 
         <kotlin.version>1.6.21</kotlin.version>
@@ -128,13 +128,13 @@
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation.version}</version>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/build.gradle.kts
@@ -42,9 +42,8 @@ dependencies {
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin")
-    compile("jakarta.validation:jakarta.validation-api")
-    compile("jakarta.annotation:jakarta.annotation-api:2.1.0")
-
+    compile("javax.validation:validation-api")
+    compile("javax.annotation:javax.annotation-api:1.3.2")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit5")
     testCompile("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "junit")

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/pom.xml
@@ -9,7 +9,7 @@
         <swagger-ui.version>4.10.3</swagger-ui.version>
         <swagger-annotations.version>1.6.6</swagger-annotations.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jakarta-annotation.version>2.1.0</jakarta-annotation.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
         <kotlin-test-junit5.version>1.6.21</kotlin-test-junit5.version>
 
         <kotlin.version>1.6.21</kotlin.version>
@@ -127,13 +127,13 @@
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation.version}</version>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/build.gradle.kts
@@ -42,9 +42,8 @@ dependencies {
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin")
-    compile("jakarta.validation:jakarta.validation-api")
-    compile("jakarta.annotation:jakarta.annotation-api:2.1.0")
-
+    compile("javax.validation:validation-api")
+    compile("javax.annotation:javax.annotation-api:1.3.2")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit5")
     testCompile("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "junit")

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/pom.xml
@@ -9,7 +9,7 @@
         <swagger-ui.version>4.10.3</swagger-ui.version>
         <swagger-annotations.version>2.2.0</swagger-annotations.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jakarta-annotation.version>2.1.0</jakarta-annotation.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
         <kotlin-test-junit5.version>1.6.21</kotlin-test-junit5.version>
 
         <kotlin.version>1.6.21</kotlin.version>
@@ -127,13 +127,13 @@
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation.version}</version>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/samples/server/petstore/kotlin-springboot-springfox/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-springfox/build.gradle.kts
@@ -42,9 +42,8 @@ dependencies {
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin")
-    compile("jakarta.validation:jakarta.validation-api")
-    compile("jakarta.annotation:jakarta.annotation-api:2.1.0")
-
+    compile("javax.validation:validation-api")
+    compile("javax.annotation:javax.annotation-api:1.3.2")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit5")
     testCompile("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "junit")

--- a/samples/server/petstore/kotlin-springboot-springfox/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-springfox/pom.xml
@@ -9,7 +9,7 @@
         <springfox-swagger2.version>2.9.2</springfox-swagger2.version>
         <swagger-ui.version>4.10.3</swagger-ui.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jakarta-annotation.version>2.1.0</jakarta-annotation.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
         <kotlin-test-junit5.version>1.6.21</kotlin-test-junit5.version>
 
         <kotlin.version>1.6.21</kotlin.version>
@@ -128,13 +128,13 @@
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation.version}</version>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/samples/server/petstore/kotlin-springboot/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot/build.gradle.kts
@@ -39,9 +39,8 @@ dependencies {
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin")
-    compile("jakarta.validation:jakarta.validation-api")
-    compile("jakarta.annotation:jakarta.annotation-api:2.1.0")
-
+    compile("javax.validation:validation-api")
+    compile("javax.annotation:javax.annotation-api:1.3.2")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit5")
     testCompile("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "junit")

--- a/samples/server/petstore/kotlin-springboot/pom.xml
+++ b/samples/server/petstore/kotlin-springboot/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0.0</version>
     <properties>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jakarta-annotation.version>2.1.0</jakarta-annotation.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
         <kotlin-test-junit5.version>1.6.21</kotlin-test-junit5.version>
 
         <kotlin.version>1.6.21</kotlin.version>
@@ -111,13 +111,13 @@
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation.version}</version>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
SpringBoot 2.x still uses javax namespace, but the build files `build.gradle.kts` and `pom.xml` where generated with the newer `jakarta.validation` and `jakarta.annotation` dependencies resulting in build errors.

Example build error:

```
~/git/openapi-generator/samples/server/petstore/kotlin-springboot-delegate> gradle build

> Task :compileKotlin FAILED
e: /home/peter/git/openapi-generator/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApiController.kt: (7, 19): Unresolved reference: Generated
e: /home/peter/git/openapi-generator/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApiDelegate.kt: (18, 19): Unresolved reference: Generated
e: /home/peter/git/openapi-generator/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/StoreApiController.kt: (7, 19): Unresolved reference: Generated
e: /home/peter/git/openapi-generator/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/StoreApiDelegate.kt: (17, 19): Unresolved reference: Generated
e: /home/peter/git/openapi-generator/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApiController.kt: (7, 19): Unresolved reference: Generated
e: /home/peter/git/openapi-generator/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApiDelegate.kt: (17, 19): Unresolved reference: Generated

FAILURE: Build failed with an exception.

```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jimschubert, @dr4ke616, @karismann, @Zomzog, @andrewemery, @4brunu, @yutaka0m, @stefankoppier