### PR TITLE
Typescript: Generate oneOf schemas as type unions

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -386,6 +386,16 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
                     }
                 }
             }
+            if (!cm.oneOf.isEmpty()) {
+                // For oneOfs only import $refs within the oneOf
+                TreeSet<String> oneOfRefs = new TreeSet<>();
+                for (String im : cm.imports) {
+                    if (cm.oneOf.contains(im)) {
+                        oneOfRefs.add(im);
+                    }
+                }
+                cm.imports = oneOfRefs;
+            }
         }
         for (ModelMap mo : models) {
             CodegenModel cm = mo.getModel();

--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -6,7 +6,7 @@ export * from '{{{ importPath }}}{{importFileExtension}}';
 
 {{#models}}
 {{#model}}
-import { {{classname}}{{#hasEnums}}{{#vars}}{{#isEnum}}, {{classname}}{{enumName}} {{/isEnum}} {{/vars}}{{/hasEnums}} } from '{{{ importPath }}}{{importFileExtension}}';
+import { {{classname}}{{#oneOf}}{{#-first}}Class{{/-first}}{{/oneOf}}{{^oneOf}}{{#hasEnums}}{{#vars}}{{#isEnum}}, {{classname}}{{enumName}} {{/isEnum}} {{/vars}}{{/hasEnums}}{{/oneOf}} } from '{{{ importPath }}}{{importFileExtension}}';
 {{/model}}
 {{/models}}
 
@@ -43,7 +43,7 @@ let typeMap: {[index: string]: any} = {
     {{#models}}
         {{#model}}
             {{^isEnum}}
-    "{{classname}}": {{classname}},
+    "{{classname}}": {{classname}}{{#oneOf}}{{#-first}}Class{{/-first}}{{/oneOf}},
             {{/isEnum}}
         {{/model}}
     {{/models}}
@@ -125,7 +125,10 @@ export class ObjectSerializer {
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
                         return discriminatorType; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type

--- a/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
@@ -12,6 +12,10 @@ import { HttpFile } from '../http/http{{importFileExtension}}';
 */
 {{/description}}
 {{^isEnum}}
+{{#oneOf}}
+{{#-first}}{{>model/modelOneOf}}{{/-first}}
+{{/oneOf}}
+{{^oneOf}}
 export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
 {{#vars}}
 {{#description}}
@@ -28,6 +32,18 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
     {{^discriminator}}
     static readonly discriminator: string | undefined = undefined;
     {{/discriminator}}
+    {{#hasDiscriminatorWithNonEmptyMapping}}
+
+    static readonly mapping: {[index: string]: string} | undefined = {
+    {{#discriminator.mappedModels}}
+        "{{mappingName}}": "{{modelName}}",
+    {{/discriminator.mappedModels}}
+    };
+    {{/hasDiscriminatorWithNonEmptyMapping}}
+    {{^hasDiscriminatorWithNonEmptyMapping}}
+
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+    {{/hasDiscriminatorWithNonEmptyMapping}}
 
     {{^isArray}}
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
@@ -89,6 +105,7 @@ export enum {{classname}}{{enumName}} {
 {{/vars}}
 
 {{/hasEnums}}
+{{/oneOf}}
 {{/isEnum}}
 {{#isEnum}}
 {{#enumTypes}}

--- a/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
@@ -1,0 +1,40 @@
+{{#hasImports}}
+import {
+    {{#imports}}
+    {{{.}}}{{importFileExtension}},
+    {{/imports}}
+} from './';
+
+{{/hasImports}}
+/**
+ * @type {{classname}}
+ * Type
+ * @export
+ */
+export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};
+
+/**
+* @type {{classname}}Class{{#description}}
+    * {{{.}}}{{/description}}
+* @export
+*/
+export class {{classname}}Class {
+    {{#discriminator}}
+    static readonly discriminator: string | undefined = "{{discriminatorName}}";
+    {{/discriminator}}
+    {{^discriminator}}
+    static readonly discriminator: string | undefined = undefined;
+    {{/discriminator}}
+    {{#hasDiscriminatorWithNonEmptyMapping}}
+
+    static readonly mapping: {[index: string]: string} | undefined = {
+    {{#discriminator.mappedModels}}
+        "{{mappingName}}": "{{modelName}}",
+    {{/discriminator.mappedModels}}
+    };
+    {{/hasDiscriminatorWithNonEmptyMapping}}
+    {{^hasDiscriminatorWithNonEmptyMapping}}
+
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+    {{/hasDiscriminatorWithNonEmptyMapping}}
+}

--- a/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
@@ -97,7 +97,10 @@ export class ObjectSerializer {
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
                         return discriminatorType; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type

--- a/samples/client/others/typescript/builds/with-unique-items/models/Response.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/models/Response.ts
@@ -18,6 +18,8 @@ export class Response {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "nonUniqueArray",

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/ApiResponse.ts
@@ -22,6 +22,8 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "code",

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Category.ts
@@ -21,6 +21,8 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
@@ -114,7 +114,10 @@ export class ObjectSerializer {
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
                         return discriminatorType; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Order.ts
@@ -28,6 +28,8 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Pet.ts
@@ -30,6 +30,8 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Tag.ts
@@ -21,6 +21,8 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/User.ts
@@ -30,6 +30,8 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Cat.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Cat.ts
@@ -18,6 +18,8 @@ export class Cat {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "hunts",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Dog.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Dog.ts
@@ -18,6 +18,8 @@ export class Dog {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "bark",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/FilePostRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/FilePostRequest.ts
@@ -17,6 +17,8 @@ export class FilePostRequest {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "file",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
@@ -12,7 +12,7 @@ import { FilePostRequest } from '../models/FilePostRequest';
 import { PetByAge } from '../models/PetByAge';
 import { PetByType, PetByTypePetTypeEnum    } from '../models/PetByType';
 import { PetsFilteredPatchRequest  , PetsFilteredPatchRequestPetTypeEnum    } from '../models/PetsFilteredPatchRequest';
-import { PetsPatchRequest   , PetsPatchRequestBreedEnum   } from '../models/PetsPatchRequest';
+import { PetsPatchRequestClass } from '../models/PetsPatchRequest';
 
 /* tslint:disable:no-unused-variable */
 let primitives = [
@@ -40,7 +40,7 @@ let typeMap: {[index: string]: any} = {
     "PetByAge": PetByAge,
     "PetByType": PetByType,
     "PetsFilteredPatchRequest": PetsFilteredPatchRequest,
-    "PetsPatchRequest": PetsPatchRequest,
+    "PetsPatchRequest": PetsPatchRequestClass,
 }
 
 type MimeTypeDescriptor = {
@@ -119,7 +119,10 @@ export class ObjectSerializer {
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
                         return discriminatorType; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByAge.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByAge.ts
@@ -18,6 +18,8 @@ export class PetByAge {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "age",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByType.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByType.ts
@@ -18,6 +18,8 @@ export class PetByType {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "petType",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsFilteredPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsFilteredPatchRequest.ts
@@ -22,6 +22,8 @@ export class PetsFilteredPatchRequest {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "age",

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
@@ -14,54 +14,20 @@ import { Cat } from '../models/Cat';
 import { Dog } from '../models/Dog';
 import { HttpFile } from '../http/http';
 
-export class PetsPatchRequest {
-    'hunts'?: boolean;
-    'age'?: number;
-    'bark'?: boolean;
-    'breed'?: PetsPatchRequestBreedEnum;
+/**
+ * @type PetsPatchRequest
+ * Type
+ * @export
+ */
+export type PetsPatchRequest = Cat | Dog;
 
+/**
+* @type PetsPatchRequestClass
+* @export
+*/
+export class PetsPatchRequestClass {
     static readonly discriminator: string | undefined = "petType";
 
-    static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
-        {
-            "name": "hunts",
-            "baseName": "hunts",
-            "type": "boolean",
-            "format": ""
-        },
-        {
-            "name": "age",
-            "baseName": "age",
-            "type": "number",
-            "format": ""
-        },
-        {
-            "name": "bark",
-            "baseName": "bark",
-            "type": "boolean",
-            "format": ""
-        },
-        {
-            "name": "breed",
-            "baseName": "breed",
-            "type": "PetsPatchRequestBreedEnum",
-            "format": ""
-        }    ];
-
-    static getAttributeTypeMap() {
-        return PetsPatchRequest.attributeTypeMap;
-    }
-
-    public constructor() {
-        this.petType = "PetsPatchRequest";
-    }
-}
-
-
-export enum PetsPatchRequestBreedEnum {
-    Dingo = 'Dingo',
-    Husky = 'Husky',
-    Retriever = 'Retriever',
-    Shepherd = 'Shepherd'
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
 }
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ApiResponse.ts
@@ -22,6 +22,8 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "code",

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Category.ts
@@ -21,6 +21,8 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
@@ -114,7 +114,10 @@ export class ObjectSerializer {
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
                         return discriminatorType; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Order.ts
@@ -28,6 +28,8 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Pet.ts
@@ -30,6 +30,8 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Tag.ts
@@ -21,6 +21,8 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/User.ts
@@ -30,6 +30,8 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/ApiResponse.ts
@@ -22,6 +22,8 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "code",

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Category.ts
@@ -21,6 +21,8 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
@@ -114,7 +114,10 @@ export class ObjectSerializer {
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
                         return discriminatorType; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Order.ts
@@ -28,6 +28,8 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Pet.ts
@@ -30,6 +30,8 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Tag.ts
@@ -21,6 +21,8 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/User.ts
@@ -30,6 +30,8 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/ApiResponse.ts
@@ -22,6 +22,8 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "code",

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Category.ts
@@ -21,6 +21,8 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
@@ -114,7 +114,10 @@ export class ObjectSerializer {
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
                         return discriminatorType; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Order.ts
@@ -28,6 +28,8 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Pet.ts
@@ -30,6 +30,8 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Tag.ts
@@ -21,6 +21,8 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/User.ts
@@ -30,6 +30,8 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/ApiResponse.ts
@@ -22,6 +22,8 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "code",

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Category.ts
@@ -21,6 +21,8 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
@@ -114,7 +114,10 @@ export class ObjectSerializer {
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
                         return discriminatorType; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Order.ts
@@ -28,6 +28,8 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Pet.ts
@@ -30,6 +30,8 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Tag.ts
@@ -21,6 +21,8 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/User.ts
@@ -30,6 +30,8 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/ApiResponse.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/ApiResponse.ts
@@ -22,6 +22,8 @@ export class ApiResponse {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "code",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Category.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Category.ts
@@ -21,6 +21,8 @@ export class Category {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
@@ -114,7 +114,10 @@ export class ObjectSerializer {
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
+                    let mapping = typeMap[expectedType].mapping;
+                    if (mapping != undefined && mapping[discriminatorType]) {
+                        return mapping[discriminatorType]; // use the type given in the discriminator
+                    } else if(typeMap[discriminatorType]) {
                         return discriminatorType; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Order.ts
@@ -28,6 +28,8 @@ export class Order {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Pet.ts
@@ -30,6 +30,8 @@ export class Pet {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Tag.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Tag.ts
@@ -21,6 +21,8 @@ export class Tag {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/User.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/User.ts
@@ -30,6 +30,8 @@ export class User {
 
     static readonly discriminator: string | undefined = undefined;
 
+    static readonly mapping: {[index: string]: string} | undefined = undefined;
+
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
             "name": "id",


### PR DESCRIPTION
### Description of the PR
I have implemented `oneOf` schemas as a type union and a `oneOf` class with a discriminator and mapping, similar to [PR 2617](https://github.com/OpenAPITools/openapi-generator/pull/2617) and [PR 2647](https://github.com/OpenAPITools/openapi-generator/pull/2647), but for the TypeScript generator.

The type union is used for methods like request/response types and for models as a type of parameters. The `oneOf` class is used for the deserialization process to determine the type of an object from the type union. It checks the discriminator in the mapping list, then in the list of all classes.

Before this PR, the TypeScript generator created a new model with all fields from all `oneOf` models. The created model is not described in the swagger files. There are the following problems:

- It doesn't work if `oneOf` models have fields with the same name but different types.
- It doesn't work if  `oneOf` models have enum fields with the same name but different values in the enum.
- It doesn't work if  `oneOf` has a mapping list.
- If  `oneOf` models contain required fields, a user has to set all required fields, even if they are not needed for the request.
- It doesn't look like  `oneOf`. If generate docs by the swagger with "oneOf", it won’t match the generated docs.

The implementation "oneOf" schemas as a type union resolve all these problems, making the generated code accurate with the swagger specification.

Sample input:

```json
"inputFieldDependencies" : {
    "type" : "array",
    "items" : {
        "oneOf" : [ {
            "$ref" : "#/components/schemas/PublicSingleFieldDependency"
        }, {
            "$ref" : "#/components/schemas/PublicConditionalSingleFieldDependency"
        } ],
        "discriminator": {
            "propertyName": "dependencyType",
            "mapping": {
                "SINGLE_FIELD": "#/components/schemas/PublicSingleFieldDependency",
                "CONDITIONAL_SINGLE_FIELD": "#/components/schemas/PublicConditionalSingleFieldDependency"
            }
        }
    }
},
```

Sample output:
```Typescript
import { PublicConditionalSingleFieldDependency } from '../models/PublicConditionalSingleFieldDependency';
import { PublicSingleFieldDependency } from '../models/PublicSingleFieldDependency';

export type PublicActionDefinitionInputFieldDependenciesInner = PublicConditionalSingleFieldDependency | PublicSingleFieldDependency;

export class PublicActionDefinitionInputFieldDependenciesInnerClass {
    static readonly discriminator: string | undefined = "dependencyType";

    static readonly mapping: {[index: string]: string} | undefined = {
        "CONDITIONAL_SINGLE_FIELD": "PublicConditionalSingleFieldDependency",
        "SINGLE_FIELD": "PublicSingleFieldDependency",
    };
}
```

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

### Related issues: 

https://github.com/OpenAPITools/openapi-generator/issues/9305