### PR TITLE
[PowerShell] Fix response type on deserialization

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/api_client.mustache
@@ -233,8 +233,7 @@ function DeserializeResponse {
         [AllowEmptyString()]
         [string]$ReturnType,
         [Parameter(Mandatory)]
-        [AllowEmptyString()]
-        [string]$Response,
+        [Object]$Response,
         [Parameter(Mandatory)]
         [AllowEmptyCollection()]
         [string[]]$ContentTypes

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Private/ApiClient.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Private/ApiClient.ps1
@@ -221,8 +221,7 @@ function DeserializeResponse {
         [AllowEmptyString()]
         [string]$ReturnType,
         [Parameter(Mandatory)]
-        [AllowEmptyString()]
-        [string]$Response,
+        [Object]$Response,
         [Parameter(Mandatory)]
         [AllowEmptyCollection()]
         [string[]]$ContentTypes

--- a/samples/client/petstore/powershell/src/PSPetstore/Private/PSApiClient.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Private/PSApiClient.ps1
@@ -237,8 +237,7 @@ function DeserializeResponse {
         [AllowEmptyString()]
         [string]$ReturnType,
         [Parameter(Mandatory)]
-        [AllowEmptyString()]
-        [string]$Response,
+        [Object]$Response,
         [Parameter(Mandatory)]
         [AllowEmptyCollection()]
         [string[]]$ContentTypes


### PR DESCRIPTION
This PR fixes an issue when the received response is of type `application/octet-stream` rather than `application/json`. 
`DeserializeResponse` in `api_client.mustache` expects a parameter of type `string`. Since the associated type of a binary content type is `Byte[]` and no intrinsic conversion exists, an exception is thrown.

The commit modifies the type of the parameter `$Response` to `Object`, so the function can handle both text and binary response bodies (if it is binary and the Content-Type of the response is correct, the parameter is returned as-is).
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@wing328 
