### PR TITLE
Refactored Identifiers

### DIFF
--- a/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/config/WorkflowSettingsTest.java
+++ b/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/config/WorkflowSettingsTest.java
@@ -62,14 +62,14 @@ public class WorkflowSettingsTest {
                 .withGlobalProperty("second", "2nd")
                 .build();
 
-        Map<String, String> properties = modified.getGlobalProperties();
-        assertEquals(properties.size(), 2, "System Properties map should allow mutation when invoked via copy constructor");
-        assertEquals(properties.getOrDefault("first", ""), "1st");
-        assertEquals(properties.getOrDefault("second", ""), "2nd");
+        Map<String, String> globalProperties = modified.getGlobalProperties();
+        assertEquals(globalProperties.size(), 2, "System Properties map should allow mutation when invoked via copy constructor");
+        assertEquals(globalProperties.getOrDefault("first", ""), "1st");
+        assertEquals(globalProperties.getOrDefault("second", ""), "2nd");
     }
 
-    private void assertOnChangesToDefaults(WorkflowSettings defaults) {
-        WorkflowSettings settings = WorkflowSettings.newBuilder()
+    private void assertOnChangesToDefaults(WorkflowSettings defaultSettings) {
+        WorkflowSettings newSettings = WorkflowSettings.newBuilder()
                 .withOutputDir("output")
                 .withVerbose(true)
                 .withSkipOverwrite(true)
@@ -81,32 +81,32 @@ public class WorkflowSettingsTest {
                 .withStrictSpecBehavior(false)
                 .build();
 
-        assertNotEquals(defaults.getOutputDir(), settings.getOutputDir());
-        assertEquals(settings.getOutputDir(), Paths.get("output").toAbsolutePath().toString());
+        assertNotEquals(defaultSettings.getOutputDir(), newSettings.getOutputDir());
+        assertEquals(newSettings.getOutputDir(), Paths.get("output").toAbsolutePath().toString());
 
-        assertNotEquals(defaults.isVerbose(), settings.isVerbose());
-        assertTrue(settings.isVerbose());
+        assertNotEquals(defaultSettings.isVerbose(), newSettings.isVerbose());
+        assertTrue(newSettings.isVerbose());
 
-        assertNotEquals(defaults.isSkipOverwrite(), settings.isSkipOverwrite());
-        assertTrue(settings.isSkipOverwrite());
+        assertNotEquals(defaultSettings.isSkipOverwrite(), newSettings.isSkipOverwrite());
+        assertTrue(newSettings.isSkipOverwrite());
 
-        assertNotEquals(defaults.isRemoveOperationIdPrefix(), settings.isRemoveOperationIdPrefix());
-        assertTrue(settings.isRemoveOperationIdPrefix());
+        assertNotEquals(defaultSettings.isRemoveOperationIdPrefix(), newSettings.isRemoveOperationIdPrefix());
+        assertTrue(newSettings.isRemoveOperationIdPrefix());
 
-        assertNotEquals(defaults.isLogToStderr(), settings.isLogToStderr());
-        assertTrue(settings.isLogToStderr());
+        assertNotEquals(defaultSettings.isLogToStderr(), newSettings.isLogToStderr());
+        assertTrue(newSettings.isLogToStderr());
 
-        assertNotEquals(defaults.isValidateSpec(), settings.isValidateSpec());
-        assertFalse(settings.isValidateSpec());
+        assertNotEquals(defaultSettings.isValidateSpec(), newSettings.isValidateSpec());
+        assertFalse(newSettings.isValidateSpec());
 
-        assertNotEquals(defaults.isEnablePostProcessFile(), settings.isEnablePostProcessFile());
-        assertTrue(settings.isEnablePostProcessFile());
+        assertNotEquals(defaultSettings.isEnablePostProcessFile(), newSettings.isEnablePostProcessFile());
+        assertTrue(newSettings.isEnablePostProcessFile());
 
-        assertNotEquals(defaults.isEnableMinimalUpdate(), settings.isEnableMinimalUpdate());
-        assertTrue(settings.isEnableMinimalUpdate());
+        assertNotEquals(defaultSettings.isEnableMinimalUpdate(), newSettings.isEnableMinimalUpdate());
+        assertTrue(newSettings.isEnableMinimalUpdate());
 
-        assertNotEquals(defaults.isStrictSpecBehavior(), settings.isStrictSpecBehavior());
-        assertFalse(settings.isStrictSpecBehavior());
+        assertNotEquals(defaultSettings.isStrictSpecBehavior(), newSettings.isStrictSpecBehavior());
+        assertFalse(newSettings.isStrictSpecBehavior());
     }
 
     @Test


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Refactored certain identifiers to more appropriate names according to the identifier's usages. This is to improve code clarity.
<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
