### PR TITLE
[PowerShell][Bug] Fix issue #18428 - [System.IO.FileInfo] object used in multipart/form-data submission does not support relative paths 

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/api.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/api.mustache
@@ -146,19 +146,34 @@ function {{{vendorExtensions.x-powershell-method-name}}} {
         if (!${{{paramName}}}) {
             throw "Error! The required parameter `{{paramName}}` missing when calling {{operationId}}."
         }
+        {{#isFile}}
+        $LocalVarFormParameters['{{baseName}}'] = $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(${{{paramName}}})
+        {{/isFile}}
+        {{^isFile}}
         $LocalVarFormParameters['{{baseName}}'] = ${{{paramName}}}
+        {{/isFile}}
 
         {{/isNullable}}
         {{/required}}
         {{^required}}
         {{^isNullable}}
         if (${{{paramName}}}) {
+        {{#isFile}}
+            $LocalVarFormParameters['{{baseName}}'] = $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(${{{paramName}}})
+        {{/isFile}}
+        {{^isFile}}
             $LocalVarFormParameters['{{baseName}}'] = ${{{paramName}}}
+        {{/isFile}}
         }
 
         {{/isNullable}}
         {{#isNullable}}
+        {{#isFile}}
+        $LocalVarFormParameters['{{baseName}}'] = $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(${{{paramName}}})
+        {{/isFile}}
+        {{^isFile}}
         $LocalVarFormParameters['{{baseName}}'] = ${{{paramName}}}
+        {{/isFile}}
 
         {{/isNullable}}
         {{/required}}

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Api/BodyApi.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Api/BodyApi.ps1
@@ -198,7 +198,7 @@ function Test-BodyMultipartFormdataArrayOfBinary {
         if (!$Files) {
             throw "Error! The required parameter `Files` missing when calling test_body_multipart_formdata_arrayOfBinary."
         }
-        $LocalVarFormParameters['files'] = $Files
+        $LocalVarFormParameters['files'] = $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Files)
 
         $LocalVarResult = Invoke-ApiClient -Method 'POST' `
                                 -Uri $LocalVarUri `
@@ -273,7 +273,7 @@ function Test-BodyMultipartFormdataSingleBinary {
         $LocalVarUri = '/body/application/octetstream/single_binary'
 
         if ($MyFile) {
-            $LocalVarFormParameters['my-file'] = $MyFile
+            $LocalVarFormParameters['my-file'] = $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($MyFile)
         }
 
         $LocalVarResult = Invoke-ApiClient -Method 'POST' `

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSFakeApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSFakeApi.ps1
@@ -909,7 +909,7 @@ function Test-PSEndpointParameters {
         $LocalVarFormParameters['byte'] = $Byte
 
         if ($Binary) {
-            $LocalVarFormParameters['binary'] = $Binary
+            $LocalVarFormParameters['binary'] = $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Binary)
         }
 
         if ($Date) {

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSPetApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSPetApi.ps1
@@ -679,7 +679,7 @@ function Invoke-PSUploadFile {
         }
 
         if ($File) {
-            $LocalVarFormParameters['file'] = $File
+            $LocalVarFormParameters['file'] = $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($File)
         }
 
 
@@ -778,7 +778,7 @@ function Invoke-PSUploadFileWithRequiredFile {
         if (!$RequiredFile) {
             throw "Error! The required parameter `RequiredFile` missing when calling uploadFileWithRequiredFile."
         }
-        $LocalVarFormParameters['requiredFile'] = $RequiredFile
+        $LocalVarFormParameters['requiredFile'] = $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($RequiredFile)
 
 
         $LocalVarResult = Invoke-PSApiClient -Method 'POST' `


### PR DESCRIPTION
When the path of an object of type `System.IO.FileInfo` is relative, the full path is calculated using as directory the value returned by `[System.IO.Directory]::GetCurrentDirectory()`, which is a constant rather than the value returned by `Get-Location`. See [Issue #18428](https://github.com/OpenAPITools/openapi-generator/issues/18428)

This fix uses the method [GetUnresolvedProviderPathFromPSPath](https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.pathintrinsics.getunresolvedproviderpathfrompspath?view=powershellsdk-1.1.0) to resolve a path relative to the current directory. Only form parameters of type `System.IO.FileInfo` are affected.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@wing328 
