### PR TITLE
[C++][Pistache] Add error handlers overload taking the response object

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-header.mustache
@@ -45,7 +45,21 @@ private:
     /// May be overridden to return custom error formats. This is called inside a catch block.
     /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
+    virtual void handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during Parameter parsing and validation.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleParsingException(const std::exception& ex) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
+    virtual void handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-source.mustache
@@ -33,6 +33,12 @@ void {{classname}}::setupRoutes() {
     router->addCustomHandler(Routes::bind(&{{classname}}::{{classnameSnakeLowerCase}}_default_handler, this));
 }
 
+void {{classname}}::handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleParsingException(ex);
+    response.send(codeAndError.first, codeAndError.second);
+}
+
 std::pair<Pistache::Http::Code, std::string> {{classname}}::handleParsingException(const std::exception& ex) const noexcept
 {
     try {
@@ -44,6 +50,12 @@ std::pair<Pistache::Http::Code, std::string> {{classname}}::handleParsingExcepti
     } catch (std::exception &e) {
         return std::make_pair(Pistache::Http::Code::Internal_Server_Error, e.what());
     }
+}
+
+void {{classname}}::handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleOperationException(ex);
+    response.send(codeAndError.first, codeAndError.second);
 }
 
 std::pair<Pistache::Http::Code, std::string> {{classname}}::handleOperationException(const std::exception& ex) const noexcept
@@ -102,8 +114,7 @@ void {{classname}}::{{operationIdSnakeCase}}_handler(const Pistache::Rest::Reque
         {{paramName}} = request.body();
     {{/isPrimitiveType}}
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -120,8 +131,7 @@ void {{classname}}::{{operationIdSnakeCase}}_handler(const Pistache::Rest::Reque
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 

--- a/samples/server/petstore/cpp-pistache-everything/api/PetApi.cpp
+++ b/samples/server/petstore/cpp-pistache-everything/api/PetApi.cpp
@@ -46,6 +46,12 @@ void PetApi::setupRoutes() {
     router->addCustomHandler(Routes::bind(&PetApi::pet_api_default_handler, this));
 }
 
+void PetApi::handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleParsingException(ex);
+    response.send(codeAndError.first, codeAndError.second);
+}
+
 std::pair<Pistache::Http::Code, std::string> PetApi::handleParsingException(const std::exception& ex) const noexcept
 {
     try {
@@ -57,6 +63,12 @@ std::pair<Pistache::Http::Code, std::string> PetApi::handleParsingException(cons
     } catch (std::exception &e) {
         return std::make_pair(Pistache::Http::Code::Internal_Server_Error, e.what());
     }
+}
+
+void PetApi::handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleOperationException(ex);
+    response.send(codeAndError.first, codeAndError.second);
 }
 
 std::pair<Pistache::Http::Code, std::string> PetApi::handleOperationException(const std::exception& ex) const noexcept
@@ -76,8 +88,7 @@ void PetApi::add_pet_handler(const Pistache::Rest::Request &request, Pistache::H
         nlohmann::json::parse(request.body()).get_to(pet);
         pet.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -87,8 +98,7 @@ void PetApi::add_pet_handler(const Pistache::Rest::Request &request, Pistache::H
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -112,8 +122,7 @@ void PetApi::delete_pet_handler(const Pistache::Rest::Request &request, Pistache
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -142,8 +151,7 @@ void PetApi::find_pets_by_status_handler(const Pistache::Rest::Request &request,
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -172,8 +180,7 @@ void PetApi::find_pets_by_tags_handler(const Pistache::Rest::Request &request, P
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -194,8 +201,7 @@ void PetApi::get_pet_by_id_handler(const Pistache::Rest::Request &request, Pista
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -216,8 +222,7 @@ void PetApi::update_pet_handler(const Pistache::Rest::Request &request, Pistache
         nlohmann::json::parse(request.body()).get_to(pet);
         pet.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -227,8 +232,7 @@ void PetApi::update_pet_handler(const Pistache::Rest::Request &request, Pistache
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -246,8 +250,7 @@ void PetApi::update_pet_with_form_handler(const Pistache::Rest::Request &request
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -265,8 +268,7 @@ void PetApi::upload_file_handler(const Pistache::Rest::Request &request, Pistach
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 

--- a/samples/server/petstore/cpp-pistache-everything/api/PetApi.h
+++ b/samples/server/petstore/cpp-pistache-everything/api/PetApi.h
@@ -62,7 +62,21 @@ private:
     /// May be overridden to return custom error formats. This is called inside a catch block.
     /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
+    virtual void handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during Parameter parsing and validation.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleParsingException(const std::exception& ex) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
+    virtual void handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.

--- a/samples/server/petstore/cpp-pistache-everything/api/StoreApi.cpp
+++ b/samples/server/petstore/cpp-pistache-everything/api/StoreApi.cpp
@@ -42,6 +42,12 @@ void StoreApi::setupRoutes() {
     router->addCustomHandler(Routes::bind(&StoreApi::store_api_default_handler, this));
 }
 
+void StoreApi::handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleParsingException(ex);
+    response.send(codeAndError.first, codeAndError.second);
+}
+
 std::pair<Pistache::Http::Code, std::string> StoreApi::handleParsingException(const std::exception& ex) const noexcept
 {
     try {
@@ -53,6 +59,12 @@ std::pair<Pistache::Http::Code, std::string> StoreApi::handleParsingException(co
     } catch (std::exception &e) {
         return std::make_pair(Pistache::Http::Code::Internal_Server_Error, e.what());
     }
+}
+
+void StoreApi::handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleOperationException(ex);
+    response.send(codeAndError.first, codeAndError.second);
 }
 
 std::pair<Pistache::Http::Code, std::string> StoreApi::handleOperationException(const std::exception& ex) const noexcept
@@ -72,8 +84,7 @@ void StoreApi::delete_order_handler(const Pistache::Rest::Request &request, Pist
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -92,8 +103,7 @@ void StoreApi::get_inventory_handler(const Pistache::Rest::Request &, Pistache::
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -114,8 +124,7 @@ void StoreApi::get_order_by_id_handler(const Pistache::Rest::Request &request, P
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -136,8 +145,7 @@ void StoreApi::place_order_handler(const Pistache::Rest::Request &request, Pista
         nlohmann::json::parse(request.body()).get_to(order);
         order.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -147,8 +155,7 @@ void StoreApi::place_order_handler(const Pistache::Rest::Request &request, Pista
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 

--- a/samples/server/petstore/cpp-pistache-everything/api/StoreApi.h
+++ b/samples/server/petstore/cpp-pistache-everything/api/StoreApi.h
@@ -57,7 +57,21 @@ private:
     /// May be overridden to return custom error formats. This is called inside a catch block.
     /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
+    virtual void handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during Parameter parsing and validation.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleParsingException(const std::exception& ex) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
+    virtual void handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.

--- a/samples/server/petstore/cpp-pistache-everything/api/UserApi.cpp
+++ b/samples/server/petstore/cpp-pistache-everything/api/UserApi.cpp
@@ -46,6 +46,12 @@ void UserApi::setupRoutes() {
     router->addCustomHandler(Routes::bind(&UserApi::user_api_default_handler, this));
 }
 
+void UserApi::handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleParsingException(ex);
+    response.send(codeAndError.first, codeAndError.second);
+}
+
 std::pair<Pistache::Http::Code, std::string> UserApi::handleParsingException(const std::exception& ex) const noexcept
 {
     try {
@@ -57,6 +63,12 @@ std::pair<Pistache::Http::Code, std::string> UserApi::handleParsingException(con
     } catch (std::exception &e) {
         return std::make_pair(Pistache::Http::Code::Internal_Server_Error, e.what());
     }
+}
+
+void UserApi::handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleOperationException(ex);
+    response.send(codeAndError.first, codeAndError.second);
 }
 
 std::pair<Pistache::Http::Code, std::string> UserApi::handleOperationException(const std::exception& ex) const noexcept
@@ -76,8 +88,7 @@ void UserApi::create_user_handler(const Pistache::Rest::Request &request, Pistac
         nlohmann::json::parse(request.body()).get_to(user);
         user.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -87,8 +98,7 @@ void UserApi::create_user_handler(const Pistache::Rest::Request &request, Pistac
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -109,8 +119,7 @@ void UserApi::create_users_with_array_input_handler(const Pistache::Rest::Reques
         for (const auto& validationParam : user)
              validationParam.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -120,8 +129,7 @@ void UserApi::create_users_with_array_input_handler(const Pistache::Rest::Reques
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -142,8 +150,7 @@ void UserApi::create_users_with_list_input_handler(const Pistache::Rest::Request
         for (const auto& validationParam : user)
              validationParam.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -153,8 +160,7 @@ void UserApi::create_users_with_list_input_handler(const Pistache::Rest::Request
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -175,8 +181,7 @@ void UserApi::delete_user_handler(const Pistache::Rest::Request &request, Pistac
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -197,8 +202,7 @@ void UserApi::get_user_by_name_handler(const Pistache::Rest::Request &request, P
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -235,8 +239,7 @@ void UserApi::login_user_handler(const Pistache::Rest::Request &request, Pistach
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -255,8 +258,7 @@ void UserApi::logout_user_handler(const Pistache::Rest::Request &, Pistache::Htt
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -279,8 +281,7 @@ void UserApi::update_user_handler(const Pistache::Rest::Request &request, Pistac
         nlohmann::json::parse(request.body()).get_to(user);
         user.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -290,8 +291,7 @@ void UserApi::update_user_handler(const Pistache::Rest::Request &request, Pistac
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 

--- a/samples/server/petstore/cpp-pistache-everything/api/UserApi.h
+++ b/samples/server/petstore/cpp-pistache-everything/api/UserApi.h
@@ -61,7 +61,21 @@ private:
     /// May be overridden to return custom error formats. This is called inside a catch block.
     /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
+    virtual void handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during Parameter parsing and validation.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleParsingException(const std::exception& ex) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
+    virtual void handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.

--- a/samples/server/petstore/cpp-pistache-nested-schema-refs/api/StoreApi.cpp
+++ b/samples/server/petstore/cpp-pistache-nested-schema-refs/api/StoreApi.cpp
@@ -39,6 +39,12 @@ void StoreApi::setupRoutes() {
     router->addCustomHandler(Routes::bind(&StoreApi::store_api_default_handler, this));
 }
 
+void StoreApi::handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleParsingException(ex);
+    response.send(codeAndError.first, codeAndError.second);
+}
+
 std::pair<Pistache::Http::Code, std::string> StoreApi::handleParsingException(const std::exception& ex) const noexcept
 {
     try {
@@ -50,6 +56,12 @@ std::pair<Pistache::Http::Code, std::string> StoreApi::handleParsingException(co
     } catch (std::exception &e) {
         return std::make_pair(Pistache::Http::Code::Internal_Server_Error, e.what());
     }
+}
+
+void StoreApi::handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleOperationException(ex);
+    response.send(codeAndError.first, codeAndError.second);
 }
 
 std::pair<Pistache::Http::Code, std::string> StoreApi::handleOperationException(const std::exception& ex) const noexcept
@@ -67,8 +79,7 @@ void StoreApi::get_nested_object_handler(const Pistache::Rest::Request &, Pistac
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 

--- a/samples/server/petstore/cpp-pistache-nested-schema-refs/api/StoreApi.h
+++ b/samples/server/petstore/cpp-pistache-nested-schema-refs/api/StoreApi.h
@@ -52,7 +52,21 @@ private:
     /// May be overridden to return custom error formats. This is called inside a catch block.
     /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
+    virtual void handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during Parameter parsing and validation.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleParsingException(const std::exception& ex) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
+    virtual void handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.

--- a/samples/server/petstore/cpp-pistache/api/PetApi.cpp
+++ b/samples/server/petstore/cpp-pistache/api/PetApi.cpp
@@ -46,6 +46,12 @@ void PetApi::setupRoutes() {
     router->addCustomHandler(Routes::bind(&PetApi::pet_api_default_handler, this));
 }
 
+void PetApi::handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleParsingException(ex);
+    response.send(codeAndError.first, codeAndError.second);
+}
+
 std::pair<Pistache::Http::Code, std::string> PetApi::handleParsingException(const std::exception& ex) const noexcept
 {
     try {
@@ -57,6 +63,12 @@ std::pair<Pistache::Http::Code, std::string> PetApi::handleParsingException(cons
     } catch (std::exception &e) {
         return std::make_pair(Pistache::Http::Code::Internal_Server_Error, e.what());
     }
+}
+
+void PetApi::handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleOperationException(ex);
+    response.send(codeAndError.first, codeAndError.second);
 }
 
 std::pair<Pistache::Http::Code, std::string> PetApi::handleOperationException(const std::exception& ex) const noexcept
@@ -76,8 +88,7 @@ void PetApi::add_pet_handler(const Pistache::Rest::Request &request, Pistache::H
         nlohmann::json::parse(request.body()).get_to(body);
         body.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -87,8 +98,7 @@ void PetApi::add_pet_handler(const Pistache::Rest::Request &request, Pistache::H
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -112,8 +122,7 @@ void PetApi::delete_pet_handler(const Pistache::Rest::Request &request, Pistache
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -142,8 +151,7 @@ void PetApi::find_pets_by_status_handler(const Pistache::Rest::Request &request,
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -172,8 +180,7 @@ void PetApi::find_pets_by_tags_handler(const Pistache::Rest::Request &request, P
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -194,8 +201,7 @@ void PetApi::get_pet_by_id_handler(const Pistache::Rest::Request &request, Pista
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -216,8 +222,7 @@ void PetApi::update_pet_handler(const Pistache::Rest::Request &request, Pistache
         nlohmann::json::parse(request.body()).get_to(body);
         body.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -227,8 +232,7 @@ void PetApi::update_pet_handler(const Pistache::Rest::Request &request, Pistache
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -246,8 +250,7 @@ void PetApi::update_pet_with_form_handler(const Pistache::Rest::Request &request
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -265,8 +268,7 @@ void PetApi::upload_file_handler(const Pistache::Rest::Request &request, Pistach
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 

--- a/samples/server/petstore/cpp-pistache/api/PetApi.h
+++ b/samples/server/petstore/cpp-pistache/api/PetApi.h
@@ -62,7 +62,21 @@ private:
     /// May be overridden to return custom error formats. This is called inside a catch block.
     /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
+    virtual void handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during Parameter parsing and validation.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleParsingException(const std::exception& ex) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
+    virtual void handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.

--- a/samples/server/petstore/cpp-pistache/api/StoreApi.cpp
+++ b/samples/server/petstore/cpp-pistache/api/StoreApi.cpp
@@ -42,6 +42,12 @@ void StoreApi::setupRoutes() {
     router->addCustomHandler(Routes::bind(&StoreApi::store_api_default_handler, this));
 }
 
+void StoreApi::handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleParsingException(ex);
+    response.send(codeAndError.first, codeAndError.second);
+}
+
 std::pair<Pistache::Http::Code, std::string> StoreApi::handleParsingException(const std::exception& ex) const noexcept
 {
     try {
@@ -53,6 +59,12 @@ std::pair<Pistache::Http::Code, std::string> StoreApi::handleParsingException(co
     } catch (std::exception &e) {
         return std::make_pair(Pistache::Http::Code::Internal_Server_Error, e.what());
     }
+}
+
+void StoreApi::handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleOperationException(ex);
+    response.send(codeAndError.first, codeAndError.second);
 }
 
 std::pair<Pistache::Http::Code, std::string> StoreApi::handleOperationException(const std::exception& ex) const noexcept
@@ -72,8 +84,7 @@ void StoreApi::delete_order_handler(const Pistache::Rest::Request &request, Pist
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -92,8 +103,7 @@ void StoreApi::get_inventory_handler(const Pistache::Rest::Request &, Pistache::
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -114,8 +124,7 @@ void StoreApi::get_order_by_id_handler(const Pistache::Rest::Request &request, P
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -136,8 +145,7 @@ void StoreApi::place_order_handler(const Pistache::Rest::Request &request, Pista
         nlohmann::json::parse(request.body()).get_to(body);
         body.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -147,8 +155,7 @@ void StoreApi::place_order_handler(const Pistache::Rest::Request &request, Pista
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 

--- a/samples/server/petstore/cpp-pistache/api/StoreApi.h
+++ b/samples/server/petstore/cpp-pistache/api/StoreApi.h
@@ -57,7 +57,21 @@ private:
     /// May be overridden to return custom error formats. This is called inside a catch block.
     /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
+    virtual void handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during Parameter parsing and validation.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleParsingException(const std::exception& ex) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
+    virtual void handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.

--- a/samples/server/petstore/cpp-pistache/api/UserApi.cpp
+++ b/samples/server/petstore/cpp-pistache/api/UserApi.cpp
@@ -46,6 +46,12 @@ void UserApi::setupRoutes() {
     router->addCustomHandler(Routes::bind(&UserApi::user_api_default_handler, this));
 }
 
+void UserApi::handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleParsingException(ex);
+    response.send(codeAndError.first, codeAndError.second);
+}
+
 std::pair<Pistache::Http::Code, std::string> UserApi::handleParsingException(const std::exception& ex) const noexcept
 {
     try {
@@ -57,6 +63,12 @@ std::pair<Pistache::Http::Code, std::string> UserApi::handleParsingException(con
     } catch (std::exception &e) {
         return std::make_pair(Pistache::Http::Code::Internal_Server_Error, e.what());
     }
+}
+
+void UserApi::handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept
+{
+    std::pair<Pistache::Http::Code, std::string> codeAndError = handleOperationException(ex);
+    response.send(codeAndError.first, codeAndError.second);
 }
 
 std::pair<Pistache::Http::Code, std::string> UserApi::handleOperationException(const std::exception& ex) const noexcept
@@ -76,8 +88,7 @@ void UserApi::create_user_handler(const Pistache::Rest::Request &request, Pistac
         nlohmann::json::parse(request.body()).get_to(body);
         body.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -87,8 +98,7 @@ void UserApi::create_user_handler(const Pistache::Rest::Request &request, Pistac
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -109,8 +119,7 @@ void UserApi::create_users_with_array_input_handler(const Pistache::Rest::Reques
         for (const auto& validationParam : body)
              validationParam.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -120,8 +129,7 @@ void UserApi::create_users_with_array_input_handler(const Pistache::Rest::Reques
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -142,8 +150,7 @@ void UserApi::create_users_with_list_input_handler(const Pistache::Rest::Request
         for (const auto& validationParam : body)
              validationParam.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -153,8 +160,7 @@ void UserApi::create_users_with_list_input_handler(const Pistache::Rest::Request
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -175,8 +181,7 @@ void UserApi::delete_user_handler(const Pistache::Rest::Request &request, Pistac
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -197,8 +202,7 @@ void UserApi::get_user_by_name_handler(const Pistache::Rest::Request &request, P
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -235,8 +239,7 @@ void UserApi::login_user_handler(const Pistache::Rest::Request &request, Pistach
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -255,8 +258,7 @@ void UserApi::logout_user_handler(const Pistache::Rest::Request &, Pistache::Htt
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 
@@ -279,8 +281,7 @@ void UserApi::update_user_handler(const Pistache::Rest::Request &request, Pistac
         nlohmann::json::parse(request.body()).get_to(body);
         body.validate();
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleParsingException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleParsingException(e, response);
         return;
     }
 
@@ -290,8 +291,7 @@ void UserApi::update_user_handler(const Pistache::Rest::Request &request, Pistac
         response.send(static_cast<Pistache::Http::Code>(e.code()), e.what());
         return;
     } catch (std::exception &e) {
-        const std::pair<Pistache::Http::Code, std::string> errorInfo = this->handleOperationException(e);
-        response.send(errorInfo.first, errorInfo.second);
+        this->handleOperationException(e, response);
         return;
     }
 

--- a/samples/server/petstore/cpp-pistache/api/UserApi.h
+++ b/samples/server/petstore/cpp-pistache/api/UserApi.h
@@ -61,7 +61,21 @@ private:
     /// May be overridden to return custom error formats. This is called inside a catch block.
     /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
+    virtual void handleParsingException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during Parameter parsing and validation.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleParsingException(const std::exception& ex) const noexcept;
+
+    /// <summary>
+    /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.
+    /// May be overridden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
+    /// </summary>
+    virtual void handleOperationException(const std::exception& ex, Pistache::Http::ResponseWriter &response) const noexcept;
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.


### PR DESCRIPTION
This allows overriders to have full access to the response object and more finely control the error handling behavior.
For example, this enables the specification of a proper `Content-Type` header in case of custom format responses (application/json, application/problem+json,...)

This should be backward compatible, providing a second overloaded version with full response access to chose from if needed. The new version taking priority if both overloads are overridden.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @ravinikam @stkrwork @etherealjoy @martindelille @muttleyxd
