### PR TITLE
[Kotlin][Client] Encode default values with kotlinx serialization

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
@@ -143,6 +143,7 @@ import java.util.concurrent.atomic.AtomicLong
     val kotlinxSerializationJson: Json by lazy {
         Json {
             serializersModule = kotlinxSerializationAdapters
+            encodeDefaults = true
             ignoreUnknownKeys = true
             isLenient = true
         }

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -45,6 +45,7 @@ object Serializer {
     val kotlinxSerializationJson: Json by lazy {
         Json {
             serializersModule = kotlinxSerializationAdapters
+            encodeDefaults = true
             ignoreUnknownKeys = true
             isLenient = true
         }

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -45,6 +45,7 @@ object Serializer {
     val kotlinxSerializationJson: Json by lazy {
         Json {
             serializersModule = kotlinxSerializationAdapters
+            encodeDefaults = true
             ignoreUnknownKeys = true
             isLenient = true
         }

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -45,6 +45,7 @@ object Serializer {
     val kotlinxSerializationJson: Json by lazy {
         Json {
             serializersModule = kotlinxSerializationAdapters
+            encodeDefaults = true
             ignoreUnknownKeys = true
             isLenient = true
         }


### PR DESCRIPTION
Currently kotlinx serialization doesn't encode properties that have the default value, which is a bit strange and can lead to errors.

Here you can find more information about it.

https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/basic-serialization.md#defaults-are-not-encoded-by-default

```
@Serializable
data class Project(val name: String, val language: String = "Kotlin")

fun main() {
    val data = Project("kotlinx.serialization")
    println(Json.encodeToString(data))
}
```

This code will have the following output

```
{"name":"kotlinx.serialization"}
```

Which will lead to errors if the server is not expecting this behaviour.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jimschubert (2017/09) [❤️](https://www.patreon.com/jimschubert), @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06)