### PR TITLE
[python] Check if the given input is a container (Array or Map) when validating enum values

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -73,15 +73,22 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
         {{/isNullable}}
         {{/required}}
+        {{#isContainer}}
         {{#isArray}}
         for i in value:
             if i not in set([{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]):
                 raise ValueError("each list item must be one of ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
         {{/isArray}}
-        {{^isArray}}
+        {{#isMap}}
+        for i in value.values():
+            if i not in set([{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]):
+                raise ValueError("dict values must be one of enum values ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
+        {{/isMap}}
+        {{/isContainer}}
+        {{^isContainer}}
         if value not in set([{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]):
             raise ValueError("must be one of enum values ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
-        {{/isArray}}
+        {{/isContainer}}
         return value
     {{/isEnum}}
 {{/vars}}

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
@@ -38,8 +38,9 @@ class MapTest(BaseModel):
         if value is None:
             return value
 
-        if value not in set(['UPPER', 'lower']):
-            raise ValueError("must be one of enum values ('UPPER', 'lower')")
+        for i in value.values():
+            if i not in set(['UPPER', 'lower']):
+                raise ValueError("dict values must be one of enum values ('UPPER', 'lower')")
         return value
 
     model_config = ConfigDict(

--- a/samples/openapi3/client/petstore/python/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/map_test.py
@@ -39,8 +39,9 @@ class MapTest(BaseModel):
         if value is None:
             return value
 
-        if value not in set(['UPPER', 'lower']):
-            raise ValueError("must be one of enum values ('UPPER', 'lower')")
+        for i in value.values():
+            if i not in set(['UPPER', 'lower']):
+                raise ValueError("dict values must be one of enum values ('UPPER', 'lower')")
         return value
 
     model_config = ConfigDict(


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

### PR description
This PR solves issue #19274 by checking the input type on enum validators. The current version does not consider Dict (i.e., Map) as a possible value. The PR includes an addition check (isContainer and isMap) to verify if all values of the given Map are from the given enum.

cc @cbornet @tomplus @krjakbrjak @fa0311 @multani