### PR TITLE
feat(typescript-axios): support useSquareBracketsInArrayNames in queryParams

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
@@ -100,7 +100,7 @@ export const {{classname}}AxiosParamCreator = function (configuration?: Configur
                 localVarQueryParameter['{{baseName}}'] = Array.from({{paramName}});
                 {{/uniqueItems}}
                 {{^uniqueItems}}
-                localVarQueryParameter['{{baseName}}'] = {{paramName}};
+                localVarQueryParameter['{{baseName}}{{#useSquareBracketsInArrayNames}}[]{{/useSquareBracketsInArrayNames}}'] = {{paramName}};
                 {{/uniqueItems}}
             {{/isCollectionFormatMulti}}
             {{^isCollectionFormatMulti}}


### PR DESCRIPTION
In the [typescript-axios README](https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/typescript-axios.md) for the parameter `useSquareBracketsInArrayNames` I read: 
> Setting this property to true will add brackets to array attribute names, e.g. my_values[].

I would expect it to work for `queryParams` but currently it works only for `formParams`: https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache#L197

According to the OpenAPI specs there is currently [no way](https://stackoverflow.com/questions/52892768/openapi-query-string-parameter-with-list-of-objects/52894157#52894157)  to define query parameters with square brackets (`q[]=string1&q[]=string2`). This is because `style: deepObject` 's behavior is not defined for arrays.

There is a workaround though, which postfixing the variable name with `[]`: https://stackoverflow.com/questions/37878018/can-i-make-swagger-php-use-arrays-on-the-query-string/43465801#43465801

Being somewhat of an hack it wouldn't be easy to automatically postfix all array variable names if you user OpenAPI generation tools like [laravel-openapi](https://github.com/vyuldashev/laravel-openapi) on the server.

If typescript-axios would honor `useSquareBracketsInArrayNames` for `queryParams` there would be no need to apply such hack on the server side because it would be done automatically on the client side instead.