### PR TITLE
fix(kotlin-spring): Template contains ": Serializable" which creates error on derived classes

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/dataClass.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/dataClass.mustache
@@ -17,7 +17,7 @@
 {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}},
 {{/hasOptional}}{{/hasRequired}}{{#optionalVars}}{{>dataClassOptVar}}{{^-last}},
 {{/-last}}{{/optionalVars}}
-) {{/discriminator}}{{#parent}}: {{{.}}}{{#serializableModel}}, Serializable{{/serializableModel}}{{/parent}}{{#serializableModel}}: Serializable{{/serializableModel}}{
+    ) {{/discriminator}}{{#parent}}: {{{.}}}{{#serializableModel}}, Serializable{{/serializableModel}}{{/parent}}{{^parent}}{{#serializableModel}}: Serializable{{/serializableModel}}{{/parent}}{
 {{#discriminator}}
     {{#requiredVars}}
         {{>interfaceReqVar}}

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Category.kt
@@ -24,7 +24,7 @@ data class Category(
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -26,7 +26,7 @@ data class ModelApiResponse(
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
     @get:JsonProperty("message") val message: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Order.kt
@@ -37,7 +37,7 @@ data class Order(
     @get:JsonProperty("status") val status: Order.Status? = null,
 
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) : Serializable{
+    ) : Serializable{
 
     /**
     * Order Status

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -42,7 +42,7 @@ data class Pet(
 
     @Deprecated(message = "")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) : Serializable{
+    ) : Serializable{
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,7 +23,7 @@ data class Tag(
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:JsonProperty("name") val name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/User.kt
@@ -41,7 +41,7 @@ data class User(
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Annotation.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Annotation.kt
@@ -21,7 +21,7 @@ data class Annotation(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("id") val id: java.util.UUID? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPet.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPet.kt
@@ -78,7 +78,7 @@ data class AnyOfUserOrPet(
     @Schema(example = "null", description = "pet status in the store")
     @Deprecated(message = "")
     @get:JsonProperty("status") val status: AnyOfUserOrPet.Status? = null
-) {
+    ) {
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPetOrArrayString.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPetOrArrayString.kt
@@ -78,7 +78,7 @@ data class AnyOfUserOrPetOrArrayString(
     @Schema(example = "null", description = "pet status in the store")
     @Deprecated(message = "")
     @get:JsonProperty("status") val status: AnyOfUserOrPetOrArrayString.Status? = null
-) {
+    ) {
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Category.kt
@@ -26,7 +26,7 @@ data class Category(
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -29,7 +29,7 @@ data class ModelApiResponse(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("message") val message: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Order.kt
@@ -43,7 +43,7 @@ data class Order(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) {
+    ) {
 
     /**
     * Order Status

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -48,7 +48,7 @@ data class Pet(
     @Schema(example = "null", description = "pet status in the store")
     @Deprecated(message = "")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) {
+    ) {
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -25,7 +25,7 @@ data class Tag(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/User.kt
@@ -49,7 +49,7 @@ data class User(
 
     @Schema(example = "null", description = "User Status")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/UserOrPet.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/UserOrPet.kt
@@ -78,7 +78,7 @@ data class UserOrPet(
     @Schema(example = "null", description = "pet status in the store")
     @Deprecated(message = "")
     @get:JsonProperty("status") val status: UserOrPet.Status? = null
-) {
+    ) {
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/UserOrPetOrArrayString.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/UserOrPetOrArrayString.kt
@@ -78,7 +78,7 @@ data class UserOrPetOrArrayString(
     @Schema(example = "null", description = "pet status in the store")
     @Deprecated(message = "")
     @get:JsonProperty("status") val status: UserOrPetOrArrayString.Status? = null
-) {
+    ) {
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Category.kt
@@ -24,7 +24,7 @@ data class Category(
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -26,7 +26,7 @@ data class ModelApiResponse(
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
     @get:JsonProperty("message") val message: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Order.kt
@@ -37,7 +37,7 @@ data class Order(
     @get:JsonProperty("status") val status: Order.Status? = null,
 
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) : Serializable{
+    ) : Serializable{
 
     /**
     * Order Status

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -42,7 +42,7 @@ data class Pet(
 
     @Deprecated(message = "")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) : Serializable{
+    ) : Serializable{
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,7 +23,7 @@ data class Tag(
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:JsonProperty("name") val name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/User.kt
@@ -41,7 +41,7 @@ data class User(
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-bigdecimal-default/src/main/kotlin/org/openapitools/model/Apa.kt
+++ b/samples/server/petstore/kotlin-springboot-bigdecimal-default/src/main/kotlin/org/openapitools/model/Apa.kt
@@ -42,7 +42,7 @@ data class Apa(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("gepa") val gepa: java.math.BigDecimal? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Category.kt
@@ -26,7 +26,7 @@ data class Category(
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -29,7 +29,7 @@ data class ModelApiResponse(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("message") val message: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Order.kt
@@ -43,7 +43,7 @@ data class Order(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) {
+    ) {
 
     /**
     * Order Status

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -48,7 +48,7 @@ data class Pet(
     @Schema(example = "null", description = "pet status in the store")
     @Deprecated(message = "")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) {
+    ) {
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -25,7 +25,7 @@ data class Tag(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/User.kt
@@ -49,7 +49,7 @@ data class User(
 
     @Schema(example = "null", description = "User Status")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Category.kt
@@ -26,7 +26,7 @@ data class Category(
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -29,7 +29,7 @@ data class ModelApiResponse(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("message") val message: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Order.kt
@@ -43,7 +43,7 @@ data class Order(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) {
+    ) {
 
     /**
     * Order Status

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -48,7 +48,7 @@ data class Pet(
     @Schema(example = "null", description = "pet status in the store")
     @Deprecated(message = "")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) {
+    ) {
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -25,7 +25,7 @@ data class Tag(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/User.kt
@@ -49,7 +49,7 @@ data class User(
 
     @Schema(example = "null", description = "User Status")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-integer-enum/src/main/kotlin/org/openapitools/model/ApiError.kt
+++ b/samples/server/petstore/kotlin-springboot-integer-enum/src/main/kotlin/org/openapitools/model/ApiError.kt
@@ -26,7 +26,7 @@ data class ApiError(
 
     @field:Valid
     @get:JsonProperty("reasonCode") val reasonCode: ReasonCode? = null
-) {
+    ) {
 
     /**
     * 

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Category.kt
@@ -26,7 +26,7 @@ data class Category(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") var name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -30,7 +30,7 @@ data class ModelApiResponse(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("message") var message: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Order.kt
@@ -44,7 +44,7 @@ data class Order(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("complete") var complete: kotlin.Boolean? = false
-) : Serializable{
+    ) : Serializable{
 
     /**
     * Order Status

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -48,7 +48,7 @@ data class Pet(
 
     @Schema(example = "null", description = "pet status in the store")
     @get:JsonProperty("status") var status: Pet.Status? = null
-) : Serializable{
+    ) : Serializable{
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -26,7 +26,7 @@ data class Tag(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") var name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/User.kt
@@ -50,7 +50,7 @@ data class User(
 
     @Schema(example = "null", description = "User Status")
     @get:JsonProperty("userStatus") var userStatus: kotlin.Int? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-multipart-request-model/src/main/kotlin/org/openapitools/model/MultipartMixedRequestMarker.kt
+++ b/samples/server/petstore/kotlin-springboot-multipart-request-model/src/main/kotlin/org/openapitools/model/MultipartMixedRequestMarker.kt
@@ -21,7 +21,7 @@ data class MultipartMixedRequestMarker(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Category.kt
@@ -25,7 +25,7 @@ data class Category(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -29,7 +29,7 @@ data class ModelApiResponse(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("message") val message: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Order.kt
@@ -43,7 +43,7 @@ data class Order(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) {
+    ) {
 
     /**
     * Order Status

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -47,7 +47,7 @@ data class Pet(
 
     @Schema(example = "null", description = "pet status in the store")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) {
+    ) {
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -25,7 +25,7 @@ data class Tag(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/User.kt
@@ -49,7 +49,7 @@ data class User(
 
     @Schema(example = "null", description = "User Status")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Cat.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Cat.kt
@@ -28,7 +28,7 @@ data class Cat(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("color") override val color: kotlin.String? = "red"
-) : Animal{
+    ) : Animal{
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Category.kt
@@ -25,7 +25,7 @@ data class Category(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("id") val id: kotlin.Long? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Client.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Client.kt
@@ -21,7 +21,7 @@ data class Client(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("client") val client: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Dog.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Dog.kt
@@ -28,7 +28,7 @@ data class Dog(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("color") override val color: kotlin.String? = "red"
-) : Animal{
+    ) : Animal{
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Foo.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Foo.kt
@@ -21,7 +21,7 @@ data class Foo(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("bar") val bar: kotlin.String? = "bar"
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/FooGetDefaultResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/FooGetDefaultResponse.kt
@@ -23,7 +23,7 @@ data class FooGetDefaultResponse(
     @field:Valid
     @Schema(example = "null", description = "")
     @get:JsonProperty("string") val string: Foo? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -29,7 +29,7 @@ data class ModelApiResponse(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("message") val message: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Order.kt
@@ -43,7 +43,7 @@ data class Order(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) {
+    ) {
 
     /**
     * Order Status

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -47,7 +47,7 @@ data class Pet(
 
     @Schema(example = "null", description = "pet status in the store")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) {
+    ) {
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -25,7 +25,7 @@ data class Tag(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/User.kt
@@ -49,7 +49,7 @@ data class User(
 
     @Schema(example = "null", description = "User Status")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/model/Category.kt
@@ -25,7 +25,7 @@ data class Category(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -29,7 +29,7 @@ data class ModelApiResponse(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("message") val message: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/model/Order.kt
@@ -43,7 +43,7 @@ data class Order(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) {
+    ) {
 
     /**
     * Order Status

--- a/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -47,7 +47,7 @@ data class Pet(
 
     @Schema(example = "null", description = "pet status in the store")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) {
+    ) {
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -25,7 +25,7 @@ data class Tag(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-request/src/main/kotlin/org/openapitools/model/User.kt
@@ -49,7 +49,7 @@ data class User(
 
     @Schema(example = "null", description = "User Status")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) {
+    ) {
 
 }
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Category.kt
@@ -26,7 +26,7 @@ data class Category(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -30,7 +30,7 @@ data class ModelApiResponse(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("message") val message: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Order.kt
@@ -44,7 +44,7 @@ data class Order(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) : Serializable{
+    ) : Serializable{
 
     /**
     * Order Status

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -48,7 +48,7 @@ data class Pet(
 
     @ApiModelProperty(example = "null", value = "pet status in the store")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) : Serializable{
+    ) : Serializable{
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -26,7 +26,7 @@ data class Tag(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/User.kt
@@ -50,7 +50,7 @@ data class User(
 
     @ApiModelProperty(example = "null", value = "User Status")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Category.kt
@@ -26,7 +26,7 @@ data class Category(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -30,7 +30,7 @@ data class ModelApiResponse(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("message") val message: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Order.kt
@@ -44,7 +44,7 @@ data class Order(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) : Serializable{
+    ) : Serializable{
 
     /**
     * Order Status

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -48,7 +48,7 @@ data class Pet(
 
     @Schema(example = "null", description = "pet status in the store")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) : Serializable{
+    ) : Serializable{
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -26,7 +26,7 @@ data class Tag(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/User.kt
@@ -50,7 +50,7 @@ data class User(
 
     @Schema(example = "null", description = "User Status")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Category.kt
@@ -26,7 +26,7 @@ data class Category(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -30,7 +30,7 @@ data class ModelApiResponse(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("message") val message: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Order.kt
@@ -44,7 +44,7 @@ data class Order(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) : Serializable{
+    ) : Serializable{
 
     /**
     * Order Status

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -48,7 +48,7 @@ data class Pet(
 
     @ApiModelProperty(example = "null", value = "pet status in the store")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) : Serializable{
+    ) : Serializable{
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -26,7 +26,7 @@ data class Tag(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/User.kt
@@ -50,7 +50,7 @@ data class User(
 
     @ApiModelProperty(example = "null", value = "User Status")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,7 +23,7 @@ data class Category(
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:JsonProperty("name") val name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -26,7 +26,7 @@ data class ModelApiResponse(
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
     @get:JsonProperty("message") val message: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
@@ -37,7 +37,7 @@ data class Order(
     @get:JsonProperty("status") val status: Order.Status? = null,
 
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) : Serializable{
+    ) : Serializable{
 
     /**
     * Order Status

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -41,7 +41,7 @@ data class Pet(
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
     @get:JsonProperty("status") val status: Pet.Status? = null
-) : Serializable{
+    ) : Serializable{
 
     /**
     * pet status in the store

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,7 +23,7 @@ data class Tag(
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:JsonProperty("name") val name: kotlin.String? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/User.kt
@@ -41,7 +41,7 @@ data class User(
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) : Serializable{
+    ) : Serializable{
 
     companion object {
         private const val serialVersionUID: kotlin.Long = 1


### PR DESCRIPTION
In `kotlin-spring` Generator, data classes have an extra ": Serializable" which breaks compilation of generated classes.

Kotlin committee members
@jimschubert
@dr4ke616
@karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Adjust dataClass.mustache and remove ": Serializable"

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
