### PR TITLE
[C++][Pistache] Fix 'unused-parameter' warning on Helpers.h file

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/helpers-header.mustache
@@ -84,10 +84,10 @@ namespace {{helpersNamespace}}
     }
 
     /// <summary>
-    /// Determine if the given vector<T> only has unique elements. T must provide the == operator.
+    /// Determine if the given set<T> only has unique elements.
     /// </summary>
     template <typename T>
-    bool hasOnlyUniqueItems(const std::set<T>& set)
+    bool hasOnlyUniqueItems(const std::set<T>&)
     {
         return true;
     }

--- a/samples/server/petstore/cpp-pistache-everything/model/Helpers.h
+++ b/samples/server/petstore/cpp-pistache-everything/model/Helpers.h
@@ -94,10 +94,10 @@ namespace org::openapitools::server::helpers
     }
 
     /// <summary>
-    /// Determine if the given vector<T> only has unique elements. T must provide the == operator.
+    /// Determine if the given set<T> only has unique elements.
     /// </summary>
     template <typename T>
-    bool hasOnlyUniqueItems(const std::set<T>& set)
+    bool hasOnlyUniqueItems(const std::set<T>&)
     {
         return true;
     }

--- a/samples/server/petstore/cpp-pistache-nested-schema-refs/model/Helpers.h
+++ b/samples/server/petstore/cpp-pistache-nested-schema-refs/model/Helpers.h
@@ -94,10 +94,10 @@ namespace org::openapitools::server::helpers
     }
 
     /// <summary>
-    /// Determine if the given vector<T> only has unique elements. T must provide the == operator.
+    /// Determine if the given set<T> only has unique elements.
     /// </summary>
     template <typename T>
-    bool hasOnlyUniqueItems(const std::set<T>& set)
+    bool hasOnlyUniqueItems(const std::set<T>&)
     {
         return true;
     }

--- a/samples/server/petstore/cpp-pistache/model/Helpers.h
+++ b/samples/server/petstore/cpp-pistache/model/Helpers.h
@@ -94,10 +94,10 @@ namespace org::openapitools::server::helpers
     }
 
     /// <summary>
-    /// Determine if the given vector<T> only has unique elements. T must provide the == operator.
+    /// Determine if the given set<T> only has unique elements.
     /// </summary>
     template <typename T>
-    bool hasOnlyUniqueItems(const std::set<T>& set)
+    bool hasOnlyUniqueItems(const std::set<T>&)
     {
         return true;
     }


### PR DESCRIPTION
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @ravinikam @stkrwork @etherealjoy @MartinDelille @muttleyxd
