### PR TITLE
Minor change to Helidon version handling allowing snapshot versions

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
@@ -770,7 +770,7 @@ public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
         }
 
         /**
-         *  Returns either the best match version of, if there is none, the requested version itself to allow references to
+         *  Returns either the best match version or, if there is none, the requested version itself to allow references to
          * unpublished releases such as snapshots.
          *
          * @param requestedVersion version to search for

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
@@ -781,7 +781,7 @@ public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
         }
 
         /**
-         * Returns either the best match version of, if there is none, the requested version itself to allow references to
+         * Returns either the best match version or, if there is none, the requested version itself to allow references to
          * unpublished releases such as snapshots.
          *
          * @param requestedVersion version to search for

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
@@ -483,7 +483,7 @@ public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
     }
 
     private void setHelidonVersion(String version) {
-        helidonVersion = VersionUtil.instance().chooseVersion(version);
+        helidonVersion = VersionUtil.instance().chooseVersionBestMatchOrSelf(version);
         setParentVersion(helidonVersion);
         helidonMajorVersion = VersionUtil.majorVersion(helidonVersion);
     }
@@ -767,6 +767,30 @@ public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
          */
         String chooseVersion(String requestedVersion) {
             return chooseVersion(requestedVersion, versions);
+        }
+
+        /**
+         *  Returns either the best match version of, if there is none, the requested version itself to allow references to
+         * unpublished releases such as snapshots.
+         *
+         * @param requestedVersion version to search for
+         * @return either the best match or, if none, the requested version itself
+         */
+        String chooseVersionBestMatchOrSelf(String requestedVersion) {
+            return chooseVersionBestMatchOrSelf(requestedVersion, versions);
+        }
+
+        /**
+         * Returns either the best match version of, if there is none, the requested version itself to allow references to
+         * unpublished releases such as snapshots.
+         *
+         * @param requestedVersion version to search for
+         * @param candidateVersions releases to consider
+         * @return either the best match or, if none, the requested version itself
+         */
+        String chooseVersionBestMatchOrSelf(String requestedVersion, List<String> candidateVersions) {
+            String bestMatch = chooseVersion(requestedVersion, candidateVersions);
+            return bestMatch != null ? bestMatch : requestedVersion;
         }
 
         /**

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/HelidonCommonCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/HelidonCommonCodegenTest.java
@@ -48,4 +48,10 @@ public class HelidonCommonCodegenTest {
     }
 
 
+
+    @Test void checkUseOfUnpublishedRelease() {
+        assertThat(test.chooseVersionBestMatchOrSelf("4.0.11-SNAPSHOT",
+                                                     List.of("4.0.10", "3.2.1", "3.2.0", "2.0.4", "1.2.3", "1.2.2", "1.1.0")))
+                .isEqualTo("4.0.11-SNAPSHOT");
+    }
 }


### PR DESCRIPTION
The Helidon generators permit users to specify which Helidon version to refer to in the generated code. The code which processes the Helidon version validates the user-specified version against known Helidon releases if possible.

This small enhancement (to the Helidon generators only) allows users to refer to unpublished releases (such as a snapshot release).

The PR includes an additional unit test for this use case.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
