### PR TITLE
[csharp][generichost] Changed default sorting of samples

### DIFF
--- a/bin/configs/csharp-generichost-net4.7-allOf.yaml
+++ b/bin/configs/csharp-generichost-net4.7-allOf.yaml
@@ -11,3 +11,5 @@ additionalProperties:
   nullableReferenceTypes: false
   equatable: true
   targetFramework: net47
+  modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net4.7-anyOf.yaml
+++ b/bin/configs/csharp-generichost-net4.7-anyOf.yaml
@@ -11,3 +11,5 @@ additionalProperties:
   nullableReferenceTypes: false
   equatable: true
   targetFramework: net47
+  modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net4.7-anyOfNoCompare.yaml
+++ b/bin/configs/csharp-generichost-net4.7-anyOfNoCompare.yaml
@@ -11,3 +11,5 @@ additionalProperties:
   nullableReferenceTypes: false
   equatable: true
   targetFramework: net47
+  modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net4.7-formModels.yaml
+++ b/bin/configs/csharp-generichost-net4.7-formModels.yaml
@@ -13,5 +13,6 @@ additionalProperties:
   targetFramework: net47
   skipFormModel: false
   modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical
 inlineSchemaOptions:
   RESOLVE_INLINE_ENUMS: true

--- a/bin/configs/csharp-generichost-net4.7-oneOf.yaml
+++ b/bin/configs/csharp-generichost-net4.7-oneOf.yaml
@@ -11,3 +11,5 @@ additionalProperties:
   nullableReferenceTypes: false
   equatable: true
   targetFramework: net47
+  modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net4.7-useDateTimeForDate.yaml
+++ b/bin/configs/csharp-generichost-net4.7-useDateTimeForDate.yaml
@@ -9,3 +9,4 @@ additionalProperties:
   useDateTimeForDate: true
   targetFramework: net47
   modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net4.7.yaml
+++ b/bin/configs/csharp-generichost-net4.7.yaml
@@ -12,3 +12,4 @@ additionalProperties:
   equatable: true
   targetFramework: net47
   modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net4.8-allOf.yaml
+++ b/bin/configs/csharp-generichost-net4.8-allOf.yaml
@@ -11,3 +11,5 @@ additionalProperties:
   nullableReferenceTypes: false
   equatable: true
   targetFramework: net48
+  modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net4.8-anyOf.yaml
+++ b/bin/configs/csharp-generichost-net4.8-anyOf.yaml
@@ -11,3 +11,5 @@ additionalProperties:
   nullableReferenceTypes: false
   equatable: true
   targetFramework: net48
+  modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net4.8-anyOfNoCompare.yaml
+++ b/bin/configs/csharp-generichost-net4.8-anyOfNoCompare.yaml
@@ -11,3 +11,5 @@ additionalProperties:
   nullableReferenceTypes: false
   equatable: true
   targetFramework: net48
+  modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net4.8-formModels.yaml
+++ b/bin/configs/csharp-generichost-net4.8-formModels.yaml
@@ -13,5 +13,6 @@ additionalProperties:
   targetFramework: net48
   skipFormModel: false
   modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical
 inlineSchemaOptions:
   RESOLVE_INLINE_ENUMS: true

--- a/bin/configs/csharp-generichost-net4.8-oneOf.yaml
+++ b/bin/configs/csharp-generichost-net4.8-oneOf.yaml
@@ -11,3 +11,5 @@ additionalProperties:
   nullableReferenceTypes: false
   equatable: true
   targetFramework: net48
+  modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net4.8-useDateTimeForDate.yaml
+++ b/bin/configs/csharp-generichost-net4.8-useDateTimeForDate.yaml
@@ -9,3 +9,4 @@ additionalProperties:
   useDateTimeForDate: true
   targetFramework: net48
   modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net4.8.yaml
+++ b/bin/configs/csharp-generichost-net4.8.yaml
@@ -12,3 +12,4 @@ additionalProperties:
   equatable: true
   targetFramework: net48
   modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net8-allOf.yaml
+++ b/bin/configs/csharp-generichost-net8-allOf.yaml
@@ -11,3 +11,5 @@ additionalProperties:
   nullableReferenceTypes: true
   equatable: true
   targetFramework: net8.0
+  modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net8-anyOf.yaml
+++ b/bin/configs/csharp-generichost-net8-anyOf.yaml
@@ -11,3 +11,5 @@ additionalProperties:
   nullableReferenceTypes: true
   equatable: true
   targetFramework: net8.0
+  modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net8-anyOfNoCompare.yaml
+++ b/bin/configs/csharp-generichost-net8-anyOfNoCompare.yaml
@@ -11,3 +11,5 @@ additionalProperties:
   nullableReferenceTypes: true
   equatable: true
   targetFramework: net8.0
+  modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net8-formModels.yaml
+++ b/bin/configs/csharp-generichost-net8-formModels.yaml
@@ -13,5 +13,6 @@ additionalProperties:
   targetFramework: net8.0
   skipFormModel: false
   modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical
 inlineSchemaOptions:
   RESOLVE_INLINE_ENUMS: true

--- a/bin/configs/csharp-generichost-net8-nrt-useSourceGeneration.yaml
+++ b/bin/configs/csharp-generichost-net8-nrt-useSourceGeneration.yaml
@@ -12,3 +12,4 @@ additionalProperties:
   equatable: true
   targetFramework: net8.0
   modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net8-nrt.yaml
+++ b/bin/configs/csharp-generichost-net8-nrt.yaml
@@ -12,3 +12,4 @@ additionalProperties:
   equatable: true
   targetFramework: net8.0
   modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net8-oneOf.yaml
+++ b/bin/configs/csharp-generichost-net8-oneOf.yaml
@@ -11,3 +11,5 @@ additionalProperties:
   nullableReferenceTypes: true
   equatable: true
   targetFramework: net8.0
+  modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net8-useDateTimeForDate.yaml
+++ b/bin/configs/csharp-generichost-net8-useDateTimeForDate.yaml
@@ -9,3 +9,4 @@ additionalProperties:
   useDateTimeForDate: true
   targetFramework: net8.0
   modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-net8.yaml
+++ b/bin/configs/csharp-generichost-net8.yaml
@@ -12,3 +12,4 @@ additionalProperties:
   equatable: true
   targetFramework: net8.0
   modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/bin/configs/csharp-generichost-netstandard2.0.yaml
+++ b/bin/configs/csharp-generichost-netstandard2.0.yaml
@@ -11,3 +11,4 @@ additionalProperties:
   targetFramework: netstandard2.0
   equatable: true
   modelPropertySorting: alphabetical
+  operationParameterSorting: alphabetical

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/docs/models/Adult.md
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/docs/models/Adult.md
@@ -5,9 +5,9 @@ A representation of an adult
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Type** | **string** |  | [optional] 
-**LastName** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
+**LastName** | **string** |  | [optional] 
+**Type** | **string** |  | [optional] 
 **Children** | [**List&lt;Child&gt;**](Child.md) |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/docs/models/Child.md
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/docs/models/Child.md
@@ -5,11 +5,11 @@ A representation of a child
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Type** | **string** |  | [optional] 
-**LastName** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
-**BoosterSeat** | **bool** |  | [optional] 
+**LastName** | **string** |  | [optional] 
+**Type** | **string** |  | [optional] 
 **Age** | **int** |  | [optional] 
+**BoosterSeat** | **bool** |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/docs/models/Person.md
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/docs/models/Person.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Type** | **string** |  | [optional] 
-**LastName** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
+**LastName** | **string** |  | [optional] 
+**Type** | **string** |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools.Test/Model/ChildTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools.Test/Model/ChildTests.cs
@@ -54,21 +54,21 @@ namespace Org.OpenAPITools.Test.Model
         }
 
         /// <summary>
-        /// Test the property 'BoosterSeat'
-        /// </summary>
-        [Fact]
-        public void BoosterSeatTest()
-        {
-            // TODO unit test for the property 'BoosterSeat'
-        }
-
-        /// <summary>
         /// Test the property 'Age'
         /// </summary>
         [Fact]
         public void AgeTest()
         {
             // TODO unit test for the property 'Age'
+        }
+
+        /// <summary>
+        /// Test the property 'BoosterSeat'
+        /// </summary>
+        [Fact]
+        public void BoosterSeatTest()
+        {
+            // TODO unit test for the property 'BoosterSeat'
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools.Test/Model/PersonTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools.Test/Model/PersonTests.cs
@@ -74,12 +74,12 @@ namespace Org.OpenAPITools.Test.Model
         }
 
         /// <summary>
-        /// Test the property 'Type'
+        /// Test the property 'FirstName'
         /// </summary>
         [Fact]
-        public void TypeTest()
+        public void FirstNameTest()
         {
-            // TODO unit test for the property 'Type'
+            // TODO unit test for the property 'FirstName'
         }
 
         /// <summary>
@@ -92,12 +92,12 @@ namespace Org.OpenAPITools.Test.Model
         }
 
         /// <summary>
-        /// Test the property 'FirstName'
+        /// Test the property 'Type'
         /// </summary>
         [Fact]
-        public void FirstNameTest()
+        public void TypeTest()
         {
-            // TODO unit test for the property 'FirstName'
+            // TODO unit test for the property 'Type'
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -32,24 +32,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Adult" /> class.
         /// </summary>
-        /// <param name="lastName">lastName</param>
-        /// <param name="firstName">firstName</param>
         /// <param name="children">children</param>
+        /// <param name="firstName">firstName</param>
+        /// <param name="lastName">lastName</param>
         [JsonConstructor]
-        public Adult(Option<string> lastName = default, Option<string> firstName = default, Option<List<Child>> children = default) : base(lastName, firstName)
+        public Adult(Option<List<Child>> children = default, Option<string> firstName = default, Option<string> lastName = default) : base(firstName, lastName)
         {
             ChildrenOption = children;
             OnCreated();
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public new string Type { get; } = "Adult";
 
         /// <summary>
         /// Used to track the state of Children
@@ -63,6 +56,13 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("children")]
         public List<Child> Children { get { return this.ChildrenOption; } set { this.ChildrenOption = new Option<List<Child>>(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public new string Type { get; } = "Adult";
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -101,10 +101,10 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<string> type = default;
-            Option<string> lastName = default;
-            Option<string> firstName = default;
             Option<List<Child>> children = default;
+            Option<string> firstName = default;
+            Option<string> lastName = default;
+            Option<string> type = default;
 
             while (utf8JsonReader.Read())
             {
@@ -121,18 +121,18 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
-                        case "$_type":
-                            type = new Option<string>(utf8JsonReader.GetString());
-                            break;
-                        case "lastName":
-                            lastName = new Option<string>(utf8JsonReader.GetString());
+                        case "children":
+                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
+                                children = new Option<List<Child>>(JsonSerializer.Deserialize<List<Child>>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "firstName":
                             firstName = new Option<string>(utf8JsonReader.GetString());
                             break;
-                        case "children":
-                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                children = new Option<List<Child>>(JsonSerializer.Deserialize<List<Child>>(ref utf8JsonReader, jsonSerializerOptions));
+                        case "lastName":
+                            lastName = new Option<string>(utf8JsonReader.GetString());
+                            break;
+                        case "$_type":
+                            type = new Option<string>(utf8JsonReader.GetString());
                             break;
                         default:
                             break;
@@ -140,19 +140,19 @@ namespace Org.OpenAPITools.Model
                 }
             }
 
-            if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Adult.");
-
-            if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Adult.");
+            if (children.IsSet && children.Value == null)
+                throw new ArgumentNullException(nameof(children), "Property is not nullable for class Adult.");
 
             if (firstName.IsSet && firstName.Value == null)
                 throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Adult.");
 
-            if (children.IsSet && children.Value == null)
-                throw new ArgumentNullException(nameof(children), "Property is not nullable for class Adult.");
+            if (lastName.IsSet && lastName.Value == null)
+                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Adult.");
 
-            return new Adult(lastName, firstName, children);
+            if (type.IsSet && type.Value == null)
+                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Adult.");
+
+            return new Adult(children, firstName, lastName);
         }
 
         /// <summary>
@@ -179,28 +179,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Adult adult, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (adult.LastNameOption.IsSet && adult.LastName == null)
-                throw new ArgumentNullException(nameof(adult.LastName), "Property is required for class Adult.");
+            if (adult.ChildrenOption.IsSet && adult.Children == null)
+                throw new ArgumentNullException(nameof(adult.Children), "Property is required for class Adult.");
 
             if (adult.FirstNameOption.IsSet && adult.FirstName == null)
                 throw new ArgumentNullException(nameof(adult.FirstName), "Property is required for class Adult.");
 
-            if (adult.ChildrenOption.IsSet && adult.Children == null)
-                throw new ArgumentNullException(nameof(adult.Children), "Property is required for class Adult.");
-
-            writer.WriteString("$_type", adult.Type);
-
-            if (adult.LastNameOption.IsSet)
-                writer.WriteString("lastName", adult.LastName);
-
-            if (adult.FirstNameOption.IsSet)
-                writer.WriteString("firstName", adult.FirstName);
+            if (adult.LastNameOption.IsSet && adult.LastName == null)
+                throw new ArgumentNullException(nameof(adult.LastName), "Property is required for class Adult.");
 
             if (adult.ChildrenOption.IsSet)
             {
                 writer.WritePropertyName("children");
                 JsonSerializer.Serialize(writer, adult.Children, jsonSerializerOptions);
             }
+            if (adult.FirstNameOption.IsSet)
+                writer.WriteString("firstName", adult.FirstName);
+
+            if (adult.LastNameOption.IsSet)
+                writer.WriteString("lastName", adult.LastName);
+
+            writer.WriteString("$_type", adult.Type);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -32,12 +32,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Child" /> class.
         /// </summary>
-        /// <param name="lastName">lastName</param>
-        /// <param name="firstName">firstName</param>
         /// <param name="age">age</param>
+        /// <param name="firstName">firstName</param>
+        /// <param name="lastName">lastName</param>
         /// <param name="boosterSeat">boosterSeat</param>
         [JsonConstructor]
-        public Child(Option<string> lastName = default, Option<string> firstName = default, Option<int?> age = default, Option<bool?> boosterSeat = default) : base(lastName, firstName)
+        public Child(Option<int?> age = default, Option<string> firstName = default, Option<string> lastName = default, Option<bool?> boosterSeat = default) : base(firstName, lastName)
         {
             AgeOption = age;
             BoosterSeatOption = boosterSeat;
@@ -45,13 +45,6 @@ namespace Org.OpenAPITools.Model
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public new string Type { get; } = "Child";
 
         /// <summary>
         /// Used to track the state of Age
@@ -65,6 +58,13 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("age")]
         public int? Age { get { return this.AgeOption; } set { this.AgeOption = new Option<int?>(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public new string Type { get; } = "Child";
 
         /// <summary>
         /// Used to track the state of BoosterSeat
@@ -88,8 +88,8 @@ namespace Org.OpenAPITools.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class Child {\n");
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
-            sb.Append("  BoosterSeat: ").Append(BoosterSeat).Append("\n");
             sb.Append("  Age: ").Append(Age).Append("\n");
+            sb.Append("  BoosterSeat: ").Append(BoosterSeat).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -117,10 +117,10 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<string> type = default;
-            Option<string> lastName = default;
-            Option<string> firstName = default;
             Option<int?> age = default;
+            Option<string> firstName = default;
+            Option<string> lastName = default;
+            Option<string> type = default;
             Option<bool?> boosterSeat = default;
 
             while (utf8JsonReader.Read())
@@ -138,18 +138,18 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
-                        case "$_type":
-                            type = new Option<string>(utf8JsonReader.GetString());
-                            break;
-                        case "lastName":
-                            lastName = new Option<string>(utf8JsonReader.GetString());
+                        case "age":
+                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
+                                age = new Option<int?>(utf8JsonReader.GetInt32());
                             break;
                         case "firstName":
                             firstName = new Option<string>(utf8JsonReader.GetString());
                             break;
-                        case "age":
-                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                age = new Option<int?>(utf8JsonReader.GetInt32());
+                        case "lastName":
+                            lastName = new Option<string>(utf8JsonReader.GetString());
+                            break;
+                        case "$_type":
+                            type = new Option<string>(utf8JsonReader.GetString());
                             break;
                         case "boosterSeat":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
@@ -161,22 +161,22 @@ namespace Org.OpenAPITools.Model
                 }
             }
 
-            if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Child.");
-
-            if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Child.");
+            if (age.IsSet && age.Value == null)
+                throw new ArgumentNullException(nameof(age), "Property is not nullable for class Child.");
 
             if (firstName.IsSet && firstName.Value == null)
                 throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Child.");
 
-            if (age.IsSet && age.Value == null)
-                throw new ArgumentNullException(nameof(age), "Property is not nullable for class Child.");
+            if (lastName.IsSet && lastName.Value == null)
+                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Child.");
+
+            if (type.IsSet && type.Value == null)
+                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Child.");
 
             if (boosterSeat.IsSet && boosterSeat.Value == null)
                 throw new ArgumentNullException(nameof(boosterSeat), "Property is not nullable for class Child.");
 
-            return new Child(lastName, firstName, age, boosterSeat);
+            return new Child(age, firstName, lastName, boosterSeat);
         }
 
         /// <summary>
@@ -203,22 +203,22 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Child child, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (child.LastNameOption.IsSet && child.LastName == null)
-                throw new ArgumentNullException(nameof(child.LastName), "Property is required for class Child.");
-
             if (child.FirstNameOption.IsSet && child.FirstName == null)
                 throw new ArgumentNullException(nameof(child.FirstName), "Property is required for class Child.");
 
-            writer.WriteString("$_type", child.Type);
+            if (child.LastNameOption.IsSet && child.LastName == null)
+                throw new ArgumentNullException(nameof(child.LastName), "Property is required for class Child.");
 
-            if (child.LastNameOption.IsSet)
-                writer.WriteString("lastName", child.LastName);
+            if (child.AgeOption.IsSet)
+                writer.WriteNumber("age", child.AgeOption.Value.Value);
 
             if (child.FirstNameOption.IsSet)
                 writer.WriteString("firstName", child.FirstName);
 
-            if (child.AgeOption.IsSet)
-                writer.WriteNumber("age", child.AgeOption.Value.Value);
+            if (child.LastNameOption.IsSet)
+                writer.WriteString("lastName", child.LastName);
+
+            writer.WriteString("$_type", child.Type);
 
             if (child.BoosterSeatOption.IsSet)
                 writer.WriteBoolean("boosterSeat", child.BoosterSeatOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -32,37 +32,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Person" /> class.
         /// </summary>
-        /// <param name="lastName">lastName</param>
         /// <param name="firstName">firstName</param>
+        /// <param name="lastName">lastName</param>
         [JsonConstructor]
-        public Person(Option<string> lastName = default, Option<string> firstName = default)
+        public Person(Option<string> firstName = default, Option<string> lastName = default)
         {
-            LastNameOption = lastName;
             FirstNameOption = firstName;
+            LastNameOption = lastName;
             OnCreated();
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public string Type { get; } = "Person";
-
-        /// <summary>
-        /// Used to track the state of LastName
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public Option<string> LastNameOption { get; private set; }
-
-        /// <summary>
-        /// Gets or Sets LastName
-        /// </summary>
-        [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -78,6 +58,26 @@ namespace Org.OpenAPITools.Model
         public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new Option<string>(value); } }
 
         /// <summary>
+        /// Used to track the state of LastName
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public Option<string> LastNameOption { get; private set; }
+
+        /// <summary>
+        /// Gets or Sets LastName
+        /// </summary>
+        [JsonPropertyName("lastName")]
+        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new Option<string>(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public string Type { get; } = "Person";
+
+        /// <summary>
         /// Gets or Sets additional properties
         /// </summary>
         [JsonExtensionData]
@@ -91,8 +91,8 @@ namespace Org.OpenAPITools.Model
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("class Person {\n");
-            sb.Append("  LastName: ").Append(LastName).Append("\n");
             sb.Append("  FirstName: ").Append(FirstName).Append("\n");
+            sb.Append("  LastName: ").Append(LastName).Append("\n");
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -141,9 +141,9 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<string> type = default;
-            Option<string> lastName = default;
             Option<string> firstName = default;
+            Option<string> lastName = default;
+            Option<string> type = default;
 
             string discriminator = ClientUtils.GetDiscriminator(utf8JsonReader, "$_type");
 
@@ -168,14 +168,14 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
-                        case "$_type":
-                            type = new Option<string>(utf8JsonReader.GetString());
+                        case "firstName":
+                            firstName = new Option<string>(utf8JsonReader.GetString());
                             break;
                         case "lastName":
                             lastName = new Option<string>(utf8JsonReader.GetString());
                             break;
-                        case "firstName":
-                            firstName = new Option<string>(utf8JsonReader.GetString());
+                        case "$_type":
+                            type = new Option<string>(utf8JsonReader.GetString());
                             break;
                         default:
                             break;
@@ -183,16 +183,16 @@ namespace Org.OpenAPITools.Model
                 }
             }
 
-            if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Person.");
+            if (firstName.IsSet && firstName.Value == null)
+                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Person.");
 
             if (lastName.IsSet && lastName.Value == null)
                 throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Person.");
 
-            if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Person.");
+            if (type.IsSet && type.Value == null)
+                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Person.");
 
-            return new Person(lastName, firstName);
+            return new Person(firstName, lastName);
         }
 
         /// <summary>
@@ -229,19 +229,19 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Person person, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (person.LastNameOption.IsSet && person.LastName == null)
-                throw new ArgumentNullException(nameof(person.LastName), "Property is required for class Person.");
-
             if (person.FirstNameOption.IsSet && person.FirstName == null)
                 throw new ArgumentNullException(nameof(person.FirstName), "Property is required for class Person.");
 
-            writer.WriteString("$_type", person.Type);
+            if (person.LastNameOption.IsSet && person.LastName == null)
+                throw new ArgumentNullException(nameof(person.LastName), "Property is required for class Person.");
+
+            if (person.FirstNameOption.IsSet)
+                writer.WriteString("firstName", person.FirstName);
 
             if (person.LastNameOption.IsSet)
                 writer.WriteString("lastName", person.LastName);
 
-            if (person.FirstNameOption.IsSet)
-                writer.WriteString("firstName", person.FirstName);
+            writer.WriteString("$_type", person.Type);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/docs/apis/FakeApi.md
@@ -1067,7 +1067,7 @@ No authorization required
 
 <a id="testendpointparameters"></a>
 # **TestEndpointParameters**
-> void TestEndpointParameters (decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, int integer = null, int int32 = null, long int64 = null, float varFloat = null, string varString = null, System.IO.Stream binary = null, DateTime date = null, DateTime dateTime = null, string password = null, string callback = null)
+> void TestEndpointParameters (decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, System.IO.Stream binary = null, string callback = null, DateTime date = null, DateTime dateTime = null, int int32 = null, long int64 = null, int integer = null, string password = null, float varFloat = null, string varString = null)
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
@@ -1095,24 +1095,24 @@ namespace Example
 
             var apiInstance = new FakeApi(config);
             var number = 8.14D;  // decimal | None
-            var varDouble = 1.2D;  // double | None
             var patternWithoutDelimiter = "patternWithoutDelimiter_example";  // string | None
             var varByte = System.Text.Encoding.ASCII.GetBytes("BYTE_ARRAY_DATA_HERE");  // byte[] | None
-            var integer = 56;  // int | None (optional) 
-            var int32 = 56;  // int | None (optional) 
-            var int64 = 789L;  // long | None (optional) 
-            var varFloat = 3.4F;  // float | None (optional) 
-            var varString = "varString_example";  // string | None (optional) 
+            var varDouble = 1.2D;  // double | None
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
+            var callback = "callback_example";  // string | None (optional) 
             var date = DateTime.Parse("2013-10-20");  // DateTime | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")
+            var int32 = 56;  // int | None (optional) 
+            var int64 = 789L;  // long | None (optional) 
+            var integer = 56;  // int | None (optional) 
             var password = "password_example";  // string | None (optional) 
-            var callback = "callback_example";  // string | None (optional) 
+            var varFloat = 3.4F;  // float | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
 
             try
             {
                 // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-                apiInstance.TestEndpointParameters(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                apiInstance.TestEndpointParameters(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             }
             catch (ApiException  e)
             {
@@ -1132,7 +1132,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    apiInstance.TestEndpointParametersWithHttpInfo(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+    apiInstance.TestEndpointParametersWithHttpInfo(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 }
 catch (ApiException e)
 {
@@ -1147,19 +1147,19 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **number** | **decimal** | None |  |
-| **varDouble** | **double** | None |  |
 | **patternWithoutDelimiter** | **string** | None |  |
 | **varByte** | **byte[]** | None |  |
-| **integer** | **int** | None | [optional]  |
-| **int32** | **int** | None | [optional]  |
-| **int64** | **long** | None | [optional]  |
-| **varFloat** | **float** | None | [optional]  |
-| **varString** | **string** | None | [optional]  |
+| **varDouble** | **double** | None |  |
 | **binary** | **System.IO.Stream****System.IO.Stream** | None | [optional]  |
+| **callback** | **string** | None | [optional]  |
 | **date** | **DateTime** | None | [optional]  |
 | **dateTime** | **DateTime** | None | [optional] [default to &quot;2010-02-01T10:20:10.111110+01:00&quot;] |
+| **int32** | **int** | None | [optional]  |
+| **int64** | **long** | None | [optional]  |
+| **integer** | **int** | None | [optional]  |
 | **password** | **string** | None | [optional]  |
-| **callback** | **string** | None | [optional]  |
+| **varFloat** | **float** | None | [optional]  |
+| **varString** | **string** | None | [optional]  |
 
 ### Return type
 
@@ -1185,7 +1185,7 @@ void (empty response body)
 
 <a id="testenumparameters"></a>
 # **TestEnumParameters**
-> void TestEnumParameters (List<TestEnumParametersRequestEnumFormStringArrayInner> enumHeaderStringArray = null, TestEnumParametersEnumHeaderStringParameter enumHeaderString = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumQueryStringArray = null, TestEnumParametersEnumHeaderStringParameter enumQueryString = null, TestEnumParametersEnumQueryIntegerParameter enumQueryInteger = null, TestEnumParametersEnumQueryDoubleParameter enumQueryDouble = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumFormStringArray = null, TestEnumParametersRequestEnumFormString enumFormString = null)
+> void TestEnumParameters (TestEnumParametersRequestEnumFormString enumFormString = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumFormStringArray = null, TestEnumParametersEnumHeaderStringParameter enumHeaderString = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumHeaderStringArray = null, TestEnumParametersEnumQueryDoubleParameter enumQueryDouble = null, TestEnumParametersEnumQueryIntegerParameter enumQueryInteger = null, TestEnumParametersEnumHeaderStringParameter enumQueryString = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumQueryStringArray = null)
 
 To test enum parameters
 
@@ -1208,19 +1208,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var enumHeaderStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Header parameter enum test (string array) (optional) 
-            var enumHeaderString = (TestEnumParametersEnumHeaderStringParameter) "_abc";  // TestEnumParametersEnumHeaderStringParameter | Header parameter enum test (string) (optional) 
-            var enumQueryStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Query parameter enum test (string array) (optional) 
-            var enumQueryString = (TestEnumParametersEnumHeaderStringParameter) "_abc";  // TestEnumParametersEnumHeaderStringParameter | Query parameter enum test (string) (optional) 
-            var enumQueryInteger = (TestEnumParametersEnumQueryIntegerParameter) "1";  // TestEnumParametersEnumQueryIntegerParameter | Query parameter enum test (double) (optional) 
-            var enumQueryDouble = (TestEnumParametersEnumQueryDoubleParameter) "1.1";  // TestEnumParametersEnumQueryDoubleParameter | Query parameter enum test (double) (optional) 
-            var enumFormStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Form parameter enum test (string array) (optional) 
             var enumFormString = (TestEnumParametersRequestEnumFormString) "_abc";  // TestEnumParametersRequestEnumFormString |  (optional) 
+            var enumFormStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Form parameter enum test (string array) (optional) 
+            var enumHeaderString = (TestEnumParametersEnumHeaderStringParameter) "_abc";  // TestEnumParametersEnumHeaderStringParameter | Header parameter enum test (string) (optional) 
+            var enumHeaderStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Header parameter enum test (string array) (optional) 
+            var enumQueryDouble = (TestEnumParametersEnumQueryDoubleParameter) "1.1";  // TestEnumParametersEnumQueryDoubleParameter | Query parameter enum test (double) (optional) 
+            var enumQueryInteger = (TestEnumParametersEnumQueryIntegerParameter) "1";  // TestEnumParametersEnumQueryIntegerParameter | Query parameter enum test (double) (optional) 
+            var enumQueryString = (TestEnumParametersEnumHeaderStringParameter) "_abc";  // TestEnumParametersEnumHeaderStringParameter | Query parameter enum test (string) (optional) 
+            var enumQueryStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Query parameter enum test (string array) (optional) 
 
             try
             {
                 // To test enum parameters
-                apiInstance.TestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                apiInstance.TestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             }
             catch (ApiException  e)
             {
@@ -1240,7 +1240,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test enum parameters
-    apiInstance.TestEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+    apiInstance.TestEnumParametersWithHttpInfo(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 }
 catch (ApiException e)
 {
@@ -1254,14 +1254,14 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **enumHeaderStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Header parameter enum test (string array) | [optional]  |
-| **enumHeaderString** | **TestEnumParametersEnumHeaderStringParameter** | Header parameter enum test (string) | [optional]  |
-| **enumQueryStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Query parameter enum test (string array) | [optional]  |
-| **enumQueryString** | **TestEnumParametersEnumHeaderStringParameter** | Query parameter enum test (string) | [optional]  |
-| **enumQueryInteger** | **TestEnumParametersEnumQueryIntegerParameter** | Query parameter enum test (double) | [optional]  |
-| **enumQueryDouble** | **TestEnumParametersEnumQueryDoubleParameter** | Query parameter enum test (double) | [optional]  |
-| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional]  |
 | **enumFormString** | **TestEnumParametersRequestEnumFormString** |  | [optional]  |
+| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional]  |
+| **enumHeaderString** | **TestEnumParametersEnumHeaderStringParameter** | Header parameter enum test (string) | [optional]  |
+| **enumHeaderStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Header parameter enum test (string array) | [optional]  |
+| **enumQueryDouble** | **TestEnumParametersEnumQueryDoubleParameter** | Query parameter enum test (double) | [optional]  |
+| **enumQueryInteger** | **TestEnumParametersEnumQueryIntegerParameter** | Query parameter enum test (double) | [optional]  |
+| **enumQueryString** | **TestEnumParametersEnumHeaderStringParameter** | Query parameter enum test (string) | [optional]  |
+| **enumQueryStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Query parameter enum test (string array) | [optional]  |
 
 ### Return type
 
@@ -1287,7 +1287,7 @@ No authorization required
 
 <a id="testgroupparameters"></a>
 # **TestGroupParameters**
-> void TestGroupParameters (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int stringGroup = null, bool booleanGroup = null, long int64Group = null)
+> void TestGroupParameters (bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, bool booleanGroup = null, long int64Group = null, int stringGroup = null)
 
 Fake endpoint to test group parameters (optional)
 
@@ -1313,17 +1313,17 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new FakeApi(config);
-            var requiredStringGroup = 56;  // int | Required String in group parameters
             var requiredBooleanGroup = true;  // bool | Required Boolean in group parameters
             var requiredInt64Group = 789L;  // long | Required Integer in group parameters
-            var stringGroup = 56;  // int | String in group parameters (optional) 
+            var requiredStringGroup = 56;  // int | Required String in group parameters
             var booleanGroup = true;  // bool | Boolean in group parameters (optional) 
             var int64Group = 789L;  // long | Integer in group parameters (optional) 
+            var stringGroup = 56;  // int | String in group parameters (optional) 
 
             try
             {
                 // Fake endpoint to test group parameters (optional)
-                apiInstance.TestGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                apiInstance.TestGroupParameters(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             }
             catch (ApiException  e)
             {
@@ -1343,7 +1343,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint to test group parameters (optional)
-    apiInstance.TestGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+    apiInstance.TestGroupParametersWithHttpInfo(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 }
 catch (ApiException e)
 {
@@ -1357,12 +1357,12 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **requiredBooleanGroup** | **bool** | Required Boolean in group parameters |  |
 | **requiredInt64Group** | **long** | Required Integer in group parameters |  |
-| **stringGroup** | **int** | String in group parameters | [optional]  |
+| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **booleanGroup** | **bool** | Boolean in group parameters | [optional]  |
 | **int64Group** | **long** | Integer in group parameters | [optional]  |
+| **stringGroup** | **int** | String in group parameters | [optional]  |
 
 ### Return type
 
@@ -1644,7 +1644,7 @@ No authorization required
 
 <a id="testqueryparametercollectionformat"></a>
 # **TestQueryParameterCollectionFormat**
-> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, string notRequiredNotNullable = null, string notRequiredNullable = null)
+> void TestQueryParameterCollectionFormat (List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, string notRequiredNotNullable = null, string notRequiredNullable = null, string requiredNullable)
 
 
 
@@ -1667,19 +1667,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var pipe = new List<string>(); // List<string> | 
-            var ioutil = new List<string>(); // List<string> | 
-            var http = new List<string>(); // List<string> | 
-            var url = new List<string>(); // List<string> | 
             var context = new List<string>(); // List<string> | 
+            var http = new List<string>(); // List<string> | 
+            var ioutil = new List<string>(); // List<string> | 
+            var pipe = new List<string>(); // List<string> | 
             var requiredNotNullable = "requiredNotNullable_example";  // string | 
-            var requiredNullable = "requiredNullable_example";  // string | 
+            var url = new List<string>(); // List<string> | 
             var notRequiredNotNullable = "notRequiredNotNullable_example";  // string |  (optional) 
             var notRequiredNullable = "notRequiredNullable_example";  // string |  (optional) 
+            var requiredNullable = "requiredNullable_example";  // string | 
 
             try
             {
-                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                apiInstance.TestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             }
             catch (ApiException  e)
             {
@@ -1698,7 +1698,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 }
 catch (ApiException e)
 {
@@ -1712,15 +1712,15 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
-| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
-| **http** | [**List&lt;string&gt;**](string.md) |  |  |
-| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **context** | [**List&lt;string&gt;**](string.md) |  |  |
+| **http** | [**List&lt;string&gt;**](string.md) |  |  |
+| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
+| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
 | **requiredNotNullable** | **string** |  |  |
-| **requiredNullable** | **string** |  |  |
+| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **notRequiredNotNullable** | **string** |  | [optional]  |
 | **notRequiredNullable** | **string** |  | [optional]  |
+| **requiredNullable** | **string** |  |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/docs/apis/UserApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/docs/apis/UserApi.md
@@ -453,7 +453,7 @@ No authorization required
 
 <a id="loginuser"></a>
 # **LoginUser**
-> string LoginUser (string username, string password)
+> string LoginUser (string password, string username)
 
 Logs user into the system
 
@@ -474,13 +474,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | The user name for login
             var password = "password_example";  // string | The password for login in clear text
+            var username = "username_example";  // string | The user name for login
 
             try
             {
                 // Logs user into the system
-                string result = apiInstance.LoginUser(username, password);
+                string result = apiInstance.LoginUser(password, username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -501,7 +501,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Logs user into the system
-    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(username, password);
+    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(password, username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -518,8 +518,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | The user name for login |  |
 | **password** | **string** | The password for login in clear text |  |
+| **username** | **string** | The user name for login |  |
 
 ### Return type
 
@@ -625,7 +625,7 @@ No authorization required
 
 <a id="updateuser"></a>
 # **UpdateUser**
-> void UpdateUser (string username, User user)
+> void UpdateUser (User user, string username)
 
 Updated user
 
@@ -648,13 +648,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | name that need to be deleted
             var user = new User(); // User | Updated user object
+            var username = "username_example";  // string | name that need to be deleted
 
             try
             {
                 // Updated user
-                apiInstance.UpdateUser(username, user);
+                apiInstance.UpdateUser(user, username);
             }
             catch (ApiException  e)
             {
@@ -674,7 +674,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Updated user
-    apiInstance.UpdateUserWithHttpInfo(username, user);
+    apiInstance.UpdateUserWithHttpInfo(user, username);
 }
 catch (ApiException e)
 {
@@ -688,8 +688,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | name that need to be deleted |  |
 | **user** | [**User**](User.md) | Updated user object |  |
+| **username** | **string** | name that need to be deleted |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
@@ -193,20 +193,20 @@ namespace Org.OpenAPITools.Test.Api
         public async Task TestEndpointParametersAsyncTest()
         {
             decimal number = default;
-            double varDouble = default;
             string patternWithoutDelimiter = default;
             byte[] varByte = default;
-            Client.Option<int> integer = default;
-            Client.Option<int> int32 = default;
-            Client.Option<long> int64 = default;
-            Client.Option<float> varFloat = default;
-            Client.Option<string> varString = default;
+            double varDouble = default;
             Client.Option<System.IO.Stream> binary = default;
+            Client.Option<string> callback = default;
             Client.Option<DateTime> date = default;
             Client.Option<DateTime> dateTime = default;
+            Client.Option<int> int32 = default;
+            Client.Option<long> int64 = default;
+            Client.Option<int> integer = default;
             Client.Option<string> password = default;
-            Client.Option<string> callback = default;
-            await _instance.TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            Client.Option<float> varFloat = default;
+            Client.Option<string> varString = default;
+            await _instance.TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
         }
 
         /// <summary>
@@ -215,15 +215,15 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestEnumParametersAsyncTest()
         {
-            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default;
-            Client.Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default;
-            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default;
-            Client.Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default;
-            Client.Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default;
-            Client.Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default;
-            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default;
             Client.Option<TestEnumParametersRequestEnumFormString> enumFormString = default;
-            await _instance.TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default;
+            Client.Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default;
+            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default;
+            Client.Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default;
+            Client.Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default;
+            Client.Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default;
+            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default;
+            await _instance.TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
         }
 
         /// <summary>
@@ -232,13 +232,13 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestGroupParametersAsyncTest()
         {
-            int requiredStringGroup = default;
             bool requiredBooleanGroup = default;
             long requiredInt64Group = default;
-            Client.Option<int> stringGroup = default;
+            int requiredStringGroup = default;
             Client.Option<bool> booleanGroup = default;
             Client.Option<long> int64Group = default;
-            await _instance.TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            Client.Option<int> stringGroup = default;
+            await _instance.TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
         }
 
         /// <summary>
@@ -278,16 +278,16 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestQueryParameterCollectionFormatAsyncTest()
         {
-            List<string> pipe = default;
-            List<string> ioutil = default;
-            List<string> http = default;
-            List<string> url = default;
             List<string> context = default;
+            List<string> http = default;
+            List<string> ioutil = default;
+            List<string> pipe = default;
             string requiredNotNullable = default;
-            string requiredNullable = default;
+            List<string> url = default;
             Client.Option<string> notRequiredNotNullable = default;
             Client.Option<string> notRequiredNullable = default;
-            await _instance.TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            string requiredNullable = default;
+            await _instance.TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
@@ -108,9 +108,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task LoginUserAsyncTest()
         {
-            string username = default;
             string password = default;
-            var response = await _instance.LoginUserAsync(username, password);
+            string username = default;
+            var response = await _instance.LoginUserAsync(password, username);
             var model = response.Ok();
             Assert.IsType<string>(model);
         }
@@ -130,9 +130,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task UpdateUserAsyncTest()
         {
-            string username = default;
             User user = default;
-            await _instance.UpdateUserAsync(username, user);
+            string username = default;
+            await _instance.UpdateUserAsync(user, username);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -313,22 +313,22 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </remarks>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -361,17 +361,17 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
         /// <param name="enumFormString"> (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersRequestEnumFormString> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<TestEnumParametersRequestEnumFormString> enumFormString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -379,17 +379,17 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test enum parameters
         /// </remarks>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
         /// <param name="enumFormString"> (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersRequestEnumFormString> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<TestEnumParametersRequestEnumFormString> enumFormString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -398,15 +398,15 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -414,15 +414,15 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test inline additionalProperties
@@ -502,18 +502,18 @@ namespace Org.OpenAPITools.Api
         /// To test the collection format in query parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -521,18 +521,18 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test the collection format in query parameters
         /// </remarks>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test referenced string map
@@ -3781,19 +3781,19 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEndpointParameters(ref decimal number, ref double varDouble, ref string patternWithoutDelimiter, ref byte[] varByte, ref Option<int> integer, ref Option<int> int32, ref Option<long> int64, ref Option<float> varFloat, ref Option<string> varString, ref Option<System.IO.Stream> binary, ref Option<DateTime> date, ref Option<DateTime> dateTime, ref Option<string> password, ref Option<string> callback);
+        partial void FormatTestEndpointParameters(ref decimal number, ref string patternWithoutDelimiter, ref byte[] varByte, ref double varDouble, ref Option<System.IO.Stream> binary, ref Option<string> callback, ref Option<DateTime> date, ref Option<DateTime> dateTime, ref Option<int> int32, ref Option<long> int64, ref Option<int> integer, ref Option<string> password, ref Option<float> varFloat, ref Option<string> varString);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="varString"></param>
         /// <param name="binary"></param>
-        /// <param name="password"></param>
         /// <param name="callback"></param>
+        /// <param name="password"></param>
+        /// <param name="varString"></param>
         /// <returns></returns>
-        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<string> varString, Option<System.IO.Stream> binary, Option<string> password, Option<string> callback)
+        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<System.IO.Stream> binary, Option<string> callback, Option<string> password, Option<string> varString)
         {
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
@@ -3801,17 +3801,17 @@ namespace Org.OpenAPITools.Api
             if (varByte == null)
                 throw new ArgumentNullException(nameof(varByte));
 
-            if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString));
-
             if (binary.IsSet && binary.Value == null)
                 throw new ArgumentNullException(nameof(binary));
+
+            if (callback.IsSet && callback.Value == null)
+                throw new ArgumentNullException(nameof(callback));
 
             if (password.IsSet && password.Value == null)
                 throw new ArgumentNullException(nameof(password));
 
-            if (callback.IsSet && callback.Value == null)
-                throw new ArgumentNullException(nameof(callback));
+            if (varString.IsSet && varString.Value == null)
+                throw new ArgumentNullException(nameof(varString));
         }
 
         /// <summary>
@@ -3819,23 +3819,23 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -3846,20 +3846,20 @@ namespace Org.OpenAPITools.Api
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -3868,23 +3868,23 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -3897,45 +3897,45 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트  Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback, cancellationToken).ConfigureAwait(false);
+                return await TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -3948,30 +3948,30 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, varString, binary, password, callback);
+                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, binary, callback, password, varString);
 
-                FormatTestEndpointParameters(ref number, ref varDouble, ref patternWithoutDelimiter, ref varByte, ref integer, ref int32, ref int64, ref varFloat, ref varString, ref binary, ref date, ref dateTime, ref password, ref callback);
+                FormatTestEndpointParameters(ref number, ref patternWithoutDelimiter, ref varByte, ref varDouble, ref binary, ref callback, ref date, ref dateTime, ref int32, ref int64, ref integer, ref password, ref varFloat, ref varString);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -3990,29 +3990,17 @@ namespace Org.OpenAPITools.Api
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("number", ClientUtils.ParameterToString(number)));
 
-                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
-
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("pattern_without_delimiter", ClientUtils.ParameterToString(patternWithoutDelimiter)));
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("byte", ClientUtils.ParameterToString(varByte)));
 
-                    if (integer.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
-
-                    if (int32.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
-
-                    if (int64.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
-
-                    if (varFloat.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
-
-                    if (varString.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
+                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
 
                     if (binary.IsSet)
                         multipartContentLocalVar.Add(new StreamContent(binary.Value));
+
+                    if (callback.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
 
                     if (date.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("date", ClientUtils.ParameterToString(date.Value)));
@@ -4020,11 +4008,23 @@ namespace Org.OpenAPITools.Api
                     if (dateTime.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("dateTime", ClientUtils.ParameterToString(dateTime.Value)));
 
+                    if (int32.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
+
+                    if (int64.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
+
+                    if (integer.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
+
                     if (password.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("password", ClientUtils.ParameterToString(password.Value)));
 
-                    if (callback.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
+                    if (varFloat.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
+
+                    if (varString.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
 
                     List<TokenBase> tokenBaseLocalVars = new List<TokenBase>();
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
@@ -4056,7 +4056,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEndpointParametersApiResponse apiResponseLocalVar = new TestEndpointParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 
                         Events.ExecuteOnTestEndpointParameters(apiResponseLocalVar);
 
@@ -4070,7 +4070,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
                 Events.ExecuteOnErrorTestEndpointParameters(e);
                 throw;
             }
@@ -4127,43 +4127,43 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEnumParameters(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, ref Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, ref Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, ref Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, ref Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, ref Option<TestEnumParametersRequestEnumFormString> enumFormString);
+        partial void FormatTestEnumParameters(ref Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, ref Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, ref Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, ref Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, ref Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
+        /// <param name="enumFormStringArray"></param>
         /// <param name="enumHeaderStringArray"></param>
         /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <returns></returns>
-        private void ValidateTestEnumParameters(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray)
+        private void ValidateTestEnumParameters(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray)
         {
+            if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumFormStringArray));
+
             if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumHeaderStringArray));
 
             if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumQueryStringArray));
-
-            if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumFormStringArray));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersRequestEnumFormString> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4173,15 +4173,15 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersRequestEnumFormString> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4189,18 +4189,18 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersRequestEnumFormString> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4212,34 +4212,34 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersRequestEnumFormString> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray);
 
         /// <summary>
         /// To test enum parameters To test enum parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
         /// <param name="enumFormString"> (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersRequestEnumFormString> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<TestEnumParametersRequestEnumFormString> enumFormString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, cancellationToken).ConfigureAwait(false);
+                return await TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4251,25 +4251,25 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
         /// <param name="enumFormString"> (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersRequestEnumFormString> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<TestEnumParametersRequestEnumFormString> enumFormString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, enumFormStringArray);
+                ValidateTestEnumParameters(enumFormStringArray, enumHeaderStringArray, enumQueryStringArray);
 
-                FormatTestEnumParameters(enumHeaderStringArray, ref enumHeaderString, enumQueryStringArray, ref enumQueryString, ref enumQueryInteger, ref enumQueryDouble, enumFormStringArray, ref enumFormString);
+                FormatTestEnumParameters(ref enumFormString, enumFormStringArray, ref enumHeaderString, enumHeaderStringArray, ref enumQueryDouble, ref enumQueryInteger, ref enumQueryString, enumQueryStringArray);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4280,25 +4280,25 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    if (enumQueryStringArray.IsSet)
-                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
-
-                    if (enumQueryString.IsSet)
-                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+                    if (enumQueryDouble.IsSet)
+                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
 
                     if (enumQueryInteger.IsSet)
                         parseQueryStringLocalVar["enum_query_integer"] = ClientUtils.ParameterToString(enumQueryInteger.Value);
 
-                    if (enumQueryDouble.IsSet)
-                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
+                    if (enumQueryString.IsSet)
+                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+
+                    if (enumQueryStringArray.IsSet)
+                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
-                    if (enumHeaderStringArray.IsSet)
-                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
-
                     if (enumHeaderString.IsSet)
                         httpRequestMessageLocalVar.Headers.Add("enum_header_string", ClientUtils.ParameterToString(enumHeaderString.Value));
+
+                    if (enumHeaderStringArray.IsSet)
+                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
 
                     MultipartContent multipartContentLocalVar = new MultipartContent();
 
@@ -4306,11 +4306,11 @@ namespace Org.OpenAPITools.Api
 
                     List<KeyValuePair<string, string>> formParameterLocalVars = new List<KeyValuePair<string, string>>();
 
-                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormStringArray.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
-
-                    if (enumFormString.IsSet)
+                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormString.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string", ClientUtils.ParameterToString(enumFormString.Value)));
+
+                    if (enumFormStringArray.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
 
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
 
@@ -4335,7 +4335,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEnumParametersApiResponse apiResponseLocalVar = new TestEnumParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 
                         Events.ExecuteOnTestEnumParameters(apiResponseLocalVar);
 
@@ -4345,7 +4345,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
                 Events.ExecuteOnErrorTestEnumParameters(e);
                 throw;
             }
@@ -4402,22 +4402,22 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestGroupParameters(ref int requiredStringGroup, ref bool requiredBooleanGroup, ref long requiredInt64Group, ref Option<int> stringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group);
+        partial void FormatTestGroupParameters(ref bool requiredBooleanGroup, ref long requiredInt64Group, ref int requiredStringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group, ref Option<int> stringGroup);
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4427,13 +4427,13 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4441,16 +4441,16 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4462,30 +4462,30 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, cancellationToken).ConfigureAwait(false);
+                return await TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4497,21 +4497,21 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                FormatTestGroupParameters(ref requiredStringGroup, ref requiredBooleanGroup, ref requiredInt64Group, ref stringGroup, ref booleanGroup, ref int64Group);
+                FormatTestGroupParameters(ref requiredBooleanGroup, ref requiredInt64Group, ref requiredStringGroup, ref booleanGroup, ref int64Group, ref stringGroup);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4522,14 +4522,14 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
                     parseQueryStringLocalVar["required_int64_group"] = ClientUtils.ParameterToString(requiredInt64Group);
-
-                    if (stringGroup.IsSet)
-                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
+                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
 
                     if (int64Group.IsSet)
                         parseQueryStringLocalVar["int64_group"] = ClientUtils.ParameterToString(int64Group.Value);
+
+                    if (stringGroup.IsSet)
+                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -4558,7 +4558,7 @@ namespace Org.OpenAPITools.Api
 
                         TestGroupParametersApiResponse apiResponseLocalVar = new TestGroupParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 
                         Events.ExecuteOnTestGroupParameters(apiResponseLocalVar);
 
@@ -4572,7 +4572,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
                 Events.ExecuteOnErrorTestGroupParameters(e);
                 throw;
             }
@@ -5208,38 +5208,38 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, ref string requiredNotNullable, ref string requiredNullable, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable);
+        partial void FormatTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, ref string requiredNotNullable, List<string> url, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable, ref string requiredNullable);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <returns></returns>
-        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, Option<string> notRequiredNotNullable)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable)
         {
-            if (pipe == null)
-                throw new ArgumentNullException(nameof(pipe));
-
-            if (ioutil == null)
-                throw new ArgumentNullException(nameof(ioutil));
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
 
             if (http == null)
                 throw new ArgumentNullException(nameof(http));
 
-            if (url == null)
-                throw new ArgumentNullException(nameof(url));
+            if (ioutil == null)
+                throw new ArgumentNullException(nameof(ioutil));
 
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
+            if (pipe == null)
+                throw new ArgumentNullException(nameof(pipe));
 
             if (requiredNotNullable == null)
                 throw new ArgumentNullException(nameof(requiredNotNullable));
+
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
 
             if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
                 throw new ArgumentNullException(nameof(notRequiredNotNullable));
@@ -5249,19 +5249,19 @@ namespace Org.OpenAPITools.Api
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -5271,16 +5271,16 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -5288,19 +5288,19 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -5312,36 +5312,36 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         ///  To test the collection format in query parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable, cancellationToken).ConfigureAwait(false);
+                return await TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -5353,26 +5353,26 @@ namespace Org.OpenAPITools.Api
         ///  To test the collection format in query parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, notRequiredNotNullable);
+                ValidateTestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable);
 
-                FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, ref requiredNotNullable, ref requiredNullable, ref notRequiredNotNullable, ref notRequiredNullable);
+                FormatTestQueryParameterCollectionFormat(context, http, ioutil, pipe, ref requiredNotNullable, url, ref notRequiredNotNullable, ref notRequiredNullable, ref requiredNullable);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -5383,12 +5383,12 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
-                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
-                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
-                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["context"] = ClientUtils.ParameterToString(context);
+                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
+                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
+                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
                     parseQueryStringLocalVar["requiredNotNullable"] = ClientUtils.ParameterToString(requiredNotNullable);
+                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["requiredNullable"] = ClientUtils.ParameterToString(requiredNullable);
 
                     if (notRequiredNotNullable.IsSet)
@@ -5412,7 +5412,7 @@ namespace Org.OpenAPITools.Api
 
                         TestQueryParameterCollectionFormatApiResponse apiResponseLocalVar = new TestQueryParameterCollectionFormatApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake/test-query-parameters", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 
                         Events.ExecuteOnTestQueryParameterCollectionFormat(apiResponseLocalVar);
 
@@ -5422,7 +5422,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
                 Events.ExecuteOnErrorTestQueryParameterCollectionFormat(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Api/UserApi.cs
@@ -155,11 +155,11 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs user into the system
@@ -167,11 +167,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs out current logged in user session
@@ -201,11 +201,11 @@ namespace Org.OpenAPITools.Api
         /// This can only be done by the logged in user.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updated user
@@ -213,11 +213,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// This can only be done by the logged in user.
         /// </remarks>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
     }
 
     /// <summary>
@@ -1622,33 +1622,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatLoginUser(ref string username, ref string password);
+        partial void FormatLoginUser(ref string password, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="password"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateLoginUser(string username, string password)
+        private void ValidateLoginUser(string password, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (password == null)
                 throw new ArgumentNullException(nameof(password));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string username, string password)
+        /// <param name="username"></param>
+        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string password, string username)
         {
             bool suppressDefaultLog = false;
-            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, username, password);
+            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, password, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -1658,9 +1658,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string username, string password);
+        /// <param name="username"></param>
+        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string password, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -1668,12 +1668,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, string password)
+        /// <param name="username"></param>
+        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string password, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, username, password);
+            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, password, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -1685,22 +1685,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, string password);
+        /// <param name="username"></param>
+        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string password, string username);
 
         /// <summary>
         /// Logs user into the system 
         /// </summary>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await LoginUserAsync(username, password, cancellationToken).ConfigureAwait(false);
+                return await LoginUserAsync(password, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -1712,19 +1712,19 @@ namespace Org.OpenAPITools.Api
         /// Logs user into the system 
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateLoginUser(username, password);
+                ValidateLoginUser(password, username);
 
-                FormatLoginUser(ref username, ref password);
+                FormatLoginUser(ref password, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1735,8 +1735,8 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
                     parseQueryStringLocalVar["password"] = ClientUtils.ParameterToString(password);
+                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -1763,7 +1763,7 @@ namespace Org.OpenAPITools.Api
 
                         LoginUserApiResponse apiResponseLocalVar = new LoginUserApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/login", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, username, password);
+                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, password, username);
 
                         Events.ExecuteOnLoginUser(apiResponseLocalVar);
 
@@ -1773,7 +1773,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, username, password);
+                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, password, username);
                 Events.ExecuteOnErrorLoginUser(e);
                 throw;
             }
@@ -2014,33 +2014,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatUpdateUser(ref string username, User user);
+        partial void FormatUpdateUser(User user, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="user"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateUpdateUser(string username, User user)
+        private void ValidateUpdateUser(User user, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, string username, User user)
+        /// <param name="username"></param>
+        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, User user, string username)
         {
             bool suppressDefaultLog = false;
-            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, username, user);
+            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, user, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -2050,9 +2050,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, string username, User user);
+        /// <param name="username"></param>
+        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, User user, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -2060,12 +2060,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, User user)
+        /// <param name="username"></param>
+        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, User user, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, username, user);
+            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, user, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -2077,22 +2077,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, User user);
+        /// <param name="username"></param>
+        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, User user, string username);
 
         /// <summary>
         /// Updated user This can only be done by the logged in user.
         /// </summary>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await UpdateUserAsync(username, user, cancellationToken).ConfigureAwait(false);
+                return await UpdateUserAsync(user, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -2104,19 +2104,19 @@ namespace Org.OpenAPITools.Api
         /// Updated user This can only be done by the logged in user.
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateUpdateUser(username, user);
+                ValidateUpdateUser(user, username);
 
-                FormatUpdateUser(ref username, user);
+                FormatUpdateUser(user, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2153,7 +2153,7 @@ namespace Org.OpenAPITools.Api
 
                         UpdateUserApiResponse apiResponseLocalVar = new UpdateUserApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/{username}", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, username, user);
+                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, user, username);
 
                         Events.ExecuteOnUpdateUser(apiResponseLocalVar);
 
@@ -2163,7 +2163,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, username, user);
+                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, user, username);
                 Events.ExecuteOnErrorUpdateUser(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/docs/apis/FakeApi.md
@@ -1067,7 +1067,7 @@ No authorization required
 
 <a id="testendpointparameters"></a>
 # **TestEndpointParameters**
-> void TestEndpointParameters (decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, int integer = null, int int32 = null, long int64 = null, float varFloat = null, string varString = null, System.IO.Stream binary = null, DateTime date = null, DateTime dateTime = null, string password = null, string callback = null)
+> void TestEndpointParameters (decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, System.IO.Stream binary = null, string callback = null, DateTime date = null, DateTime dateTime = null, int int32 = null, long int64 = null, int integer = null, string password = null, float varFloat = null, string varString = null)
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
@@ -1095,24 +1095,24 @@ namespace Example
 
             var apiInstance = new FakeApi(config);
             var number = 8.14D;  // decimal | None
-            var varDouble = 1.2D;  // double | None
             var patternWithoutDelimiter = "patternWithoutDelimiter_example";  // string | None
             var varByte = System.Text.Encoding.ASCII.GetBytes("BYTE_ARRAY_DATA_HERE");  // byte[] | None
-            var integer = 56;  // int | None (optional) 
-            var int32 = 56;  // int | None (optional) 
-            var int64 = 789L;  // long | None (optional) 
-            var varFloat = 3.4F;  // float | None (optional) 
-            var varString = "varString_example";  // string | None (optional) 
+            var varDouble = 1.2D;  // double | None
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
+            var callback = "callback_example";  // string | None (optional) 
             var date = DateTime.Parse("2013-10-20");  // DateTime | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")
+            var int32 = 56;  // int | None (optional) 
+            var int64 = 789L;  // long | None (optional) 
+            var integer = 56;  // int | None (optional) 
             var password = "password_example";  // string | None (optional) 
-            var callback = "callback_example";  // string | None (optional) 
+            var varFloat = 3.4F;  // float | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
 
             try
             {
                 // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-                apiInstance.TestEndpointParameters(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                apiInstance.TestEndpointParameters(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             }
             catch (ApiException  e)
             {
@@ -1132,7 +1132,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    apiInstance.TestEndpointParametersWithHttpInfo(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+    apiInstance.TestEndpointParametersWithHttpInfo(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 }
 catch (ApiException e)
 {
@@ -1147,19 +1147,19 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **number** | **decimal** | None |  |
-| **varDouble** | **double** | None |  |
 | **patternWithoutDelimiter** | **string** | None |  |
 | **varByte** | **byte[]** | None |  |
-| **integer** | **int** | None | [optional]  |
-| **int32** | **int** | None | [optional]  |
-| **int64** | **long** | None | [optional]  |
-| **varFloat** | **float** | None | [optional]  |
-| **varString** | **string** | None | [optional]  |
+| **varDouble** | **double** | None |  |
 | **binary** | **System.IO.Stream****System.IO.Stream** | None | [optional]  |
+| **callback** | **string** | None | [optional]  |
 | **date** | **DateTime** | None | [optional]  |
 | **dateTime** | **DateTime** | None | [optional] [default to &quot;2010-02-01T10:20:10.111110+01:00&quot;] |
+| **int32** | **int** | None | [optional]  |
+| **int64** | **long** | None | [optional]  |
+| **integer** | **int** | None | [optional]  |
 | **password** | **string** | None | [optional]  |
-| **callback** | **string** | None | [optional]  |
+| **varFloat** | **float** | None | [optional]  |
+| **varString** | **string** | None | [optional]  |
 
 ### Return type
 
@@ -1185,7 +1185,7 @@ void (empty response body)
 
 <a id="testenumparameters"></a>
 # **TestEnumParameters**
-> void TestEnumParameters (List<string> enumHeaderStringArray = null, string enumHeaderString = null, List<string> enumQueryStringArray = null, string enumQueryString = null, int enumQueryInteger = null, double enumQueryDouble = null, List<string> enumFormStringArray = null, string enumFormString = null)
+> void TestEnumParameters (string enumFormString = null, List<string> enumFormStringArray = null, string enumHeaderString = null, List<string> enumHeaderStringArray = null, double enumQueryDouble = null, int enumQueryInteger = null, string enumQueryString = null, List<string> enumQueryStringArray = null)
 
 To test enum parameters
 
@@ -1208,19 +1208,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var enumHeaderStringArray = new List<string>(); // List<string> | Header parameter enum test (string array) (optional) 
-            var enumHeaderString = "_abc";  // string | Header parameter enum test (string) (optional)  (default to -efg)
-            var enumQueryStringArray = new List<string>(); // List<string> | Query parameter enum test (string array) (optional) 
-            var enumQueryString = "_abc";  // string | Query parameter enum test (string) (optional)  (default to -efg)
-            var enumQueryInteger = 1;  // int | Query parameter enum test (double) (optional) 
-            var enumQueryDouble = 1.1D;  // double | Query parameter enum test (double) (optional) 
-            var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional)  (default to $)
             var enumFormString = "_abc";  // string | Form parameter enum test (string) (optional)  (default to -efg)
+            var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional)  (default to $)
+            var enumHeaderString = "_abc";  // string | Header parameter enum test (string) (optional)  (default to -efg)
+            var enumHeaderStringArray = new List<string>(); // List<string> | Header parameter enum test (string array) (optional) 
+            var enumQueryDouble = 1.1D;  // double | Query parameter enum test (double) (optional) 
+            var enumQueryInteger = 1;  // int | Query parameter enum test (double) (optional) 
+            var enumQueryString = "_abc";  // string | Query parameter enum test (string) (optional)  (default to -efg)
+            var enumQueryStringArray = new List<string>(); // List<string> | Query parameter enum test (string array) (optional) 
 
             try
             {
                 // To test enum parameters
-                apiInstance.TestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                apiInstance.TestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             }
             catch (ApiException  e)
             {
@@ -1240,7 +1240,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test enum parameters
-    apiInstance.TestEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+    apiInstance.TestEnumParametersWithHttpInfo(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 }
 catch (ApiException e)
 {
@@ -1254,14 +1254,14 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **enumHeaderStringArray** | [**List&lt;string&gt;**](string.md) | Header parameter enum test (string array) | [optional]  |
-| **enumHeaderString** | **string** | Header parameter enum test (string) | [optional] [default to -efg] |
-| **enumQueryStringArray** | [**List&lt;string&gt;**](string.md) | Query parameter enum test (string array) | [optional]  |
-| **enumQueryString** | **string** | Query parameter enum test (string) | [optional] [default to -efg] |
-| **enumQueryInteger** | **int** | Query parameter enum test (double) | [optional]  |
-| **enumQueryDouble** | **double** | Query parameter enum test (double) | [optional]  |
-| **enumFormStringArray** | [**List&lt;string&gt;**](string.md) | Form parameter enum test (string array) | [optional] [default to $] |
 | **enumFormString** | **string** | Form parameter enum test (string) | [optional] [default to -efg] |
+| **enumFormStringArray** | [**List&lt;string&gt;**](string.md) | Form parameter enum test (string array) | [optional] [default to $] |
+| **enumHeaderString** | **string** | Header parameter enum test (string) | [optional] [default to -efg] |
+| **enumHeaderStringArray** | [**List&lt;string&gt;**](string.md) | Header parameter enum test (string array) | [optional]  |
+| **enumQueryDouble** | **double** | Query parameter enum test (double) | [optional]  |
+| **enumQueryInteger** | **int** | Query parameter enum test (double) | [optional]  |
+| **enumQueryString** | **string** | Query parameter enum test (string) | [optional] [default to -efg] |
+| **enumQueryStringArray** | [**List&lt;string&gt;**](string.md) | Query parameter enum test (string array) | [optional]  |
 
 ### Return type
 
@@ -1287,7 +1287,7 @@ No authorization required
 
 <a id="testgroupparameters"></a>
 # **TestGroupParameters**
-> void TestGroupParameters (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int stringGroup = null, bool booleanGroup = null, long int64Group = null)
+> void TestGroupParameters (bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, bool booleanGroup = null, long int64Group = null, int stringGroup = null)
 
 Fake endpoint to test group parameters (optional)
 
@@ -1313,17 +1313,17 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new FakeApi(config);
-            var requiredStringGroup = 56;  // int | Required String in group parameters
             var requiredBooleanGroup = true;  // bool | Required Boolean in group parameters
             var requiredInt64Group = 789L;  // long | Required Integer in group parameters
-            var stringGroup = 56;  // int | String in group parameters (optional) 
+            var requiredStringGroup = 56;  // int | Required String in group parameters
             var booleanGroup = true;  // bool | Boolean in group parameters (optional) 
             var int64Group = 789L;  // long | Integer in group parameters (optional) 
+            var stringGroup = 56;  // int | String in group parameters (optional) 
 
             try
             {
                 // Fake endpoint to test group parameters (optional)
-                apiInstance.TestGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                apiInstance.TestGroupParameters(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             }
             catch (ApiException  e)
             {
@@ -1343,7 +1343,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint to test group parameters (optional)
-    apiInstance.TestGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+    apiInstance.TestGroupParametersWithHttpInfo(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 }
 catch (ApiException e)
 {
@@ -1357,12 +1357,12 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **requiredBooleanGroup** | **bool** | Required Boolean in group parameters |  |
 | **requiredInt64Group** | **long** | Required Integer in group parameters |  |
-| **stringGroup** | **int** | String in group parameters | [optional]  |
+| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **booleanGroup** | **bool** | Boolean in group parameters | [optional]  |
 | **int64Group** | **long** | Integer in group parameters | [optional]  |
+| **stringGroup** | **int** | String in group parameters | [optional]  |
 
 ### Return type
 
@@ -1644,7 +1644,7 @@ No authorization required
 
 <a id="testqueryparametercollectionformat"></a>
 # **TestQueryParameterCollectionFormat**
-> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, string notRequiredNotNullable = null, string notRequiredNullable = null)
+> void TestQueryParameterCollectionFormat (List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, string notRequiredNotNullable = null, string notRequiredNullable = null, string requiredNullable)
 
 
 
@@ -1667,19 +1667,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var pipe = new List<string>(); // List<string> | 
-            var ioutil = new List<string>(); // List<string> | 
-            var http = new List<string>(); // List<string> | 
-            var url = new List<string>(); // List<string> | 
             var context = new List<string>(); // List<string> | 
+            var http = new List<string>(); // List<string> | 
+            var ioutil = new List<string>(); // List<string> | 
+            var pipe = new List<string>(); // List<string> | 
             var requiredNotNullable = "requiredNotNullable_example";  // string | 
-            var requiredNullable = "requiredNullable_example";  // string | 
+            var url = new List<string>(); // List<string> | 
             var notRequiredNotNullable = "notRequiredNotNullable_example";  // string |  (optional) 
             var notRequiredNullable = "notRequiredNullable_example";  // string |  (optional) 
+            var requiredNullable = "requiredNullable_example";  // string | 
 
             try
             {
-                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                apiInstance.TestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             }
             catch (ApiException  e)
             {
@@ -1698,7 +1698,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 }
 catch (ApiException e)
 {
@@ -1712,15 +1712,15 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
-| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
-| **http** | [**List&lt;string&gt;**](string.md) |  |  |
-| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **context** | [**List&lt;string&gt;**](string.md) |  |  |
+| **http** | [**List&lt;string&gt;**](string.md) |  |  |
+| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
+| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
 | **requiredNotNullable** | **string** |  |  |
-| **requiredNullable** | **string** |  |  |
+| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **notRequiredNotNullable** | **string** |  | [optional]  |
 | **notRequiredNullable** | **string** |  | [optional]  |
+| **requiredNullable** | **string** |  |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/docs/apis/UserApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/docs/apis/UserApi.md
@@ -453,7 +453,7 @@ No authorization required
 
 <a id="loginuser"></a>
 # **LoginUser**
-> string LoginUser (string username, string password)
+> string LoginUser (string password, string username)
 
 Logs user into the system
 
@@ -474,13 +474,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | The user name for login
             var password = "password_example";  // string | The password for login in clear text
+            var username = "username_example";  // string | The user name for login
 
             try
             {
                 // Logs user into the system
-                string result = apiInstance.LoginUser(username, password);
+                string result = apiInstance.LoginUser(password, username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -501,7 +501,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Logs user into the system
-    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(username, password);
+    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(password, username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -518,8 +518,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | The user name for login |  |
 | **password** | **string** | The password for login in clear text |  |
+| **username** | **string** | The user name for login |  |
 
 ### Return type
 
@@ -625,7 +625,7 @@ No authorization required
 
 <a id="updateuser"></a>
 # **UpdateUser**
-> void UpdateUser (string username, User user)
+> void UpdateUser (User user, string username)
 
 Updated user
 
@@ -648,13 +648,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | name that need to be deleted
             var user = new User(); // User | Updated user object
+            var username = "username_example";  // string | name that need to be deleted
 
             try
             {
                 // Updated user
-                apiInstance.UpdateUser(username, user);
+                apiInstance.UpdateUser(user, username);
             }
             catch (ApiException  e)
             {
@@ -674,7 +674,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Updated user
-    apiInstance.UpdateUserWithHttpInfo(username, user);
+    apiInstance.UpdateUserWithHttpInfo(user, username);
 }
 catch (ApiException e)
 {
@@ -688,8 +688,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | name that need to be deleted |  |
 | **user** | [**User**](User.md) | Updated user object |  |
+| **username** | **string** | name that need to be deleted |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
@@ -193,20 +193,20 @@ namespace Org.OpenAPITools.Test.Api
         public async Task TestEndpointParametersAsyncTest()
         {
             decimal number = default;
-            double varDouble = default;
             string patternWithoutDelimiter = default;
             byte[] varByte = default;
-            Client.Option<int> integer = default;
-            Client.Option<int> int32 = default;
-            Client.Option<long> int64 = default;
-            Client.Option<float> varFloat = default;
-            Client.Option<string> varString = default;
+            double varDouble = default;
             Client.Option<System.IO.Stream> binary = default;
+            Client.Option<string> callback = default;
             Client.Option<DateTime> date = default;
             Client.Option<DateTime> dateTime = default;
+            Client.Option<int> int32 = default;
+            Client.Option<long> int64 = default;
+            Client.Option<int> integer = default;
             Client.Option<string> password = default;
-            Client.Option<string> callback = default;
-            await _instance.TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            Client.Option<float> varFloat = default;
+            Client.Option<string> varString = default;
+            await _instance.TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
         }
 
         /// <summary>
@@ -215,15 +215,15 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestEnumParametersAsyncTest()
         {
-            Client.Option<List<string>> enumHeaderStringArray = default;
-            Client.Option<string> enumHeaderString = default;
-            Client.Option<List<string>> enumQueryStringArray = default;
-            Client.Option<string> enumQueryString = default;
-            Client.Option<int> enumQueryInteger = default;
-            Client.Option<double> enumQueryDouble = default;
-            Client.Option<List<string>> enumFormStringArray = default;
             Client.Option<string> enumFormString = default;
-            await _instance.TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            Client.Option<List<string>> enumFormStringArray = default;
+            Client.Option<string> enumHeaderString = default;
+            Client.Option<List<string>> enumHeaderStringArray = default;
+            Client.Option<double> enumQueryDouble = default;
+            Client.Option<int> enumQueryInteger = default;
+            Client.Option<string> enumQueryString = default;
+            Client.Option<List<string>> enumQueryStringArray = default;
+            await _instance.TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
         }
 
         /// <summary>
@@ -232,13 +232,13 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestGroupParametersAsyncTest()
         {
-            int requiredStringGroup = default;
             bool requiredBooleanGroup = default;
             long requiredInt64Group = default;
-            Client.Option<int> stringGroup = default;
+            int requiredStringGroup = default;
             Client.Option<bool> booleanGroup = default;
             Client.Option<long> int64Group = default;
-            await _instance.TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            Client.Option<int> stringGroup = default;
+            await _instance.TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
         }
 
         /// <summary>
@@ -278,16 +278,16 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestQueryParameterCollectionFormatAsyncTest()
         {
-            List<string> pipe = default;
-            List<string> ioutil = default;
-            List<string> http = default;
-            List<string> url = default;
             List<string> context = default;
+            List<string> http = default;
+            List<string> ioutil = default;
+            List<string> pipe = default;
             string requiredNotNullable = default;
-            string requiredNullable = default;
+            List<string> url = default;
             Client.Option<string> notRequiredNotNullable = default;
             Client.Option<string> notRequiredNullable = default;
-            await _instance.TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            string requiredNullable = default;
+            await _instance.TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
@@ -108,9 +108,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task LoginUserAsyncTest()
         {
-            string username = default;
             string password = default;
-            var response = await _instance.LoginUserAsync(username, password);
+            string username = default;
+            var response = await _instance.LoginUserAsync(password, username);
             var model = response.Ok();
             Assert.IsType<string>(model);
         }
@@ -130,9 +130,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task UpdateUserAsyncTest()
         {
-            string username = default;
             User user = default;
-            await _instance.UpdateUserAsync(username, user);
+            string username = default;
+            await _instance.UpdateUserAsync(user, username);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -313,22 +313,22 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </remarks>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -361,17 +361,17 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -379,17 +379,17 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test enum parameters
         /// </remarks>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -398,15 +398,15 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -414,15 +414,15 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test inline additionalProperties
@@ -502,18 +502,18 @@ namespace Org.OpenAPITools.Api
         /// To test the collection format in query parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -521,18 +521,18 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test the collection format in query parameters
         /// </remarks>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test referenced string map
@@ -3781,19 +3781,19 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEndpointParameters(ref decimal number, ref double varDouble, ref string patternWithoutDelimiter, ref byte[] varByte, ref Option<int> integer, ref Option<int> int32, ref Option<long> int64, ref Option<float> varFloat, ref Option<string> varString, ref Option<System.IO.Stream> binary, ref Option<DateTime> date, ref Option<DateTime> dateTime, ref Option<string> password, ref Option<string> callback);
+        partial void FormatTestEndpointParameters(ref decimal number, ref string patternWithoutDelimiter, ref byte[] varByte, ref double varDouble, ref Option<System.IO.Stream> binary, ref Option<string> callback, ref Option<DateTime> date, ref Option<DateTime> dateTime, ref Option<int> int32, ref Option<long> int64, ref Option<int> integer, ref Option<string> password, ref Option<float> varFloat, ref Option<string> varString);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="varString"></param>
         /// <param name="binary"></param>
-        /// <param name="password"></param>
         /// <param name="callback"></param>
+        /// <param name="password"></param>
+        /// <param name="varString"></param>
         /// <returns></returns>
-        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<string> varString, Option<System.IO.Stream> binary, Option<string> password, Option<string> callback)
+        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<System.IO.Stream> binary, Option<string> callback, Option<string> password, Option<string> varString)
         {
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
@@ -3801,17 +3801,17 @@ namespace Org.OpenAPITools.Api
             if (varByte == null)
                 throw new ArgumentNullException(nameof(varByte));
 
-            if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString));
-
             if (binary.IsSet && binary.Value == null)
                 throw new ArgumentNullException(nameof(binary));
+
+            if (callback.IsSet && callback.Value == null)
+                throw new ArgumentNullException(nameof(callback));
 
             if (password.IsSet && password.Value == null)
                 throw new ArgumentNullException(nameof(password));
 
-            if (callback.IsSet && callback.Value == null)
-                throw new ArgumentNullException(nameof(callback));
+            if (varString.IsSet && varString.Value == null)
+                throw new ArgumentNullException(nameof(varString));
         }
 
         /// <summary>
@@ -3819,23 +3819,23 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -3846,20 +3846,20 @@ namespace Org.OpenAPITools.Api
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -3868,23 +3868,23 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -3897,45 +3897,45 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트  Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback, cancellationToken).ConfigureAwait(false);
+                return await TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -3948,30 +3948,30 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, varString, binary, password, callback);
+                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, binary, callback, password, varString);
 
-                FormatTestEndpointParameters(ref number, ref varDouble, ref patternWithoutDelimiter, ref varByte, ref integer, ref int32, ref int64, ref varFloat, ref varString, ref binary, ref date, ref dateTime, ref password, ref callback);
+                FormatTestEndpointParameters(ref number, ref patternWithoutDelimiter, ref varByte, ref varDouble, ref binary, ref callback, ref date, ref dateTime, ref int32, ref int64, ref integer, ref password, ref varFloat, ref varString);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -3990,29 +3990,17 @@ namespace Org.OpenAPITools.Api
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("number", ClientUtils.ParameterToString(number)));
 
-                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
-
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("pattern_without_delimiter", ClientUtils.ParameterToString(patternWithoutDelimiter)));
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("byte", ClientUtils.ParameterToString(varByte)));
 
-                    if (integer.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
-
-                    if (int32.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
-
-                    if (int64.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
-
-                    if (varFloat.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
-
-                    if (varString.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
+                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
 
                     if (binary.IsSet)
                         multipartContentLocalVar.Add(new StreamContent(binary.Value));
+
+                    if (callback.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
 
                     if (date.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("date", ClientUtils.ParameterToString(date.Value)));
@@ -4020,11 +4008,23 @@ namespace Org.OpenAPITools.Api
                     if (dateTime.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("dateTime", ClientUtils.ParameterToString(dateTime.Value)));
 
+                    if (int32.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
+
+                    if (int64.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
+
+                    if (integer.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
+
                     if (password.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("password", ClientUtils.ParameterToString(password.Value)));
 
-                    if (callback.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
+                    if (varFloat.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
+
+                    if (varString.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
 
                     List<TokenBase> tokenBaseLocalVars = new List<TokenBase>();
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
@@ -4056,7 +4056,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEndpointParametersApiResponse apiResponseLocalVar = new TestEndpointParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 
                         Events.ExecuteOnTestEndpointParameters(apiResponseLocalVar);
 
@@ -4070,7 +4070,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
                 Events.ExecuteOnErrorTestEndpointParameters(e);
                 throw;
             }
@@ -4127,55 +4127,55 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEnumParameters(Option<List<string>> enumHeaderStringArray, ref Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, ref Option<string> enumQueryString, ref Option<int> enumQueryInteger, ref Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, ref Option<string> enumFormString);
+        partial void FormatTestEnumParameters(ref Option<string> enumFormString, Option<List<string>> enumFormStringArray, ref Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, ref Option<double> enumQueryDouble, ref Option<int> enumQueryInteger, ref Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
         /// <returns></returns>
-        private void ValidateTestEnumParameters(Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        private void ValidateTestEnumParameters(Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
-            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderStringArray));
-
-            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderString));
-
-            if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumQueryStringArray));
-
-            if (enumQueryString.IsSet && enumQueryString.Value == null)
-                throw new ArgumentNullException(nameof(enumQueryString));
+            if (enumFormString.IsSet && enumFormString.Value == null)
+                throw new ArgumentNullException(nameof(enumFormString));
 
             if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumFormStringArray));
 
-            if (enumFormString.IsSet && enumFormString.Value == null)
-                throw new ArgumentNullException(nameof(enumFormString));
+            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderString));
+
+            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderStringArray));
+
+            if (enumQueryString.IsSet && enumQueryString.Value == null)
+                throw new ArgumentNullException(nameof(enumQueryString));
+
+            if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumQueryStringArray));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4185,15 +4185,15 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4201,18 +4201,18 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4224,34 +4224,34 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// To test enum parameters To test enum parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, cancellationToken).ConfigureAwait(false);
+                return await TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4263,25 +4263,25 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumFormStringArray, enumFormString);
+                ValidateTestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryString, enumQueryStringArray);
 
-                FormatTestEnumParameters(enumHeaderStringArray, ref enumHeaderString, enumQueryStringArray, ref enumQueryString, ref enumQueryInteger, ref enumQueryDouble, enumFormStringArray, ref enumFormString);
+                FormatTestEnumParameters(ref enumFormString, enumFormStringArray, ref enumHeaderString, enumHeaderStringArray, ref enumQueryDouble, ref enumQueryInteger, ref enumQueryString, enumQueryStringArray);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4292,25 +4292,25 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    if (enumQueryStringArray.IsSet)
-                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
-
-                    if (enumQueryString.IsSet)
-                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+                    if (enumQueryDouble.IsSet)
+                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
 
                     if (enumQueryInteger.IsSet)
                         parseQueryStringLocalVar["enum_query_integer"] = ClientUtils.ParameterToString(enumQueryInteger.Value);
 
-                    if (enumQueryDouble.IsSet)
-                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
+                    if (enumQueryString.IsSet)
+                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+
+                    if (enumQueryStringArray.IsSet)
+                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
-                    if (enumHeaderStringArray.IsSet)
-                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
-
                     if (enumHeaderString.IsSet)
                         httpRequestMessageLocalVar.Headers.Add("enum_header_string", ClientUtils.ParameterToString(enumHeaderString.Value));
+
+                    if (enumHeaderStringArray.IsSet)
+                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
 
                     MultipartContent multipartContentLocalVar = new MultipartContent();
 
@@ -4318,11 +4318,11 @@ namespace Org.OpenAPITools.Api
 
                     List<KeyValuePair<string, string>> formParameterLocalVars = new List<KeyValuePair<string, string>>();
 
-                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormStringArray.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
-
-                    if (enumFormString.IsSet)
+                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormString.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string", ClientUtils.ParameterToString(enumFormString.Value)));
+
+                    if (enumFormStringArray.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
 
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
 
@@ -4347,7 +4347,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEnumParametersApiResponse apiResponseLocalVar = new TestEnumParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 
                         Events.ExecuteOnTestEnumParameters(apiResponseLocalVar);
 
@@ -4357,7 +4357,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
                 Events.ExecuteOnErrorTestEnumParameters(e);
                 throw;
             }
@@ -4414,22 +4414,22 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestGroupParameters(ref int requiredStringGroup, ref bool requiredBooleanGroup, ref long requiredInt64Group, ref Option<int> stringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group);
+        partial void FormatTestGroupParameters(ref bool requiredBooleanGroup, ref long requiredInt64Group, ref int requiredStringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group, ref Option<int> stringGroup);
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4439,13 +4439,13 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4453,16 +4453,16 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4474,30 +4474,30 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, cancellationToken).ConfigureAwait(false);
+                return await TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4509,21 +4509,21 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                FormatTestGroupParameters(ref requiredStringGroup, ref requiredBooleanGroup, ref requiredInt64Group, ref stringGroup, ref booleanGroup, ref int64Group);
+                FormatTestGroupParameters(ref requiredBooleanGroup, ref requiredInt64Group, ref requiredStringGroup, ref booleanGroup, ref int64Group, ref stringGroup);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4534,14 +4534,14 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
                     parseQueryStringLocalVar["required_int64_group"] = ClientUtils.ParameterToString(requiredInt64Group);
-
-                    if (stringGroup.IsSet)
-                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
+                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
 
                     if (int64Group.IsSet)
                         parseQueryStringLocalVar["int64_group"] = ClientUtils.ParameterToString(int64Group.Value);
+
+                    if (stringGroup.IsSet)
+                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -4570,7 +4570,7 @@ namespace Org.OpenAPITools.Api
 
                         TestGroupParametersApiResponse apiResponseLocalVar = new TestGroupParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 
                         Events.ExecuteOnTestGroupParameters(apiResponseLocalVar);
 
@@ -4584,7 +4584,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
                 Events.ExecuteOnErrorTestGroupParameters(e);
                 throw;
             }
@@ -5220,38 +5220,38 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, ref string requiredNotNullable, ref string requiredNullable, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable);
+        partial void FormatTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, ref string requiredNotNullable, List<string> url, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable, ref string requiredNullable);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <returns></returns>
-        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, Option<string> notRequiredNotNullable)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable)
         {
-            if (pipe == null)
-                throw new ArgumentNullException(nameof(pipe));
-
-            if (ioutil == null)
-                throw new ArgumentNullException(nameof(ioutil));
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
 
             if (http == null)
                 throw new ArgumentNullException(nameof(http));
 
-            if (url == null)
-                throw new ArgumentNullException(nameof(url));
+            if (ioutil == null)
+                throw new ArgumentNullException(nameof(ioutil));
 
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
+            if (pipe == null)
+                throw new ArgumentNullException(nameof(pipe));
 
             if (requiredNotNullable == null)
                 throw new ArgumentNullException(nameof(requiredNotNullable));
+
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
 
             if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
                 throw new ArgumentNullException(nameof(notRequiredNotNullable));
@@ -5261,19 +5261,19 @@ namespace Org.OpenAPITools.Api
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -5283,16 +5283,16 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -5300,19 +5300,19 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -5324,36 +5324,36 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         ///  To test the collection format in query parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable, cancellationToken).ConfigureAwait(false);
+                return await TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -5365,26 +5365,26 @@ namespace Org.OpenAPITools.Api
         ///  To test the collection format in query parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, notRequiredNotNullable);
+                ValidateTestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable);
 
-                FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, ref requiredNotNullable, ref requiredNullable, ref notRequiredNotNullable, ref notRequiredNullable);
+                FormatTestQueryParameterCollectionFormat(context, http, ioutil, pipe, ref requiredNotNullable, url, ref notRequiredNotNullable, ref notRequiredNullable, ref requiredNullable);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -5395,12 +5395,12 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
-                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
-                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
-                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["context"] = ClientUtils.ParameterToString(context);
+                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
+                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
+                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
                     parseQueryStringLocalVar["requiredNotNullable"] = ClientUtils.ParameterToString(requiredNotNullable);
+                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["requiredNullable"] = ClientUtils.ParameterToString(requiredNullable);
 
                     if (notRequiredNotNullable.IsSet)
@@ -5424,7 +5424,7 @@ namespace Org.OpenAPITools.Api
 
                         TestQueryParameterCollectionFormatApiResponse apiResponseLocalVar = new TestQueryParameterCollectionFormatApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake/test-query-parameters", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 
                         Events.ExecuteOnTestQueryParameterCollectionFormat(apiResponseLocalVar);
 
@@ -5434,7 +5434,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
                 Events.ExecuteOnErrorTestQueryParameterCollectionFormat(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
@@ -155,11 +155,11 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs user into the system
@@ -167,11 +167,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs out current logged in user session
@@ -201,11 +201,11 @@ namespace Org.OpenAPITools.Api
         /// This can only be done by the logged in user.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updated user
@@ -213,11 +213,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// This can only be done by the logged in user.
         /// </remarks>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
     }
 
     /// <summary>
@@ -1622,33 +1622,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatLoginUser(ref string username, ref string password);
+        partial void FormatLoginUser(ref string password, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="password"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateLoginUser(string username, string password)
+        private void ValidateLoginUser(string password, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (password == null)
                 throw new ArgumentNullException(nameof(password));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string username, string password)
+        /// <param name="username"></param>
+        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string password, string username)
         {
             bool suppressDefaultLog = false;
-            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, username, password);
+            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, password, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -1658,9 +1658,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string username, string password);
+        /// <param name="username"></param>
+        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string password, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -1668,12 +1668,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, string password)
+        /// <param name="username"></param>
+        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string password, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, username, password);
+            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, password, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -1685,22 +1685,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, string password);
+        /// <param name="username"></param>
+        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string password, string username);
 
         /// <summary>
         /// Logs user into the system 
         /// </summary>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await LoginUserAsync(username, password, cancellationToken).ConfigureAwait(false);
+                return await LoginUserAsync(password, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -1712,19 +1712,19 @@ namespace Org.OpenAPITools.Api
         /// Logs user into the system 
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateLoginUser(username, password);
+                ValidateLoginUser(password, username);
 
-                FormatLoginUser(ref username, ref password);
+                FormatLoginUser(ref password, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1735,8 +1735,8 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
                     parseQueryStringLocalVar["password"] = ClientUtils.ParameterToString(password);
+                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -1763,7 +1763,7 @@ namespace Org.OpenAPITools.Api
 
                         LoginUserApiResponse apiResponseLocalVar = new LoginUserApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/login", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, username, password);
+                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, password, username);
 
                         Events.ExecuteOnLoginUser(apiResponseLocalVar);
 
@@ -1773,7 +1773,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, username, password);
+                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, password, username);
                 Events.ExecuteOnErrorLoginUser(e);
                 throw;
             }
@@ -2014,33 +2014,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatUpdateUser(ref string username, User user);
+        partial void FormatUpdateUser(User user, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="user"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateUpdateUser(string username, User user)
+        private void ValidateUpdateUser(User user, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, string username, User user)
+        /// <param name="username"></param>
+        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, User user, string username)
         {
             bool suppressDefaultLog = false;
-            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, username, user);
+            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, user, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -2050,9 +2050,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, string username, User user);
+        /// <param name="username"></param>
+        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, User user, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -2060,12 +2060,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, User user)
+        /// <param name="username"></param>
+        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, User user, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, username, user);
+            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, user, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -2077,22 +2077,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, User user);
+        /// <param name="username"></param>
+        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, User user, string username);
 
         /// <summary>
         /// Updated user This can only be done by the logged in user.
         /// </summary>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await UpdateUserAsync(username, user, cancellationToken).ConfigureAwait(false);
+                return await UpdateUserAsync(user, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -2104,19 +2104,19 @@ namespace Org.OpenAPITools.Api
         /// Updated user This can only be done by the logged in user.
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateUpdateUser(username, user);
+                ValidateUpdateUser(user, username);
 
-                FormatUpdateUser(ref username, user);
+                FormatUpdateUser(user, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2153,7 +2153,7 @@ namespace Org.OpenAPITools.Api
 
                         UpdateUserApiResponse apiResponseLocalVar = new UpdateUserApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/{username}", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, username, user);
+                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, user, username);
 
                         Events.ExecuteOnUpdateUser(apiResponseLocalVar);
 
@@ -2163,7 +2163,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, username, user);
+                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, user, username);
                 Events.ExecuteOnErrorUpdateUser(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/docs/models/Adult.md
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/docs/models/Adult.md
@@ -5,9 +5,9 @@ A representation of an adult
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Type** | **string** |  | [optional] 
-**LastName** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
+**LastName** | **string** |  | [optional] 
+**Type** | **string** |  | [optional] 
 **Children** | [**List&lt;Child&gt;**](Child.md) |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/docs/models/Child.md
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/docs/models/Child.md
@@ -5,11 +5,11 @@ A representation of a child
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Type** | **string** |  | [optional] 
-**LastName** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
-**BoosterSeat** | **bool** |  | [optional] 
+**LastName** | **string** |  | [optional] 
+**Type** | **string** |  | [optional] 
 **Age** | **int** |  | [optional] 
+**BoosterSeat** | **bool** |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/docs/models/Person.md
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/docs/models/Person.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Type** | **string** |  | [optional] 
-**LastName** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
+**LastName** | **string** |  | [optional] 
+**Type** | **string** |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools.Test/Model/ChildTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools.Test/Model/ChildTests.cs
@@ -54,21 +54,21 @@ namespace Org.OpenAPITools.Test.Model
         }
 
         /// <summary>
-        /// Test the property 'BoosterSeat'
-        /// </summary>
-        [Fact]
-        public void BoosterSeatTest()
-        {
-            // TODO unit test for the property 'BoosterSeat'
-        }
-
-        /// <summary>
         /// Test the property 'Age'
         /// </summary>
         [Fact]
         public void AgeTest()
         {
             // TODO unit test for the property 'Age'
+        }
+
+        /// <summary>
+        /// Test the property 'BoosterSeat'
+        /// </summary>
+        [Fact]
+        public void BoosterSeatTest()
+        {
+            // TODO unit test for the property 'BoosterSeat'
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools.Test/Model/PersonTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools.Test/Model/PersonTests.cs
@@ -74,12 +74,12 @@ namespace Org.OpenAPITools.Test.Model
         }
 
         /// <summary>
-        /// Test the property 'Type'
+        /// Test the property 'FirstName'
         /// </summary>
         [Fact]
-        public void TypeTest()
+        public void FirstNameTest()
         {
-            // TODO unit test for the property 'Type'
+            // TODO unit test for the property 'FirstName'
         }
 
         /// <summary>
@@ -92,12 +92,12 @@ namespace Org.OpenAPITools.Test.Model
         }
 
         /// <summary>
-        /// Test the property 'FirstName'
+        /// Test the property 'Type'
         /// </summary>
         [Fact]
-        public void FirstNameTest()
+        public void TypeTest()
         {
-            // TODO unit test for the property 'FirstName'
+            // TODO unit test for the property 'Type'
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -32,24 +32,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Adult" /> class.
         /// </summary>
-        /// <param name="lastName">lastName</param>
-        /// <param name="firstName">firstName</param>
         /// <param name="children">children</param>
+        /// <param name="firstName">firstName</param>
+        /// <param name="lastName">lastName</param>
         [JsonConstructor]
-        public Adult(Option<string> lastName = default, Option<string> firstName = default, Option<List<Child>> children = default) : base(lastName, firstName)
+        public Adult(Option<List<Child>> children = default, Option<string> firstName = default, Option<string> lastName = default) : base(firstName, lastName)
         {
             ChildrenOption = children;
             OnCreated();
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public new string Type { get; } = "Adult";
 
         /// <summary>
         /// Used to track the state of Children
@@ -63,6 +56,13 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("children")]
         public List<Child> Children { get { return this.ChildrenOption; } set { this.ChildrenOption = new Option<List<Child>>(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public new string Type { get; } = "Adult";
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -101,10 +101,10 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<string> type = default;
-            Option<string> lastName = default;
-            Option<string> firstName = default;
             Option<List<Child>> children = default;
+            Option<string> firstName = default;
+            Option<string> lastName = default;
+            Option<string> type = default;
 
             while (utf8JsonReader.Read())
             {
@@ -121,18 +121,18 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
-                        case "$_type":
-                            type = new Option<string>(utf8JsonReader.GetString());
-                            break;
-                        case "lastName":
-                            lastName = new Option<string>(utf8JsonReader.GetString());
+                        case "children":
+                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
+                                children = new Option<List<Child>>(JsonSerializer.Deserialize<List<Child>>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "firstName":
                             firstName = new Option<string>(utf8JsonReader.GetString());
                             break;
-                        case "children":
-                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                children = new Option<List<Child>>(JsonSerializer.Deserialize<List<Child>>(ref utf8JsonReader, jsonSerializerOptions));
+                        case "lastName":
+                            lastName = new Option<string>(utf8JsonReader.GetString());
+                            break;
+                        case "$_type":
+                            type = new Option<string>(utf8JsonReader.GetString());
                             break;
                         default:
                             break;
@@ -140,19 +140,19 @@ namespace Org.OpenAPITools.Model
                 }
             }
 
-            if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Adult.");
-
-            if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Adult.");
+            if (children.IsSet && children.Value == null)
+                throw new ArgumentNullException(nameof(children), "Property is not nullable for class Adult.");
 
             if (firstName.IsSet && firstName.Value == null)
                 throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Adult.");
 
-            if (children.IsSet && children.Value == null)
-                throw new ArgumentNullException(nameof(children), "Property is not nullable for class Adult.");
+            if (lastName.IsSet && lastName.Value == null)
+                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Adult.");
 
-            return new Adult(lastName, firstName, children);
+            if (type.IsSet && type.Value == null)
+                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Adult.");
+
+            return new Adult(children, firstName, lastName);
         }
 
         /// <summary>
@@ -179,28 +179,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Adult adult, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (adult.LastNameOption.IsSet && adult.LastName == null)
-                throw new ArgumentNullException(nameof(adult.LastName), "Property is required for class Adult.");
+            if (adult.ChildrenOption.IsSet && adult.Children == null)
+                throw new ArgumentNullException(nameof(adult.Children), "Property is required for class Adult.");
 
             if (adult.FirstNameOption.IsSet && adult.FirstName == null)
                 throw new ArgumentNullException(nameof(adult.FirstName), "Property is required for class Adult.");
 
-            if (adult.ChildrenOption.IsSet && adult.Children == null)
-                throw new ArgumentNullException(nameof(adult.Children), "Property is required for class Adult.");
-
-            writer.WriteString("$_type", adult.Type);
-
-            if (adult.LastNameOption.IsSet)
-                writer.WriteString("lastName", adult.LastName);
-
-            if (adult.FirstNameOption.IsSet)
-                writer.WriteString("firstName", adult.FirstName);
+            if (adult.LastNameOption.IsSet && adult.LastName == null)
+                throw new ArgumentNullException(nameof(adult.LastName), "Property is required for class Adult.");
 
             if (adult.ChildrenOption.IsSet)
             {
                 writer.WritePropertyName("children");
                 JsonSerializer.Serialize(writer, adult.Children, jsonSerializerOptions);
             }
+            if (adult.FirstNameOption.IsSet)
+                writer.WriteString("firstName", adult.FirstName);
+
+            if (adult.LastNameOption.IsSet)
+                writer.WriteString("lastName", adult.LastName);
+
+            writer.WriteString("$_type", adult.Type);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -32,12 +32,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Child" /> class.
         /// </summary>
-        /// <param name="lastName">lastName</param>
-        /// <param name="firstName">firstName</param>
         /// <param name="age">age</param>
+        /// <param name="firstName">firstName</param>
+        /// <param name="lastName">lastName</param>
         /// <param name="boosterSeat">boosterSeat</param>
         [JsonConstructor]
-        public Child(Option<string> lastName = default, Option<string> firstName = default, Option<int?> age = default, Option<bool?> boosterSeat = default) : base(lastName, firstName)
+        public Child(Option<int?> age = default, Option<string> firstName = default, Option<string> lastName = default, Option<bool?> boosterSeat = default) : base(firstName, lastName)
         {
             AgeOption = age;
             BoosterSeatOption = boosterSeat;
@@ -45,13 +45,6 @@ namespace Org.OpenAPITools.Model
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public new string Type { get; } = "Child";
 
         /// <summary>
         /// Used to track the state of Age
@@ -65,6 +58,13 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("age")]
         public int? Age { get { return this.AgeOption; } set { this.AgeOption = new Option<int?>(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public new string Type { get; } = "Child";
 
         /// <summary>
         /// Used to track the state of BoosterSeat
@@ -88,8 +88,8 @@ namespace Org.OpenAPITools.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class Child {\n");
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
-            sb.Append("  BoosterSeat: ").Append(BoosterSeat).Append("\n");
             sb.Append("  Age: ").Append(Age).Append("\n");
+            sb.Append("  BoosterSeat: ").Append(BoosterSeat).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -117,10 +117,10 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<string> type = default;
-            Option<string> lastName = default;
-            Option<string> firstName = default;
             Option<int?> age = default;
+            Option<string> firstName = default;
+            Option<string> lastName = default;
+            Option<string> type = default;
             Option<bool?> boosterSeat = default;
 
             while (utf8JsonReader.Read())
@@ -138,18 +138,18 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
-                        case "$_type":
-                            type = new Option<string>(utf8JsonReader.GetString());
-                            break;
-                        case "lastName":
-                            lastName = new Option<string>(utf8JsonReader.GetString());
+                        case "age":
+                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
+                                age = new Option<int?>(utf8JsonReader.GetInt32());
                             break;
                         case "firstName":
                             firstName = new Option<string>(utf8JsonReader.GetString());
                             break;
-                        case "age":
-                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                age = new Option<int?>(utf8JsonReader.GetInt32());
+                        case "lastName":
+                            lastName = new Option<string>(utf8JsonReader.GetString());
+                            break;
+                        case "$_type":
+                            type = new Option<string>(utf8JsonReader.GetString());
                             break;
                         case "boosterSeat":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
@@ -161,22 +161,22 @@ namespace Org.OpenAPITools.Model
                 }
             }
 
-            if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Child.");
-
-            if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Child.");
+            if (age.IsSet && age.Value == null)
+                throw new ArgumentNullException(nameof(age), "Property is not nullable for class Child.");
 
             if (firstName.IsSet && firstName.Value == null)
                 throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Child.");
 
-            if (age.IsSet && age.Value == null)
-                throw new ArgumentNullException(nameof(age), "Property is not nullable for class Child.");
+            if (lastName.IsSet && lastName.Value == null)
+                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Child.");
+
+            if (type.IsSet && type.Value == null)
+                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Child.");
 
             if (boosterSeat.IsSet && boosterSeat.Value == null)
                 throw new ArgumentNullException(nameof(boosterSeat), "Property is not nullable for class Child.");
 
-            return new Child(lastName, firstName, age, boosterSeat);
+            return new Child(age, firstName, lastName, boosterSeat);
         }
 
         /// <summary>
@@ -203,22 +203,22 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Child child, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (child.LastNameOption.IsSet && child.LastName == null)
-                throw new ArgumentNullException(nameof(child.LastName), "Property is required for class Child.");
-
             if (child.FirstNameOption.IsSet && child.FirstName == null)
                 throw new ArgumentNullException(nameof(child.FirstName), "Property is required for class Child.");
 
-            writer.WriteString("$_type", child.Type);
+            if (child.LastNameOption.IsSet && child.LastName == null)
+                throw new ArgumentNullException(nameof(child.LastName), "Property is required for class Child.");
 
-            if (child.LastNameOption.IsSet)
-                writer.WriteString("lastName", child.LastName);
+            if (child.AgeOption.IsSet)
+                writer.WriteNumber("age", child.AgeOption.Value.Value);
 
             if (child.FirstNameOption.IsSet)
                 writer.WriteString("firstName", child.FirstName);
 
-            if (child.AgeOption.IsSet)
-                writer.WriteNumber("age", child.AgeOption.Value.Value);
+            if (child.LastNameOption.IsSet)
+                writer.WriteString("lastName", child.LastName);
+
+            writer.WriteString("$_type", child.Type);
 
             if (child.BoosterSeatOption.IsSet)
                 writer.WriteBoolean("boosterSeat", child.BoosterSeatOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -32,37 +32,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Person" /> class.
         /// </summary>
-        /// <param name="lastName">lastName</param>
         /// <param name="firstName">firstName</param>
+        /// <param name="lastName">lastName</param>
         [JsonConstructor]
-        public Person(Option<string> lastName = default, Option<string> firstName = default)
+        public Person(Option<string> firstName = default, Option<string> lastName = default)
         {
-            LastNameOption = lastName;
             FirstNameOption = firstName;
+            LastNameOption = lastName;
             OnCreated();
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public string Type { get; } = "Person";
-
-        /// <summary>
-        /// Used to track the state of LastName
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public Option<string> LastNameOption { get; private set; }
-
-        /// <summary>
-        /// Gets or Sets LastName
-        /// </summary>
-        [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -78,6 +58,26 @@ namespace Org.OpenAPITools.Model
         public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new Option<string>(value); } }
 
         /// <summary>
+        /// Used to track the state of LastName
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public Option<string> LastNameOption { get; private set; }
+
+        /// <summary>
+        /// Gets or Sets LastName
+        /// </summary>
+        [JsonPropertyName("lastName")]
+        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new Option<string>(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public string Type { get; } = "Person";
+
+        /// <summary>
         /// Gets or Sets additional properties
         /// </summary>
         [JsonExtensionData]
@@ -91,8 +91,8 @@ namespace Org.OpenAPITools.Model
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("class Person {\n");
-            sb.Append("  LastName: ").Append(LastName).Append("\n");
             sb.Append("  FirstName: ").Append(FirstName).Append("\n");
+            sb.Append("  LastName: ").Append(LastName).Append("\n");
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -141,9 +141,9 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<string> type = default;
-            Option<string> lastName = default;
             Option<string> firstName = default;
+            Option<string> lastName = default;
+            Option<string> type = default;
 
             string discriminator = ClientUtils.GetDiscriminator(utf8JsonReader, "$_type");
 
@@ -168,14 +168,14 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
-                        case "$_type":
-                            type = new Option<string>(utf8JsonReader.GetString());
+                        case "firstName":
+                            firstName = new Option<string>(utf8JsonReader.GetString());
                             break;
                         case "lastName":
                             lastName = new Option<string>(utf8JsonReader.GetString());
                             break;
-                        case "firstName":
-                            firstName = new Option<string>(utf8JsonReader.GetString());
+                        case "$_type":
+                            type = new Option<string>(utf8JsonReader.GetString());
                             break;
                         default:
                             break;
@@ -183,16 +183,16 @@ namespace Org.OpenAPITools.Model
                 }
             }
 
-            if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Person.");
+            if (firstName.IsSet && firstName.Value == null)
+                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Person.");
 
             if (lastName.IsSet && lastName.Value == null)
                 throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Person.");
 
-            if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Person.");
+            if (type.IsSet && type.Value == null)
+                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Person.");
 
-            return new Person(lastName, firstName);
+            return new Person(firstName, lastName);
         }
 
         /// <summary>
@@ -229,19 +229,19 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Person person, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (person.LastNameOption.IsSet && person.LastName == null)
-                throw new ArgumentNullException(nameof(person.LastName), "Property is required for class Person.");
-
             if (person.FirstNameOption.IsSet && person.FirstName == null)
                 throw new ArgumentNullException(nameof(person.FirstName), "Property is required for class Person.");
 
-            writer.WriteString("$_type", person.Type);
+            if (person.LastNameOption.IsSet && person.LastName == null)
+                throw new ArgumentNullException(nameof(person.LastName), "Property is required for class Person.");
+
+            if (person.FirstNameOption.IsSet)
+                writer.WriteString("firstName", person.FirstName);
 
             if (person.LastNameOption.IsSet)
                 writer.WriteString("lastName", person.LastName);
 
-            if (person.FirstNameOption.IsSet)
-                writer.WriteString("firstName", person.FirstName);
+            writer.WriteString("$_type", person.Type);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/docs/apis/FakeApi.md
@@ -1067,7 +1067,7 @@ No authorization required
 
 <a id="testendpointparameters"></a>
 # **TestEndpointParameters**
-> void TestEndpointParameters (decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, int integer = null, int int32 = null, long int64 = null, float varFloat = null, string varString = null, System.IO.Stream binary = null, DateTime date = null, DateTime dateTime = null, string password = null, string callback = null)
+> void TestEndpointParameters (decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, System.IO.Stream binary = null, string callback = null, DateTime date = null, DateTime dateTime = null, int int32 = null, long int64 = null, int integer = null, string password = null, float varFloat = null, string varString = null)
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
@@ -1095,24 +1095,24 @@ namespace Example
 
             var apiInstance = new FakeApi(config);
             var number = 8.14D;  // decimal | None
-            var varDouble = 1.2D;  // double | None
             var patternWithoutDelimiter = "patternWithoutDelimiter_example";  // string | None
             var varByte = System.Text.Encoding.ASCII.GetBytes("BYTE_ARRAY_DATA_HERE");  // byte[] | None
-            var integer = 56;  // int | None (optional) 
-            var int32 = 56;  // int | None (optional) 
-            var int64 = 789L;  // long | None (optional) 
-            var varFloat = 3.4F;  // float | None (optional) 
-            var varString = "varString_example";  // string | None (optional) 
+            var varDouble = 1.2D;  // double | None
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
+            var callback = "callback_example";  // string | None (optional) 
             var date = DateTime.Parse("2013-10-20");  // DateTime | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")
+            var int32 = 56;  // int | None (optional) 
+            var int64 = 789L;  // long | None (optional) 
+            var integer = 56;  // int | None (optional) 
             var password = "password_example";  // string | None (optional) 
-            var callback = "callback_example";  // string | None (optional) 
+            var varFloat = 3.4F;  // float | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
 
             try
             {
                 // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-                apiInstance.TestEndpointParameters(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                apiInstance.TestEndpointParameters(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             }
             catch (ApiException  e)
             {
@@ -1132,7 +1132,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    apiInstance.TestEndpointParametersWithHttpInfo(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+    apiInstance.TestEndpointParametersWithHttpInfo(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 }
 catch (ApiException e)
 {
@@ -1147,19 +1147,19 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **number** | **decimal** | None |  |
-| **varDouble** | **double** | None |  |
 | **patternWithoutDelimiter** | **string** | None |  |
 | **varByte** | **byte[]** | None |  |
-| **integer** | **int** | None | [optional]  |
-| **int32** | **int** | None | [optional]  |
-| **int64** | **long** | None | [optional]  |
-| **varFloat** | **float** | None | [optional]  |
-| **varString** | **string** | None | [optional]  |
+| **varDouble** | **double** | None |  |
 | **binary** | **System.IO.Stream****System.IO.Stream** | None | [optional]  |
+| **callback** | **string** | None | [optional]  |
 | **date** | **DateTime** | None | [optional]  |
 | **dateTime** | **DateTime** | None | [optional] [default to &quot;2010-02-01T10:20:10.111110+01:00&quot;] |
+| **int32** | **int** | None | [optional]  |
+| **int64** | **long** | None | [optional]  |
+| **integer** | **int** | None | [optional]  |
 | **password** | **string** | None | [optional]  |
-| **callback** | **string** | None | [optional]  |
+| **varFloat** | **float** | None | [optional]  |
+| **varString** | **string** | None | [optional]  |
 
 ### Return type
 
@@ -1185,7 +1185,7 @@ void (empty response body)
 
 <a id="testenumparameters"></a>
 # **TestEnumParameters**
-> void TestEnumParameters (List<TestEnumParametersRequestEnumFormStringArrayInner> enumHeaderStringArray = null, TestEnumParametersEnumHeaderStringParameter enumHeaderString = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumQueryStringArray = null, TestEnumParametersEnumHeaderStringParameter enumQueryString = null, TestEnumParametersEnumQueryIntegerParameter enumQueryInteger = null, TestEnumParametersEnumQueryDoubleParameter enumQueryDouble = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumFormStringArray = null, TestEnumParametersRequestEnumFormString enumFormString = null)
+> void TestEnumParameters (TestEnumParametersRequestEnumFormString enumFormString = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumFormStringArray = null, TestEnumParametersEnumHeaderStringParameter enumHeaderString = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumHeaderStringArray = null, TestEnumParametersEnumQueryDoubleParameter enumQueryDouble = null, TestEnumParametersEnumQueryIntegerParameter enumQueryInteger = null, TestEnumParametersEnumHeaderStringParameter enumQueryString = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumQueryStringArray = null)
 
 To test enum parameters
 
@@ -1208,19 +1208,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var enumHeaderStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Header parameter enum test (string array) (optional) 
-            var enumHeaderString = (TestEnumParametersEnumHeaderStringParameter) "_abc";  // TestEnumParametersEnumHeaderStringParameter | Header parameter enum test (string) (optional) 
-            var enumQueryStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Query parameter enum test (string array) (optional) 
-            var enumQueryString = (TestEnumParametersEnumHeaderStringParameter) "_abc";  // TestEnumParametersEnumHeaderStringParameter | Query parameter enum test (string) (optional) 
-            var enumQueryInteger = (TestEnumParametersEnumQueryIntegerParameter) "1";  // TestEnumParametersEnumQueryIntegerParameter | Query parameter enum test (double) (optional) 
-            var enumQueryDouble = (TestEnumParametersEnumQueryDoubleParameter) "1.1";  // TestEnumParametersEnumQueryDoubleParameter | Query parameter enum test (double) (optional) 
-            var enumFormStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Form parameter enum test (string array) (optional) 
             var enumFormString = (TestEnumParametersRequestEnumFormString) "_abc";  // TestEnumParametersRequestEnumFormString |  (optional) 
+            var enumFormStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Form parameter enum test (string array) (optional) 
+            var enumHeaderString = (TestEnumParametersEnumHeaderStringParameter) "_abc";  // TestEnumParametersEnumHeaderStringParameter | Header parameter enum test (string) (optional) 
+            var enumHeaderStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Header parameter enum test (string array) (optional) 
+            var enumQueryDouble = (TestEnumParametersEnumQueryDoubleParameter) "1.1";  // TestEnumParametersEnumQueryDoubleParameter | Query parameter enum test (double) (optional) 
+            var enumQueryInteger = (TestEnumParametersEnumQueryIntegerParameter) "1";  // TestEnumParametersEnumQueryIntegerParameter | Query parameter enum test (double) (optional) 
+            var enumQueryString = (TestEnumParametersEnumHeaderStringParameter) "_abc";  // TestEnumParametersEnumHeaderStringParameter | Query parameter enum test (string) (optional) 
+            var enumQueryStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Query parameter enum test (string array) (optional) 
 
             try
             {
                 // To test enum parameters
-                apiInstance.TestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                apiInstance.TestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             }
             catch (ApiException  e)
             {
@@ -1240,7 +1240,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test enum parameters
-    apiInstance.TestEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+    apiInstance.TestEnumParametersWithHttpInfo(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 }
 catch (ApiException e)
 {
@@ -1254,14 +1254,14 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **enumHeaderStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Header parameter enum test (string array) | [optional]  |
-| **enumHeaderString** | **TestEnumParametersEnumHeaderStringParameter** | Header parameter enum test (string) | [optional]  |
-| **enumQueryStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Query parameter enum test (string array) | [optional]  |
-| **enumQueryString** | **TestEnumParametersEnumHeaderStringParameter** | Query parameter enum test (string) | [optional]  |
-| **enumQueryInteger** | **TestEnumParametersEnumQueryIntegerParameter** | Query parameter enum test (double) | [optional]  |
-| **enumQueryDouble** | **TestEnumParametersEnumQueryDoubleParameter** | Query parameter enum test (double) | [optional]  |
-| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional]  |
 | **enumFormString** | **TestEnumParametersRequestEnumFormString** |  | [optional]  |
+| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional]  |
+| **enumHeaderString** | **TestEnumParametersEnumHeaderStringParameter** | Header parameter enum test (string) | [optional]  |
+| **enumHeaderStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Header parameter enum test (string array) | [optional]  |
+| **enumQueryDouble** | **TestEnumParametersEnumQueryDoubleParameter** | Query parameter enum test (double) | [optional]  |
+| **enumQueryInteger** | **TestEnumParametersEnumQueryIntegerParameter** | Query parameter enum test (double) | [optional]  |
+| **enumQueryString** | **TestEnumParametersEnumHeaderStringParameter** | Query parameter enum test (string) | [optional]  |
+| **enumQueryStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Query parameter enum test (string array) | [optional]  |
 
 ### Return type
 
@@ -1287,7 +1287,7 @@ No authorization required
 
 <a id="testgroupparameters"></a>
 # **TestGroupParameters**
-> void TestGroupParameters (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int stringGroup = null, bool booleanGroup = null, long int64Group = null)
+> void TestGroupParameters (bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, bool booleanGroup = null, long int64Group = null, int stringGroup = null)
 
 Fake endpoint to test group parameters (optional)
 
@@ -1313,17 +1313,17 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new FakeApi(config);
-            var requiredStringGroup = 56;  // int | Required String in group parameters
             var requiredBooleanGroup = true;  // bool | Required Boolean in group parameters
             var requiredInt64Group = 789L;  // long | Required Integer in group parameters
-            var stringGroup = 56;  // int | String in group parameters (optional) 
+            var requiredStringGroup = 56;  // int | Required String in group parameters
             var booleanGroup = true;  // bool | Boolean in group parameters (optional) 
             var int64Group = 789L;  // long | Integer in group parameters (optional) 
+            var stringGroup = 56;  // int | String in group parameters (optional) 
 
             try
             {
                 // Fake endpoint to test group parameters (optional)
-                apiInstance.TestGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                apiInstance.TestGroupParameters(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             }
             catch (ApiException  e)
             {
@@ -1343,7 +1343,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint to test group parameters (optional)
-    apiInstance.TestGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+    apiInstance.TestGroupParametersWithHttpInfo(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 }
 catch (ApiException e)
 {
@@ -1357,12 +1357,12 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **requiredBooleanGroup** | **bool** | Required Boolean in group parameters |  |
 | **requiredInt64Group** | **long** | Required Integer in group parameters |  |
-| **stringGroup** | **int** | String in group parameters | [optional]  |
+| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **booleanGroup** | **bool** | Boolean in group parameters | [optional]  |
 | **int64Group** | **long** | Integer in group parameters | [optional]  |
+| **stringGroup** | **int** | String in group parameters | [optional]  |
 
 ### Return type
 
@@ -1644,7 +1644,7 @@ No authorization required
 
 <a id="testqueryparametercollectionformat"></a>
 # **TestQueryParameterCollectionFormat**
-> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, string notRequiredNotNullable = null, string notRequiredNullable = null)
+> void TestQueryParameterCollectionFormat (List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, string notRequiredNotNullable = null, string notRequiredNullable = null, string requiredNullable)
 
 
 
@@ -1667,19 +1667,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var pipe = new List<string>(); // List<string> | 
-            var ioutil = new List<string>(); // List<string> | 
-            var http = new List<string>(); // List<string> | 
-            var url = new List<string>(); // List<string> | 
             var context = new List<string>(); // List<string> | 
+            var http = new List<string>(); // List<string> | 
+            var ioutil = new List<string>(); // List<string> | 
+            var pipe = new List<string>(); // List<string> | 
             var requiredNotNullable = "requiredNotNullable_example";  // string | 
-            var requiredNullable = "requiredNullable_example";  // string | 
+            var url = new List<string>(); // List<string> | 
             var notRequiredNotNullable = "notRequiredNotNullable_example";  // string |  (optional) 
             var notRequiredNullable = "notRequiredNullable_example";  // string |  (optional) 
+            var requiredNullable = "requiredNullable_example";  // string | 
 
             try
             {
-                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                apiInstance.TestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             }
             catch (ApiException  e)
             {
@@ -1698,7 +1698,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 }
 catch (ApiException e)
 {
@@ -1712,15 +1712,15 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
-| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
-| **http** | [**List&lt;string&gt;**](string.md) |  |  |
-| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **context** | [**List&lt;string&gt;**](string.md) |  |  |
+| **http** | [**List&lt;string&gt;**](string.md) |  |  |
+| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
+| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
 | **requiredNotNullable** | **string** |  |  |
-| **requiredNullable** | **string** |  |  |
+| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **notRequiredNotNullable** | **string** |  | [optional]  |
 | **notRequiredNullable** | **string** |  | [optional]  |
+| **requiredNullable** | **string** |  |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/docs/apis/UserApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/docs/apis/UserApi.md
@@ -453,7 +453,7 @@ No authorization required
 
 <a id="loginuser"></a>
 # **LoginUser**
-> string LoginUser (string username, string password)
+> string LoginUser (string password, string username)
 
 Logs user into the system
 
@@ -474,13 +474,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | The user name for login
             var password = "password_example";  // string | The password for login in clear text
+            var username = "username_example";  // string | The user name for login
 
             try
             {
                 // Logs user into the system
-                string result = apiInstance.LoginUser(username, password);
+                string result = apiInstance.LoginUser(password, username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -501,7 +501,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Logs user into the system
-    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(username, password);
+    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(password, username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -518,8 +518,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | The user name for login |  |
 | **password** | **string** | The password for login in clear text |  |
+| **username** | **string** | The user name for login |  |
 
 ### Return type
 
@@ -625,7 +625,7 @@ No authorization required
 
 <a id="updateuser"></a>
 # **UpdateUser**
-> void UpdateUser (string username, User user)
+> void UpdateUser (User user, string username)
 
 Updated user
 
@@ -648,13 +648,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | name that need to be deleted
             var user = new User(); // User | Updated user object
+            var username = "username_example";  // string | name that need to be deleted
 
             try
             {
                 // Updated user
-                apiInstance.UpdateUser(username, user);
+                apiInstance.UpdateUser(user, username);
             }
             catch (ApiException  e)
             {
@@ -674,7 +674,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Updated user
-    apiInstance.UpdateUserWithHttpInfo(username, user);
+    apiInstance.UpdateUserWithHttpInfo(user, username);
 }
 catch (ApiException e)
 {
@@ -688,8 +688,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | name that need to be deleted |  |
 | **user** | [**User**](User.md) | Updated user object |  |
+| **username** | **string** | name that need to be deleted |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
@@ -193,20 +193,20 @@ namespace Org.OpenAPITools.Test.Api
         public async Task TestEndpointParametersAsyncTest()
         {
             decimal number = default;
-            double varDouble = default;
             string patternWithoutDelimiter = default;
             byte[] varByte = default;
-            Client.Option<int> integer = default;
-            Client.Option<int> int32 = default;
-            Client.Option<long> int64 = default;
-            Client.Option<float> varFloat = default;
-            Client.Option<string> varString = default;
+            double varDouble = default;
             Client.Option<System.IO.Stream> binary = default;
+            Client.Option<string> callback = default;
             Client.Option<DateTime> date = default;
             Client.Option<DateTime> dateTime = default;
+            Client.Option<int> int32 = default;
+            Client.Option<long> int64 = default;
+            Client.Option<int> integer = default;
             Client.Option<string> password = default;
-            Client.Option<string> callback = default;
-            await _instance.TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            Client.Option<float> varFloat = default;
+            Client.Option<string> varString = default;
+            await _instance.TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
         }
 
         /// <summary>
@@ -215,15 +215,15 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestEnumParametersAsyncTest()
         {
-            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default;
-            Client.Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default;
-            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default;
-            Client.Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default;
-            Client.Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default;
-            Client.Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default;
-            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default;
             Client.Option<TestEnumParametersRequestEnumFormString> enumFormString = default;
-            await _instance.TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default;
+            Client.Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default;
+            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default;
+            Client.Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default;
+            Client.Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default;
+            Client.Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default;
+            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default;
+            await _instance.TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
         }
 
         /// <summary>
@@ -232,13 +232,13 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestGroupParametersAsyncTest()
         {
-            int requiredStringGroup = default;
             bool requiredBooleanGroup = default;
             long requiredInt64Group = default;
-            Client.Option<int> stringGroup = default;
+            int requiredStringGroup = default;
             Client.Option<bool> booleanGroup = default;
             Client.Option<long> int64Group = default;
-            await _instance.TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            Client.Option<int> stringGroup = default;
+            await _instance.TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
         }
 
         /// <summary>
@@ -278,16 +278,16 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestQueryParameterCollectionFormatAsyncTest()
         {
-            List<string> pipe = default;
-            List<string> ioutil = default;
-            List<string> http = default;
-            List<string> url = default;
             List<string> context = default;
+            List<string> http = default;
+            List<string> ioutil = default;
+            List<string> pipe = default;
             string requiredNotNullable = default;
-            string requiredNullable = default;
+            List<string> url = default;
             Client.Option<string> notRequiredNotNullable = default;
             Client.Option<string> notRequiredNullable = default;
-            await _instance.TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            string requiredNullable = default;
+            await _instance.TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
@@ -108,9 +108,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task LoginUserAsyncTest()
         {
-            string username = default;
             string password = default;
-            var response = await _instance.LoginUserAsync(username, password);
+            string username = default;
+            var response = await _instance.LoginUserAsync(password, username);
             var model = response.Ok();
             Assert.IsType<string>(model);
         }
@@ -130,9 +130,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task UpdateUserAsyncTest()
         {
-            string username = default;
             User user = default;
-            await _instance.UpdateUserAsync(username, user);
+            string username = default;
+            await _instance.UpdateUserAsync(user, username);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -313,22 +313,22 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </remarks>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -361,17 +361,17 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
         /// <param name="enumFormString"> (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersRequestEnumFormString> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<TestEnumParametersRequestEnumFormString> enumFormString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -379,17 +379,17 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test enum parameters
         /// </remarks>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
         /// <param name="enumFormString"> (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersRequestEnumFormString> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<TestEnumParametersRequestEnumFormString> enumFormString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -398,15 +398,15 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -414,15 +414,15 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test inline additionalProperties
@@ -502,18 +502,18 @@ namespace Org.OpenAPITools.Api
         /// To test the collection format in query parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -521,18 +521,18 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test the collection format in query parameters
         /// </remarks>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test referenced string map
@@ -3781,19 +3781,19 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEndpointParameters(ref decimal number, ref double varDouble, ref string patternWithoutDelimiter, ref byte[] varByte, ref Option<int> integer, ref Option<int> int32, ref Option<long> int64, ref Option<float> varFloat, ref Option<string> varString, ref Option<System.IO.Stream> binary, ref Option<DateTime> date, ref Option<DateTime> dateTime, ref Option<string> password, ref Option<string> callback);
+        partial void FormatTestEndpointParameters(ref decimal number, ref string patternWithoutDelimiter, ref byte[] varByte, ref double varDouble, ref Option<System.IO.Stream> binary, ref Option<string> callback, ref Option<DateTime> date, ref Option<DateTime> dateTime, ref Option<int> int32, ref Option<long> int64, ref Option<int> integer, ref Option<string> password, ref Option<float> varFloat, ref Option<string> varString);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="varString"></param>
         /// <param name="binary"></param>
-        /// <param name="password"></param>
         /// <param name="callback"></param>
+        /// <param name="password"></param>
+        /// <param name="varString"></param>
         /// <returns></returns>
-        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<string> varString, Option<System.IO.Stream> binary, Option<string> password, Option<string> callback)
+        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<System.IO.Stream> binary, Option<string> callback, Option<string> password, Option<string> varString)
         {
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
@@ -3801,17 +3801,17 @@ namespace Org.OpenAPITools.Api
             if (varByte == null)
                 throw new ArgumentNullException(nameof(varByte));
 
-            if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString));
-
             if (binary.IsSet && binary.Value == null)
                 throw new ArgumentNullException(nameof(binary));
+
+            if (callback.IsSet && callback.Value == null)
+                throw new ArgumentNullException(nameof(callback));
 
             if (password.IsSet && password.Value == null)
                 throw new ArgumentNullException(nameof(password));
 
-            if (callback.IsSet && callback.Value == null)
-                throw new ArgumentNullException(nameof(callback));
+            if (varString.IsSet && varString.Value == null)
+                throw new ArgumentNullException(nameof(varString));
         }
 
         /// <summary>
@@ -3819,23 +3819,23 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -3846,20 +3846,20 @@ namespace Org.OpenAPITools.Api
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -3868,23 +3868,23 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -3897,45 +3897,45 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트  Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback, cancellationToken).ConfigureAwait(false);
+                return await TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -3948,30 +3948,30 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, varString, binary, password, callback);
+                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, binary, callback, password, varString);
 
-                FormatTestEndpointParameters(ref number, ref varDouble, ref patternWithoutDelimiter, ref varByte, ref integer, ref int32, ref int64, ref varFloat, ref varString, ref binary, ref date, ref dateTime, ref password, ref callback);
+                FormatTestEndpointParameters(ref number, ref patternWithoutDelimiter, ref varByte, ref varDouble, ref binary, ref callback, ref date, ref dateTime, ref int32, ref int64, ref integer, ref password, ref varFloat, ref varString);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -3990,29 +3990,17 @@ namespace Org.OpenAPITools.Api
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("number", ClientUtils.ParameterToString(number)));
 
-                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
-
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("pattern_without_delimiter", ClientUtils.ParameterToString(patternWithoutDelimiter)));
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("byte", ClientUtils.ParameterToString(varByte)));
 
-                    if (integer.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
-
-                    if (int32.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
-
-                    if (int64.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
-
-                    if (varFloat.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
-
-                    if (varString.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
+                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
 
                     if (binary.IsSet)
                         multipartContentLocalVar.Add(new StreamContent(binary.Value));
+
+                    if (callback.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
 
                     if (date.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("date", ClientUtils.ParameterToString(date.Value)));
@@ -4020,11 +4008,23 @@ namespace Org.OpenAPITools.Api
                     if (dateTime.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("dateTime", ClientUtils.ParameterToString(dateTime.Value)));
 
+                    if (int32.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
+
+                    if (int64.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
+
+                    if (integer.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
+
                     if (password.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("password", ClientUtils.ParameterToString(password.Value)));
 
-                    if (callback.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
+                    if (varFloat.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
+
+                    if (varString.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
 
                     List<TokenBase> tokenBaseLocalVars = new List<TokenBase>();
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
@@ -4056,7 +4056,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEndpointParametersApiResponse apiResponseLocalVar = new TestEndpointParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 
                         Events.ExecuteOnTestEndpointParameters(apiResponseLocalVar);
 
@@ -4070,7 +4070,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
                 Events.ExecuteOnErrorTestEndpointParameters(e);
                 throw;
             }
@@ -4127,43 +4127,43 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEnumParameters(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, ref Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, ref Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, ref Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, ref Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, ref Option<TestEnumParametersRequestEnumFormString> enumFormString);
+        partial void FormatTestEnumParameters(ref Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, ref Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, ref Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, ref Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, ref Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
+        /// <param name="enumFormStringArray"></param>
         /// <param name="enumHeaderStringArray"></param>
         /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <returns></returns>
-        private void ValidateTestEnumParameters(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray)
+        private void ValidateTestEnumParameters(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray)
         {
+            if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumFormStringArray));
+
             if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumHeaderStringArray));
 
             if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumQueryStringArray));
-
-            if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumFormStringArray));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersRequestEnumFormString> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4173,15 +4173,15 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersRequestEnumFormString> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4189,18 +4189,18 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersRequestEnumFormString> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4212,34 +4212,34 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersRequestEnumFormString> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray);
 
         /// <summary>
         /// To test enum parameters To test enum parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
         /// <param name="enumFormString"> (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersRequestEnumFormString> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<TestEnumParametersRequestEnumFormString> enumFormString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, cancellationToken).ConfigureAwait(false);
+                return await TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4251,25 +4251,25 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
         /// <param name="enumFormString"> (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersRequestEnumFormString> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<TestEnumParametersRequestEnumFormString> enumFormString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, enumFormStringArray);
+                ValidateTestEnumParameters(enumFormStringArray, enumHeaderStringArray, enumQueryStringArray);
 
-                FormatTestEnumParameters(enumHeaderStringArray, ref enumHeaderString, enumQueryStringArray, ref enumQueryString, ref enumQueryInteger, ref enumQueryDouble, enumFormStringArray, ref enumFormString);
+                FormatTestEnumParameters(ref enumFormString, enumFormStringArray, ref enumHeaderString, enumHeaderStringArray, ref enumQueryDouble, ref enumQueryInteger, ref enumQueryString, enumQueryStringArray);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4280,25 +4280,25 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    if (enumQueryStringArray.IsSet)
-                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
-
-                    if (enumQueryString.IsSet)
-                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+                    if (enumQueryDouble.IsSet)
+                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
 
                     if (enumQueryInteger.IsSet)
                         parseQueryStringLocalVar["enum_query_integer"] = ClientUtils.ParameterToString(enumQueryInteger.Value);
 
-                    if (enumQueryDouble.IsSet)
-                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
+                    if (enumQueryString.IsSet)
+                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+
+                    if (enumQueryStringArray.IsSet)
+                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
-                    if (enumHeaderStringArray.IsSet)
-                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
-
                     if (enumHeaderString.IsSet)
                         httpRequestMessageLocalVar.Headers.Add("enum_header_string", ClientUtils.ParameterToString(enumHeaderString.Value));
+
+                    if (enumHeaderStringArray.IsSet)
+                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
 
                     MultipartContent multipartContentLocalVar = new MultipartContent();
 
@@ -4306,11 +4306,11 @@ namespace Org.OpenAPITools.Api
 
                     List<KeyValuePair<string, string>> formParameterLocalVars = new List<KeyValuePair<string, string>>();
 
-                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormStringArray.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
-
-                    if (enumFormString.IsSet)
+                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormString.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string", ClientUtils.ParameterToString(enumFormString.Value)));
+
+                    if (enumFormStringArray.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
 
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
 
@@ -4335,7 +4335,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEnumParametersApiResponse apiResponseLocalVar = new TestEnumParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 
                         Events.ExecuteOnTestEnumParameters(apiResponseLocalVar);
 
@@ -4345,7 +4345,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
                 Events.ExecuteOnErrorTestEnumParameters(e);
                 throw;
             }
@@ -4402,22 +4402,22 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestGroupParameters(ref int requiredStringGroup, ref bool requiredBooleanGroup, ref long requiredInt64Group, ref Option<int> stringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group);
+        partial void FormatTestGroupParameters(ref bool requiredBooleanGroup, ref long requiredInt64Group, ref int requiredStringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group, ref Option<int> stringGroup);
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4427,13 +4427,13 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4441,16 +4441,16 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4462,30 +4462,30 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, cancellationToken).ConfigureAwait(false);
+                return await TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4497,21 +4497,21 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                FormatTestGroupParameters(ref requiredStringGroup, ref requiredBooleanGroup, ref requiredInt64Group, ref stringGroup, ref booleanGroup, ref int64Group);
+                FormatTestGroupParameters(ref requiredBooleanGroup, ref requiredInt64Group, ref requiredStringGroup, ref booleanGroup, ref int64Group, ref stringGroup);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4522,14 +4522,14 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
                     parseQueryStringLocalVar["required_int64_group"] = ClientUtils.ParameterToString(requiredInt64Group);
-
-                    if (stringGroup.IsSet)
-                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
+                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
 
                     if (int64Group.IsSet)
                         parseQueryStringLocalVar["int64_group"] = ClientUtils.ParameterToString(int64Group.Value);
+
+                    if (stringGroup.IsSet)
+                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -4558,7 +4558,7 @@ namespace Org.OpenAPITools.Api
 
                         TestGroupParametersApiResponse apiResponseLocalVar = new TestGroupParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 
                         Events.ExecuteOnTestGroupParameters(apiResponseLocalVar);
 
@@ -4572,7 +4572,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
                 Events.ExecuteOnErrorTestGroupParameters(e);
                 throw;
             }
@@ -5208,38 +5208,38 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, ref string requiredNotNullable, ref string requiredNullable, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable);
+        partial void FormatTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, ref string requiredNotNullable, List<string> url, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable, ref string requiredNullable);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <returns></returns>
-        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, Option<string> notRequiredNotNullable)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable)
         {
-            if (pipe == null)
-                throw new ArgumentNullException(nameof(pipe));
-
-            if (ioutil == null)
-                throw new ArgumentNullException(nameof(ioutil));
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
 
             if (http == null)
                 throw new ArgumentNullException(nameof(http));
 
-            if (url == null)
-                throw new ArgumentNullException(nameof(url));
+            if (ioutil == null)
+                throw new ArgumentNullException(nameof(ioutil));
 
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
+            if (pipe == null)
+                throw new ArgumentNullException(nameof(pipe));
 
             if (requiredNotNullable == null)
                 throw new ArgumentNullException(nameof(requiredNotNullable));
+
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
 
             if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
                 throw new ArgumentNullException(nameof(notRequiredNotNullable));
@@ -5249,19 +5249,19 @@ namespace Org.OpenAPITools.Api
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -5271,16 +5271,16 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -5288,19 +5288,19 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -5312,36 +5312,36 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         ///  To test the collection format in query parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable, cancellationToken).ConfigureAwait(false);
+                return await TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -5353,26 +5353,26 @@ namespace Org.OpenAPITools.Api
         ///  To test the collection format in query parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, notRequiredNotNullable);
+                ValidateTestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable);
 
-                FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, ref requiredNotNullable, ref requiredNullable, ref notRequiredNotNullable, ref notRequiredNullable);
+                FormatTestQueryParameterCollectionFormat(context, http, ioutil, pipe, ref requiredNotNullable, url, ref notRequiredNotNullable, ref notRequiredNullable, ref requiredNullable);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -5383,12 +5383,12 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
-                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
-                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
-                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["context"] = ClientUtils.ParameterToString(context);
+                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
+                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
+                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
                     parseQueryStringLocalVar["requiredNotNullable"] = ClientUtils.ParameterToString(requiredNotNullable);
+                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["requiredNullable"] = ClientUtils.ParameterToString(requiredNullable);
 
                     if (notRequiredNotNullable.IsSet)
@@ -5412,7 +5412,7 @@ namespace Org.OpenAPITools.Api
 
                         TestQueryParameterCollectionFormatApiResponse apiResponseLocalVar = new TestQueryParameterCollectionFormatApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake/test-query-parameters", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 
                         Events.ExecuteOnTestQueryParameterCollectionFormat(apiResponseLocalVar);
 
@@ -5422,7 +5422,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
                 Events.ExecuteOnErrorTestQueryParameterCollectionFormat(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Api/UserApi.cs
@@ -155,11 +155,11 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs user into the system
@@ -167,11 +167,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs out current logged in user session
@@ -201,11 +201,11 @@ namespace Org.OpenAPITools.Api
         /// This can only be done by the logged in user.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updated user
@@ -213,11 +213,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// This can only be done by the logged in user.
         /// </remarks>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
     }
 
     /// <summary>
@@ -1622,33 +1622,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatLoginUser(ref string username, ref string password);
+        partial void FormatLoginUser(ref string password, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="password"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateLoginUser(string username, string password)
+        private void ValidateLoginUser(string password, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (password == null)
                 throw new ArgumentNullException(nameof(password));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string username, string password)
+        /// <param name="username"></param>
+        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string password, string username)
         {
             bool suppressDefaultLog = false;
-            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, username, password);
+            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, password, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -1658,9 +1658,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string username, string password);
+        /// <param name="username"></param>
+        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string password, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -1668,12 +1668,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, string password)
+        /// <param name="username"></param>
+        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string password, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, username, password);
+            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, password, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -1685,22 +1685,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, string password);
+        /// <param name="username"></param>
+        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string password, string username);
 
         /// <summary>
         /// Logs user into the system 
         /// </summary>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await LoginUserAsync(username, password, cancellationToken).ConfigureAwait(false);
+                return await LoginUserAsync(password, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -1712,19 +1712,19 @@ namespace Org.OpenAPITools.Api
         /// Logs user into the system 
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateLoginUser(username, password);
+                ValidateLoginUser(password, username);
 
-                FormatLoginUser(ref username, ref password);
+                FormatLoginUser(ref password, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1735,8 +1735,8 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
                     parseQueryStringLocalVar["password"] = ClientUtils.ParameterToString(password);
+                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -1763,7 +1763,7 @@ namespace Org.OpenAPITools.Api
 
                         LoginUserApiResponse apiResponseLocalVar = new LoginUserApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/login", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, username, password);
+                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, password, username);
 
                         Events.ExecuteOnLoginUser(apiResponseLocalVar);
 
@@ -1773,7 +1773,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, username, password);
+                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, password, username);
                 Events.ExecuteOnErrorLoginUser(e);
                 throw;
             }
@@ -2014,33 +2014,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatUpdateUser(ref string username, User user);
+        partial void FormatUpdateUser(User user, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="user"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateUpdateUser(string username, User user)
+        private void ValidateUpdateUser(User user, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, string username, User user)
+        /// <param name="username"></param>
+        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, User user, string username)
         {
             bool suppressDefaultLog = false;
-            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, username, user);
+            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, user, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -2050,9 +2050,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, string username, User user);
+        /// <param name="username"></param>
+        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, User user, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -2060,12 +2060,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, User user)
+        /// <param name="username"></param>
+        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, User user, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, username, user);
+            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, user, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -2077,22 +2077,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, User user);
+        /// <param name="username"></param>
+        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, User user, string username);
 
         /// <summary>
         /// Updated user This can only be done by the logged in user.
         /// </summary>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await UpdateUserAsync(username, user, cancellationToken).ConfigureAwait(false);
+                return await UpdateUserAsync(user, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -2104,19 +2104,19 @@ namespace Org.OpenAPITools.Api
         /// Updated user This can only be done by the logged in user.
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateUpdateUser(username, user);
+                ValidateUpdateUser(user, username);
 
-                FormatUpdateUser(ref username, user);
+                FormatUpdateUser(user, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2153,7 +2153,7 @@ namespace Org.OpenAPITools.Api
 
                         UpdateUserApiResponse apiResponseLocalVar = new UpdateUserApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/{username}", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, username, user);
+                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, user, username);
 
                         Events.ExecuteOnUpdateUser(apiResponseLocalVar);
 
@@ -2163,7 +2163,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, username, user);
+                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, user, username);
                 Events.ExecuteOnErrorUpdateUser(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/docs/apis/FakeApi.md
@@ -1067,7 +1067,7 @@ No authorization required
 
 <a id="testendpointparameters"></a>
 # **TestEndpointParameters**
-> void TestEndpointParameters (decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, int integer = null, int int32 = null, long int64 = null, float varFloat = null, string varString = null, System.IO.Stream binary = null, DateTime date = null, DateTime dateTime = null, string password = null, string callback = null)
+> void TestEndpointParameters (decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, System.IO.Stream binary = null, string callback = null, DateTime date = null, DateTime dateTime = null, int int32 = null, long int64 = null, int integer = null, string password = null, float varFloat = null, string varString = null)
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
@@ -1095,24 +1095,24 @@ namespace Example
 
             var apiInstance = new FakeApi(config);
             var number = 8.14D;  // decimal | None
-            var varDouble = 1.2D;  // double | None
             var patternWithoutDelimiter = "patternWithoutDelimiter_example";  // string | None
             var varByte = System.Text.Encoding.ASCII.GetBytes("BYTE_ARRAY_DATA_HERE");  // byte[] | None
-            var integer = 56;  // int | None (optional) 
-            var int32 = 56;  // int | None (optional) 
-            var int64 = 789L;  // long | None (optional) 
-            var varFloat = 3.4F;  // float | None (optional) 
-            var varString = "varString_example";  // string | None (optional) 
+            var varDouble = 1.2D;  // double | None
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
+            var callback = "callback_example";  // string | None (optional) 
             var date = DateTime.Parse("2013-10-20");  // DateTime | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")
+            var int32 = 56;  // int | None (optional) 
+            var int64 = 789L;  // long | None (optional) 
+            var integer = 56;  // int | None (optional) 
             var password = "password_example";  // string | None (optional) 
-            var callback = "callback_example";  // string | None (optional) 
+            var varFloat = 3.4F;  // float | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
 
             try
             {
                 // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-                apiInstance.TestEndpointParameters(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                apiInstance.TestEndpointParameters(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             }
             catch (ApiException  e)
             {
@@ -1132,7 +1132,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    apiInstance.TestEndpointParametersWithHttpInfo(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+    apiInstance.TestEndpointParametersWithHttpInfo(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 }
 catch (ApiException e)
 {
@@ -1147,19 +1147,19 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **number** | **decimal** | None |  |
-| **varDouble** | **double** | None |  |
 | **patternWithoutDelimiter** | **string** | None |  |
 | **varByte** | **byte[]** | None |  |
-| **integer** | **int** | None | [optional]  |
-| **int32** | **int** | None | [optional]  |
-| **int64** | **long** | None | [optional]  |
-| **varFloat** | **float** | None | [optional]  |
-| **varString** | **string** | None | [optional]  |
+| **varDouble** | **double** | None |  |
 | **binary** | **System.IO.Stream****System.IO.Stream** | None | [optional]  |
+| **callback** | **string** | None | [optional]  |
 | **date** | **DateTime** | None | [optional]  |
 | **dateTime** | **DateTime** | None | [optional] [default to &quot;2010-02-01T10:20:10.111110+01:00&quot;] |
+| **int32** | **int** | None | [optional]  |
+| **int64** | **long** | None | [optional]  |
+| **integer** | **int** | None | [optional]  |
 | **password** | **string** | None | [optional]  |
-| **callback** | **string** | None | [optional]  |
+| **varFloat** | **float** | None | [optional]  |
+| **varString** | **string** | None | [optional]  |
 
 ### Return type
 
@@ -1185,7 +1185,7 @@ void (empty response body)
 
 <a id="testenumparameters"></a>
 # **TestEnumParameters**
-> void TestEnumParameters (List<string> enumHeaderStringArray = null, string enumHeaderString = null, List<string> enumQueryStringArray = null, string enumQueryString = null, int enumQueryInteger = null, double enumQueryDouble = null, List<string> enumFormStringArray = null, string enumFormString = null)
+> void TestEnumParameters (string enumFormString = null, List<string> enumFormStringArray = null, string enumHeaderString = null, List<string> enumHeaderStringArray = null, double enumQueryDouble = null, int enumQueryInteger = null, string enumQueryString = null, List<string> enumQueryStringArray = null)
 
 To test enum parameters
 
@@ -1208,19 +1208,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var enumHeaderStringArray = new List<string>(); // List<string> | Header parameter enum test (string array) (optional) 
-            var enumHeaderString = "_abc";  // string | Header parameter enum test (string) (optional)  (default to -efg)
-            var enumQueryStringArray = new List<string>(); // List<string> | Query parameter enum test (string array) (optional) 
-            var enumQueryString = "_abc";  // string | Query parameter enum test (string) (optional)  (default to -efg)
-            var enumQueryInteger = 1;  // int | Query parameter enum test (double) (optional) 
-            var enumQueryDouble = 1.1D;  // double | Query parameter enum test (double) (optional) 
-            var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional)  (default to $)
             var enumFormString = "_abc";  // string | Form parameter enum test (string) (optional)  (default to -efg)
+            var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional)  (default to $)
+            var enumHeaderString = "_abc";  // string | Header parameter enum test (string) (optional)  (default to -efg)
+            var enumHeaderStringArray = new List<string>(); // List<string> | Header parameter enum test (string array) (optional) 
+            var enumQueryDouble = 1.1D;  // double | Query parameter enum test (double) (optional) 
+            var enumQueryInteger = 1;  // int | Query parameter enum test (double) (optional) 
+            var enumQueryString = "_abc";  // string | Query parameter enum test (string) (optional)  (default to -efg)
+            var enumQueryStringArray = new List<string>(); // List<string> | Query parameter enum test (string array) (optional) 
 
             try
             {
                 // To test enum parameters
-                apiInstance.TestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                apiInstance.TestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             }
             catch (ApiException  e)
             {
@@ -1240,7 +1240,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test enum parameters
-    apiInstance.TestEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+    apiInstance.TestEnumParametersWithHttpInfo(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 }
 catch (ApiException e)
 {
@@ -1254,14 +1254,14 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **enumHeaderStringArray** | [**List&lt;string&gt;**](string.md) | Header parameter enum test (string array) | [optional]  |
-| **enumHeaderString** | **string** | Header parameter enum test (string) | [optional] [default to -efg] |
-| **enumQueryStringArray** | [**List&lt;string&gt;**](string.md) | Query parameter enum test (string array) | [optional]  |
-| **enumQueryString** | **string** | Query parameter enum test (string) | [optional] [default to -efg] |
-| **enumQueryInteger** | **int** | Query parameter enum test (double) | [optional]  |
-| **enumQueryDouble** | **double** | Query parameter enum test (double) | [optional]  |
-| **enumFormStringArray** | [**List&lt;string&gt;**](string.md) | Form parameter enum test (string array) | [optional] [default to $] |
 | **enumFormString** | **string** | Form parameter enum test (string) | [optional] [default to -efg] |
+| **enumFormStringArray** | [**List&lt;string&gt;**](string.md) | Form parameter enum test (string array) | [optional] [default to $] |
+| **enumHeaderString** | **string** | Header parameter enum test (string) | [optional] [default to -efg] |
+| **enumHeaderStringArray** | [**List&lt;string&gt;**](string.md) | Header parameter enum test (string array) | [optional]  |
+| **enumQueryDouble** | **double** | Query parameter enum test (double) | [optional]  |
+| **enumQueryInteger** | **int** | Query parameter enum test (double) | [optional]  |
+| **enumQueryString** | **string** | Query parameter enum test (string) | [optional] [default to -efg] |
+| **enumQueryStringArray** | [**List&lt;string&gt;**](string.md) | Query parameter enum test (string array) | [optional]  |
 
 ### Return type
 
@@ -1287,7 +1287,7 @@ No authorization required
 
 <a id="testgroupparameters"></a>
 # **TestGroupParameters**
-> void TestGroupParameters (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int stringGroup = null, bool booleanGroup = null, long int64Group = null)
+> void TestGroupParameters (bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, bool booleanGroup = null, long int64Group = null, int stringGroup = null)
 
 Fake endpoint to test group parameters (optional)
 
@@ -1313,17 +1313,17 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new FakeApi(config);
-            var requiredStringGroup = 56;  // int | Required String in group parameters
             var requiredBooleanGroup = true;  // bool | Required Boolean in group parameters
             var requiredInt64Group = 789L;  // long | Required Integer in group parameters
-            var stringGroup = 56;  // int | String in group parameters (optional) 
+            var requiredStringGroup = 56;  // int | Required String in group parameters
             var booleanGroup = true;  // bool | Boolean in group parameters (optional) 
             var int64Group = 789L;  // long | Integer in group parameters (optional) 
+            var stringGroup = 56;  // int | String in group parameters (optional) 
 
             try
             {
                 // Fake endpoint to test group parameters (optional)
-                apiInstance.TestGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                apiInstance.TestGroupParameters(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             }
             catch (ApiException  e)
             {
@@ -1343,7 +1343,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint to test group parameters (optional)
-    apiInstance.TestGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+    apiInstance.TestGroupParametersWithHttpInfo(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 }
 catch (ApiException e)
 {
@@ -1357,12 +1357,12 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **requiredBooleanGroup** | **bool** | Required Boolean in group parameters |  |
 | **requiredInt64Group** | **long** | Required Integer in group parameters |  |
-| **stringGroup** | **int** | String in group parameters | [optional]  |
+| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **booleanGroup** | **bool** | Boolean in group parameters | [optional]  |
 | **int64Group** | **long** | Integer in group parameters | [optional]  |
+| **stringGroup** | **int** | String in group parameters | [optional]  |
 
 ### Return type
 
@@ -1644,7 +1644,7 @@ No authorization required
 
 <a id="testqueryparametercollectionformat"></a>
 # **TestQueryParameterCollectionFormat**
-> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, string notRequiredNotNullable = null, string notRequiredNullable = null)
+> void TestQueryParameterCollectionFormat (List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, string notRequiredNotNullable = null, string notRequiredNullable = null, string requiredNullable)
 
 
 
@@ -1667,19 +1667,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var pipe = new List<string>(); // List<string> | 
-            var ioutil = new List<string>(); // List<string> | 
-            var http = new List<string>(); // List<string> | 
-            var url = new List<string>(); // List<string> | 
             var context = new List<string>(); // List<string> | 
+            var http = new List<string>(); // List<string> | 
+            var ioutil = new List<string>(); // List<string> | 
+            var pipe = new List<string>(); // List<string> | 
             var requiredNotNullable = "requiredNotNullable_example";  // string | 
-            var requiredNullable = "requiredNullable_example";  // string | 
+            var url = new List<string>(); // List<string> | 
             var notRequiredNotNullable = "notRequiredNotNullable_example";  // string |  (optional) 
             var notRequiredNullable = "notRequiredNullable_example";  // string |  (optional) 
+            var requiredNullable = "requiredNullable_example";  // string | 
 
             try
             {
-                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                apiInstance.TestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             }
             catch (ApiException  e)
             {
@@ -1698,7 +1698,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 }
 catch (ApiException e)
 {
@@ -1712,15 +1712,15 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
-| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
-| **http** | [**List&lt;string&gt;**](string.md) |  |  |
-| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **context** | [**List&lt;string&gt;**](string.md) |  |  |
+| **http** | [**List&lt;string&gt;**](string.md) |  |  |
+| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
+| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
 | **requiredNotNullable** | **string** |  |  |
-| **requiredNullable** | **string** |  |  |
+| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **notRequiredNotNullable** | **string** |  | [optional]  |
 | **notRequiredNullable** | **string** |  | [optional]  |
+| **requiredNullable** | **string** |  |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/docs/apis/UserApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/docs/apis/UserApi.md
@@ -453,7 +453,7 @@ No authorization required
 
 <a id="loginuser"></a>
 # **LoginUser**
-> string LoginUser (string username, string password)
+> string LoginUser (string password, string username)
 
 Logs user into the system
 
@@ -474,13 +474,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | The user name for login
             var password = "password_example";  // string | The password for login in clear text
+            var username = "username_example";  // string | The user name for login
 
             try
             {
                 // Logs user into the system
-                string result = apiInstance.LoginUser(username, password);
+                string result = apiInstance.LoginUser(password, username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -501,7 +501,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Logs user into the system
-    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(username, password);
+    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(password, username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -518,8 +518,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | The user name for login |  |
 | **password** | **string** | The password for login in clear text |  |
+| **username** | **string** | The user name for login |  |
 
 ### Return type
 
@@ -625,7 +625,7 @@ No authorization required
 
 <a id="updateuser"></a>
 # **UpdateUser**
-> void UpdateUser (string username, User user)
+> void UpdateUser (User user, string username)
 
 Updated user
 
@@ -648,13 +648,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | name that need to be deleted
             var user = new User(); // User | Updated user object
+            var username = "username_example";  // string | name that need to be deleted
 
             try
             {
                 // Updated user
-                apiInstance.UpdateUser(username, user);
+                apiInstance.UpdateUser(user, username);
             }
             catch (ApiException  e)
             {
@@ -674,7 +674,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Updated user
-    apiInstance.UpdateUserWithHttpInfo(username, user);
+    apiInstance.UpdateUserWithHttpInfo(user, username);
 }
 catch (ApiException e)
 {
@@ -688,8 +688,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | name that need to be deleted |  |
 | **user** | [**User**](User.md) | Updated user object |  |
+| **username** | **string** | name that need to be deleted |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
@@ -193,20 +193,20 @@ namespace Org.OpenAPITools.Test.Api
         public async Task TestEndpointParametersAsyncTest()
         {
             decimal number = default;
-            double varDouble = default;
             string patternWithoutDelimiter = default;
             byte[] varByte = default;
-            Client.Option<int> integer = default;
-            Client.Option<int> int32 = default;
-            Client.Option<long> int64 = default;
-            Client.Option<float> varFloat = default;
-            Client.Option<string> varString = default;
+            double varDouble = default;
             Client.Option<System.IO.Stream> binary = default;
+            Client.Option<string> callback = default;
             Client.Option<DateTime> date = default;
             Client.Option<DateTime> dateTime = default;
+            Client.Option<int> int32 = default;
+            Client.Option<long> int64 = default;
+            Client.Option<int> integer = default;
             Client.Option<string> password = default;
-            Client.Option<string> callback = default;
-            await _instance.TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            Client.Option<float> varFloat = default;
+            Client.Option<string> varString = default;
+            await _instance.TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
         }
 
         /// <summary>
@@ -215,15 +215,15 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestEnumParametersAsyncTest()
         {
-            Client.Option<List<string>> enumHeaderStringArray = default;
-            Client.Option<string> enumHeaderString = default;
-            Client.Option<List<string>> enumQueryStringArray = default;
-            Client.Option<string> enumQueryString = default;
-            Client.Option<int> enumQueryInteger = default;
-            Client.Option<double> enumQueryDouble = default;
-            Client.Option<List<string>> enumFormStringArray = default;
             Client.Option<string> enumFormString = default;
-            await _instance.TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            Client.Option<List<string>> enumFormStringArray = default;
+            Client.Option<string> enumHeaderString = default;
+            Client.Option<List<string>> enumHeaderStringArray = default;
+            Client.Option<double> enumQueryDouble = default;
+            Client.Option<int> enumQueryInteger = default;
+            Client.Option<string> enumQueryString = default;
+            Client.Option<List<string>> enumQueryStringArray = default;
+            await _instance.TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
         }
 
         /// <summary>
@@ -232,13 +232,13 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestGroupParametersAsyncTest()
         {
-            int requiredStringGroup = default;
             bool requiredBooleanGroup = default;
             long requiredInt64Group = default;
-            Client.Option<int> stringGroup = default;
+            int requiredStringGroup = default;
             Client.Option<bool> booleanGroup = default;
             Client.Option<long> int64Group = default;
-            await _instance.TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            Client.Option<int> stringGroup = default;
+            await _instance.TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
         }
 
         /// <summary>
@@ -278,16 +278,16 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestQueryParameterCollectionFormatAsyncTest()
         {
-            List<string> pipe = default;
-            List<string> ioutil = default;
-            List<string> http = default;
-            List<string> url = default;
             List<string> context = default;
+            List<string> http = default;
+            List<string> ioutil = default;
+            List<string> pipe = default;
             string requiredNotNullable = default;
-            string requiredNullable = default;
+            List<string> url = default;
             Client.Option<string> notRequiredNotNullable = default;
             Client.Option<string> notRequiredNullable = default;
-            await _instance.TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            string requiredNullable = default;
+            await _instance.TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
@@ -108,9 +108,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task LoginUserAsyncTest()
         {
-            string username = default;
             string password = default;
-            var response = await _instance.LoginUserAsync(username, password);
+            string username = default;
+            var response = await _instance.LoginUserAsync(password, username);
             var model = response.Ok();
             Assert.IsType<string>(model);
         }
@@ -130,9 +130,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task UpdateUserAsyncTest()
         {
-            string username = default;
             User user = default;
-            await _instance.UpdateUserAsync(username, user);
+            string username = default;
+            await _instance.UpdateUserAsync(user, username);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -313,22 +313,22 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </remarks>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -361,17 +361,17 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -379,17 +379,17 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test enum parameters
         /// </remarks>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -398,15 +398,15 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -414,15 +414,15 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test inline additionalProperties
@@ -502,18 +502,18 @@ namespace Org.OpenAPITools.Api
         /// To test the collection format in query parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -521,18 +521,18 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test the collection format in query parameters
         /// </remarks>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test referenced string map
@@ -3781,19 +3781,19 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEndpointParameters(ref decimal number, ref double varDouble, ref string patternWithoutDelimiter, ref byte[] varByte, ref Option<int> integer, ref Option<int> int32, ref Option<long> int64, ref Option<float> varFloat, ref Option<string> varString, ref Option<System.IO.Stream> binary, ref Option<DateTime> date, ref Option<DateTime> dateTime, ref Option<string> password, ref Option<string> callback);
+        partial void FormatTestEndpointParameters(ref decimal number, ref string patternWithoutDelimiter, ref byte[] varByte, ref double varDouble, ref Option<System.IO.Stream> binary, ref Option<string> callback, ref Option<DateTime> date, ref Option<DateTime> dateTime, ref Option<int> int32, ref Option<long> int64, ref Option<int> integer, ref Option<string> password, ref Option<float> varFloat, ref Option<string> varString);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="varString"></param>
         /// <param name="binary"></param>
-        /// <param name="password"></param>
         /// <param name="callback"></param>
+        /// <param name="password"></param>
+        /// <param name="varString"></param>
         /// <returns></returns>
-        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<string> varString, Option<System.IO.Stream> binary, Option<string> password, Option<string> callback)
+        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<System.IO.Stream> binary, Option<string> callback, Option<string> password, Option<string> varString)
         {
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
@@ -3801,17 +3801,17 @@ namespace Org.OpenAPITools.Api
             if (varByte == null)
                 throw new ArgumentNullException(nameof(varByte));
 
-            if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString));
-
             if (binary.IsSet && binary.Value == null)
                 throw new ArgumentNullException(nameof(binary));
+
+            if (callback.IsSet && callback.Value == null)
+                throw new ArgumentNullException(nameof(callback));
 
             if (password.IsSet && password.Value == null)
                 throw new ArgumentNullException(nameof(password));
 
-            if (callback.IsSet && callback.Value == null)
-                throw new ArgumentNullException(nameof(callback));
+            if (varString.IsSet && varString.Value == null)
+                throw new ArgumentNullException(nameof(varString));
         }
 
         /// <summary>
@@ -3819,23 +3819,23 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -3846,20 +3846,20 @@ namespace Org.OpenAPITools.Api
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -3868,23 +3868,23 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -3897,45 +3897,45 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트  Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback, cancellationToken).ConfigureAwait(false);
+                return await TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -3948,30 +3948,30 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, varString, binary, password, callback);
+                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, binary, callback, password, varString);
 
-                FormatTestEndpointParameters(ref number, ref varDouble, ref patternWithoutDelimiter, ref varByte, ref integer, ref int32, ref int64, ref varFloat, ref varString, ref binary, ref date, ref dateTime, ref password, ref callback);
+                FormatTestEndpointParameters(ref number, ref patternWithoutDelimiter, ref varByte, ref varDouble, ref binary, ref callback, ref date, ref dateTime, ref int32, ref int64, ref integer, ref password, ref varFloat, ref varString);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -3990,29 +3990,17 @@ namespace Org.OpenAPITools.Api
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("number", ClientUtils.ParameterToString(number)));
 
-                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
-
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("pattern_without_delimiter", ClientUtils.ParameterToString(patternWithoutDelimiter)));
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("byte", ClientUtils.ParameterToString(varByte)));
 
-                    if (integer.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
-
-                    if (int32.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
-
-                    if (int64.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
-
-                    if (varFloat.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
-
-                    if (varString.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
+                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
 
                     if (binary.IsSet)
                         multipartContentLocalVar.Add(new StreamContent(binary.Value));
+
+                    if (callback.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
 
                     if (date.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("date", ClientUtils.ParameterToString(date.Value)));
@@ -4020,11 +4008,23 @@ namespace Org.OpenAPITools.Api
                     if (dateTime.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("dateTime", ClientUtils.ParameterToString(dateTime.Value)));
 
+                    if (int32.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
+
+                    if (int64.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
+
+                    if (integer.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
+
                     if (password.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("password", ClientUtils.ParameterToString(password.Value)));
 
-                    if (callback.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
+                    if (varFloat.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
+
+                    if (varString.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
 
                     List<TokenBase> tokenBaseLocalVars = new List<TokenBase>();
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
@@ -4056,7 +4056,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEndpointParametersApiResponse apiResponseLocalVar = new TestEndpointParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 
                         Events.ExecuteOnTestEndpointParameters(apiResponseLocalVar);
 
@@ -4070,7 +4070,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
                 Events.ExecuteOnErrorTestEndpointParameters(e);
                 throw;
             }
@@ -4127,55 +4127,55 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEnumParameters(Option<List<string>> enumHeaderStringArray, ref Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, ref Option<string> enumQueryString, ref Option<int> enumQueryInteger, ref Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, ref Option<string> enumFormString);
+        partial void FormatTestEnumParameters(ref Option<string> enumFormString, Option<List<string>> enumFormStringArray, ref Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, ref Option<double> enumQueryDouble, ref Option<int> enumQueryInteger, ref Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
         /// <returns></returns>
-        private void ValidateTestEnumParameters(Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        private void ValidateTestEnumParameters(Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
-            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderStringArray));
-
-            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderString));
-
-            if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumQueryStringArray));
-
-            if (enumQueryString.IsSet && enumQueryString.Value == null)
-                throw new ArgumentNullException(nameof(enumQueryString));
+            if (enumFormString.IsSet && enumFormString.Value == null)
+                throw new ArgumentNullException(nameof(enumFormString));
 
             if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumFormStringArray));
 
-            if (enumFormString.IsSet && enumFormString.Value == null)
-                throw new ArgumentNullException(nameof(enumFormString));
+            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderString));
+
+            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderStringArray));
+
+            if (enumQueryString.IsSet && enumQueryString.Value == null)
+                throw new ArgumentNullException(nameof(enumQueryString));
+
+            if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumQueryStringArray));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4185,15 +4185,15 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4201,18 +4201,18 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4224,34 +4224,34 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// To test enum parameters To test enum parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, cancellationToken).ConfigureAwait(false);
+                return await TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4263,25 +4263,25 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumFormStringArray, enumFormString);
+                ValidateTestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryString, enumQueryStringArray);
 
-                FormatTestEnumParameters(enumHeaderStringArray, ref enumHeaderString, enumQueryStringArray, ref enumQueryString, ref enumQueryInteger, ref enumQueryDouble, enumFormStringArray, ref enumFormString);
+                FormatTestEnumParameters(ref enumFormString, enumFormStringArray, ref enumHeaderString, enumHeaderStringArray, ref enumQueryDouble, ref enumQueryInteger, ref enumQueryString, enumQueryStringArray);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4292,25 +4292,25 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    if (enumQueryStringArray.IsSet)
-                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
-
-                    if (enumQueryString.IsSet)
-                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+                    if (enumQueryDouble.IsSet)
+                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
 
                     if (enumQueryInteger.IsSet)
                         parseQueryStringLocalVar["enum_query_integer"] = ClientUtils.ParameterToString(enumQueryInteger.Value);
 
-                    if (enumQueryDouble.IsSet)
-                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
+                    if (enumQueryString.IsSet)
+                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+
+                    if (enumQueryStringArray.IsSet)
+                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
-                    if (enumHeaderStringArray.IsSet)
-                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
-
                     if (enumHeaderString.IsSet)
                         httpRequestMessageLocalVar.Headers.Add("enum_header_string", ClientUtils.ParameterToString(enumHeaderString.Value));
+
+                    if (enumHeaderStringArray.IsSet)
+                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
 
                     MultipartContent multipartContentLocalVar = new MultipartContent();
 
@@ -4318,11 +4318,11 @@ namespace Org.OpenAPITools.Api
 
                     List<KeyValuePair<string, string>> formParameterLocalVars = new List<KeyValuePair<string, string>>();
 
-                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormStringArray.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
-
-                    if (enumFormString.IsSet)
+                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormString.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string", ClientUtils.ParameterToString(enumFormString.Value)));
+
+                    if (enumFormStringArray.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
 
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
 
@@ -4347,7 +4347,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEnumParametersApiResponse apiResponseLocalVar = new TestEnumParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 
                         Events.ExecuteOnTestEnumParameters(apiResponseLocalVar);
 
@@ -4357,7 +4357,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
                 Events.ExecuteOnErrorTestEnumParameters(e);
                 throw;
             }
@@ -4414,22 +4414,22 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestGroupParameters(ref int requiredStringGroup, ref bool requiredBooleanGroup, ref long requiredInt64Group, ref Option<int> stringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group);
+        partial void FormatTestGroupParameters(ref bool requiredBooleanGroup, ref long requiredInt64Group, ref int requiredStringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group, ref Option<int> stringGroup);
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4439,13 +4439,13 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4453,16 +4453,16 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4474,30 +4474,30 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, cancellationToken).ConfigureAwait(false);
+                return await TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4509,21 +4509,21 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                FormatTestGroupParameters(ref requiredStringGroup, ref requiredBooleanGroup, ref requiredInt64Group, ref stringGroup, ref booleanGroup, ref int64Group);
+                FormatTestGroupParameters(ref requiredBooleanGroup, ref requiredInt64Group, ref requiredStringGroup, ref booleanGroup, ref int64Group, ref stringGroup);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4534,14 +4534,14 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
                     parseQueryStringLocalVar["required_int64_group"] = ClientUtils.ParameterToString(requiredInt64Group);
-
-                    if (stringGroup.IsSet)
-                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
+                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
 
                     if (int64Group.IsSet)
                         parseQueryStringLocalVar["int64_group"] = ClientUtils.ParameterToString(int64Group.Value);
+
+                    if (stringGroup.IsSet)
+                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -4570,7 +4570,7 @@ namespace Org.OpenAPITools.Api
 
                         TestGroupParametersApiResponse apiResponseLocalVar = new TestGroupParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 
                         Events.ExecuteOnTestGroupParameters(apiResponseLocalVar);
 
@@ -4584,7 +4584,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
                 Events.ExecuteOnErrorTestGroupParameters(e);
                 throw;
             }
@@ -5220,38 +5220,38 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, ref string requiredNotNullable, ref string requiredNullable, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable);
+        partial void FormatTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, ref string requiredNotNullable, List<string> url, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable, ref string requiredNullable);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <returns></returns>
-        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, Option<string> notRequiredNotNullable)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable)
         {
-            if (pipe == null)
-                throw new ArgumentNullException(nameof(pipe));
-
-            if (ioutil == null)
-                throw new ArgumentNullException(nameof(ioutil));
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
 
             if (http == null)
                 throw new ArgumentNullException(nameof(http));
 
-            if (url == null)
-                throw new ArgumentNullException(nameof(url));
+            if (ioutil == null)
+                throw new ArgumentNullException(nameof(ioutil));
 
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
+            if (pipe == null)
+                throw new ArgumentNullException(nameof(pipe));
 
             if (requiredNotNullable == null)
                 throw new ArgumentNullException(nameof(requiredNotNullable));
+
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
 
             if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
                 throw new ArgumentNullException(nameof(notRequiredNotNullable));
@@ -5261,19 +5261,19 @@ namespace Org.OpenAPITools.Api
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -5283,16 +5283,16 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -5300,19 +5300,19 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -5324,36 +5324,36 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         ///  To test the collection format in query parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable, cancellationToken).ConfigureAwait(false);
+                return await TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -5365,26 +5365,26 @@ namespace Org.OpenAPITools.Api
         ///  To test the collection format in query parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, notRequiredNotNullable);
+                ValidateTestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable);
 
-                FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, ref requiredNotNullable, ref requiredNullable, ref notRequiredNotNullable, ref notRequiredNullable);
+                FormatTestQueryParameterCollectionFormat(context, http, ioutil, pipe, ref requiredNotNullable, url, ref notRequiredNotNullable, ref notRequiredNullable, ref requiredNullable);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -5395,12 +5395,12 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
-                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
-                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
-                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["context"] = ClientUtils.ParameterToString(context);
+                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
+                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
+                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
                     parseQueryStringLocalVar["requiredNotNullable"] = ClientUtils.ParameterToString(requiredNotNullable);
+                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["requiredNullable"] = ClientUtils.ParameterToString(requiredNullable);
 
                     if (notRequiredNotNullable.IsSet)
@@ -5424,7 +5424,7 @@ namespace Org.OpenAPITools.Api
 
                         TestQueryParameterCollectionFormatApiResponse apiResponseLocalVar = new TestQueryParameterCollectionFormatApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake/test-query-parameters", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 
                         Events.ExecuteOnTestQueryParameterCollectionFormat(apiResponseLocalVar);
 
@@ -5434,7 +5434,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
                 Events.ExecuteOnErrorTestQueryParameterCollectionFormat(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
@@ -155,11 +155,11 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs user into the system
@@ -167,11 +167,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs out current logged in user session
@@ -201,11 +201,11 @@ namespace Org.OpenAPITools.Api
         /// This can only be done by the logged in user.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updated user
@@ -213,11 +213,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// This can only be done by the logged in user.
         /// </remarks>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
     }
 
     /// <summary>
@@ -1622,33 +1622,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatLoginUser(ref string username, ref string password);
+        partial void FormatLoginUser(ref string password, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="password"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateLoginUser(string username, string password)
+        private void ValidateLoginUser(string password, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (password == null)
                 throw new ArgumentNullException(nameof(password));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string username, string password)
+        /// <param name="username"></param>
+        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string password, string username)
         {
             bool suppressDefaultLog = false;
-            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, username, password);
+            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, password, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -1658,9 +1658,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string username, string password);
+        /// <param name="username"></param>
+        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string password, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -1668,12 +1668,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, string password)
+        /// <param name="username"></param>
+        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string password, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, username, password);
+            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, password, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -1685,22 +1685,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, string password);
+        /// <param name="username"></param>
+        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string password, string username);
 
         /// <summary>
         /// Logs user into the system 
         /// </summary>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await LoginUserAsync(username, password, cancellationToken).ConfigureAwait(false);
+                return await LoginUserAsync(password, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -1712,19 +1712,19 @@ namespace Org.OpenAPITools.Api
         /// Logs user into the system 
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateLoginUser(username, password);
+                ValidateLoginUser(password, username);
 
-                FormatLoginUser(ref username, ref password);
+                FormatLoginUser(ref password, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1735,8 +1735,8 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
                     parseQueryStringLocalVar["password"] = ClientUtils.ParameterToString(password);
+                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -1763,7 +1763,7 @@ namespace Org.OpenAPITools.Api
 
                         LoginUserApiResponse apiResponseLocalVar = new LoginUserApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/login", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, username, password);
+                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, password, username);
 
                         Events.ExecuteOnLoginUser(apiResponseLocalVar);
 
@@ -1773,7 +1773,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, username, password);
+                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, password, username);
                 Events.ExecuteOnErrorLoginUser(e);
                 throw;
             }
@@ -2014,33 +2014,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatUpdateUser(ref string username, User user);
+        partial void FormatUpdateUser(User user, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="user"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateUpdateUser(string username, User user)
+        private void ValidateUpdateUser(User user, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, string username, User user)
+        /// <param name="username"></param>
+        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, User user, string username)
         {
             bool suppressDefaultLog = false;
-            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, username, user);
+            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, user, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -2050,9 +2050,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, string username, User user);
+        /// <param name="username"></param>
+        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, User user, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -2060,12 +2060,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, User user)
+        /// <param name="username"></param>
+        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, User user, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, username, user);
+            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, user, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -2077,22 +2077,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, User user);
+        /// <param name="username"></param>
+        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, User user, string username);
 
         /// <summary>
         /// Updated user This can only be done by the logged in user.
         /// </summary>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await UpdateUserAsync(username, user, cancellationToken).ConfigureAwait(false);
+                return await UpdateUserAsync(user, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -2104,19 +2104,19 @@ namespace Org.OpenAPITools.Api
         /// Updated user This can only be done by the logged in user.
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateUpdateUser(username, user);
+                ValidateUpdateUser(user, username);
 
-                FormatUpdateUser(ref username, user);
+                FormatUpdateUser(user, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2153,7 +2153,7 @@ namespace Org.OpenAPITools.Api
 
                         UpdateUserApiResponse apiResponseLocalVar = new UpdateUserApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/{username}", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, username, user);
+                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, user, username);
 
                         Events.ExecuteOnUpdateUser(apiResponseLocalVar);
 
@@ -2163,7 +2163,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, username, user);
+                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, user, username);
                 Events.ExecuteOnErrorUpdateUser(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/docs/models/Adult.md
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/docs/models/Adult.md
@@ -5,9 +5,9 @@ A representation of an adult
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Type** | **string** |  | [optional] 
-**LastName** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
+**LastName** | **string** |  | [optional] 
+**Type** | **string** |  | [optional] 
 **Children** | [**List&lt;Child&gt;**](Child.md) |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/docs/models/Child.md
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/docs/models/Child.md
@@ -5,11 +5,11 @@ A representation of a child
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Type** | **string** |  | [optional] 
-**LastName** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
-**BoosterSeat** | **bool** |  | [optional] 
+**LastName** | **string** |  | [optional] 
+**Type** | **string** |  | [optional] 
 **Age** | **int** |  | [optional] 
+**BoosterSeat** | **bool** |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/docs/models/Person.md
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/docs/models/Person.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Type** | **string** |  | [optional] 
-**LastName** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
+**LastName** | **string** |  | [optional] 
+**Type** | **string** |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools.Test/Model/ChildTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools.Test/Model/ChildTests.cs
@@ -54,21 +54,21 @@ namespace Org.OpenAPITools.Test.Model
         }
 
         /// <summary>
-        /// Test the property 'BoosterSeat'
-        /// </summary>
-        [Fact]
-        public void BoosterSeatTest()
-        {
-            // TODO unit test for the property 'BoosterSeat'
-        }
-
-        /// <summary>
         /// Test the property 'Age'
         /// </summary>
         [Fact]
         public void AgeTest()
         {
             // TODO unit test for the property 'Age'
+        }
+
+        /// <summary>
+        /// Test the property 'BoosterSeat'
+        /// </summary>
+        [Fact]
+        public void BoosterSeatTest()
+        {
+            // TODO unit test for the property 'BoosterSeat'
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools.Test/Model/PersonTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools.Test/Model/PersonTests.cs
@@ -74,12 +74,12 @@ namespace Org.OpenAPITools.Test.Model
         }
 
         /// <summary>
-        /// Test the property 'Type'
+        /// Test the property 'FirstName'
         /// </summary>
         [Fact]
-        public void TypeTest()
+        public void FirstNameTest()
         {
-            // TODO unit test for the property 'Type'
+            // TODO unit test for the property 'FirstName'
         }
 
         /// <summary>
@@ -92,12 +92,12 @@ namespace Org.OpenAPITools.Test.Model
         }
 
         /// <summary>
-        /// Test the property 'FirstName'
+        /// Test the property 'Type'
         /// </summary>
         [Fact]
-        public void FirstNameTest()
+        public void TypeTest()
         {
-            // TODO unit test for the property 'FirstName'
+            // TODO unit test for the property 'Type'
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -34,24 +34,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Adult" /> class.
         /// </summary>
-        /// <param name="lastName">lastName</param>
-        /// <param name="firstName">firstName</param>
         /// <param name="children">children</param>
+        /// <param name="firstName">firstName</param>
+        /// <param name="lastName">lastName</param>
         [JsonConstructor]
-        public Adult(Option<string?> lastName = default, Option<string?> firstName = default, Option<List<Child>?> children = default) : base(lastName, firstName)
+        public Adult(Option<List<Child>?> children = default, Option<string?> firstName = default, Option<string?> lastName = default) : base(firstName, lastName)
         {
             ChildrenOption = children;
             OnCreated();
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public new string Type { get; } = "Adult";
 
         /// <summary>
         /// Used to track the state of Children
@@ -65,6 +58,13 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("children")]
         public List<Child>? Children { get { return this.ChildrenOption; } set { this.ChildrenOption = new(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public new string Type { get; } = "Adult";
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -103,10 +103,10 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<string?> type = default;
-            Option<string?> lastName = default;
-            Option<string?> firstName = default;
             Option<List<Child>?> children = default;
+            Option<string?> firstName = default;
+            Option<string?> lastName = default;
+            Option<string?> type = default;
 
             while (utf8JsonReader.Read())
             {
@@ -123,18 +123,18 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
-                        case "$_type":
-                            type = new Option<string?>(utf8JsonReader.GetString()!);
-                            break;
-                        case "lastName":
-                            lastName = new Option<string?>(utf8JsonReader.GetString()!);
+                        case "children":
+                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
+                                children = new Option<List<Child>?>(JsonSerializer.Deserialize<List<Child>>(ref utf8JsonReader, jsonSerializerOptions)!);
                             break;
                         case "firstName":
                             firstName = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
-                        case "children":
-                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                children = new Option<List<Child>?>(JsonSerializer.Deserialize<List<Child>>(ref utf8JsonReader, jsonSerializerOptions)!);
+                        case "lastName":
+                            lastName = new Option<string?>(utf8JsonReader.GetString()!);
+                            break;
+                        case "$_type":
+                            type = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         default:
                             break;
@@ -142,19 +142,19 @@ namespace Org.OpenAPITools.Model
                 }
             }
 
-            if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Adult.");
-
-            if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Adult.");
+            if (children.IsSet && children.Value == null)
+                throw new ArgumentNullException(nameof(children), "Property is not nullable for class Adult.");
 
             if (firstName.IsSet && firstName.Value == null)
                 throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Adult.");
 
-            if (children.IsSet && children.Value == null)
-                throw new ArgumentNullException(nameof(children), "Property is not nullable for class Adult.");
+            if (lastName.IsSet && lastName.Value == null)
+                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Adult.");
 
-            return new Adult(lastName, firstName, children);
+            if (type.IsSet && type.Value == null)
+                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Adult.");
+
+            return new Adult(children, firstName, lastName);
         }
 
         /// <summary>
@@ -181,28 +181,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Adult adult, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (adult.LastNameOption.IsSet && adult.LastName == null)
-                throw new ArgumentNullException(nameof(adult.LastName), "Property is required for class Adult.");
+            if (adult.ChildrenOption.IsSet && adult.Children == null)
+                throw new ArgumentNullException(nameof(adult.Children), "Property is required for class Adult.");
 
             if (adult.FirstNameOption.IsSet && adult.FirstName == null)
                 throw new ArgumentNullException(nameof(adult.FirstName), "Property is required for class Adult.");
 
-            if (adult.ChildrenOption.IsSet && adult.Children == null)
-                throw new ArgumentNullException(nameof(adult.Children), "Property is required for class Adult.");
-
-            writer.WriteString("$_type", adult.Type);
-
-            if (adult.LastNameOption.IsSet)
-                writer.WriteString("lastName", adult.LastName);
-
-            if (adult.FirstNameOption.IsSet)
-                writer.WriteString("firstName", adult.FirstName);
+            if (adult.LastNameOption.IsSet && adult.LastName == null)
+                throw new ArgumentNullException(nameof(adult.LastName), "Property is required for class Adult.");
 
             if (adult.ChildrenOption.IsSet)
             {
                 writer.WritePropertyName("children");
                 JsonSerializer.Serialize(writer, adult.Children, jsonSerializerOptions);
             }
+            if (adult.FirstNameOption.IsSet)
+                writer.WriteString("firstName", adult.FirstName);
+
+            if (adult.LastNameOption.IsSet)
+                writer.WriteString("lastName", adult.LastName);
+
+            writer.WriteString("$_type", adult.Type);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -34,12 +34,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Child" /> class.
         /// </summary>
-        /// <param name="lastName">lastName</param>
-        /// <param name="firstName">firstName</param>
         /// <param name="age">age</param>
+        /// <param name="firstName">firstName</param>
+        /// <param name="lastName">lastName</param>
         /// <param name="boosterSeat">boosterSeat</param>
         [JsonConstructor]
-        public Child(Option<string?> lastName = default, Option<string?> firstName = default, Option<int?> age = default, Option<bool?> boosterSeat = default) : base(lastName, firstName)
+        public Child(Option<int?> age = default, Option<string?> firstName = default, Option<string?> lastName = default, Option<bool?> boosterSeat = default) : base(firstName, lastName)
         {
             AgeOption = age;
             BoosterSeatOption = boosterSeat;
@@ -47,13 +47,6 @@ namespace Org.OpenAPITools.Model
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public new string Type { get; } = "Child";
 
         /// <summary>
         /// Used to track the state of Age
@@ -67,6 +60,13 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("age")]
         public int? Age { get { return this.AgeOption; } set { this.AgeOption = new(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public new string Type { get; } = "Child";
 
         /// <summary>
         /// Used to track the state of BoosterSeat
@@ -90,8 +90,8 @@ namespace Org.OpenAPITools.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class Child {\n");
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
-            sb.Append("  BoosterSeat: ").Append(BoosterSeat).Append("\n");
             sb.Append("  Age: ").Append(Age).Append("\n");
+            sb.Append("  BoosterSeat: ").Append(BoosterSeat).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -119,10 +119,10 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<string?> type = default;
-            Option<string?> lastName = default;
-            Option<string?> firstName = default;
             Option<int?> age = default;
+            Option<string?> firstName = default;
+            Option<string?> lastName = default;
+            Option<string?> type = default;
             Option<bool?> boosterSeat = default;
 
             while (utf8JsonReader.Read())
@@ -140,18 +140,18 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
-                        case "$_type":
-                            type = new Option<string?>(utf8JsonReader.GetString()!);
-                            break;
-                        case "lastName":
-                            lastName = new Option<string?>(utf8JsonReader.GetString()!);
+                        case "age":
+                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
+                                age = new Option<int?>(utf8JsonReader.GetInt32());
                             break;
                         case "firstName":
                             firstName = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
-                        case "age":
-                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                age = new Option<int?>(utf8JsonReader.GetInt32());
+                        case "lastName":
+                            lastName = new Option<string?>(utf8JsonReader.GetString()!);
+                            break;
+                        case "$_type":
+                            type = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "boosterSeat":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
@@ -163,22 +163,22 @@ namespace Org.OpenAPITools.Model
                 }
             }
 
-            if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Child.");
-
-            if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Child.");
+            if (age.IsSet && age.Value == null)
+                throw new ArgumentNullException(nameof(age), "Property is not nullable for class Child.");
 
             if (firstName.IsSet && firstName.Value == null)
                 throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Child.");
 
-            if (age.IsSet && age.Value == null)
-                throw new ArgumentNullException(nameof(age), "Property is not nullable for class Child.");
+            if (lastName.IsSet && lastName.Value == null)
+                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Child.");
+
+            if (type.IsSet && type.Value == null)
+                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Child.");
 
             if (boosterSeat.IsSet && boosterSeat.Value == null)
                 throw new ArgumentNullException(nameof(boosterSeat), "Property is not nullable for class Child.");
 
-            return new Child(lastName, firstName, age, boosterSeat);
+            return new Child(age, firstName, lastName, boosterSeat);
         }
 
         /// <summary>
@@ -205,22 +205,22 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Child child, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (child.LastNameOption.IsSet && child.LastName == null)
-                throw new ArgumentNullException(nameof(child.LastName), "Property is required for class Child.");
-
             if (child.FirstNameOption.IsSet && child.FirstName == null)
                 throw new ArgumentNullException(nameof(child.FirstName), "Property is required for class Child.");
 
-            writer.WriteString("$_type", child.Type);
+            if (child.LastNameOption.IsSet && child.LastName == null)
+                throw new ArgumentNullException(nameof(child.LastName), "Property is required for class Child.");
 
-            if (child.LastNameOption.IsSet)
-                writer.WriteString("lastName", child.LastName);
+            if (child.AgeOption.IsSet)
+                writer.WriteNumber("age", child.AgeOption.Value!.Value);
 
             if (child.FirstNameOption.IsSet)
                 writer.WriteString("firstName", child.FirstName);
 
-            if (child.AgeOption.IsSet)
-                writer.WriteNumber("age", child.AgeOption.Value!.Value);
+            if (child.LastNameOption.IsSet)
+                writer.WriteString("lastName", child.LastName);
+
+            writer.WriteString("$_type", child.Type);
 
             if (child.BoosterSeatOption.IsSet)
                 writer.WriteBoolean("boosterSeat", child.BoosterSeatOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -34,37 +34,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Person" /> class.
         /// </summary>
-        /// <param name="lastName">lastName</param>
         /// <param name="firstName">firstName</param>
+        /// <param name="lastName">lastName</param>
         [JsonConstructor]
-        public Person(Option<string?> lastName = default, Option<string?> firstName = default)
+        public Person(Option<string?> firstName = default, Option<string?> lastName = default)
         {
-            LastNameOption = lastName;
             FirstNameOption = firstName;
+            LastNameOption = lastName;
             OnCreated();
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public string Type { get; } = "Person";
-
-        /// <summary>
-        /// Used to track the state of LastName
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public Option<string?> LastNameOption { get; private set; }
-
-        /// <summary>
-        /// Gets or Sets LastName
-        /// </summary>
-        [JsonPropertyName("lastName")]
-        public string? LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -80,6 +60,26 @@ namespace Org.OpenAPITools.Model
         public string? FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
+        /// Used to track the state of LastName
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public Option<string?> LastNameOption { get; private set; }
+
+        /// <summary>
+        /// Gets or Sets LastName
+        /// </summary>
+        [JsonPropertyName("lastName")]
+        public string? LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public string Type { get; } = "Person";
+
+        /// <summary>
         /// Gets or Sets additional properties
         /// </summary>
         [JsonExtensionData]
@@ -93,8 +93,8 @@ namespace Org.OpenAPITools.Model
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("class Person {\n");
-            sb.Append("  LastName: ").Append(LastName).Append("\n");
             sb.Append("  FirstName: ").Append(FirstName).Append("\n");
+            sb.Append("  LastName: ").Append(LastName).Append("\n");
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -143,9 +143,9 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<string?> type = default;
-            Option<string?> lastName = default;
             Option<string?> firstName = default;
+            Option<string?> lastName = default;
+            Option<string?> type = default;
 
             string? discriminator = ClientUtils.GetDiscriminator(utf8JsonReader, "$_type");
 
@@ -170,14 +170,14 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
-                        case "$_type":
-                            type = new Option<string?>(utf8JsonReader.GetString()!);
+                        case "firstName":
+                            firstName = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "lastName":
                             lastName = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
-                        case "firstName":
-                            firstName = new Option<string?>(utf8JsonReader.GetString()!);
+                        case "$_type":
+                            type = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         default:
                             break;
@@ -185,16 +185,16 @@ namespace Org.OpenAPITools.Model
                 }
             }
 
-            if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Person.");
+            if (firstName.IsSet && firstName.Value == null)
+                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Person.");
 
             if (lastName.IsSet && lastName.Value == null)
                 throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Person.");
 
-            if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Person.");
+            if (type.IsSet && type.Value == null)
+                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Person.");
 
-            return new Person(lastName, firstName);
+            return new Person(firstName, lastName);
         }
 
         /// <summary>
@@ -231,19 +231,19 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Person person, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (person.LastNameOption.IsSet && person.LastName == null)
-                throw new ArgumentNullException(nameof(person.LastName), "Property is required for class Person.");
-
             if (person.FirstNameOption.IsSet && person.FirstName == null)
                 throw new ArgumentNullException(nameof(person.FirstName), "Property is required for class Person.");
 
-            writer.WriteString("$_type", person.Type);
+            if (person.LastNameOption.IsSet && person.LastName == null)
+                throw new ArgumentNullException(nameof(person.LastName), "Property is required for class Person.");
+
+            if (person.FirstNameOption.IsSet)
+                writer.WriteString("firstName", person.FirstName);
 
             if (person.LastNameOption.IsSet)
                 writer.WriteString("lastName", person.LastName);
 
-            if (person.FirstNameOption.IsSet)
-                writer.WriteString("firstName", person.FirstName);
+            writer.WriteString("$_type", person.Type);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/docs/apis/FakeApi.md
@@ -1067,7 +1067,7 @@ No authorization required
 
 <a id="testendpointparameters"></a>
 # **TestEndpointParameters**
-> void TestEndpointParameters (decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, int integer = null, int int32 = null, long int64 = null, float varFloat = null, string varString = null, System.IO.Stream binary = null, DateOnly date = null, DateTime dateTime = null, string password = null, string callback = null)
+> void TestEndpointParameters (decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, System.IO.Stream binary = null, string callback = null, DateOnly date = null, DateTime dateTime = null, int int32 = null, long int64 = null, int integer = null, string password = null, float varFloat = null, string varString = null)
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
@@ -1095,24 +1095,24 @@ namespace Example
 
             var apiInstance = new FakeApi(config);
             var number = 8.14D;  // decimal | None
-            var varDouble = 1.2D;  // double | None
             var patternWithoutDelimiter = "patternWithoutDelimiter_example";  // string | None
             var varByte = System.Text.Encoding.ASCII.GetBytes("BYTE_ARRAY_DATA_HERE");  // byte[] | None
-            var integer = 56;  // int | None (optional) 
-            var int32 = 56;  // int | None (optional) 
-            var int64 = 789L;  // long | None (optional) 
-            var varFloat = 3.4F;  // float | None (optional) 
-            var varString = "varString_example";  // string | None (optional) 
+            var varDouble = 1.2D;  // double | None
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
+            var callback = "callback_example";  // string | None (optional) 
             var date = DateOnly.Parse("2013-10-20");  // DateOnly | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")
+            var int32 = 56;  // int | None (optional) 
+            var int64 = 789L;  // long | None (optional) 
+            var integer = 56;  // int | None (optional) 
             var password = "password_example";  // string | None (optional) 
-            var callback = "callback_example";  // string | None (optional) 
+            var varFloat = 3.4F;  // float | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
 
             try
             {
                 // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-                apiInstance.TestEndpointParameters(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                apiInstance.TestEndpointParameters(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             }
             catch (ApiException  e)
             {
@@ -1132,7 +1132,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    apiInstance.TestEndpointParametersWithHttpInfo(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+    apiInstance.TestEndpointParametersWithHttpInfo(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 }
 catch (ApiException e)
 {
@@ -1147,19 +1147,19 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **number** | **decimal** | None |  |
-| **varDouble** | **double** | None |  |
 | **patternWithoutDelimiter** | **string** | None |  |
 | **varByte** | **byte[]** | None |  |
-| **integer** | **int** | None | [optional]  |
-| **int32** | **int** | None | [optional]  |
-| **int64** | **long** | None | [optional]  |
-| **varFloat** | **float** | None | [optional]  |
-| **varString** | **string** | None | [optional]  |
+| **varDouble** | **double** | None |  |
 | **binary** | **System.IO.Stream****System.IO.Stream** | None | [optional]  |
+| **callback** | **string** | None | [optional]  |
 | **date** | **DateOnly** | None | [optional]  |
 | **dateTime** | **DateTime** | None | [optional] [default to &quot;2010-02-01T10:20:10.111110+01:00&quot;] |
+| **int32** | **int** | None | [optional]  |
+| **int64** | **long** | None | [optional]  |
+| **integer** | **int** | None | [optional]  |
 | **password** | **string** | None | [optional]  |
-| **callback** | **string** | None | [optional]  |
+| **varFloat** | **float** | None | [optional]  |
+| **varString** | **string** | None | [optional]  |
 
 ### Return type
 
@@ -1185,7 +1185,7 @@ void (empty response body)
 
 <a id="testenumparameters"></a>
 # **TestEnumParameters**
-> void TestEnumParameters (List<TestEnumParametersRequestEnumFormStringArrayInner> enumHeaderStringArray = null, TestEnumParametersEnumHeaderStringParameter enumHeaderString = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumQueryStringArray = null, TestEnumParametersEnumHeaderStringParameter enumQueryString = null, TestEnumParametersEnumQueryIntegerParameter enumQueryInteger = null, TestEnumParametersEnumQueryDoubleParameter enumQueryDouble = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumFormStringArray = null, TestEnumParametersRequestEnumFormString enumFormString = null)
+> void TestEnumParameters (TestEnumParametersRequestEnumFormString enumFormString = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumFormStringArray = null, TestEnumParametersEnumHeaderStringParameter enumHeaderString = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumHeaderStringArray = null, TestEnumParametersEnumQueryDoubleParameter enumQueryDouble = null, TestEnumParametersEnumQueryIntegerParameter enumQueryInteger = null, TestEnumParametersEnumHeaderStringParameter enumQueryString = null, List<TestEnumParametersRequestEnumFormStringArrayInner> enumQueryStringArray = null)
 
 To test enum parameters
 
@@ -1208,19 +1208,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var enumHeaderStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Header parameter enum test (string array) (optional) 
-            var enumHeaderString = (TestEnumParametersEnumHeaderStringParameter) "_abc";  // TestEnumParametersEnumHeaderStringParameter | Header parameter enum test (string) (optional) 
-            var enumQueryStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Query parameter enum test (string array) (optional) 
-            var enumQueryString = (TestEnumParametersEnumHeaderStringParameter) "_abc";  // TestEnumParametersEnumHeaderStringParameter | Query parameter enum test (string) (optional) 
-            var enumQueryInteger = (TestEnumParametersEnumQueryIntegerParameter) "1";  // TestEnumParametersEnumQueryIntegerParameter | Query parameter enum test (double) (optional) 
-            var enumQueryDouble = (TestEnumParametersEnumQueryDoubleParameter) "1.1";  // TestEnumParametersEnumQueryDoubleParameter | Query parameter enum test (double) (optional) 
-            var enumFormStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Form parameter enum test (string array) (optional) 
             var enumFormString = (TestEnumParametersRequestEnumFormString) "_abc";  // TestEnumParametersRequestEnumFormString |  (optional) 
+            var enumFormStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Form parameter enum test (string array) (optional) 
+            var enumHeaderString = (TestEnumParametersEnumHeaderStringParameter) "_abc";  // TestEnumParametersEnumHeaderStringParameter | Header parameter enum test (string) (optional) 
+            var enumHeaderStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Header parameter enum test (string array) (optional) 
+            var enumQueryDouble = (TestEnumParametersEnumQueryDoubleParameter) "1.1";  // TestEnumParametersEnumQueryDoubleParameter | Query parameter enum test (double) (optional) 
+            var enumQueryInteger = (TestEnumParametersEnumQueryIntegerParameter) "1";  // TestEnumParametersEnumQueryIntegerParameter | Query parameter enum test (double) (optional) 
+            var enumQueryString = (TestEnumParametersEnumHeaderStringParameter) "_abc";  // TestEnumParametersEnumHeaderStringParameter | Query parameter enum test (string) (optional) 
+            var enumQueryStringArray = new List<TestEnumParametersRequestEnumFormStringArrayInner>(); // List<TestEnumParametersRequestEnumFormStringArrayInner> | Query parameter enum test (string array) (optional) 
 
             try
             {
                 // To test enum parameters
-                apiInstance.TestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                apiInstance.TestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             }
             catch (ApiException  e)
             {
@@ -1240,7 +1240,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test enum parameters
-    apiInstance.TestEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+    apiInstance.TestEnumParametersWithHttpInfo(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 }
 catch (ApiException e)
 {
@@ -1254,14 +1254,14 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **enumHeaderStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Header parameter enum test (string array) | [optional]  |
-| **enumHeaderString** | **TestEnumParametersEnumHeaderStringParameter** | Header parameter enum test (string) | [optional]  |
-| **enumQueryStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Query parameter enum test (string array) | [optional]  |
-| **enumQueryString** | **TestEnumParametersEnumHeaderStringParameter** | Query parameter enum test (string) | [optional]  |
-| **enumQueryInteger** | **TestEnumParametersEnumQueryIntegerParameter** | Query parameter enum test (double) | [optional]  |
-| **enumQueryDouble** | **TestEnumParametersEnumQueryDoubleParameter** | Query parameter enum test (double) | [optional]  |
-| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional]  |
 | **enumFormString** | **TestEnumParametersRequestEnumFormString** |  | [optional]  |
+| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional]  |
+| **enumHeaderString** | **TestEnumParametersEnumHeaderStringParameter** | Header parameter enum test (string) | [optional]  |
+| **enumHeaderStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Header parameter enum test (string array) | [optional]  |
+| **enumQueryDouble** | **TestEnumParametersEnumQueryDoubleParameter** | Query parameter enum test (double) | [optional]  |
+| **enumQueryInteger** | **TestEnumParametersEnumQueryIntegerParameter** | Query parameter enum test (double) | [optional]  |
+| **enumQueryString** | **TestEnumParametersEnumHeaderStringParameter** | Query parameter enum test (string) | [optional]  |
+| **enumQueryStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Query parameter enum test (string array) | [optional]  |
 
 ### Return type
 
@@ -1287,7 +1287,7 @@ No authorization required
 
 <a id="testgroupparameters"></a>
 # **TestGroupParameters**
-> void TestGroupParameters (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int stringGroup = null, bool booleanGroup = null, long int64Group = null)
+> void TestGroupParameters (bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, bool booleanGroup = null, long int64Group = null, int stringGroup = null)
 
 Fake endpoint to test group parameters (optional)
 
@@ -1313,17 +1313,17 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new FakeApi(config);
-            var requiredStringGroup = 56;  // int | Required String in group parameters
             var requiredBooleanGroup = true;  // bool | Required Boolean in group parameters
             var requiredInt64Group = 789L;  // long | Required Integer in group parameters
-            var stringGroup = 56;  // int | String in group parameters (optional) 
+            var requiredStringGroup = 56;  // int | Required String in group parameters
             var booleanGroup = true;  // bool | Boolean in group parameters (optional) 
             var int64Group = 789L;  // long | Integer in group parameters (optional) 
+            var stringGroup = 56;  // int | String in group parameters (optional) 
 
             try
             {
                 // Fake endpoint to test group parameters (optional)
-                apiInstance.TestGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                apiInstance.TestGroupParameters(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             }
             catch (ApiException  e)
             {
@@ -1343,7 +1343,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint to test group parameters (optional)
-    apiInstance.TestGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+    apiInstance.TestGroupParametersWithHttpInfo(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 }
 catch (ApiException e)
 {
@@ -1357,12 +1357,12 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **requiredBooleanGroup** | **bool** | Required Boolean in group parameters |  |
 | **requiredInt64Group** | **long** | Required Integer in group parameters |  |
-| **stringGroup** | **int** | String in group parameters | [optional]  |
+| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **booleanGroup** | **bool** | Boolean in group parameters | [optional]  |
 | **int64Group** | **long** | Integer in group parameters | [optional]  |
+| **stringGroup** | **int** | String in group parameters | [optional]  |
 
 ### Return type
 
@@ -1644,7 +1644,7 @@ No authorization required
 
 <a id="testqueryparametercollectionformat"></a>
 # **TestQueryParameterCollectionFormat**
-> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, string notRequiredNotNullable = null, string notRequiredNullable = null)
+> void TestQueryParameterCollectionFormat (List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, string notRequiredNotNullable = null, string notRequiredNullable = null, string requiredNullable)
 
 
 
@@ -1667,19 +1667,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var pipe = new List<string>(); // List<string> | 
-            var ioutil = new List<string>(); // List<string> | 
-            var http = new List<string>(); // List<string> | 
-            var url = new List<string>(); // List<string> | 
             var context = new List<string>(); // List<string> | 
+            var http = new List<string>(); // List<string> | 
+            var ioutil = new List<string>(); // List<string> | 
+            var pipe = new List<string>(); // List<string> | 
             var requiredNotNullable = "requiredNotNullable_example";  // string | 
-            var requiredNullable = "requiredNullable_example";  // string | 
+            var url = new List<string>(); // List<string> | 
             var notRequiredNotNullable = "notRequiredNotNullable_example";  // string |  (optional) 
             var notRequiredNullable = "notRequiredNullable_example";  // string |  (optional) 
+            var requiredNullable = "requiredNullable_example";  // string | 
 
             try
             {
-                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                apiInstance.TestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             }
             catch (ApiException  e)
             {
@@ -1698,7 +1698,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 }
 catch (ApiException e)
 {
@@ -1712,15 +1712,15 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
-| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
-| **http** | [**List&lt;string&gt;**](string.md) |  |  |
-| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **context** | [**List&lt;string&gt;**](string.md) |  |  |
+| **http** | [**List&lt;string&gt;**](string.md) |  |  |
+| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
+| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
 | **requiredNotNullable** | **string** |  |  |
-| **requiredNullable** | **string** |  |  |
+| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **notRequiredNotNullable** | **string** |  | [optional]  |
 | **notRequiredNullable** | **string** |  | [optional]  |
+| **requiredNullable** | **string** |  |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/docs/apis/UserApi.md
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/docs/apis/UserApi.md
@@ -453,7 +453,7 @@ No authorization required
 
 <a id="loginuser"></a>
 # **LoginUser**
-> string LoginUser (string username, string password)
+> string LoginUser (string password, string username)
 
 Logs user into the system
 
@@ -474,13 +474,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | The user name for login
             var password = "password_example";  // string | The password for login in clear text
+            var username = "username_example";  // string | The user name for login
 
             try
             {
                 // Logs user into the system
-                string result = apiInstance.LoginUser(username, password);
+                string result = apiInstance.LoginUser(password, username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -501,7 +501,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Logs user into the system
-    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(username, password);
+    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(password, username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -518,8 +518,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | The user name for login |  |
 | **password** | **string** | The password for login in clear text |  |
+| **username** | **string** | The user name for login |  |
 
 ### Return type
 
@@ -625,7 +625,7 @@ No authorization required
 
 <a id="updateuser"></a>
 # **UpdateUser**
-> void UpdateUser (string username, User user)
+> void UpdateUser (User user, string username)
 
 Updated user
 
@@ -648,13 +648,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | name that need to be deleted
             var user = new User(); // User | Updated user object
+            var username = "username_example";  // string | name that need to be deleted
 
             try
             {
                 // Updated user
-                apiInstance.UpdateUser(username, user);
+                apiInstance.UpdateUser(user, username);
             }
             catch (ApiException  e)
             {
@@ -674,7 +674,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Updated user
-    apiInstance.UpdateUserWithHttpInfo(username, user);
+    apiInstance.UpdateUserWithHttpInfo(user, username);
 }
 catch (ApiException e)
 {
@@ -688,8 +688,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | name that need to be deleted |  |
 | **user** | [**User**](User.md) | Updated user object |  |
+| **username** | **string** | name that need to be deleted |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
@@ -193,20 +193,20 @@ namespace Org.OpenAPITools.Test.Api
         public async Task TestEndpointParametersAsyncTest()
         {
             decimal number = default;
-            double varDouble = default;
             string patternWithoutDelimiter = default;
             byte[] varByte = default;
-            Client.Option<int> integer = default;
-            Client.Option<int> int32 = default;
-            Client.Option<long> int64 = default;
-            Client.Option<float> varFloat = default;
-            Client.Option<string> varString = default;
+            double varDouble = default;
             Client.Option<System.IO.Stream> binary = default;
+            Client.Option<string> callback = default;
             Client.Option<DateOnly> date = default;
             Client.Option<DateTime> dateTime = default;
+            Client.Option<int> int32 = default;
+            Client.Option<long> int64 = default;
+            Client.Option<int> integer = default;
             Client.Option<string> password = default;
-            Client.Option<string> callback = default;
-            await _instance.TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            Client.Option<float> varFloat = default;
+            Client.Option<string> varString = default;
+            await _instance.TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
         }
 
         /// <summary>
@@ -215,15 +215,15 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestEnumParametersAsyncTest()
         {
-            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default;
-            Client.Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default;
-            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default;
-            Client.Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default;
-            Client.Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default;
-            Client.Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default;
-            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default;
             Client.Option<TestEnumParametersRequestEnumFormString> enumFormString = default;
-            await _instance.TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default;
+            Client.Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default;
+            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default;
+            Client.Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default;
+            Client.Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default;
+            Client.Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default;
+            Client.Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default;
+            await _instance.TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
         }
 
         /// <summary>
@@ -232,13 +232,13 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestGroupParametersAsyncTest()
         {
-            int requiredStringGroup = default;
             bool requiredBooleanGroup = default;
             long requiredInt64Group = default;
-            Client.Option<int> stringGroup = default;
+            int requiredStringGroup = default;
             Client.Option<bool> booleanGroup = default;
             Client.Option<long> int64Group = default;
-            await _instance.TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            Client.Option<int> stringGroup = default;
+            await _instance.TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
         }
 
         /// <summary>
@@ -278,16 +278,16 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestQueryParameterCollectionFormatAsyncTest()
         {
-            List<string> pipe = default;
-            List<string> ioutil = default;
-            List<string> http = default;
-            List<string> url = default;
             List<string> context = default;
+            List<string> http = default;
+            List<string> ioutil = default;
+            List<string> pipe = default;
             string requiredNotNullable = default;
-            string requiredNullable = default;
+            List<string> url = default;
             Client.Option<string> notRequiredNotNullable = default;
             Client.Option<string> notRequiredNullable = default;
-            await _instance.TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            string requiredNullable = default;
+            await _instance.TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
@@ -108,9 +108,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task LoginUserAsyncTest()
         {
-            string username = default;
             string password = default;
-            var response = await _instance.LoginUserAsync(username, password);
+            string username = default;
+            var response = await _instance.LoginUserAsync(password, username);
             var model = response.Ok();
             Assert.IsType<string>(model);
         }
@@ -130,9 +130,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task UpdateUserAsyncTest()
         {
-            string username = default;
             User user = default;
-            await _instance.UpdateUserAsync(username, user);
+            string username = default;
+            await _instance.UpdateUserAsync(user, username);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -313,22 +313,22 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </remarks>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -361,17 +361,17 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
         /// <param name="enumFormString"> (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersRequestEnumFormString> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<TestEnumParametersRequestEnumFormString> enumFormString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -379,17 +379,17 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test enum parameters
         /// </remarks>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
         /// <param name="enumFormString"> (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersRequestEnumFormString> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<TestEnumParametersRequestEnumFormString> enumFormString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -398,15 +398,15 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -414,15 +414,15 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test inline additionalProperties
@@ -502,18 +502,18 @@ namespace Org.OpenAPITools.Api
         /// To test the collection format in query parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -521,18 +521,18 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test the collection format in query parameters
         /// </remarks>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test referenced string map
@@ -3790,19 +3790,19 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEndpointParameters(ref decimal number, ref double varDouble, ref string patternWithoutDelimiter, ref byte[] varByte, ref Option<int> integer, ref Option<int> int32, ref Option<long> int64, ref Option<float> varFloat, ref Option<string> varString, ref Option<System.IO.Stream> binary, ref Option<DateOnly> date, ref Option<DateTime> dateTime, ref Option<string> password, ref Option<string> callback);
+        partial void FormatTestEndpointParameters(ref decimal number, ref string patternWithoutDelimiter, ref byte[] varByte, ref double varDouble, ref Option<System.IO.Stream> binary, ref Option<string> callback, ref Option<DateOnly> date, ref Option<DateTime> dateTime, ref Option<int> int32, ref Option<long> int64, ref Option<int> integer, ref Option<string> password, ref Option<float> varFloat, ref Option<string> varString);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="varString"></param>
         /// <param name="binary"></param>
-        /// <param name="password"></param>
         /// <param name="callback"></param>
+        /// <param name="password"></param>
+        /// <param name="varString"></param>
         /// <returns></returns>
-        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<string> varString, Option<System.IO.Stream> binary, Option<string> password, Option<string> callback)
+        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<System.IO.Stream> binary, Option<string> callback, Option<string> password, Option<string> varString)
         {
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
@@ -3810,17 +3810,17 @@ namespace Org.OpenAPITools.Api
             if (varByte == null)
                 throw new ArgumentNullException(nameof(varByte));
 
-            if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString));
-
             if (binary.IsSet && binary.Value == null)
                 throw new ArgumentNullException(nameof(binary));
+
+            if (callback.IsSet && callback.Value == null)
+                throw new ArgumentNullException(nameof(callback));
 
             if (password.IsSet && password.Value == null)
                 throw new ArgumentNullException(nameof(password));
 
-            if (callback.IsSet && callback.Value == null)
-                throw new ArgumentNullException(nameof(callback));
+            if (varString.IsSet && varString.Value == null)
+                throw new ArgumentNullException(nameof(varString));
         }
 
         /// <summary>
@@ -3828,23 +3828,23 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -3855,20 +3855,20 @@ namespace Org.OpenAPITools.Api
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -3877,23 +3877,23 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -3906,45 +3906,45 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트  Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback, cancellationToken).ConfigureAwait(false);
+                return await TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -3957,30 +3957,30 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, varString, binary, password, callback);
+                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, binary, callback, password, varString);
 
-                FormatTestEndpointParameters(ref number, ref varDouble, ref patternWithoutDelimiter, ref varByte, ref integer, ref int32, ref int64, ref varFloat, ref varString, ref binary, ref date, ref dateTime, ref password, ref callback);
+                FormatTestEndpointParameters(ref number, ref patternWithoutDelimiter, ref varByte, ref varDouble, ref binary, ref callback, ref date, ref dateTime, ref int32, ref int64, ref integer, ref password, ref varFloat, ref varString);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -3999,29 +3999,17 @@ namespace Org.OpenAPITools.Api
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("number", ClientUtils.ParameterToString(number)));
 
-                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
-
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("pattern_without_delimiter", ClientUtils.ParameterToString(patternWithoutDelimiter)));
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("byte", ClientUtils.ParameterToString(varByte)));
 
-                    if (integer.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
-
-                    if (int32.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
-
-                    if (int64.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
-
-                    if (varFloat.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
-
-                    if (varString.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
+                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
 
                     if (binary.IsSet)
                         multipartContentLocalVar.Add(new StreamContent(binary.Value));
+
+                    if (callback.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
 
                     if (date.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("date", ClientUtils.ParameterToString(date.Value)));
@@ -4029,11 +4017,23 @@ namespace Org.OpenAPITools.Api
                     if (dateTime.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("dateTime", ClientUtils.ParameterToString(dateTime.Value)));
 
+                    if (int32.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
+
+                    if (int64.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
+
+                    if (integer.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
+
                     if (password.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("password", ClientUtils.ParameterToString(password.Value)));
 
-                    if (callback.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
+                    if (varFloat.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
+
+                    if (varString.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
 
                     List<TokenBase> tokenBaseLocalVars = new List<TokenBase>();
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
@@ -4065,7 +4065,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEndpointParametersApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 
                         Events.ExecuteOnTestEndpointParameters(apiResponseLocalVar);
 
@@ -4079,7 +4079,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
                 Events.ExecuteOnErrorTestEndpointParameters(e);
                 throw;
             }
@@ -4136,43 +4136,43 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEnumParameters(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, ref Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, ref Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, ref Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, ref Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, ref Option<TestEnumParametersRequestEnumFormString> enumFormString);
+        partial void FormatTestEnumParameters(ref Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, ref Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, ref Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, ref Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, ref Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
+        /// <param name="enumFormStringArray"></param>
         /// <param name="enumHeaderStringArray"></param>
         /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <returns></returns>
-        private void ValidateTestEnumParameters(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray)
+        private void ValidateTestEnumParameters(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray)
         {
+            if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumFormStringArray));
+
             if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumHeaderStringArray));
 
             if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumQueryStringArray));
-
-            if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumFormStringArray));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersRequestEnumFormString> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4182,15 +4182,15 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersRequestEnumFormString> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4198,18 +4198,18 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersRequestEnumFormString> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4221,34 +4221,34 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersRequestEnumFormString> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<TestEnumParametersRequestEnumFormString> enumFormString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray);
 
         /// <summary>
         /// To test enum parameters To test enum parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
         /// <param name="enumFormString"> (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersRequestEnumFormString> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<TestEnumParametersRequestEnumFormString> enumFormString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, cancellationToken).ConfigureAwait(false);
+                return await TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4260,25 +4260,25 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
         /// <param name="enumFormString"> (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersRequestEnumFormString> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<TestEnumParametersRequestEnumFormString> enumFormString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumFormStringArray = default, Option<TestEnumParametersEnumHeaderStringParameter> enumHeaderString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumHeaderStringArray = default, Option<TestEnumParametersEnumQueryDoubleParameter> enumQueryDouble = default, Option<TestEnumParametersEnumQueryIntegerParameter> enumQueryInteger = default, Option<TestEnumParametersEnumHeaderStringParameter> enumQueryString = default, Option<List<TestEnumParametersRequestEnumFormStringArrayInner>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, enumFormStringArray);
+                ValidateTestEnumParameters(enumFormStringArray, enumHeaderStringArray, enumQueryStringArray);
 
-                FormatTestEnumParameters(enumHeaderStringArray, ref enumHeaderString, enumQueryStringArray, ref enumQueryString, ref enumQueryInteger, ref enumQueryDouble, enumFormStringArray, ref enumFormString);
+                FormatTestEnumParameters(ref enumFormString, enumFormStringArray, ref enumHeaderString, enumHeaderStringArray, ref enumQueryDouble, ref enumQueryInteger, ref enumQueryString, enumQueryStringArray);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4289,25 +4289,25 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    if (enumQueryStringArray.IsSet)
-                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
-
-                    if (enumQueryString.IsSet)
-                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+                    if (enumQueryDouble.IsSet)
+                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
 
                     if (enumQueryInteger.IsSet)
                         parseQueryStringLocalVar["enum_query_integer"] = ClientUtils.ParameterToString(enumQueryInteger.Value);
 
-                    if (enumQueryDouble.IsSet)
-                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
+                    if (enumQueryString.IsSet)
+                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+
+                    if (enumQueryStringArray.IsSet)
+                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
-                    if (enumHeaderStringArray.IsSet)
-                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
-
                     if (enumHeaderString.IsSet)
                         httpRequestMessageLocalVar.Headers.Add("enum_header_string", ClientUtils.ParameterToString(enumHeaderString.Value));
+
+                    if (enumHeaderStringArray.IsSet)
+                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
 
                     MultipartContent multipartContentLocalVar = new MultipartContent();
 
@@ -4315,11 +4315,11 @@ namespace Org.OpenAPITools.Api
 
                     List<KeyValuePair<string, string>> formParameterLocalVars = new List<KeyValuePair<string, string>>();
 
-                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormStringArray.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
-
-                    if (enumFormString.IsSet)
+                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormString.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string", ClientUtils.ParameterToString(enumFormString.Value)));
+
+                    if (enumFormStringArray.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
 
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
 
@@ -4344,7 +4344,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEnumParametersApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 
                         Events.ExecuteOnTestEnumParameters(apiResponseLocalVar);
 
@@ -4354,7 +4354,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
                 Events.ExecuteOnErrorTestEnumParameters(e);
                 throw;
             }
@@ -4411,22 +4411,22 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestGroupParameters(ref int requiredStringGroup, ref bool requiredBooleanGroup, ref long requiredInt64Group, ref Option<int> stringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group);
+        partial void FormatTestGroupParameters(ref bool requiredBooleanGroup, ref long requiredInt64Group, ref int requiredStringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group, ref Option<int> stringGroup);
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4436,13 +4436,13 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4450,16 +4450,16 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4471,30 +4471,30 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, cancellationToken).ConfigureAwait(false);
+                return await TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4506,21 +4506,21 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                FormatTestGroupParameters(ref requiredStringGroup, ref requiredBooleanGroup, ref requiredInt64Group, ref stringGroup, ref booleanGroup, ref int64Group);
+                FormatTestGroupParameters(ref requiredBooleanGroup, ref requiredInt64Group, ref requiredStringGroup, ref booleanGroup, ref int64Group, ref stringGroup);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4531,14 +4531,14 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
                     parseQueryStringLocalVar["required_int64_group"] = ClientUtils.ParameterToString(requiredInt64Group);
-
-                    if (stringGroup.IsSet)
-                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
+                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
 
                     if (int64Group.IsSet)
                         parseQueryStringLocalVar["int64_group"] = ClientUtils.ParameterToString(int64Group.Value);
+
+                    if (stringGroup.IsSet)
+                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -4568,7 +4568,7 @@ namespace Org.OpenAPITools.Api
 
                         TestGroupParametersApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 
                         Events.ExecuteOnTestGroupParameters(apiResponseLocalVar);
 
@@ -4582,7 +4582,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
                 Events.ExecuteOnErrorTestGroupParameters(e);
                 throw;
             }
@@ -5218,38 +5218,38 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, ref string requiredNotNullable, ref string requiredNullable, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable);
+        partial void FormatTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, ref string requiredNotNullable, List<string> url, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable, ref string requiredNullable);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <returns></returns>
-        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, Option<string> notRequiredNotNullable)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable)
         {
-            if (pipe == null)
-                throw new ArgumentNullException(nameof(pipe));
-
-            if (ioutil == null)
-                throw new ArgumentNullException(nameof(ioutil));
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
 
             if (http == null)
                 throw new ArgumentNullException(nameof(http));
 
-            if (url == null)
-                throw new ArgumentNullException(nameof(url));
+            if (ioutil == null)
+                throw new ArgumentNullException(nameof(ioutil));
 
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
+            if (pipe == null)
+                throw new ArgumentNullException(nameof(pipe));
 
             if (requiredNotNullable == null)
                 throw new ArgumentNullException(nameof(requiredNotNullable));
+
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
 
             if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
                 throw new ArgumentNullException(nameof(notRequiredNotNullable));
@@ -5259,19 +5259,19 @@ namespace Org.OpenAPITools.Api
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -5281,16 +5281,16 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -5298,19 +5298,19 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -5322,36 +5322,36 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         ///  To test the collection format in query parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable, cancellationToken).ConfigureAwait(false);
+                return await TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -5363,26 +5363,26 @@ namespace Org.OpenAPITools.Api
         ///  To test the collection format in query parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, notRequiredNotNullable);
+                ValidateTestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable);
 
-                FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, ref requiredNotNullable, ref requiredNullable, ref notRequiredNotNullable, ref notRequiredNullable);
+                FormatTestQueryParameterCollectionFormat(context, http, ioutil, pipe, ref requiredNotNullable, url, ref notRequiredNotNullable, ref notRequiredNullable, ref requiredNullable);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -5393,12 +5393,12 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
-                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
-                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
-                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["context"] = ClientUtils.ParameterToString(context);
+                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
+                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
+                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
                     parseQueryStringLocalVar["requiredNotNullable"] = ClientUtils.ParameterToString(requiredNotNullable);
+                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["requiredNullable"] = ClientUtils.ParameterToString(requiredNullable);
 
                     if (notRequiredNotNullable.IsSet)
@@ -5423,7 +5423,7 @@ namespace Org.OpenAPITools.Api
 
                         TestQueryParameterCollectionFormatApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake/test-query-parameters", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 
                         Events.ExecuteOnTestQueryParameterCollectionFormat(apiResponseLocalVar);
 
@@ -5433,7 +5433,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
                 Events.ExecuteOnErrorTestQueryParameterCollectionFormat(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Api/UserApi.cs
@@ -156,11 +156,11 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs user into the system
@@ -168,11 +168,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs out current logged in user session
@@ -202,11 +202,11 @@ namespace Org.OpenAPITools.Api
         /// This can only be done by the logged in user.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updated user
@@ -214,11 +214,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// This can only be done by the logged in user.
         /// </remarks>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
     }
 
     /// <summary>
@@ -1632,33 +1632,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatLoginUser(ref string username, ref string password);
+        partial void FormatLoginUser(ref string password, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="password"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateLoginUser(string username, string password)
+        private void ValidateLoginUser(string password, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (password == null)
                 throw new ArgumentNullException(nameof(password));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string username, string password)
+        /// <param name="username"></param>
+        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string password, string username)
         {
             bool suppressDefaultLog = false;
-            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, username, password);
+            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, password, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -1668,9 +1668,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string username, string password);
+        /// <param name="username"></param>
+        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string password, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -1678,12 +1678,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, string password)
+        /// <param name="username"></param>
+        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string password, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, username, password);
+            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, password, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -1695,22 +1695,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, string password);
+        /// <param name="username"></param>
+        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string password, string username);
 
         /// <summary>
         /// Logs user into the system 
         /// </summary>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await LoginUserAsync(username, password, cancellationToken).ConfigureAwait(false);
+                return await LoginUserAsync(password, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -1722,19 +1722,19 @@ namespace Org.OpenAPITools.Api
         /// Logs user into the system 
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateLoginUser(username, password);
+                ValidateLoginUser(password, username);
 
-                FormatLoginUser(ref username, ref password);
+                FormatLoginUser(ref password, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1745,8 +1745,8 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
                     parseQueryStringLocalVar["password"] = ClientUtils.ParameterToString(password);
+                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -1774,7 +1774,7 @@ namespace Org.OpenAPITools.Api
 
                         LoginUserApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/login", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, username, password);
+                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, password, username);
 
                         Events.ExecuteOnLoginUser(apiResponseLocalVar);
 
@@ -1811,7 +1811,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, username, password);
+                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, password, username);
                 Events.ExecuteOnErrorLoginUser(e);
                 throw;
             }
@@ -2053,33 +2053,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatUpdateUser(ref string username, User user);
+        partial void FormatUpdateUser(User user, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="user"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateUpdateUser(string username, User user)
+        private void ValidateUpdateUser(User user, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, string username, User user)
+        /// <param name="username"></param>
+        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, User user, string username)
         {
             bool suppressDefaultLog = false;
-            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, username, user);
+            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, user, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -2089,9 +2089,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, string username, User user);
+        /// <param name="username"></param>
+        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, User user, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -2099,12 +2099,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, User user)
+        /// <param name="username"></param>
+        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, User user, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, username, user);
+            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, user, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -2116,22 +2116,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, User user);
+        /// <param name="username"></param>
+        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, User user, string username);
 
         /// <summary>
         /// Updated user This can only be done by the logged in user.
         /// </summary>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await UpdateUserAsync(username, user, cancellationToken).ConfigureAwait(false);
+                return await UpdateUserAsync(user, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -2143,19 +2143,19 @@ namespace Org.OpenAPITools.Api
         /// Updated user This can only be done by the logged in user.
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateUpdateUser(username, user);
+                ValidateUpdateUser(user, username);
 
-                FormatUpdateUser(ref username, user);
+                FormatUpdateUser(user, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2192,7 +2192,7 @@ namespace Org.OpenAPITools.Api
 
                         UpdateUserApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/{username}", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, username, user);
+                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, user, username);
 
                         Events.ExecuteOnUpdateUser(apiResponseLocalVar);
 
@@ -2202,7 +2202,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, username, user);
+                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, user, username);
                 Events.ExecuteOnErrorUpdateUser(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/docs/apis/FakeApi.md
@@ -1067,7 +1067,7 @@ No authorization required
 
 <a id="testendpointparameters"></a>
 # **TestEndpointParameters**
-> void TestEndpointParameters (decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, int integer = null, int int32 = null, long int64 = null, float varFloat = null, string varString = null, System.IO.Stream binary = null, DateOnly date = null, DateTime dateTime = null, string password = null, string callback = null)
+> void TestEndpointParameters (decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, System.IO.Stream binary = null, string callback = null, DateOnly date = null, DateTime dateTime = null, int int32 = null, long int64 = null, int integer = null, string password = null, float varFloat = null, string varString = null)
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
@@ -1095,24 +1095,24 @@ namespace Example
 
             var apiInstance = new FakeApi(config);
             var number = 8.14D;  // decimal | None
-            var varDouble = 1.2D;  // double | None
             var patternWithoutDelimiter = "patternWithoutDelimiter_example";  // string | None
             var varByte = System.Text.Encoding.ASCII.GetBytes("BYTE_ARRAY_DATA_HERE");  // byte[] | None
-            var integer = 56;  // int | None (optional) 
-            var int32 = 56;  // int | None (optional) 
-            var int64 = 789L;  // long | None (optional) 
-            var varFloat = 3.4F;  // float | None (optional) 
-            var varString = "varString_example";  // string | None (optional) 
+            var varDouble = 1.2D;  // double | None
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
+            var callback = "callback_example";  // string | None (optional) 
             var date = DateOnly.Parse("2013-10-20");  // DateOnly | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")
+            var int32 = 56;  // int | None (optional) 
+            var int64 = 789L;  // long | None (optional) 
+            var integer = 56;  // int | None (optional) 
             var password = "password_example";  // string | None (optional) 
-            var callback = "callback_example";  // string | None (optional) 
+            var varFloat = 3.4F;  // float | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
 
             try
             {
                 // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-                apiInstance.TestEndpointParameters(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                apiInstance.TestEndpointParameters(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             }
             catch (ApiException  e)
             {
@@ -1132,7 +1132,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    apiInstance.TestEndpointParametersWithHttpInfo(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+    apiInstance.TestEndpointParametersWithHttpInfo(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 }
 catch (ApiException e)
 {
@@ -1147,19 +1147,19 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **number** | **decimal** | None |  |
-| **varDouble** | **double** | None |  |
 | **patternWithoutDelimiter** | **string** | None |  |
 | **varByte** | **byte[]** | None |  |
-| **integer** | **int** | None | [optional]  |
-| **int32** | **int** | None | [optional]  |
-| **int64** | **long** | None | [optional]  |
-| **varFloat** | **float** | None | [optional]  |
-| **varString** | **string** | None | [optional]  |
+| **varDouble** | **double** | None |  |
 | **binary** | **System.IO.Stream****System.IO.Stream** | None | [optional]  |
+| **callback** | **string** | None | [optional]  |
 | **date** | **DateOnly** | None | [optional]  |
 | **dateTime** | **DateTime** | None | [optional] [default to &quot;2010-02-01T10:20:10.111110+01:00&quot;] |
+| **int32** | **int** | None | [optional]  |
+| **int64** | **long** | None | [optional]  |
+| **integer** | **int** | None | [optional]  |
 | **password** | **string** | None | [optional]  |
-| **callback** | **string** | None | [optional]  |
+| **varFloat** | **float** | None | [optional]  |
+| **varString** | **string** | None | [optional]  |
 
 ### Return type
 
@@ -1185,7 +1185,7 @@ void (empty response body)
 
 <a id="testenumparameters"></a>
 # **TestEnumParameters**
-> void TestEnumParameters (List<string> enumHeaderStringArray = null, string enumHeaderString = null, List<string> enumQueryStringArray = null, string enumQueryString = null, int enumQueryInteger = null, double enumQueryDouble = null, List<string> enumFormStringArray = null, string enumFormString = null)
+> void TestEnumParameters (string enumFormString = null, List<string> enumFormStringArray = null, string enumHeaderString = null, List<string> enumHeaderStringArray = null, double enumQueryDouble = null, int enumQueryInteger = null, string enumQueryString = null, List<string> enumQueryStringArray = null)
 
 To test enum parameters
 
@@ -1208,19 +1208,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var enumHeaderStringArray = new List<string>(); // List<string> | Header parameter enum test (string array) (optional) 
-            var enumHeaderString = "_abc";  // string | Header parameter enum test (string) (optional)  (default to -efg)
-            var enumQueryStringArray = new List<string>(); // List<string> | Query parameter enum test (string array) (optional) 
-            var enumQueryString = "_abc";  // string | Query parameter enum test (string) (optional)  (default to -efg)
-            var enumQueryInteger = 1;  // int | Query parameter enum test (double) (optional) 
-            var enumQueryDouble = 1.1D;  // double | Query parameter enum test (double) (optional) 
-            var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional)  (default to $)
             var enumFormString = "_abc";  // string | Form parameter enum test (string) (optional)  (default to -efg)
+            var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional)  (default to $)
+            var enumHeaderString = "_abc";  // string | Header parameter enum test (string) (optional)  (default to -efg)
+            var enumHeaderStringArray = new List<string>(); // List<string> | Header parameter enum test (string array) (optional) 
+            var enumQueryDouble = 1.1D;  // double | Query parameter enum test (double) (optional) 
+            var enumQueryInteger = 1;  // int | Query parameter enum test (double) (optional) 
+            var enumQueryString = "_abc";  // string | Query parameter enum test (string) (optional)  (default to -efg)
+            var enumQueryStringArray = new List<string>(); // List<string> | Query parameter enum test (string array) (optional) 
 
             try
             {
                 // To test enum parameters
-                apiInstance.TestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                apiInstance.TestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             }
             catch (ApiException  e)
             {
@@ -1240,7 +1240,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test enum parameters
-    apiInstance.TestEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+    apiInstance.TestEnumParametersWithHttpInfo(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 }
 catch (ApiException e)
 {
@@ -1254,14 +1254,14 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **enumHeaderStringArray** | [**List&lt;string&gt;**](string.md) | Header parameter enum test (string array) | [optional]  |
-| **enumHeaderString** | **string** | Header parameter enum test (string) | [optional] [default to -efg] |
-| **enumQueryStringArray** | [**List&lt;string&gt;**](string.md) | Query parameter enum test (string array) | [optional]  |
-| **enumQueryString** | **string** | Query parameter enum test (string) | [optional] [default to -efg] |
-| **enumQueryInteger** | **int** | Query parameter enum test (double) | [optional]  |
-| **enumQueryDouble** | **double** | Query parameter enum test (double) | [optional]  |
-| **enumFormStringArray** | [**List&lt;string&gt;**](string.md) | Form parameter enum test (string array) | [optional] [default to $] |
 | **enumFormString** | **string** | Form parameter enum test (string) | [optional] [default to -efg] |
+| **enumFormStringArray** | [**List&lt;string&gt;**](string.md) | Form parameter enum test (string array) | [optional] [default to $] |
+| **enumHeaderString** | **string** | Header parameter enum test (string) | [optional] [default to -efg] |
+| **enumHeaderStringArray** | [**List&lt;string&gt;**](string.md) | Header parameter enum test (string array) | [optional]  |
+| **enumQueryDouble** | **double** | Query parameter enum test (double) | [optional]  |
+| **enumQueryInteger** | **int** | Query parameter enum test (double) | [optional]  |
+| **enumQueryString** | **string** | Query parameter enum test (string) | [optional] [default to -efg] |
+| **enumQueryStringArray** | [**List&lt;string&gt;**](string.md) | Query parameter enum test (string array) | [optional]  |
 
 ### Return type
 
@@ -1287,7 +1287,7 @@ No authorization required
 
 <a id="testgroupparameters"></a>
 # **TestGroupParameters**
-> void TestGroupParameters (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int stringGroup = null, bool booleanGroup = null, long int64Group = null)
+> void TestGroupParameters (bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, bool booleanGroup = null, long int64Group = null, int stringGroup = null)
 
 Fake endpoint to test group parameters (optional)
 
@@ -1313,17 +1313,17 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new FakeApi(config);
-            var requiredStringGroup = 56;  // int | Required String in group parameters
             var requiredBooleanGroup = true;  // bool | Required Boolean in group parameters
             var requiredInt64Group = 789L;  // long | Required Integer in group parameters
-            var stringGroup = 56;  // int | String in group parameters (optional) 
+            var requiredStringGroup = 56;  // int | Required String in group parameters
             var booleanGroup = true;  // bool | Boolean in group parameters (optional) 
             var int64Group = 789L;  // long | Integer in group parameters (optional) 
+            var stringGroup = 56;  // int | String in group parameters (optional) 
 
             try
             {
                 // Fake endpoint to test group parameters (optional)
-                apiInstance.TestGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                apiInstance.TestGroupParameters(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             }
             catch (ApiException  e)
             {
@@ -1343,7 +1343,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint to test group parameters (optional)
-    apiInstance.TestGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+    apiInstance.TestGroupParametersWithHttpInfo(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 }
 catch (ApiException e)
 {
@@ -1357,12 +1357,12 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **requiredBooleanGroup** | **bool** | Required Boolean in group parameters |  |
 | **requiredInt64Group** | **long** | Required Integer in group parameters |  |
-| **stringGroup** | **int** | String in group parameters | [optional]  |
+| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **booleanGroup** | **bool** | Boolean in group parameters | [optional]  |
 | **int64Group** | **long** | Integer in group parameters | [optional]  |
+| **stringGroup** | **int** | String in group parameters | [optional]  |
 
 ### Return type
 
@@ -1644,7 +1644,7 @@ No authorization required
 
 <a id="testqueryparametercollectionformat"></a>
 # **TestQueryParameterCollectionFormat**
-> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, string notRequiredNotNullable = null, string notRequiredNullable = null)
+> void TestQueryParameterCollectionFormat (List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, string notRequiredNotNullable = null, string notRequiredNullable = null, string requiredNullable)
 
 
 
@@ -1667,19 +1667,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var pipe = new List<string>(); // List<string> | 
-            var ioutil = new List<string>(); // List<string> | 
-            var http = new List<string>(); // List<string> | 
-            var url = new List<string>(); // List<string> | 
             var context = new List<string>(); // List<string> | 
+            var http = new List<string>(); // List<string> | 
+            var ioutil = new List<string>(); // List<string> | 
+            var pipe = new List<string>(); // List<string> | 
             var requiredNotNullable = "requiredNotNullable_example";  // string | 
-            var requiredNullable = "requiredNullable_example";  // string | 
+            var url = new List<string>(); // List<string> | 
             var notRequiredNotNullable = "notRequiredNotNullable_example";  // string |  (optional) 
             var notRequiredNullable = "notRequiredNullable_example";  // string |  (optional) 
+            var requiredNullable = "requiredNullable_example";  // string | 
 
             try
             {
-                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                apiInstance.TestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             }
             catch (ApiException  e)
             {
@@ -1698,7 +1698,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 }
 catch (ApiException e)
 {
@@ -1712,15 +1712,15 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
-| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
-| **http** | [**List&lt;string&gt;**](string.md) |  |  |
-| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **context** | [**List&lt;string&gt;**](string.md) |  |  |
+| **http** | [**List&lt;string&gt;**](string.md) |  |  |
+| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
+| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
 | **requiredNotNullable** | **string** |  |  |
-| **requiredNullable** | **string** |  |  |
+| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **notRequiredNotNullable** | **string** |  | [optional]  |
 | **notRequiredNullable** | **string** |  | [optional]  |
+| **requiredNullable** | **string** |  |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/docs/apis/UserApi.md
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/docs/apis/UserApi.md
@@ -453,7 +453,7 @@ No authorization required
 
 <a id="loginuser"></a>
 # **LoginUser**
-> string LoginUser (string username, string password)
+> string LoginUser (string password, string username)
 
 Logs user into the system
 
@@ -474,13 +474,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | The user name for login
             var password = "password_example";  // string | The password for login in clear text
+            var username = "username_example";  // string | The user name for login
 
             try
             {
                 // Logs user into the system
-                string result = apiInstance.LoginUser(username, password);
+                string result = apiInstance.LoginUser(password, username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -501,7 +501,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Logs user into the system
-    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(username, password);
+    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(password, username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -518,8 +518,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | The user name for login |  |
 | **password** | **string** | The password for login in clear text |  |
+| **username** | **string** | The user name for login |  |
 
 ### Return type
 
@@ -625,7 +625,7 @@ No authorization required
 
 <a id="updateuser"></a>
 # **UpdateUser**
-> void UpdateUser (string username, User user)
+> void UpdateUser (User user, string username)
 
 Updated user
 
@@ -648,13 +648,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | name that need to be deleted
             var user = new User(); // User | Updated user object
+            var username = "username_example";  // string | name that need to be deleted
 
             try
             {
                 // Updated user
-                apiInstance.UpdateUser(username, user);
+                apiInstance.UpdateUser(user, username);
             }
             catch (ApiException  e)
             {
@@ -674,7 +674,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Updated user
-    apiInstance.UpdateUserWithHttpInfo(username, user);
+    apiInstance.UpdateUserWithHttpInfo(user, username);
 }
 catch (ApiException e)
 {
@@ -688,8 +688,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | name that need to be deleted |  |
 | **user** | [**User**](User.md) | Updated user object |  |
+| **username** | **string** | name that need to be deleted |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
@@ -193,20 +193,20 @@ namespace Org.OpenAPITools.Test.Api
         public async Task TestEndpointParametersAsyncTest()
         {
             decimal number = default!;
-            double varDouble = default!;
             string patternWithoutDelimiter = default!;
             byte[] varByte = default!;
-            Client.Option<int> integer = default!;
-            Client.Option<int> int32 = default!;
-            Client.Option<long> int64 = default!;
-            Client.Option<float> varFloat = default!;
-            Client.Option<string> varString = default!;
+            double varDouble = default!;
             Client.Option<System.IO.Stream> binary = default!;
+            Client.Option<string> callback = default!;
             Client.Option<DateOnly> date = default!;
             Client.Option<DateTime> dateTime = default!;
+            Client.Option<int> int32 = default!;
+            Client.Option<long> int64 = default!;
+            Client.Option<int> integer = default!;
             Client.Option<string> password = default!;
-            Client.Option<string> callback = default!;
-            await _instance.TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            Client.Option<float> varFloat = default!;
+            Client.Option<string> varString = default!;
+            await _instance.TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
         }
 
         /// <summary>
@@ -215,15 +215,15 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestEnumParametersAsyncTest()
         {
-            Client.Option<List<string>> enumHeaderStringArray = default!;
-            Client.Option<string> enumHeaderString = default!;
-            Client.Option<List<string>> enumQueryStringArray = default!;
-            Client.Option<string> enumQueryString = default!;
-            Client.Option<int> enumQueryInteger = default!;
-            Client.Option<double> enumQueryDouble = default!;
-            Client.Option<List<string>> enumFormStringArray = default!;
             Client.Option<string> enumFormString = default!;
-            await _instance.TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            Client.Option<List<string>> enumFormStringArray = default!;
+            Client.Option<string> enumHeaderString = default!;
+            Client.Option<List<string>> enumHeaderStringArray = default!;
+            Client.Option<double> enumQueryDouble = default!;
+            Client.Option<int> enumQueryInteger = default!;
+            Client.Option<string> enumQueryString = default!;
+            Client.Option<List<string>> enumQueryStringArray = default!;
+            await _instance.TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
         }
 
         /// <summary>
@@ -232,13 +232,13 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestGroupParametersAsyncTest()
         {
-            int requiredStringGroup = default!;
             bool requiredBooleanGroup = default!;
             long requiredInt64Group = default!;
-            Client.Option<int> stringGroup = default!;
+            int requiredStringGroup = default!;
             Client.Option<bool> booleanGroup = default!;
             Client.Option<long> int64Group = default!;
-            await _instance.TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            Client.Option<int> stringGroup = default!;
+            await _instance.TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
         }
 
         /// <summary>
@@ -278,16 +278,16 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestQueryParameterCollectionFormatAsyncTest()
         {
-            List<string> pipe = default!;
-            List<string> ioutil = default!;
-            List<string> http = default!;
-            List<string> url = default!;
             List<string> context = default!;
+            List<string> http = default!;
+            List<string> ioutil = default!;
+            List<string> pipe = default!;
             string requiredNotNullable = default!;
-            string? requiredNullable = default!;
+            List<string> url = default!;
             Client.Option<string> notRequiredNotNullable = default!;
             Client.Option<string?> notRequiredNullable = default!;
-            await _instance.TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            string? requiredNullable = default!;
+            await _instance.TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
@@ -108,9 +108,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task LoginUserAsyncTest()
         {
-            string username = default!;
             string password = default!;
-            var response = await _instance.LoginUserAsync(username, password);
+            string username = default!;
+            var response = await _instance.LoginUserAsync(password, username);
             var model = response.Ok();
             Assert.IsType<string>(model);
         }
@@ -130,9 +130,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task UpdateUserAsyncTest()
         {
-            string username = default!;
             User user = default!;
-            await _instance.UpdateUserAsync(username, user);
+            string username = default!;
+            await _instance.UpdateUserAsync(user, username);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -315,22 +315,22 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -339,22 +339,22 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </remarks>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>?&gt;</returns>
-        Task<ITestEndpointParametersApiResponse?> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse?> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -363,17 +363,17 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -381,17 +381,17 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test enum parameters
         /// </remarks>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>?&gt;</returns>
-        Task<ITestEnumParametersApiResponse?> TestEnumParametersOrDefaultAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse?> TestEnumParametersOrDefaultAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -400,15 +400,15 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -416,15 +416,15 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>?&gt;</returns>
-        Task<ITestGroupParametersApiResponse?> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse?> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test inline additionalProperties
@@ -504,18 +504,18 @@ namespace Org.OpenAPITools.Api
         /// To test the collection format in query parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, string? requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -523,18 +523,18 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test the collection format in query parameters
         /// </remarks>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>?&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse?> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse?> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, string? requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test referenced string map
@@ -3792,19 +3792,19 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEndpointParameters(ref decimal number, ref double varDouble, ref string patternWithoutDelimiter, ref byte[] varByte, ref Option<int> integer, ref Option<int> int32, ref Option<long> int64, ref Option<float> varFloat, ref Option<string> varString, ref Option<System.IO.Stream> binary, ref Option<DateOnly> date, ref Option<DateTime> dateTime, ref Option<string> password, ref Option<string> callback);
+        partial void FormatTestEndpointParameters(ref decimal number, ref string patternWithoutDelimiter, ref byte[] varByte, ref double varDouble, ref Option<System.IO.Stream> binary, ref Option<string> callback, ref Option<DateOnly> date, ref Option<DateTime> dateTime, ref Option<int> int32, ref Option<long> int64, ref Option<int> integer, ref Option<string> password, ref Option<float> varFloat, ref Option<string> varString);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="varString"></param>
         /// <param name="binary"></param>
-        /// <param name="password"></param>
         /// <param name="callback"></param>
+        /// <param name="password"></param>
+        /// <param name="varString"></param>
         /// <returns></returns>
-        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<string> varString, Option<System.IO.Stream> binary, Option<string> password, Option<string> callback)
+        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<System.IO.Stream> binary, Option<string> callback, Option<string> password, Option<string> varString)
         {
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
@@ -3812,17 +3812,17 @@ namespace Org.OpenAPITools.Api
             if (varByte == null)
                 throw new ArgumentNullException(nameof(varByte));
 
-            if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString));
-
             if (binary.IsSet && binary.Value == null)
                 throw new ArgumentNullException(nameof(binary));
+
+            if (callback.IsSet && callback.Value == null)
+                throw new ArgumentNullException(nameof(callback));
 
             if (password.IsSet && password.Value == null)
                 throw new ArgumentNullException(nameof(password));
 
-            if (callback.IsSet && callback.Value == null)
-                throw new ArgumentNullException(nameof(callback));
+            if (varString.IsSet && varString.Value == null)
+                throw new ArgumentNullException(nameof(varString));
         }
 
         /// <summary>
@@ -3830,23 +3830,23 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -3857,20 +3857,20 @@ namespace Org.OpenAPITools.Api
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -3879,23 +3879,23 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -3908,45 +3908,45 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트  Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse?> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse?> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback, cancellationToken).ConfigureAwait(false);
+                return await TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -3959,30 +3959,30 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, varString, binary, password, callback);
+                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, binary, callback, password, varString);
 
-                FormatTestEndpointParameters(ref number, ref varDouble, ref patternWithoutDelimiter, ref varByte, ref integer, ref int32, ref int64, ref varFloat, ref varString, ref binary, ref date, ref dateTime, ref password, ref callback);
+                FormatTestEndpointParameters(ref number, ref patternWithoutDelimiter, ref varByte, ref varDouble, ref binary, ref callback, ref date, ref dateTime, ref int32, ref int64, ref integer, ref password, ref varFloat, ref varString);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4001,29 +4001,17 @@ namespace Org.OpenAPITools.Api
 
                     formParameterLocalVars.Add(new KeyValuePair<string?, string?>("number", ClientUtils.ParameterToString(number)));
 
-                    formParameterLocalVars.Add(new KeyValuePair<string?, string?>("double", ClientUtils.ParameterToString(varDouble)));
-
                     formParameterLocalVars.Add(new KeyValuePair<string?, string?>("pattern_without_delimiter", ClientUtils.ParameterToString(patternWithoutDelimiter)));
 
                     formParameterLocalVars.Add(new KeyValuePair<string?, string?>("byte", ClientUtils.ParameterToString(varByte)));
 
-                    if (integer.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("integer", ClientUtils.ParameterToString(integer.Value)));
-
-                    if (int32.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("int32", ClientUtils.ParameterToString(int32.Value)));
-
-                    if (int64.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("int64", ClientUtils.ParameterToString(int64.Value)));
-
-                    if (varFloat.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("float", ClientUtils.ParameterToString(varFloat.Value)));
-
-                    if (varString.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("string", ClientUtils.ParameterToString(varString.Value)));
+                    formParameterLocalVars.Add(new KeyValuePair<string?, string?>("double", ClientUtils.ParameterToString(varDouble)));
 
                     if (binary.IsSet)
                         multipartContentLocalVar.Add(new StreamContent(binary.Value));
+
+                    if (callback.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("callback", ClientUtils.ParameterToString(callback.Value)));
 
                     if (date.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string?, string?>("date", ClientUtils.ParameterToString(date.Value)));
@@ -4031,11 +4019,23 @@ namespace Org.OpenAPITools.Api
                     if (dateTime.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string?, string?>("dateTime", ClientUtils.ParameterToString(dateTime.Value)));
 
+                    if (int32.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("int32", ClientUtils.ParameterToString(int32.Value)));
+
+                    if (int64.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("int64", ClientUtils.ParameterToString(int64.Value)));
+
+                    if (integer.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("integer", ClientUtils.ParameterToString(integer.Value)));
+
                     if (password.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string?, string?>("password", ClientUtils.ParameterToString(password.Value)));
 
-                    if (callback.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("callback", ClientUtils.ParameterToString(callback.Value)));
+                    if (varFloat.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("float", ClientUtils.ParameterToString(varFloat.Value)));
+
+                    if (varString.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("string", ClientUtils.ParameterToString(varString.Value)));
 
                     List<TokenBase> tokenBaseLocalVars = new List<TokenBase>();
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
@@ -4067,7 +4067,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEndpointParametersApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 
                         Events.ExecuteOnTestEndpointParameters(apiResponseLocalVar);
 
@@ -4081,7 +4081,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
                 Events.ExecuteOnErrorTestEndpointParameters(e);
                 throw;
             }
@@ -4138,55 +4138,55 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEnumParameters(Option<List<string>> enumHeaderStringArray, ref Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, ref Option<string> enumQueryString, ref Option<int> enumQueryInteger, ref Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, ref Option<string> enumFormString);
+        partial void FormatTestEnumParameters(ref Option<string> enumFormString, Option<List<string>> enumFormStringArray, ref Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, ref Option<double> enumQueryDouble, ref Option<int> enumQueryInteger, ref Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
         /// <returns></returns>
-        private void ValidateTestEnumParameters(Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        private void ValidateTestEnumParameters(Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
-            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderStringArray));
-
-            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderString));
-
-            if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumQueryStringArray));
-
-            if (enumQueryString.IsSet && enumQueryString.Value == null)
-                throw new ArgumentNullException(nameof(enumQueryString));
+            if (enumFormString.IsSet && enumFormString.Value == null)
+                throw new ArgumentNullException(nameof(enumFormString));
 
             if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumFormStringArray));
 
-            if (enumFormString.IsSet && enumFormString.Value == null)
-                throw new ArgumentNullException(nameof(enumFormString));
+            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderString));
+
+            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderStringArray));
+
+            if (enumQueryString.IsSet && enumQueryString.Value == null)
+                throw new ArgumentNullException(nameof(enumQueryString));
+
+            if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumQueryStringArray));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4196,15 +4196,15 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4212,18 +4212,18 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4235,34 +4235,34 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// To test enum parameters To test enum parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse?> TestEnumParametersOrDefaultAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse?> TestEnumParametersOrDefaultAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, cancellationToken).ConfigureAwait(false);
+                return await TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4274,25 +4274,25 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumFormStringArray, enumFormString);
+                ValidateTestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryString, enumQueryStringArray);
 
-                FormatTestEnumParameters(enumHeaderStringArray, ref enumHeaderString, enumQueryStringArray, ref enumQueryString, ref enumQueryInteger, ref enumQueryDouble, enumFormStringArray, ref enumFormString);
+                FormatTestEnumParameters(ref enumFormString, enumFormStringArray, ref enumHeaderString, enumHeaderStringArray, ref enumQueryDouble, ref enumQueryInteger, ref enumQueryString, enumQueryStringArray);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4303,25 +4303,25 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    if (enumQueryStringArray.IsSet)
-                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
-
-                    if (enumQueryString.IsSet)
-                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+                    if (enumQueryDouble.IsSet)
+                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
 
                     if (enumQueryInteger.IsSet)
                         parseQueryStringLocalVar["enum_query_integer"] = ClientUtils.ParameterToString(enumQueryInteger.Value);
 
-                    if (enumQueryDouble.IsSet)
-                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
+                    if (enumQueryString.IsSet)
+                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+
+                    if (enumQueryStringArray.IsSet)
+                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
-                    if (enumHeaderStringArray.IsSet)
-                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
-
                     if (enumHeaderString.IsSet)
                         httpRequestMessageLocalVar.Headers.Add("enum_header_string", ClientUtils.ParameterToString(enumHeaderString.Value));
+
+                    if (enumHeaderStringArray.IsSet)
+                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
 
                     MultipartContent multipartContentLocalVar = new MultipartContent();
 
@@ -4329,11 +4329,11 @@ namespace Org.OpenAPITools.Api
 
                     List<KeyValuePair<string?, string?>> formParameterLocalVars = new List<KeyValuePair<string?, string?>>();
 
-                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormStringArray.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
-
-                    if (enumFormString.IsSet)
+                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormString.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string?, string?>("enum_form_string", ClientUtils.ParameterToString(enumFormString.Value)));
+
+                    if (enumFormStringArray.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
 
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
 
@@ -4358,7 +4358,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEnumParametersApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 
                         Events.ExecuteOnTestEnumParameters(apiResponseLocalVar);
 
@@ -4368,7 +4368,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
                 Events.ExecuteOnErrorTestEnumParameters(e);
                 throw;
             }
@@ -4425,22 +4425,22 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestGroupParameters(ref int requiredStringGroup, ref bool requiredBooleanGroup, ref long requiredInt64Group, ref Option<int> stringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group);
+        partial void FormatTestGroupParameters(ref bool requiredBooleanGroup, ref long requiredInt64Group, ref int requiredStringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group, ref Option<int> stringGroup);
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4450,13 +4450,13 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4464,16 +4464,16 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4485,30 +4485,30 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse?> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse?> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, cancellationToken).ConfigureAwait(false);
+                return await TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4520,21 +4520,21 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                FormatTestGroupParameters(ref requiredStringGroup, ref requiredBooleanGroup, ref requiredInt64Group, ref stringGroup, ref booleanGroup, ref int64Group);
+                FormatTestGroupParameters(ref requiredBooleanGroup, ref requiredInt64Group, ref requiredStringGroup, ref booleanGroup, ref int64Group, ref stringGroup);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4545,14 +4545,14 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
                     parseQueryStringLocalVar["required_int64_group"] = ClientUtils.ParameterToString(requiredInt64Group);
-
-                    if (stringGroup.IsSet)
-                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
+                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
 
                     if (int64Group.IsSet)
                         parseQueryStringLocalVar["int64_group"] = ClientUtils.ParameterToString(int64Group.Value);
+
+                    if (stringGroup.IsSet)
+                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -4582,7 +4582,7 @@ namespace Org.OpenAPITools.Api
 
                         TestGroupParametersApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 
                         Events.ExecuteOnTestGroupParameters(apiResponseLocalVar);
 
@@ -4596,7 +4596,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
                 Events.ExecuteOnErrorTestGroupParameters(e);
                 throw;
             }
@@ -5232,38 +5232,38 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, ref string requiredNotNullable, ref string? requiredNullable, ref Option<string> notRequiredNotNullable, ref Option<string?> notRequiredNullable);
+        partial void FormatTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, ref string requiredNotNullable, List<string> url, ref Option<string> notRequiredNotNullable, ref Option<string?> notRequiredNullable, ref string? requiredNullable);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <returns></returns>
-        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, Option<string> notRequiredNotNullable)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable)
         {
-            if (pipe == null)
-                throw new ArgumentNullException(nameof(pipe));
-
-            if (ioutil == null)
-                throw new ArgumentNullException(nameof(ioutil));
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
 
             if (http == null)
                 throw new ArgumentNullException(nameof(http));
 
-            if (url == null)
-                throw new ArgumentNullException(nameof(url));
+            if (ioutil == null)
+                throw new ArgumentNullException(nameof(ioutil));
 
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
+            if (pipe == null)
+                throw new ArgumentNullException(nameof(pipe));
 
             if (requiredNotNullable == null)
                 throw new ArgumentNullException(nameof(requiredNotNullable));
+
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
 
             if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
                 throw new ArgumentNullException(nameof(notRequiredNotNullable));
@@ -5273,19 +5273,19 @@ namespace Org.OpenAPITools.Api
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable, string? requiredNullable)
         {
             bool suppressDefaultLog = false;
-            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -5295,16 +5295,16 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable, string? requiredNullable);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -5312,19 +5312,19 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable, string? requiredNullable)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -5336,36 +5336,36 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable, string? requiredNullable);
 
         /// <summary>
         ///  To test the collection format in query parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse?> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse?> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, string? requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable, cancellationToken).ConfigureAwait(false);
+                return await TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -5377,26 +5377,26 @@ namespace Org.OpenAPITools.Api
         ///  To test the collection format in query parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, string? requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, notRequiredNotNullable);
+                ValidateTestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable);
 
-                FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, ref requiredNotNullable, ref requiredNullable, ref notRequiredNotNullable, ref notRequiredNullable);
+                FormatTestQueryParameterCollectionFormat(context, http, ioutil, pipe, ref requiredNotNullable, url, ref notRequiredNotNullable, ref notRequiredNullable, ref requiredNullable);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -5407,12 +5407,12 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
-                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
-                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
-                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["context"] = ClientUtils.ParameterToString(context);
+                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
+                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
+                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
                     parseQueryStringLocalVar["requiredNotNullable"] = ClientUtils.ParameterToString(requiredNotNullable);
+                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["requiredNullable"] = ClientUtils.ParameterToString(requiredNullable);
 
                     if (notRequiredNotNullable.IsSet)
@@ -5437,7 +5437,7 @@ namespace Org.OpenAPITools.Api
 
                         TestQueryParameterCollectionFormatApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake/test-query-parameters", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 
                         Events.ExecuteOnTestQueryParameterCollectionFormat(apiResponseLocalVar);
 
@@ -5447,7 +5447,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
                 Events.ExecuteOnErrorTestQueryParameterCollectionFormat(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Api/UserApi.cs
@@ -158,11 +158,11 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs user into the system
@@ -170,11 +170,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>?&gt;</returns>
-        Task<ILoginUserApiResponse?> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse?> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs out current logged in user session
@@ -204,11 +204,11 @@ namespace Org.OpenAPITools.Api
         /// This can only be done by the logged in user.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updated user
@@ -216,11 +216,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// This can only be done by the logged in user.
         /// </remarks>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>?&gt;</returns>
-        Task<IUpdateUserApiResponse?> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse?> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
     }
 
     /// <summary>
@@ -1634,33 +1634,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatLoginUser(ref string username, ref string password);
+        partial void FormatLoginUser(ref string password, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="password"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateLoginUser(string username, string password)
+        private void ValidateLoginUser(string password, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (password == null)
                 throw new ArgumentNullException(nameof(password));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string username, string password)
+        /// <param name="username"></param>
+        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string password, string username)
         {
             bool suppressDefaultLog = false;
-            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, username, password);
+            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, password, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -1670,9 +1670,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string username, string password);
+        /// <param name="username"></param>
+        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string password, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -1680,12 +1680,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, string password)
+        /// <param name="username"></param>
+        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string password, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, username, password);
+            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, password, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -1697,22 +1697,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, string password);
+        /// <param name="username"></param>
+        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string password, string username);
 
         /// <summary>
         /// Logs user into the system 
         /// </summary>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse?> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse?> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await LoginUserAsync(username, password, cancellationToken).ConfigureAwait(false);
+                return await LoginUserAsync(password, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -1724,19 +1724,19 @@ namespace Org.OpenAPITools.Api
         /// Logs user into the system 
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateLoginUser(username, password);
+                ValidateLoginUser(password, username);
 
-                FormatLoginUser(ref username, ref password);
+                FormatLoginUser(ref password, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1747,8 +1747,8 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
                     parseQueryStringLocalVar["password"] = ClientUtils.ParameterToString(password);
+                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -1776,7 +1776,7 @@ namespace Org.OpenAPITools.Api
 
                         LoginUserApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/login", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, username, password);
+                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, password, username);
 
                         Events.ExecuteOnLoginUser(apiResponseLocalVar);
 
@@ -1813,7 +1813,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, username, password);
+                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, password, username);
                 Events.ExecuteOnErrorLoginUser(e);
                 throw;
             }
@@ -2055,33 +2055,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatUpdateUser(ref string username, User user);
+        partial void FormatUpdateUser(User user, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="user"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateUpdateUser(string username, User user)
+        private void ValidateUpdateUser(User user, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, string username, User user)
+        /// <param name="username"></param>
+        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, User user, string username)
         {
             bool suppressDefaultLog = false;
-            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, username, user);
+            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, user, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -2091,9 +2091,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, string username, User user);
+        /// <param name="username"></param>
+        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, User user, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -2101,12 +2101,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, User user)
+        /// <param name="username"></param>
+        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, User user, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, username, user);
+            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, user, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -2118,22 +2118,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, User user);
+        /// <param name="username"></param>
+        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, User user, string username);
 
         /// <summary>
         /// Updated user This can only be done by the logged in user.
         /// </summary>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse?> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse?> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await UpdateUserAsync(username, user, cancellationToken).ConfigureAwait(false);
+                return await UpdateUserAsync(user, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -2145,19 +2145,19 @@ namespace Org.OpenAPITools.Api
         /// Updated user This can only be done by the logged in user.
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateUpdateUser(username, user);
+                ValidateUpdateUser(user, username);
 
-                FormatUpdateUser(ref username, user);
+                FormatUpdateUser(user, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2194,7 +2194,7 @@ namespace Org.OpenAPITools.Api
 
                         UpdateUserApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/{username}", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, username, user);
+                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, user, username);
 
                         Events.ExecuteOnUpdateUser(apiResponseLocalVar);
 
@@ -2204,7 +2204,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, username, user);
+                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, user, username);
                 Events.ExecuteOnErrorUpdateUser(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/docs/apis/FakeApi.md
@@ -1067,7 +1067,7 @@ No authorization required
 
 <a id="testendpointparameters"></a>
 # **TestEndpointParameters**
-> void TestEndpointParameters (decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, int integer = null, int int32 = null, long int64 = null, float varFloat = null, string varString = null, System.IO.Stream binary = null, DateOnly date = null, DateTime dateTime = null, string password = null, string callback = null)
+> void TestEndpointParameters (decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, System.IO.Stream binary = null, string callback = null, DateOnly date = null, DateTime dateTime = null, int int32 = null, long int64 = null, int integer = null, string password = null, float varFloat = null, string varString = null)
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
@@ -1095,24 +1095,24 @@ namespace Example
 
             var apiInstance = new FakeApi(config);
             var number = 8.14D;  // decimal | None
-            var varDouble = 1.2D;  // double | None
             var patternWithoutDelimiter = "patternWithoutDelimiter_example";  // string | None
             var varByte = System.Text.Encoding.ASCII.GetBytes("BYTE_ARRAY_DATA_HERE");  // byte[] | None
-            var integer = 56;  // int | None (optional) 
-            var int32 = 56;  // int | None (optional) 
-            var int64 = 789L;  // long | None (optional) 
-            var varFloat = 3.4F;  // float | None (optional) 
-            var varString = "varString_example";  // string | None (optional) 
+            var varDouble = 1.2D;  // double | None
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
+            var callback = "callback_example";  // string | None (optional) 
             var date = DateOnly.Parse("2013-10-20");  // DateOnly | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")
+            var int32 = 56;  // int | None (optional) 
+            var int64 = 789L;  // long | None (optional) 
+            var integer = 56;  // int | None (optional) 
             var password = "password_example";  // string | None (optional) 
-            var callback = "callback_example";  // string | None (optional) 
+            var varFloat = 3.4F;  // float | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
 
             try
             {
                 // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-                apiInstance.TestEndpointParameters(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                apiInstance.TestEndpointParameters(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             }
             catch (ApiException  e)
             {
@@ -1132,7 +1132,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    apiInstance.TestEndpointParametersWithHttpInfo(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+    apiInstance.TestEndpointParametersWithHttpInfo(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 }
 catch (ApiException e)
 {
@@ -1147,19 +1147,19 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **number** | **decimal** | None |  |
-| **varDouble** | **double** | None |  |
 | **patternWithoutDelimiter** | **string** | None |  |
 | **varByte** | **byte[]** | None |  |
-| **integer** | **int** | None | [optional]  |
-| **int32** | **int** | None | [optional]  |
-| **int64** | **long** | None | [optional]  |
-| **varFloat** | **float** | None | [optional]  |
-| **varString** | **string** | None | [optional]  |
+| **varDouble** | **double** | None |  |
 | **binary** | **System.IO.Stream****System.IO.Stream** | None | [optional]  |
+| **callback** | **string** | None | [optional]  |
 | **date** | **DateOnly** | None | [optional]  |
 | **dateTime** | **DateTime** | None | [optional] [default to &quot;2010-02-01T10:20:10.111110+01:00&quot;] |
+| **int32** | **int** | None | [optional]  |
+| **int64** | **long** | None | [optional]  |
+| **integer** | **int** | None | [optional]  |
 | **password** | **string** | None | [optional]  |
-| **callback** | **string** | None | [optional]  |
+| **varFloat** | **float** | None | [optional]  |
+| **varString** | **string** | None | [optional]  |
 
 ### Return type
 
@@ -1185,7 +1185,7 @@ void (empty response body)
 
 <a id="testenumparameters"></a>
 # **TestEnumParameters**
-> void TestEnumParameters (List<string> enumHeaderStringArray = null, string enumHeaderString = null, List<string> enumQueryStringArray = null, string enumQueryString = null, int enumQueryInteger = null, double enumQueryDouble = null, List<string> enumFormStringArray = null, string enumFormString = null)
+> void TestEnumParameters (string enumFormString = null, List<string> enumFormStringArray = null, string enumHeaderString = null, List<string> enumHeaderStringArray = null, double enumQueryDouble = null, int enumQueryInteger = null, string enumQueryString = null, List<string> enumQueryStringArray = null)
 
 To test enum parameters
 
@@ -1208,19 +1208,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var enumHeaderStringArray = new List<string>(); // List<string> | Header parameter enum test (string array) (optional) 
-            var enumHeaderString = "_abc";  // string | Header parameter enum test (string) (optional)  (default to -efg)
-            var enumQueryStringArray = new List<string>(); // List<string> | Query parameter enum test (string array) (optional) 
-            var enumQueryString = "_abc";  // string | Query parameter enum test (string) (optional)  (default to -efg)
-            var enumQueryInteger = 1;  // int | Query parameter enum test (double) (optional) 
-            var enumQueryDouble = 1.1D;  // double | Query parameter enum test (double) (optional) 
-            var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional)  (default to $)
             var enumFormString = "_abc";  // string | Form parameter enum test (string) (optional)  (default to -efg)
+            var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional)  (default to $)
+            var enumHeaderString = "_abc";  // string | Header parameter enum test (string) (optional)  (default to -efg)
+            var enumHeaderStringArray = new List<string>(); // List<string> | Header parameter enum test (string array) (optional) 
+            var enumQueryDouble = 1.1D;  // double | Query parameter enum test (double) (optional) 
+            var enumQueryInteger = 1;  // int | Query parameter enum test (double) (optional) 
+            var enumQueryString = "_abc";  // string | Query parameter enum test (string) (optional)  (default to -efg)
+            var enumQueryStringArray = new List<string>(); // List<string> | Query parameter enum test (string array) (optional) 
 
             try
             {
                 // To test enum parameters
-                apiInstance.TestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                apiInstance.TestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             }
             catch (ApiException  e)
             {
@@ -1240,7 +1240,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test enum parameters
-    apiInstance.TestEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+    apiInstance.TestEnumParametersWithHttpInfo(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 }
 catch (ApiException e)
 {
@@ -1254,14 +1254,14 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **enumHeaderStringArray** | [**List&lt;string&gt;**](string.md) | Header parameter enum test (string array) | [optional]  |
-| **enumHeaderString** | **string** | Header parameter enum test (string) | [optional] [default to -efg] |
-| **enumQueryStringArray** | [**List&lt;string&gt;**](string.md) | Query parameter enum test (string array) | [optional]  |
-| **enumQueryString** | **string** | Query parameter enum test (string) | [optional] [default to -efg] |
-| **enumQueryInteger** | **int** | Query parameter enum test (double) | [optional]  |
-| **enumQueryDouble** | **double** | Query parameter enum test (double) | [optional]  |
-| **enumFormStringArray** | [**List&lt;string&gt;**](string.md) | Form parameter enum test (string array) | [optional] [default to $] |
 | **enumFormString** | **string** | Form parameter enum test (string) | [optional] [default to -efg] |
+| **enumFormStringArray** | [**List&lt;string&gt;**](string.md) | Form parameter enum test (string array) | [optional] [default to $] |
+| **enumHeaderString** | **string** | Header parameter enum test (string) | [optional] [default to -efg] |
+| **enumHeaderStringArray** | [**List&lt;string&gt;**](string.md) | Header parameter enum test (string array) | [optional]  |
+| **enumQueryDouble** | **double** | Query parameter enum test (double) | [optional]  |
+| **enumQueryInteger** | **int** | Query parameter enum test (double) | [optional]  |
+| **enumQueryString** | **string** | Query parameter enum test (string) | [optional] [default to -efg] |
+| **enumQueryStringArray** | [**List&lt;string&gt;**](string.md) | Query parameter enum test (string array) | [optional]  |
 
 ### Return type
 
@@ -1287,7 +1287,7 @@ No authorization required
 
 <a id="testgroupparameters"></a>
 # **TestGroupParameters**
-> void TestGroupParameters (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int stringGroup = null, bool booleanGroup = null, long int64Group = null)
+> void TestGroupParameters (bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, bool booleanGroup = null, long int64Group = null, int stringGroup = null)
 
 Fake endpoint to test group parameters (optional)
 
@@ -1313,17 +1313,17 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new FakeApi(config);
-            var requiredStringGroup = 56;  // int | Required String in group parameters
             var requiredBooleanGroup = true;  // bool | Required Boolean in group parameters
             var requiredInt64Group = 789L;  // long | Required Integer in group parameters
-            var stringGroup = 56;  // int | String in group parameters (optional) 
+            var requiredStringGroup = 56;  // int | Required String in group parameters
             var booleanGroup = true;  // bool | Boolean in group parameters (optional) 
             var int64Group = 789L;  // long | Integer in group parameters (optional) 
+            var stringGroup = 56;  // int | String in group parameters (optional) 
 
             try
             {
                 // Fake endpoint to test group parameters (optional)
-                apiInstance.TestGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                apiInstance.TestGroupParameters(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             }
             catch (ApiException  e)
             {
@@ -1343,7 +1343,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint to test group parameters (optional)
-    apiInstance.TestGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+    apiInstance.TestGroupParametersWithHttpInfo(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 }
 catch (ApiException e)
 {
@@ -1357,12 +1357,12 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **requiredBooleanGroup** | **bool** | Required Boolean in group parameters |  |
 | **requiredInt64Group** | **long** | Required Integer in group parameters |  |
-| **stringGroup** | **int** | String in group parameters | [optional]  |
+| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **booleanGroup** | **bool** | Boolean in group parameters | [optional]  |
 | **int64Group** | **long** | Integer in group parameters | [optional]  |
+| **stringGroup** | **int** | String in group parameters | [optional]  |
 
 ### Return type
 
@@ -1644,7 +1644,7 @@ No authorization required
 
 <a id="testqueryparametercollectionformat"></a>
 # **TestQueryParameterCollectionFormat**
-> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, string notRequiredNotNullable = null, string notRequiredNullable = null)
+> void TestQueryParameterCollectionFormat (List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, string notRequiredNotNullable = null, string notRequiredNullable = null, string requiredNullable)
 
 
 
@@ -1667,19 +1667,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var pipe = new List<string>(); // List<string> | 
-            var ioutil = new List<string>(); // List<string> | 
-            var http = new List<string>(); // List<string> | 
-            var url = new List<string>(); // List<string> | 
             var context = new List<string>(); // List<string> | 
+            var http = new List<string>(); // List<string> | 
+            var ioutil = new List<string>(); // List<string> | 
+            var pipe = new List<string>(); // List<string> | 
             var requiredNotNullable = "requiredNotNullable_example";  // string | 
-            var requiredNullable = "requiredNullable_example";  // string | 
+            var url = new List<string>(); // List<string> | 
             var notRequiredNotNullable = "notRequiredNotNullable_example";  // string |  (optional) 
             var notRequiredNullable = "notRequiredNullable_example";  // string |  (optional) 
+            var requiredNullable = "requiredNullable_example";  // string | 
 
             try
             {
-                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                apiInstance.TestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             }
             catch (ApiException  e)
             {
@@ -1698,7 +1698,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 }
 catch (ApiException e)
 {
@@ -1712,15 +1712,15 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
-| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
-| **http** | [**List&lt;string&gt;**](string.md) |  |  |
-| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **context** | [**List&lt;string&gt;**](string.md) |  |  |
+| **http** | [**List&lt;string&gt;**](string.md) |  |  |
+| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
+| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
 | **requiredNotNullable** | **string** |  |  |
-| **requiredNullable** | **string** |  |  |
+| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **notRequiredNotNullable** | **string** |  | [optional]  |
 | **notRequiredNullable** | **string** |  | [optional]  |
+| **requiredNullable** | **string** |  |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/docs/apis/UserApi.md
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/docs/apis/UserApi.md
@@ -453,7 +453,7 @@ No authorization required
 
 <a id="loginuser"></a>
 # **LoginUser**
-> string LoginUser (string username, string password)
+> string LoginUser (string password, string username)
 
 Logs user into the system
 
@@ -474,13 +474,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | The user name for login
             var password = "password_example";  // string | The password for login in clear text
+            var username = "username_example";  // string | The user name for login
 
             try
             {
                 // Logs user into the system
-                string result = apiInstance.LoginUser(username, password);
+                string result = apiInstance.LoginUser(password, username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -501,7 +501,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Logs user into the system
-    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(username, password);
+    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(password, username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -518,8 +518,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | The user name for login |  |
 | **password** | **string** | The password for login in clear text |  |
+| **username** | **string** | The user name for login |  |
 
 ### Return type
 
@@ -625,7 +625,7 @@ No authorization required
 
 <a id="updateuser"></a>
 # **UpdateUser**
-> void UpdateUser (string username, User user)
+> void UpdateUser (User user, string username)
 
 Updated user
 
@@ -648,13 +648,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | name that need to be deleted
             var user = new User(); // User | Updated user object
+            var username = "username_example";  // string | name that need to be deleted
 
             try
             {
                 // Updated user
-                apiInstance.UpdateUser(username, user);
+                apiInstance.UpdateUser(user, username);
             }
             catch (ApiException  e)
             {
@@ -674,7 +674,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Updated user
-    apiInstance.UpdateUserWithHttpInfo(username, user);
+    apiInstance.UpdateUserWithHttpInfo(user, username);
 }
 catch (ApiException e)
 {
@@ -688,8 +688,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | name that need to be deleted |  |
 | **user** | [**User**](User.md) | Updated user object |  |
+| **username** | **string** | name that need to be deleted |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
@@ -193,20 +193,20 @@ namespace Org.OpenAPITools.Test.Api
         public async Task TestEndpointParametersAsyncTest()
         {
             decimal number = default;
-            double varDouble = default;
             string patternWithoutDelimiter = default;
             byte[] varByte = default;
-            Client.Option<int> integer = default;
-            Client.Option<int> int32 = default;
-            Client.Option<long> int64 = default;
-            Client.Option<float> varFloat = default;
-            Client.Option<string> varString = default;
+            double varDouble = default;
             Client.Option<System.IO.Stream> binary = default;
+            Client.Option<string> callback = default;
             Client.Option<DateOnly> date = default;
             Client.Option<DateTime> dateTime = default;
+            Client.Option<int> int32 = default;
+            Client.Option<long> int64 = default;
+            Client.Option<int> integer = default;
             Client.Option<string> password = default;
-            Client.Option<string> callback = default;
-            await _instance.TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            Client.Option<float> varFloat = default;
+            Client.Option<string> varString = default;
+            await _instance.TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
         }
 
         /// <summary>
@@ -215,15 +215,15 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestEnumParametersAsyncTest()
         {
-            Client.Option<List<string>> enumHeaderStringArray = default;
-            Client.Option<string> enumHeaderString = default;
-            Client.Option<List<string>> enumQueryStringArray = default;
-            Client.Option<string> enumQueryString = default;
-            Client.Option<int> enumQueryInteger = default;
-            Client.Option<double> enumQueryDouble = default;
-            Client.Option<List<string>> enumFormStringArray = default;
             Client.Option<string> enumFormString = default;
-            await _instance.TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            Client.Option<List<string>> enumFormStringArray = default;
+            Client.Option<string> enumHeaderString = default;
+            Client.Option<List<string>> enumHeaderStringArray = default;
+            Client.Option<double> enumQueryDouble = default;
+            Client.Option<int> enumQueryInteger = default;
+            Client.Option<string> enumQueryString = default;
+            Client.Option<List<string>> enumQueryStringArray = default;
+            await _instance.TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
         }
 
         /// <summary>
@@ -232,13 +232,13 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestGroupParametersAsyncTest()
         {
-            int requiredStringGroup = default;
             bool requiredBooleanGroup = default;
             long requiredInt64Group = default;
-            Client.Option<int> stringGroup = default;
+            int requiredStringGroup = default;
             Client.Option<bool> booleanGroup = default;
             Client.Option<long> int64Group = default;
-            await _instance.TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            Client.Option<int> stringGroup = default;
+            await _instance.TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
         }
 
         /// <summary>
@@ -278,16 +278,16 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestQueryParameterCollectionFormatAsyncTest()
         {
-            List<string> pipe = default;
-            List<string> ioutil = default;
-            List<string> http = default;
-            List<string> url = default;
             List<string> context = default;
+            List<string> http = default;
+            List<string> ioutil = default;
+            List<string> pipe = default;
             string requiredNotNullable = default;
-            string requiredNullable = default;
+            List<string> url = default;
             Client.Option<string> notRequiredNotNullable = default;
             Client.Option<string> notRequiredNullable = default;
-            await _instance.TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            string requiredNullable = default;
+            await _instance.TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
@@ -108,9 +108,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task LoginUserAsyncTest()
         {
-            string username = default;
             string password = default;
-            var response = await _instance.LoginUserAsync(username, password);
+            string username = default;
+            var response = await _instance.LoginUserAsync(password, username);
             var model = response.Ok();
             Assert.IsType<string>(model);
         }
@@ -130,9 +130,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task UpdateUserAsyncTest()
         {
-            string username = default;
             User user = default;
-            await _instance.UpdateUserAsync(username, user);
+            string username = default;
+            await _instance.UpdateUserAsync(user, username);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -313,22 +313,22 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </remarks>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -361,17 +361,17 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -379,17 +379,17 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test enum parameters
         /// </remarks>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -398,15 +398,15 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -414,15 +414,15 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test inline additionalProperties
@@ -502,18 +502,18 @@ namespace Org.OpenAPITools.Api
         /// To test the collection format in query parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -521,18 +521,18 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test the collection format in query parameters
         /// </remarks>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test referenced string map
@@ -3790,19 +3790,19 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEndpointParameters(ref decimal number, ref double varDouble, ref string patternWithoutDelimiter, ref byte[] varByte, ref Option<int> integer, ref Option<int> int32, ref Option<long> int64, ref Option<float> varFloat, ref Option<string> varString, ref Option<System.IO.Stream> binary, ref Option<DateOnly> date, ref Option<DateTime> dateTime, ref Option<string> password, ref Option<string> callback);
+        partial void FormatTestEndpointParameters(ref decimal number, ref string patternWithoutDelimiter, ref byte[] varByte, ref double varDouble, ref Option<System.IO.Stream> binary, ref Option<string> callback, ref Option<DateOnly> date, ref Option<DateTime> dateTime, ref Option<int> int32, ref Option<long> int64, ref Option<int> integer, ref Option<string> password, ref Option<float> varFloat, ref Option<string> varString);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="varString"></param>
         /// <param name="binary"></param>
-        /// <param name="password"></param>
         /// <param name="callback"></param>
+        /// <param name="password"></param>
+        /// <param name="varString"></param>
         /// <returns></returns>
-        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<string> varString, Option<System.IO.Stream> binary, Option<string> password, Option<string> callback)
+        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<System.IO.Stream> binary, Option<string> callback, Option<string> password, Option<string> varString)
         {
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
@@ -3810,17 +3810,17 @@ namespace Org.OpenAPITools.Api
             if (varByte == null)
                 throw new ArgumentNullException(nameof(varByte));
 
-            if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString));
-
             if (binary.IsSet && binary.Value == null)
                 throw new ArgumentNullException(nameof(binary));
+
+            if (callback.IsSet && callback.Value == null)
+                throw new ArgumentNullException(nameof(callback));
 
             if (password.IsSet && password.Value == null)
                 throw new ArgumentNullException(nameof(password));
 
-            if (callback.IsSet && callback.Value == null)
-                throw new ArgumentNullException(nameof(callback));
+            if (varString.IsSet && varString.Value == null)
+                throw new ArgumentNullException(nameof(varString));
         }
 
         /// <summary>
@@ -3828,23 +3828,23 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -3855,20 +3855,20 @@ namespace Org.OpenAPITools.Api
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -3877,23 +3877,23 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -3906,45 +3906,45 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트  Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback, cancellationToken).ConfigureAwait(false);
+                return await TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -3957,30 +3957,30 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, varString, binary, password, callback);
+                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, binary, callback, password, varString);
 
-                FormatTestEndpointParameters(ref number, ref varDouble, ref patternWithoutDelimiter, ref varByte, ref integer, ref int32, ref int64, ref varFloat, ref varString, ref binary, ref date, ref dateTime, ref password, ref callback);
+                FormatTestEndpointParameters(ref number, ref patternWithoutDelimiter, ref varByte, ref varDouble, ref binary, ref callback, ref date, ref dateTime, ref int32, ref int64, ref integer, ref password, ref varFloat, ref varString);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -3999,29 +3999,17 @@ namespace Org.OpenAPITools.Api
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("number", ClientUtils.ParameterToString(number)));
 
-                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
-
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("pattern_without_delimiter", ClientUtils.ParameterToString(patternWithoutDelimiter)));
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("byte", ClientUtils.ParameterToString(varByte)));
 
-                    if (integer.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
-
-                    if (int32.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
-
-                    if (int64.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
-
-                    if (varFloat.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
-
-                    if (varString.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
+                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
 
                     if (binary.IsSet)
                         multipartContentLocalVar.Add(new StreamContent(binary.Value));
+
+                    if (callback.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
 
                     if (date.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("date", ClientUtils.ParameterToString(date.Value)));
@@ -4029,11 +4017,23 @@ namespace Org.OpenAPITools.Api
                     if (dateTime.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("dateTime", ClientUtils.ParameterToString(dateTime.Value)));
 
+                    if (int32.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
+
+                    if (int64.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
+
+                    if (integer.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
+
                     if (password.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("password", ClientUtils.ParameterToString(password.Value)));
 
-                    if (callback.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
+                    if (varFloat.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
+
+                    if (varString.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
 
                     List<TokenBase> tokenBaseLocalVars = new List<TokenBase>();
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
@@ -4065,7 +4065,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEndpointParametersApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 
                         Events.ExecuteOnTestEndpointParameters(apiResponseLocalVar);
 
@@ -4079,7 +4079,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
                 Events.ExecuteOnErrorTestEndpointParameters(e);
                 throw;
             }
@@ -4136,55 +4136,55 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEnumParameters(Option<List<string>> enumHeaderStringArray, ref Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, ref Option<string> enumQueryString, ref Option<int> enumQueryInteger, ref Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, ref Option<string> enumFormString);
+        partial void FormatTestEnumParameters(ref Option<string> enumFormString, Option<List<string>> enumFormStringArray, ref Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, ref Option<double> enumQueryDouble, ref Option<int> enumQueryInteger, ref Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
         /// <returns></returns>
-        private void ValidateTestEnumParameters(Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        private void ValidateTestEnumParameters(Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
-            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderStringArray));
-
-            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderString));
-
-            if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumQueryStringArray));
-
-            if (enumQueryString.IsSet && enumQueryString.Value == null)
-                throw new ArgumentNullException(nameof(enumQueryString));
+            if (enumFormString.IsSet && enumFormString.Value == null)
+                throw new ArgumentNullException(nameof(enumFormString));
 
             if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumFormStringArray));
 
-            if (enumFormString.IsSet && enumFormString.Value == null)
-                throw new ArgumentNullException(nameof(enumFormString));
+            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderString));
+
+            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderStringArray));
+
+            if (enumQueryString.IsSet && enumQueryString.Value == null)
+                throw new ArgumentNullException(nameof(enumQueryString));
+
+            if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumQueryStringArray));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4194,15 +4194,15 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4210,18 +4210,18 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4233,34 +4233,34 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// To test enum parameters To test enum parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, cancellationToken).ConfigureAwait(false);
+                return await TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4272,25 +4272,25 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumFormStringArray, enumFormString);
+                ValidateTestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryString, enumQueryStringArray);
 
-                FormatTestEnumParameters(enumHeaderStringArray, ref enumHeaderString, enumQueryStringArray, ref enumQueryString, ref enumQueryInteger, ref enumQueryDouble, enumFormStringArray, ref enumFormString);
+                FormatTestEnumParameters(ref enumFormString, enumFormStringArray, ref enumHeaderString, enumHeaderStringArray, ref enumQueryDouble, ref enumQueryInteger, ref enumQueryString, enumQueryStringArray);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4301,25 +4301,25 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    if (enumQueryStringArray.IsSet)
-                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
-
-                    if (enumQueryString.IsSet)
-                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+                    if (enumQueryDouble.IsSet)
+                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
 
                     if (enumQueryInteger.IsSet)
                         parseQueryStringLocalVar["enum_query_integer"] = ClientUtils.ParameterToString(enumQueryInteger.Value);
 
-                    if (enumQueryDouble.IsSet)
-                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
+                    if (enumQueryString.IsSet)
+                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+
+                    if (enumQueryStringArray.IsSet)
+                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
-                    if (enumHeaderStringArray.IsSet)
-                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
-
                     if (enumHeaderString.IsSet)
                         httpRequestMessageLocalVar.Headers.Add("enum_header_string", ClientUtils.ParameterToString(enumHeaderString.Value));
+
+                    if (enumHeaderStringArray.IsSet)
+                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
 
                     MultipartContent multipartContentLocalVar = new MultipartContent();
 
@@ -4327,11 +4327,11 @@ namespace Org.OpenAPITools.Api
 
                     List<KeyValuePair<string, string>> formParameterLocalVars = new List<KeyValuePair<string, string>>();
 
-                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormStringArray.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
-
-                    if (enumFormString.IsSet)
+                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormString.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string", ClientUtils.ParameterToString(enumFormString.Value)));
+
+                    if (enumFormStringArray.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
 
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
 
@@ -4356,7 +4356,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEnumParametersApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 
                         Events.ExecuteOnTestEnumParameters(apiResponseLocalVar);
 
@@ -4366,7 +4366,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
                 Events.ExecuteOnErrorTestEnumParameters(e);
                 throw;
             }
@@ -4423,22 +4423,22 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestGroupParameters(ref int requiredStringGroup, ref bool requiredBooleanGroup, ref long requiredInt64Group, ref Option<int> stringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group);
+        partial void FormatTestGroupParameters(ref bool requiredBooleanGroup, ref long requiredInt64Group, ref int requiredStringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group, ref Option<int> stringGroup);
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4448,13 +4448,13 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4462,16 +4462,16 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4483,30 +4483,30 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, cancellationToken).ConfigureAwait(false);
+                return await TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4518,21 +4518,21 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                FormatTestGroupParameters(ref requiredStringGroup, ref requiredBooleanGroup, ref requiredInt64Group, ref stringGroup, ref booleanGroup, ref int64Group);
+                FormatTestGroupParameters(ref requiredBooleanGroup, ref requiredInt64Group, ref requiredStringGroup, ref booleanGroup, ref int64Group, ref stringGroup);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4543,14 +4543,14 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
                     parseQueryStringLocalVar["required_int64_group"] = ClientUtils.ParameterToString(requiredInt64Group);
-
-                    if (stringGroup.IsSet)
-                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
+                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
 
                     if (int64Group.IsSet)
                         parseQueryStringLocalVar["int64_group"] = ClientUtils.ParameterToString(int64Group.Value);
+
+                    if (stringGroup.IsSet)
+                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -4580,7 +4580,7 @@ namespace Org.OpenAPITools.Api
 
                         TestGroupParametersApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 
                         Events.ExecuteOnTestGroupParameters(apiResponseLocalVar);
 
@@ -4594,7 +4594,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
                 Events.ExecuteOnErrorTestGroupParameters(e);
                 throw;
             }
@@ -5230,38 +5230,38 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, ref string requiredNotNullable, ref string requiredNullable, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable);
+        partial void FormatTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, ref string requiredNotNullable, List<string> url, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable, ref string requiredNullable);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <returns></returns>
-        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, Option<string> notRequiredNotNullable)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable)
         {
-            if (pipe == null)
-                throw new ArgumentNullException(nameof(pipe));
-
-            if (ioutil == null)
-                throw new ArgumentNullException(nameof(ioutil));
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
 
             if (http == null)
                 throw new ArgumentNullException(nameof(http));
 
-            if (url == null)
-                throw new ArgumentNullException(nameof(url));
+            if (ioutil == null)
+                throw new ArgumentNullException(nameof(ioutil));
 
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
+            if (pipe == null)
+                throw new ArgumentNullException(nameof(pipe));
 
             if (requiredNotNullable == null)
                 throw new ArgumentNullException(nameof(requiredNotNullable));
+
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
 
             if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
                 throw new ArgumentNullException(nameof(notRequiredNotNullable));
@@ -5271,19 +5271,19 @@ namespace Org.OpenAPITools.Api
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -5293,16 +5293,16 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -5310,19 +5310,19 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -5334,36 +5334,36 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         ///  To test the collection format in query parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable, cancellationToken).ConfigureAwait(false);
+                return await TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -5375,26 +5375,26 @@ namespace Org.OpenAPITools.Api
         ///  To test the collection format in query parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, notRequiredNotNullable);
+                ValidateTestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable);
 
-                FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, ref requiredNotNullable, ref requiredNullable, ref notRequiredNotNullable, ref notRequiredNullable);
+                FormatTestQueryParameterCollectionFormat(context, http, ioutil, pipe, ref requiredNotNullable, url, ref notRequiredNotNullable, ref notRequiredNullable, ref requiredNullable);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -5405,12 +5405,12 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
-                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
-                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
-                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["context"] = ClientUtils.ParameterToString(context);
+                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
+                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
+                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
                     parseQueryStringLocalVar["requiredNotNullable"] = ClientUtils.ParameterToString(requiredNotNullable);
+                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["requiredNullable"] = ClientUtils.ParameterToString(requiredNullable);
 
                     if (notRequiredNotNullable.IsSet)
@@ -5435,7 +5435,7 @@ namespace Org.OpenAPITools.Api
 
                         TestQueryParameterCollectionFormatApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake/test-query-parameters", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 
                         Events.ExecuteOnTestQueryParameterCollectionFormat(apiResponseLocalVar);
 
@@ -5445,7 +5445,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
                 Events.ExecuteOnErrorTestQueryParameterCollectionFormat(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
@@ -156,11 +156,11 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs user into the system
@@ -168,11 +168,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs out current logged in user session
@@ -202,11 +202,11 @@ namespace Org.OpenAPITools.Api
         /// This can only be done by the logged in user.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updated user
@@ -214,11 +214,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// This can only be done by the logged in user.
         /// </remarks>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
     }
 
     /// <summary>
@@ -1632,33 +1632,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatLoginUser(ref string username, ref string password);
+        partial void FormatLoginUser(ref string password, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="password"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateLoginUser(string username, string password)
+        private void ValidateLoginUser(string password, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (password == null)
                 throw new ArgumentNullException(nameof(password));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string username, string password)
+        /// <param name="username"></param>
+        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string password, string username)
         {
             bool suppressDefaultLog = false;
-            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, username, password);
+            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, password, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -1668,9 +1668,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string username, string password);
+        /// <param name="username"></param>
+        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string password, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -1678,12 +1678,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, string password)
+        /// <param name="username"></param>
+        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string password, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, username, password);
+            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, password, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -1695,22 +1695,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, string password);
+        /// <param name="username"></param>
+        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string password, string username);
 
         /// <summary>
         /// Logs user into the system 
         /// </summary>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await LoginUserAsync(username, password, cancellationToken).ConfigureAwait(false);
+                return await LoginUserAsync(password, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -1722,19 +1722,19 @@ namespace Org.OpenAPITools.Api
         /// Logs user into the system 
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateLoginUser(username, password);
+                ValidateLoginUser(password, username);
 
-                FormatLoginUser(ref username, ref password);
+                FormatLoginUser(ref password, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1745,8 +1745,8 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
                     parseQueryStringLocalVar["password"] = ClientUtils.ParameterToString(password);
+                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -1774,7 +1774,7 @@ namespace Org.OpenAPITools.Api
 
                         LoginUserApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/login", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, username, password);
+                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, password, username);
 
                         Events.ExecuteOnLoginUser(apiResponseLocalVar);
 
@@ -1811,7 +1811,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, username, password);
+                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, password, username);
                 Events.ExecuteOnErrorLoginUser(e);
                 throw;
             }
@@ -2053,33 +2053,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatUpdateUser(ref string username, User user);
+        partial void FormatUpdateUser(User user, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="user"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateUpdateUser(string username, User user)
+        private void ValidateUpdateUser(User user, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, string username, User user)
+        /// <param name="username"></param>
+        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, User user, string username)
         {
             bool suppressDefaultLog = false;
-            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, username, user);
+            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, user, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -2089,9 +2089,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, string username, User user);
+        /// <param name="username"></param>
+        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, User user, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -2099,12 +2099,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, User user)
+        /// <param name="username"></param>
+        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, User user, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, username, user);
+            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, user, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -2116,22 +2116,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, User user);
+        /// <param name="username"></param>
+        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, User user, string username);
 
         /// <summary>
         /// Updated user This can only be done by the logged in user.
         /// </summary>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await UpdateUserAsync(username, user, cancellationToken).ConfigureAwait(false);
+                return await UpdateUserAsync(user, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -2143,19 +2143,19 @@ namespace Org.OpenAPITools.Api
         /// Updated user This can only be done by the logged in user.
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateUpdateUser(username, user);
+                ValidateUpdateUser(user, username);
 
-                FormatUpdateUser(ref username, user);
+                FormatUpdateUser(user, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2192,7 +2192,7 @@ namespace Org.OpenAPITools.Api
 
                         UpdateUserApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/{username}", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, username, user);
+                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, user, username);
 
                         Events.ExecuteOnUpdateUser(apiResponseLocalVar);
 
@@ -2202,7 +2202,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, username, user);
+                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, user, username);
                 Events.ExecuteOnErrorUpdateUser(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/docs/apis/FakeApi.md
@@ -1067,7 +1067,7 @@ No authorization required
 
 <a id="testendpointparameters"></a>
 # **TestEndpointParameters**
-> void TestEndpointParameters (decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, int integer = null, int int32 = null, long int64 = null, float varFloat = null, string varString = null, System.IO.Stream binary = null, DateOnly date = null, DateTime dateTime = null, string password = null, string callback = null)
+> void TestEndpointParameters (decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, System.IO.Stream binary = null, string callback = null, DateOnly date = null, DateTime dateTime = null, int int32 = null, long int64 = null, int integer = null, string password = null, float varFloat = null, string varString = null)
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
@@ -1095,24 +1095,24 @@ namespace Example
 
             var apiInstance = new FakeApi(config);
             var number = 8.14D;  // decimal | None
-            var varDouble = 1.2D;  // double | None
             var patternWithoutDelimiter = "patternWithoutDelimiter_example";  // string | None
             var varByte = System.Text.Encoding.ASCII.GetBytes("BYTE_ARRAY_DATA_HERE");  // byte[] | None
-            var integer = 56;  // int | None (optional) 
-            var int32 = 56;  // int | None (optional) 
-            var int64 = 789L;  // long | None (optional) 
-            var varFloat = 3.4F;  // float | None (optional) 
-            var varString = "varString_example";  // string | None (optional) 
+            var varDouble = 1.2D;  // double | None
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
+            var callback = "callback_example";  // string | None (optional) 
             var date = DateOnly.Parse("2013-10-20");  // DateOnly | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")
+            var int32 = 56;  // int | None (optional) 
+            var int64 = 789L;  // long | None (optional) 
+            var integer = 56;  // int | None (optional) 
             var password = "password_example";  // string | None (optional) 
-            var callback = "callback_example";  // string | None (optional) 
+            var varFloat = 3.4F;  // float | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
 
             try
             {
                 // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-                apiInstance.TestEndpointParameters(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                apiInstance.TestEndpointParameters(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             }
             catch (ApiException  e)
             {
@@ -1132,7 +1132,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    apiInstance.TestEndpointParametersWithHttpInfo(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+    apiInstance.TestEndpointParametersWithHttpInfo(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 }
 catch (ApiException e)
 {
@@ -1147,19 +1147,19 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **number** | **decimal** | None |  |
-| **varDouble** | **double** | None |  |
 | **patternWithoutDelimiter** | **string** | None |  |
 | **varByte** | **byte[]** | None |  |
-| **integer** | **int** | None | [optional]  |
-| **int32** | **int** | None | [optional]  |
-| **int64** | **long** | None | [optional]  |
-| **varFloat** | **float** | None | [optional]  |
-| **varString** | **string** | None | [optional]  |
+| **varDouble** | **double** | None |  |
 | **binary** | **System.IO.Stream****System.IO.Stream** | None | [optional]  |
+| **callback** | **string** | None | [optional]  |
 | **date** | **DateOnly** | None | [optional]  |
 | **dateTime** | **DateTime** | None | [optional] [default to &quot;2010-02-01T10:20:10.111110+01:00&quot;] |
+| **int32** | **int** | None | [optional]  |
+| **int64** | **long** | None | [optional]  |
+| **integer** | **int** | None | [optional]  |
 | **password** | **string** | None | [optional]  |
-| **callback** | **string** | None | [optional]  |
+| **varFloat** | **float** | None | [optional]  |
+| **varString** | **string** | None | [optional]  |
 
 ### Return type
 
@@ -1185,7 +1185,7 @@ void (empty response body)
 
 <a id="testenumparameters"></a>
 # **TestEnumParameters**
-> void TestEnumParameters (List<string> enumHeaderStringArray = null, string enumHeaderString = null, List<string> enumQueryStringArray = null, string enumQueryString = null, int enumQueryInteger = null, double enumQueryDouble = null, List<string> enumFormStringArray = null, string enumFormString = null)
+> void TestEnumParameters (string enumFormString = null, List<string> enumFormStringArray = null, string enumHeaderString = null, List<string> enumHeaderStringArray = null, double enumQueryDouble = null, int enumQueryInteger = null, string enumQueryString = null, List<string> enumQueryStringArray = null)
 
 To test enum parameters
 
@@ -1208,19 +1208,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var enumHeaderStringArray = new List<string>(); // List<string> | Header parameter enum test (string array) (optional) 
-            var enumHeaderString = "_abc";  // string | Header parameter enum test (string) (optional)  (default to -efg)
-            var enumQueryStringArray = new List<string>(); // List<string> | Query parameter enum test (string array) (optional) 
-            var enumQueryString = "_abc";  // string | Query parameter enum test (string) (optional)  (default to -efg)
-            var enumQueryInteger = 1;  // int | Query parameter enum test (double) (optional) 
-            var enumQueryDouble = 1.1D;  // double | Query parameter enum test (double) (optional) 
-            var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional)  (default to $)
             var enumFormString = "_abc";  // string | Form parameter enum test (string) (optional)  (default to -efg)
+            var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional)  (default to $)
+            var enumHeaderString = "_abc";  // string | Header parameter enum test (string) (optional)  (default to -efg)
+            var enumHeaderStringArray = new List<string>(); // List<string> | Header parameter enum test (string array) (optional) 
+            var enumQueryDouble = 1.1D;  // double | Query parameter enum test (double) (optional) 
+            var enumQueryInteger = 1;  // int | Query parameter enum test (double) (optional) 
+            var enumQueryString = "_abc";  // string | Query parameter enum test (string) (optional)  (default to -efg)
+            var enumQueryStringArray = new List<string>(); // List<string> | Query parameter enum test (string array) (optional) 
 
             try
             {
                 // To test enum parameters
-                apiInstance.TestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                apiInstance.TestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             }
             catch (ApiException  e)
             {
@@ -1240,7 +1240,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test enum parameters
-    apiInstance.TestEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+    apiInstance.TestEnumParametersWithHttpInfo(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 }
 catch (ApiException e)
 {
@@ -1254,14 +1254,14 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **enumHeaderStringArray** | [**List&lt;string&gt;**](string.md) | Header parameter enum test (string array) | [optional]  |
-| **enumHeaderString** | **string** | Header parameter enum test (string) | [optional] [default to -efg] |
-| **enumQueryStringArray** | [**List&lt;string&gt;**](string.md) | Query parameter enum test (string array) | [optional]  |
-| **enumQueryString** | **string** | Query parameter enum test (string) | [optional] [default to -efg] |
-| **enumQueryInteger** | **int** | Query parameter enum test (double) | [optional]  |
-| **enumQueryDouble** | **double** | Query parameter enum test (double) | [optional]  |
-| **enumFormStringArray** | [**List&lt;string&gt;**](string.md) | Form parameter enum test (string array) | [optional] [default to $] |
 | **enumFormString** | **string** | Form parameter enum test (string) | [optional] [default to -efg] |
+| **enumFormStringArray** | [**List&lt;string&gt;**](string.md) | Form parameter enum test (string array) | [optional] [default to $] |
+| **enumHeaderString** | **string** | Header parameter enum test (string) | [optional] [default to -efg] |
+| **enumHeaderStringArray** | [**List&lt;string&gt;**](string.md) | Header parameter enum test (string array) | [optional]  |
+| **enumQueryDouble** | **double** | Query parameter enum test (double) | [optional]  |
+| **enumQueryInteger** | **int** | Query parameter enum test (double) | [optional]  |
+| **enumQueryString** | **string** | Query parameter enum test (string) | [optional] [default to -efg] |
+| **enumQueryStringArray** | [**List&lt;string&gt;**](string.md) | Query parameter enum test (string array) | [optional]  |
 
 ### Return type
 
@@ -1287,7 +1287,7 @@ No authorization required
 
 <a id="testgroupparameters"></a>
 # **TestGroupParameters**
-> void TestGroupParameters (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int stringGroup = null, bool booleanGroup = null, long int64Group = null)
+> void TestGroupParameters (bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, bool booleanGroup = null, long int64Group = null, int stringGroup = null)
 
 Fake endpoint to test group parameters (optional)
 
@@ -1313,17 +1313,17 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new FakeApi(config);
-            var requiredStringGroup = 56;  // int | Required String in group parameters
             var requiredBooleanGroup = true;  // bool | Required Boolean in group parameters
             var requiredInt64Group = 789L;  // long | Required Integer in group parameters
-            var stringGroup = 56;  // int | String in group parameters (optional) 
+            var requiredStringGroup = 56;  // int | Required String in group parameters
             var booleanGroup = true;  // bool | Boolean in group parameters (optional) 
             var int64Group = 789L;  // long | Integer in group parameters (optional) 
+            var stringGroup = 56;  // int | String in group parameters (optional) 
 
             try
             {
                 // Fake endpoint to test group parameters (optional)
-                apiInstance.TestGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                apiInstance.TestGroupParameters(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             }
             catch (ApiException  e)
             {
@@ -1343,7 +1343,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint to test group parameters (optional)
-    apiInstance.TestGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+    apiInstance.TestGroupParametersWithHttpInfo(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 }
 catch (ApiException e)
 {
@@ -1357,12 +1357,12 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **requiredBooleanGroup** | **bool** | Required Boolean in group parameters |  |
 | **requiredInt64Group** | **long** | Required Integer in group parameters |  |
-| **stringGroup** | **int** | String in group parameters | [optional]  |
+| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **booleanGroup** | **bool** | Boolean in group parameters | [optional]  |
 | **int64Group** | **long** | Integer in group parameters | [optional]  |
+| **stringGroup** | **int** | String in group parameters | [optional]  |
 
 ### Return type
 
@@ -1644,7 +1644,7 @@ No authorization required
 
 <a id="testqueryparametercollectionformat"></a>
 # **TestQueryParameterCollectionFormat**
-> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, string notRequiredNotNullable = null, string notRequiredNullable = null)
+> void TestQueryParameterCollectionFormat (List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, string notRequiredNotNullable = null, string notRequiredNullable = null, string requiredNullable)
 
 
 
@@ -1667,19 +1667,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var pipe = new List<string>(); // List<string> | 
-            var ioutil = new List<string>(); // List<string> | 
-            var http = new List<string>(); // List<string> | 
-            var url = new List<string>(); // List<string> | 
             var context = new List<string>(); // List<string> | 
+            var http = new List<string>(); // List<string> | 
+            var ioutil = new List<string>(); // List<string> | 
+            var pipe = new List<string>(); // List<string> | 
             var requiredNotNullable = "requiredNotNullable_example";  // string | 
-            var requiredNullable = "requiredNullable_example";  // string | 
+            var url = new List<string>(); // List<string> | 
             var notRequiredNotNullable = "notRequiredNotNullable_example";  // string |  (optional) 
             var notRequiredNullable = "notRequiredNullable_example";  // string |  (optional) 
+            var requiredNullable = "requiredNullable_example";  // string | 
 
             try
             {
-                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                apiInstance.TestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             }
             catch (ApiException  e)
             {
@@ -1698,7 +1698,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 }
 catch (ApiException e)
 {
@@ -1712,15 +1712,15 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
-| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
-| **http** | [**List&lt;string&gt;**](string.md) |  |  |
-| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **context** | [**List&lt;string&gt;**](string.md) |  |  |
+| **http** | [**List&lt;string&gt;**](string.md) |  |  |
+| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
+| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
 | **requiredNotNullable** | **string** |  |  |
-| **requiredNullable** | **string** |  |  |
+| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **notRequiredNotNullable** | **string** |  | [optional]  |
 | **notRequiredNullable** | **string** |  | [optional]  |
+| **requiredNullable** | **string** |  |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/docs/apis/UserApi.md
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/docs/apis/UserApi.md
@@ -453,7 +453,7 @@ No authorization required
 
 <a id="loginuser"></a>
 # **LoginUser**
-> string LoginUser (string username, string password)
+> string LoginUser (string password, string username)
 
 Logs user into the system
 
@@ -474,13 +474,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | The user name for login
             var password = "password_example";  // string | The password for login in clear text
+            var username = "username_example";  // string | The user name for login
 
             try
             {
                 // Logs user into the system
-                string result = apiInstance.LoginUser(username, password);
+                string result = apiInstance.LoginUser(password, username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -501,7 +501,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Logs user into the system
-    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(username, password);
+    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(password, username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -518,8 +518,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | The user name for login |  |
 | **password** | **string** | The password for login in clear text |  |
+| **username** | **string** | The user name for login |  |
 
 ### Return type
 
@@ -625,7 +625,7 @@ No authorization required
 
 <a id="updateuser"></a>
 # **UpdateUser**
-> void UpdateUser (string username, User user)
+> void UpdateUser (User user, string username)
 
 Updated user
 
@@ -648,13 +648,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | name that need to be deleted
             var user = new User(); // User | Updated user object
+            var username = "username_example";  // string | name that need to be deleted
 
             try
             {
                 // Updated user
-                apiInstance.UpdateUser(username, user);
+                apiInstance.UpdateUser(user, username);
             }
             catch (ApiException  e)
             {
@@ -674,7 +674,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Updated user
-    apiInstance.UpdateUserWithHttpInfo(username, user);
+    apiInstance.UpdateUserWithHttpInfo(user, username);
 }
 catch (ApiException e)
 {
@@ -688,8 +688,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | name that need to be deleted |  |
 | **user** | [**User**](User.md) | Updated user object |  |
+| **username** | **string** | name that need to be deleted |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
@@ -193,20 +193,20 @@ namespace Org.OpenAPITools.Test.Api
         public async Task TestEndpointParametersAsyncTest()
         {
             decimal number = default!;
-            double varDouble = default!;
             string patternWithoutDelimiter = default!;
             byte[] varByte = default!;
-            Client.Option<int> integer = default!;
-            Client.Option<int> int32 = default!;
-            Client.Option<long> int64 = default!;
-            Client.Option<float> varFloat = default!;
-            Client.Option<string> varString = default!;
+            double varDouble = default!;
             Client.Option<System.IO.Stream> binary = default!;
+            Client.Option<string> callback = default!;
             Client.Option<DateOnly> date = default!;
             Client.Option<DateTime> dateTime = default!;
+            Client.Option<int> int32 = default!;
+            Client.Option<long> int64 = default!;
+            Client.Option<int> integer = default!;
             Client.Option<string> password = default!;
-            Client.Option<string> callback = default!;
-            await _instance.TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            Client.Option<float> varFloat = default!;
+            Client.Option<string> varString = default!;
+            await _instance.TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
         }
 
         /// <summary>
@@ -215,15 +215,15 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestEnumParametersAsyncTest()
         {
-            Client.Option<List<string>> enumHeaderStringArray = default!;
-            Client.Option<string> enumHeaderString = default!;
-            Client.Option<List<string>> enumQueryStringArray = default!;
-            Client.Option<string> enumQueryString = default!;
-            Client.Option<int> enumQueryInteger = default!;
-            Client.Option<double> enumQueryDouble = default!;
-            Client.Option<List<string>> enumFormStringArray = default!;
             Client.Option<string> enumFormString = default!;
-            await _instance.TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            Client.Option<List<string>> enumFormStringArray = default!;
+            Client.Option<string> enumHeaderString = default!;
+            Client.Option<List<string>> enumHeaderStringArray = default!;
+            Client.Option<double> enumQueryDouble = default!;
+            Client.Option<int> enumQueryInteger = default!;
+            Client.Option<string> enumQueryString = default!;
+            Client.Option<List<string>> enumQueryStringArray = default!;
+            await _instance.TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
         }
 
         /// <summary>
@@ -232,13 +232,13 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestGroupParametersAsyncTest()
         {
-            int requiredStringGroup = default!;
             bool requiredBooleanGroup = default!;
             long requiredInt64Group = default!;
-            Client.Option<int> stringGroup = default!;
+            int requiredStringGroup = default!;
             Client.Option<bool> booleanGroup = default!;
             Client.Option<long> int64Group = default!;
-            await _instance.TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            Client.Option<int> stringGroup = default!;
+            await _instance.TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
         }
 
         /// <summary>
@@ -278,16 +278,16 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestQueryParameterCollectionFormatAsyncTest()
         {
-            List<string> pipe = default!;
-            List<string> ioutil = default!;
-            List<string> http = default!;
-            List<string> url = default!;
             List<string> context = default!;
+            List<string> http = default!;
+            List<string> ioutil = default!;
+            List<string> pipe = default!;
             string requiredNotNullable = default!;
-            string? requiredNullable = default!;
+            List<string> url = default!;
             Client.Option<string> notRequiredNotNullable = default!;
             Client.Option<string?> notRequiredNullable = default!;
-            await _instance.TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            string? requiredNullable = default!;
+            await _instance.TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
@@ -108,9 +108,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task LoginUserAsyncTest()
         {
-            string username = default!;
             string password = default!;
-            var response = await _instance.LoginUserAsync(username, password);
+            string username = default!;
+            var response = await _instance.LoginUserAsync(password, username);
             var model = response.Ok();
             Assert.IsType<string>(model);
         }
@@ -130,9 +130,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task UpdateUserAsyncTest()
         {
-            string username = default!;
             User user = default!;
-            await _instance.UpdateUserAsync(username, user);
+            string username = default!;
+            await _instance.UpdateUserAsync(user, username);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -315,22 +315,22 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -339,22 +339,22 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </remarks>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>?&gt;</returns>
-        Task<ITestEndpointParametersApiResponse?> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse?> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -363,17 +363,17 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -381,17 +381,17 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test enum parameters
         /// </remarks>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>?&gt;</returns>
-        Task<ITestEnumParametersApiResponse?> TestEnumParametersOrDefaultAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse?> TestEnumParametersOrDefaultAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -400,15 +400,15 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -416,15 +416,15 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>?&gt;</returns>
-        Task<ITestGroupParametersApiResponse?> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse?> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test inline additionalProperties
@@ -504,18 +504,18 @@ namespace Org.OpenAPITools.Api
         /// To test the collection format in query parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, string? requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -523,18 +523,18 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test the collection format in query parameters
         /// </remarks>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>?&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse?> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse?> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, string? requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test referenced string map
@@ -3792,19 +3792,19 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEndpointParameters(ref decimal number, ref double varDouble, ref string patternWithoutDelimiter, ref byte[] varByte, ref Option<int> integer, ref Option<int> int32, ref Option<long> int64, ref Option<float> varFloat, ref Option<string> varString, ref Option<System.IO.Stream> binary, ref Option<DateOnly> date, ref Option<DateTime> dateTime, ref Option<string> password, ref Option<string> callback);
+        partial void FormatTestEndpointParameters(ref decimal number, ref string patternWithoutDelimiter, ref byte[] varByte, ref double varDouble, ref Option<System.IO.Stream> binary, ref Option<string> callback, ref Option<DateOnly> date, ref Option<DateTime> dateTime, ref Option<int> int32, ref Option<long> int64, ref Option<int> integer, ref Option<string> password, ref Option<float> varFloat, ref Option<string> varString);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="varString"></param>
         /// <param name="binary"></param>
-        /// <param name="password"></param>
         /// <param name="callback"></param>
+        /// <param name="password"></param>
+        /// <param name="varString"></param>
         /// <returns></returns>
-        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<string> varString, Option<System.IO.Stream> binary, Option<string> password, Option<string> callback)
+        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<System.IO.Stream> binary, Option<string> callback, Option<string> password, Option<string> varString)
         {
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
@@ -3812,17 +3812,17 @@ namespace Org.OpenAPITools.Api
             if (varByte == null)
                 throw new ArgumentNullException(nameof(varByte));
 
-            if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString));
-
             if (binary.IsSet && binary.Value == null)
                 throw new ArgumentNullException(nameof(binary));
+
+            if (callback.IsSet && callback.Value == null)
+                throw new ArgumentNullException(nameof(callback));
 
             if (password.IsSet && password.Value == null)
                 throw new ArgumentNullException(nameof(password));
 
-            if (callback.IsSet && callback.Value == null)
-                throw new ArgumentNullException(nameof(callback));
+            if (varString.IsSet && varString.Value == null)
+                throw new ArgumentNullException(nameof(varString));
         }
 
         /// <summary>
@@ -3830,23 +3830,23 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -3857,20 +3857,20 @@ namespace Org.OpenAPITools.Api
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -3879,23 +3879,23 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -3908,45 +3908,45 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateOnly> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateOnly> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트  Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse?> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse?> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback, cancellationToken).ConfigureAwait(false);
+                return await TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -3959,30 +3959,30 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateOnly> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, varString, binary, password, callback);
+                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, binary, callback, password, varString);
 
-                FormatTestEndpointParameters(ref number, ref varDouble, ref patternWithoutDelimiter, ref varByte, ref integer, ref int32, ref int64, ref varFloat, ref varString, ref binary, ref date, ref dateTime, ref password, ref callback);
+                FormatTestEndpointParameters(ref number, ref patternWithoutDelimiter, ref varByte, ref varDouble, ref binary, ref callback, ref date, ref dateTime, ref int32, ref int64, ref integer, ref password, ref varFloat, ref varString);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4001,29 +4001,17 @@ namespace Org.OpenAPITools.Api
 
                     formParameterLocalVars.Add(new KeyValuePair<string?, string?>("number", ClientUtils.ParameterToString(number)));
 
-                    formParameterLocalVars.Add(new KeyValuePair<string?, string?>("double", ClientUtils.ParameterToString(varDouble)));
-
                     formParameterLocalVars.Add(new KeyValuePair<string?, string?>("pattern_without_delimiter", ClientUtils.ParameterToString(patternWithoutDelimiter)));
 
                     formParameterLocalVars.Add(new KeyValuePair<string?, string?>("byte", ClientUtils.ParameterToString(varByte)));
 
-                    if (integer.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("integer", ClientUtils.ParameterToString(integer.Value)));
-
-                    if (int32.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("int32", ClientUtils.ParameterToString(int32.Value)));
-
-                    if (int64.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("int64", ClientUtils.ParameterToString(int64.Value)));
-
-                    if (varFloat.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("float", ClientUtils.ParameterToString(varFloat.Value)));
-
-                    if (varString.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("string", ClientUtils.ParameterToString(varString.Value)));
+                    formParameterLocalVars.Add(new KeyValuePair<string?, string?>("double", ClientUtils.ParameterToString(varDouble)));
 
                     if (binary.IsSet)
                         multipartContentLocalVar.Add(new StreamContent(binary.Value));
+
+                    if (callback.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("callback", ClientUtils.ParameterToString(callback.Value)));
 
                     if (date.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string?, string?>("date", ClientUtils.ParameterToString(date.Value)));
@@ -4031,11 +4019,23 @@ namespace Org.OpenAPITools.Api
                     if (dateTime.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string?, string?>("dateTime", ClientUtils.ParameterToString(dateTime.Value)));
 
+                    if (int32.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("int32", ClientUtils.ParameterToString(int32.Value)));
+
+                    if (int64.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("int64", ClientUtils.ParameterToString(int64.Value)));
+
+                    if (integer.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("integer", ClientUtils.ParameterToString(integer.Value)));
+
                     if (password.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string?, string?>("password", ClientUtils.ParameterToString(password.Value)));
 
-                    if (callback.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("callback", ClientUtils.ParameterToString(callback.Value)));
+                    if (varFloat.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("float", ClientUtils.ParameterToString(varFloat.Value)));
+
+                    if (varString.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("string", ClientUtils.ParameterToString(varString.Value)));
 
                     List<TokenBase> tokenBaseLocalVars = new List<TokenBase>();
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
@@ -4067,7 +4067,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEndpointParametersApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 
                         Events.ExecuteOnTestEndpointParameters(apiResponseLocalVar);
 
@@ -4081,7 +4081,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
                 Events.ExecuteOnErrorTestEndpointParameters(e);
                 throw;
             }
@@ -4138,55 +4138,55 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEnumParameters(Option<List<string>> enumHeaderStringArray, ref Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, ref Option<string> enumQueryString, ref Option<int> enumQueryInteger, ref Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, ref Option<string> enumFormString);
+        partial void FormatTestEnumParameters(ref Option<string> enumFormString, Option<List<string>> enumFormStringArray, ref Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, ref Option<double> enumQueryDouble, ref Option<int> enumQueryInteger, ref Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
         /// <returns></returns>
-        private void ValidateTestEnumParameters(Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        private void ValidateTestEnumParameters(Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
-            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderStringArray));
-
-            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderString));
-
-            if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumQueryStringArray));
-
-            if (enumQueryString.IsSet && enumQueryString.Value == null)
-                throw new ArgumentNullException(nameof(enumQueryString));
+            if (enumFormString.IsSet && enumFormString.Value == null)
+                throw new ArgumentNullException(nameof(enumFormString));
 
             if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumFormStringArray));
 
-            if (enumFormString.IsSet && enumFormString.Value == null)
-                throw new ArgumentNullException(nameof(enumFormString));
+            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderString));
+
+            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderStringArray));
+
+            if (enumQueryString.IsSet && enumQueryString.Value == null)
+                throw new ArgumentNullException(nameof(enumQueryString));
+
+            if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumQueryStringArray));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4196,15 +4196,15 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4212,18 +4212,18 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4235,34 +4235,34 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// To test enum parameters To test enum parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse?> TestEnumParametersOrDefaultAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse?> TestEnumParametersOrDefaultAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, cancellationToken).ConfigureAwait(false);
+                return await TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4274,25 +4274,25 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumFormStringArray, enumFormString);
+                ValidateTestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryString, enumQueryStringArray);
 
-                FormatTestEnumParameters(enumHeaderStringArray, ref enumHeaderString, enumQueryStringArray, ref enumQueryString, ref enumQueryInteger, ref enumQueryDouble, enumFormStringArray, ref enumFormString);
+                FormatTestEnumParameters(ref enumFormString, enumFormStringArray, ref enumHeaderString, enumHeaderStringArray, ref enumQueryDouble, ref enumQueryInteger, ref enumQueryString, enumQueryStringArray);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4303,25 +4303,25 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    if (enumQueryStringArray.IsSet)
-                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
-
-                    if (enumQueryString.IsSet)
-                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+                    if (enumQueryDouble.IsSet)
+                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
 
                     if (enumQueryInteger.IsSet)
                         parseQueryStringLocalVar["enum_query_integer"] = ClientUtils.ParameterToString(enumQueryInteger.Value);
 
-                    if (enumQueryDouble.IsSet)
-                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
+                    if (enumQueryString.IsSet)
+                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+
+                    if (enumQueryStringArray.IsSet)
+                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
-                    if (enumHeaderStringArray.IsSet)
-                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
-
                     if (enumHeaderString.IsSet)
                         httpRequestMessageLocalVar.Headers.Add("enum_header_string", ClientUtils.ParameterToString(enumHeaderString.Value));
+
+                    if (enumHeaderStringArray.IsSet)
+                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
 
                     MultipartContent multipartContentLocalVar = new MultipartContent();
 
@@ -4329,11 +4329,11 @@ namespace Org.OpenAPITools.Api
 
                     List<KeyValuePair<string?, string?>> formParameterLocalVars = new List<KeyValuePair<string?, string?>>();
 
-                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormStringArray.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
-
-                    if (enumFormString.IsSet)
+                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormString.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string?, string?>("enum_form_string", ClientUtils.ParameterToString(enumFormString.Value)));
+
+                    if (enumFormStringArray.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string?, string?>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
 
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
 
@@ -4358,7 +4358,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEnumParametersApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 
                         Events.ExecuteOnTestEnumParameters(apiResponseLocalVar);
 
@@ -4368,7 +4368,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
                 Events.ExecuteOnErrorTestEnumParameters(e);
                 throw;
             }
@@ -4425,22 +4425,22 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestGroupParameters(ref int requiredStringGroup, ref bool requiredBooleanGroup, ref long requiredInt64Group, ref Option<int> stringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group);
+        partial void FormatTestGroupParameters(ref bool requiredBooleanGroup, ref long requiredInt64Group, ref int requiredStringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group, ref Option<int> stringGroup);
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4450,13 +4450,13 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4464,16 +4464,16 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4485,30 +4485,30 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse?> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse?> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, cancellationToken).ConfigureAwait(false);
+                return await TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4520,21 +4520,21 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                FormatTestGroupParameters(ref requiredStringGroup, ref requiredBooleanGroup, ref requiredInt64Group, ref stringGroup, ref booleanGroup, ref int64Group);
+                FormatTestGroupParameters(ref requiredBooleanGroup, ref requiredInt64Group, ref requiredStringGroup, ref booleanGroup, ref int64Group, ref stringGroup);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4545,14 +4545,14 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
                     parseQueryStringLocalVar["required_int64_group"] = ClientUtils.ParameterToString(requiredInt64Group);
-
-                    if (stringGroup.IsSet)
-                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
+                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
 
                     if (int64Group.IsSet)
                         parseQueryStringLocalVar["int64_group"] = ClientUtils.ParameterToString(int64Group.Value);
+
+                    if (stringGroup.IsSet)
+                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -4582,7 +4582,7 @@ namespace Org.OpenAPITools.Api
 
                         TestGroupParametersApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 
                         Events.ExecuteOnTestGroupParameters(apiResponseLocalVar);
 
@@ -4596,7 +4596,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
                 Events.ExecuteOnErrorTestGroupParameters(e);
                 throw;
             }
@@ -5232,38 +5232,38 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, ref string requiredNotNullable, ref string? requiredNullable, ref Option<string> notRequiredNotNullable, ref Option<string?> notRequiredNullable);
+        partial void FormatTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, ref string requiredNotNullable, List<string> url, ref Option<string> notRequiredNotNullable, ref Option<string?> notRequiredNullable, ref string? requiredNullable);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <returns></returns>
-        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, Option<string> notRequiredNotNullable)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable)
         {
-            if (pipe == null)
-                throw new ArgumentNullException(nameof(pipe));
-
-            if (ioutil == null)
-                throw new ArgumentNullException(nameof(ioutil));
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
 
             if (http == null)
                 throw new ArgumentNullException(nameof(http));
 
-            if (url == null)
-                throw new ArgumentNullException(nameof(url));
+            if (ioutil == null)
+                throw new ArgumentNullException(nameof(ioutil));
 
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
+            if (pipe == null)
+                throw new ArgumentNullException(nameof(pipe));
 
             if (requiredNotNullable == null)
                 throw new ArgumentNullException(nameof(requiredNotNullable));
+
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
 
             if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
                 throw new ArgumentNullException(nameof(notRequiredNotNullable));
@@ -5273,19 +5273,19 @@ namespace Org.OpenAPITools.Api
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable, string? requiredNullable)
         {
             bool suppressDefaultLog = false;
-            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -5295,16 +5295,16 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable, string? requiredNullable);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -5312,19 +5312,19 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable, string? requiredNullable)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -5336,36 +5336,36 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string?> notRequiredNullable, string? requiredNullable);
 
         /// <summary>
         ///  To test the collection format in query parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse?> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse?> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, string? requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable, cancellationToken).ConfigureAwait(false);
+                return await TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -5377,26 +5377,26 @@ namespace Org.OpenAPITools.Api
         ///  To test the collection format in query parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string? requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string?> notRequiredNullable = default, string? requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, notRequiredNotNullable);
+                ValidateTestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable);
 
-                FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, ref requiredNotNullable, ref requiredNullable, ref notRequiredNotNullable, ref notRequiredNullable);
+                FormatTestQueryParameterCollectionFormat(context, http, ioutil, pipe, ref requiredNotNullable, url, ref notRequiredNotNullable, ref notRequiredNullable, ref requiredNullable);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -5407,12 +5407,12 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
-                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
-                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
-                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["context"] = ClientUtils.ParameterToString(context);
+                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
+                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
+                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
                     parseQueryStringLocalVar["requiredNotNullable"] = ClientUtils.ParameterToString(requiredNotNullable);
+                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["requiredNullable"] = ClientUtils.ParameterToString(requiredNullable);
 
                     if (notRequiredNotNullable.IsSet)
@@ -5437,7 +5437,7 @@ namespace Org.OpenAPITools.Api
 
                         TestQueryParameterCollectionFormatApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake/test-query-parameters", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 
                         Events.ExecuteOnTestQueryParameterCollectionFormat(apiResponseLocalVar);
 
@@ -5447,7 +5447,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
                 Events.ExecuteOnErrorTestQueryParameterCollectionFormat(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Api/UserApi.cs
@@ -158,11 +158,11 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs user into the system
@@ -170,11 +170,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>?&gt;</returns>
-        Task<ILoginUserApiResponse?> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse?> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs out current logged in user session
@@ -204,11 +204,11 @@ namespace Org.OpenAPITools.Api
         /// This can only be done by the logged in user.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updated user
@@ -216,11 +216,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// This can only be done by the logged in user.
         /// </remarks>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>?&gt;</returns>
-        Task<IUpdateUserApiResponse?> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse?> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
     }
 
     /// <summary>
@@ -1634,33 +1634,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatLoginUser(ref string username, ref string password);
+        partial void FormatLoginUser(ref string password, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="password"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateLoginUser(string username, string password)
+        private void ValidateLoginUser(string password, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (password == null)
                 throw new ArgumentNullException(nameof(password));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string username, string password)
+        /// <param name="username"></param>
+        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string password, string username)
         {
             bool suppressDefaultLog = false;
-            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, username, password);
+            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, password, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -1670,9 +1670,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string username, string password);
+        /// <param name="username"></param>
+        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string password, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -1680,12 +1680,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, string password)
+        /// <param name="username"></param>
+        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string password, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, username, password);
+            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, password, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -1697,22 +1697,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, string password);
+        /// <param name="username"></param>
+        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string password, string username);
 
         /// <summary>
         /// Logs user into the system 
         /// </summary>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse?> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse?> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await LoginUserAsync(username, password, cancellationToken).ConfigureAwait(false);
+                return await LoginUserAsync(password, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -1724,19 +1724,19 @@ namespace Org.OpenAPITools.Api
         /// Logs user into the system 
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateLoginUser(username, password);
+                ValidateLoginUser(password, username);
 
-                FormatLoginUser(ref username, ref password);
+                FormatLoginUser(ref password, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1747,8 +1747,8 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
                     parseQueryStringLocalVar["password"] = ClientUtils.ParameterToString(password);
+                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -1776,7 +1776,7 @@ namespace Org.OpenAPITools.Api
 
                         LoginUserApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/login", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, username, password);
+                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, password, username);
 
                         Events.ExecuteOnLoginUser(apiResponseLocalVar);
 
@@ -1813,7 +1813,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, username, password);
+                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, password, username);
                 Events.ExecuteOnErrorLoginUser(e);
                 throw;
             }
@@ -2055,33 +2055,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatUpdateUser(ref string username, User user);
+        partial void FormatUpdateUser(User user, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="user"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateUpdateUser(string username, User user)
+        private void ValidateUpdateUser(User user, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, string username, User user)
+        /// <param name="username"></param>
+        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, User user, string username)
         {
             bool suppressDefaultLog = false;
-            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, username, user);
+            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, user, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -2091,9 +2091,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, string username, User user);
+        /// <param name="username"></param>
+        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, User user, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -2101,12 +2101,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, User user)
+        /// <param name="username"></param>
+        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, User user, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, username, user);
+            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, user, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -2118,22 +2118,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, User user);
+        /// <param name="username"></param>
+        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, User user, string username);
 
         /// <summary>
         /// Updated user This can only be done by the logged in user.
         /// </summary>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse?> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse?> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await UpdateUserAsync(username, user, cancellationToken).ConfigureAwait(false);
+                return await UpdateUserAsync(user, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -2145,19 +2145,19 @@ namespace Org.OpenAPITools.Api
         /// Updated user This can only be done by the logged in user.
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateUpdateUser(username, user);
+                ValidateUpdateUser(user, username);
 
-                FormatUpdateUser(ref username, user);
+                FormatUpdateUser(user, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2194,7 +2194,7 @@ namespace Org.OpenAPITools.Api
 
                         UpdateUserApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/{username}", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, username, user);
+                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, user, username);
 
                         Events.ExecuteOnUpdateUser(apiResponseLocalVar);
 
@@ -2204,7 +2204,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, username, user);
+                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, user, username);
                 Events.ExecuteOnErrorUpdateUser(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/docs/apis/FakeApi.md
@@ -1067,7 +1067,7 @@ No authorization required
 
 <a id="testendpointparameters"></a>
 # **TestEndpointParameters**
-> void TestEndpointParameters (decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, int integer = null, int int32 = null, long int64 = null, float varFloat = null, string varString = null, System.IO.Stream binary = null, DateTime date = null, DateTime dateTime = null, string password = null, string callback = null)
+> void TestEndpointParameters (decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, System.IO.Stream binary = null, string callback = null, DateTime date = null, DateTime dateTime = null, int int32 = null, long int64 = null, int integer = null, string password = null, float varFloat = null, string varString = null)
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
@@ -1095,24 +1095,24 @@ namespace Example
 
             var apiInstance = new FakeApi(config);
             var number = 8.14D;  // decimal | None
-            var varDouble = 1.2D;  // double | None
             var patternWithoutDelimiter = "patternWithoutDelimiter_example";  // string | None
             var varByte = System.Text.Encoding.ASCII.GetBytes("BYTE_ARRAY_DATA_HERE");  // byte[] | None
-            var integer = 56;  // int | None (optional) 
-            var int32 = 56;  // int | None (optional) 
-            var int64 = 789L;  // long | None (optional) 
-            var varFloat = 3.4F;  // float | None (optional) 
-            var varString = "varString_example";  // string | None (optional) 
+            var varDouble = 1.2D;  // double | None
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
+            var callback = "callback_example";  // string | None (optional) 
             var date = DateTime.Parse("2013-10-20");  // DateTime | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")
+            var int32 = 56;  // int | None (optional) 
+            var int64 = 789L;  // long | None (optional) 
+            var integer = 56;  // int | None (optional) 
             var password = "password_example";  // string | None (optional) 
-            var callback = "callback_example";  // string | None (optional) 
+            var varFloat = 3.4F;  // float | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
 
             try
             {
                 // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-                apiInstance.TestEndpointParameters(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                apiInstance.TestEndpointParameters(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             }
             catch (ApiException  e)
             {
@@ -1132,7 +1132,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    apiInstance.TestEndpointParametersWithHttpInfo(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+    apiInstance.TestEndpointParametersWithHttpInfo(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 }
 catch (ApiException e)
 {
@@ -1147,19 +1147,19 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **number** | **decimal** | None |  |
-| **varDouble** | **double** | None |  |
 | **patternWithoutDelimiter** | **string** | None |  |
 | **varByte** | **byte[]** | None |  |
-| **integer** | **int** | None | [optional]  |
-| **int32** | **int** | None | [optional]  |
-| **int64** | **long** | None | [optional]  |
-| **varFloat** | **float** | None | [optional]  |
-| **varString** | **string** | None | [optional]  |
+| **varDouble** | **double** | None |  |
 | **binary** | **System.IO.Stream****System.IO.Stream** | None | [optional]  |
+| **callback** | **string** | None | [optional]  |
 | **date** | **DateTime** | None | [optional]  |
 | **dateTime** | **DateTime** | None | [optional] [default to &quot;2010-02-01T10:20:10.111110+01:00&quot;] |
+| **int32** | **int** | None | [optional]  |
+| **int64** | **long** | None | [optional]  |
+| **integer** | **int** | None | [optional]  |
 | **password** | **string** | None | [optional]  |
-| **callback** | **string** | None | [optional]  |
+| **varFloat** | **float** | None | [optional]  |
+| **varString** | **string** | None | [optional]  |
 
 ### Return type
 
@@ -1185,7 +1185,7 @@ void (empty response body)
 
 <a id="testenumparameters"></a>
 # **TestEnumParameters**
-> void TestEnumParameters (List<string> enumHeaderStringArray = null, string enumHeaderString = null, List<string> enumQueryStringArray = null, string enumQueryString = null, int enumQueryInteger = null, double enumQueryDouble = null, List<string> enumFormStringArray = null, string enumFormString = null)
+> void TestEnumParameters (string enumFormString = null, List<string> enumFormStringArray = null, string enumHeaderString = null, List<string> enumHeaderStringArray = null, double enumQueryDouble = null, int enumQueryInteger = null, string enumQueryString = null, List<string> enumQueryStringArray = null)
 
 To test enum parameters
 
@@ -1208,19 +1208,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var enumHeaderStringArray = new List<string>(); // List<string> | Header parameter enum test (string array) (optional) 
-            var enumHeaderString = "_abc";  // string | Header parameter enum test (string) (optional)  (default to -efg)
-            var enumQueryStringArray = new List<string>(); // List<string> | Query parameter enum test (string array) (optional) 
-            var enumQueryString = "_abc";  // string | Query parameter enum test (string) (optional)  (default to -efg)
-            var enumQueryInteger = 1;  // int | Query parameter enum test (double) (optional) 
-            var enumQueryDouble = 1.1D;  // double | Query parameter enum test (double) (optional) 
-            var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional)  (default to $)
             var enumFormString = "_abc";  // string | Form parameter enum test (string) (optional)  (default to -efg)
+            var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional)  (default to $)
+            var enumHeaderString = "_abc";  // string | Header parameter enum test (string) (optional)  (default to -efg)
+            var enumHeaderStringArray = new List<string>(); // List<string> | Header parameter enum test (string array) (optional) 
+            var enumQueryDouble = 1.1D;  // double | Query parameter enum test (double) (optional) 
+            var enumQueryInteger = 1;  // int | Query parameter enum test (double) (optional) 
+            var enumQueryString = "_abc";  // string | Query parameter enum test (string) (optional)  (default to -efg)
+            var enumQueryStringArray = new List<string>(); // List<string> | Query parameter enum test (string array) (optional) 
 
             try
             {
                 // To test enum parameters
-                apiInstance.TestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                apiInstance.TestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             }
             catch (ApiException  e)
             {
@@ -1240,7 +1240,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test enum parameters
-    apiInstance.TestEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+    apiInstance.TestEnumParametersWithHttpInfo(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 }
 catch (ApiException e)
 {
@@ -1254,14 +1254,14 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **enumHeaderStringArray** | [**List&lt;string&gt;**](string.md) | Header parameter enum test (string array) | [optional]  |
-| **enumHeaderString** | **string** | Header parameter enum test (string) | [optional] [default to -efg] |
-| **enumQueryStringArray** | [**List&lt;string&gt;**](string.md) | Query parameter enum test (string array) | [optional]  |
-| **enumQueryString** | **string** | Query parameter enum test (string) | [optional] [default to -efg] |
-| **enumQueryInteger** | **int** | Query parameter enum test (double) | [optional]  |
-| **enumQueryDouble** | **double** | Query parameter enum test (double) | [optional]  |
-| **enumFormStringArray** | [**List&lt;string&gt;**](string.md) | Form parameter enum test (string array) | [optional] [default to $] |
 | **enumFormString** | **string** | Form parameter enum test (string) | [optional] [default to -efg] |
+| **enumFormStringArray** | [**List&lt;string&gt;**](string.md) | Form parameter enum test (string array) | [optional] [default to $] |
+| **enumHeaderString** | **string** | Header parameter enum test (string) | [optional] [default to -efg] |
+| **enumHeaderStringArray** | [**List&lt;string&gt;**](string.md) | Header parameter enum test (string array) | [optional]  |
+| **enumQueryDouble** | **double** | Query parameter enum test (double) | [optional]  |
+| **enumQueryInteger** | **int** | Query parameter enum test (double) | [optional]  |
+| **enumQueryString** | **string** | Query parameter enum test (string) | [optional] [default to -efg] |
+| **enumQueryStringArray** | [**List&lt;string&gt;**](string.md) | Query parameter enum test (string array) | [optional]  |
 
 ### Return type
 
@@ -1287,7 +1287,7 @@ No authorization required
 
 <a id="testgroupparameters"></a>
 # **TestGroupParameters**
-> void TestGroupParameters (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int stringGroup = null, bool booleanGroup = null, long int64Group = null)
+> void TestGroupParameters (bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, bool booleanGroup = null, long int64Group = null, int stringGroup = null)
 
 Fake endpoint to test group parameters (optional)
 
@@ -1313,17 +1313,17 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new FakeApi(config);
-            var requiredStringGroup = 56;  // int | Required String in group parameters
             var requiredBooleanGroup = true;  // bool | Required Boolean in group parameters
             var requiredInt64Group = 789L;  // long | Required Integer in group parameters
-            var stringGroup = 56;  // int | String in group parameters (optional) 
+            var requiredStringGroup = 56;  // int | Required String in group parameters
             var booleanGroup = true;  // bool | Boolean in group parameters (optional) 
             var int64Group = 789L;  // long | Integer in group parameters (optional) 
+            var stringGroup = 56;  // int | String in group parameters (optional) 
 
             try
             {
                 // Fake endpoint to test group parameters (optional)
-                apiInstance.TestGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                apiInstance.TestGroupParameters(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             }
             catch (ApiException  e)
             {
@@ -1343,7 +1343,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Fake endpoint to test group parameters (optional)
-    apiInstance.TestGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+    apiInstance.TestGroupParametersWithHttpInfo(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 }
 catch (ApiException e)
 {
@@ -1357,12 +1357,12 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **requiredBooleanGroup** | **bool** | Required Boolean in group parameters |  |
 | **requiredInt64Group** | **long** | Required Integer in group parameters |  |
-| **stringGroup** | **int** | String in group parameters | [optional]  |
+| **requiredStringGroup** | **int** | Required String in group parameters |  |
 | **booleanGroup** | **bool** | Boolean in group parameters | [optional]  |
 | **int64Group** | **long** | Integer in group parameters | [optional]  |
+| **stringGroup** | **int** | String in group parameters | [optional]  |
 
 ### Return type
 
@@ -1644,7 +1644,7 @@ No authorization required
 
 <a id="testqueryparametercollectionformat"></a>
 # **TestQueryParameterCollectionFormat**
-> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, string notRequiredNotNullable = null, string notRequiredNullable = null)
+> void TestQueryParameterCollectionFormat (List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, string notRequiredNotNullable = null, string notRequiredNullable = null, string requiredNullable)
 
 
 
@@ -1667,19 +1667,19 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new FakeApi(config);
-            var pipe = new List<string>(); // List<string> | 
-            var ioutil = new List<string>(); // List<string> | 
-            var http = new List<string>(); // List<string> | 
-            var url = new List<string>(); // List<string> | 
             var context = new List<string>(); // List<string> | 
+            var http = new List<string>(); // List<string> | 
+            var ioutil = new List<string>(); // List<string> | 
+            var pipe = new List<string>(); // List<string> | 
             var requiredNotNullable = "requiredNotNullable_example";  // string | 
-            var requiredNullable = "requiredNullable_example";  // string | 
+            var url = new List<string>(); // List<string> | 
             var notRequiredNotNullable = "notRequiredNotNullable_example";  // string |  (optional) 
             var notRequiredNullable = "notRequiredNullable_example";  // string |  (optional) 
+            var requiredNullable = "requiredNullable_example";  // string | 
 
             try
             {
-                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                apiInstance.TestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             }
             catch (ApiException  e)
             {
@@ -1698,7 +1698,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+    apiInstance.TestQueryParameterCollectionFormatWithHttpInfo(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 }
 catch (ApiException e)
 {
@@ -1712,15 +1712,15 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
-| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
-| **http** | [**List&lt;string&gt;**](string.md) |  |  |
-| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **context** | [**List&lt;string&gt;**](string.md) |  |  |
+| **http** | [**List&lt;string&gt;**](string.md) |  |  |
+| **ioutil** | [**List&lt;string&gt;**](string.md) |  |  |
+| **pipe** | [**List&lt;string&gt;**](string.md) |  |  |
 | **requiredNotNullable** | **string** |  |  |
-| **requiredNullable** | **string** |  |  |
+| **url** | [**List&lt;string&gt;**](string.md) |  |  |
 | **notRequiredNotNullable** | **string** |  | [optional]  |
 | **notRequiredNullable** | **string** |  | [optional]  |
+| **requiredNullable** | **string** |  |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/docs/apis/UserApi.md
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/docs/apis/UserApi.md
@@ -453,7 +453,7 @@ No authorization required
 
 <a id="loginuser"></a>
 # **LoginUser**
-> string LoginUser (string username, string password)
+> string LoginUser (string password, string username)
 
 Logs user into the system
 
@@ -474,13 +474,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | The user name for login
             var password = "password_example";  // string | The password for login in clear text
+            var username = "username_example";  // string | The user name for login
 
             try
             {
                 // Logs user into the system
-                string result = apiInstance.LoginUser(username, password);
+                string result = apiInstance.LoginUser(password, username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -501,7 +501,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Logs user into the system
-    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(username, password);
+    ApiResponse<string> response = apiInstance.LoginUserWithHttpInfo(password, username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -518,8 +518,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | The user name for login |  |
 | **password** | **string** | The password for login in clear text |  |
+| **username** | **string** | The user name for login |  |
 
 ### Return type
 
@@ -625,7 +625,7 @@ No authorization required
 
 <a id="updateuser"></a>
 # **UpdateUser**
-> void UpdateUser (string username, User user)
+> void UpdateUser (User user, string username)
 
 Updated user
 
@@ -648,13 +648,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://petstore.swagger.io:80/v2";
             var apiInstance = new UserApi(config);
-            var username = "username_example";  // string | name that need to be deleted
             var user = new User(); // User | Updated user object
+            var username = "username_example";  // string | name that need to be deleted
 
             try
             {
                 // Updated user
-                apiInstance.UpdateUser(username, user);
+                apiInstance.UpdateUser(user, username);
             }
             catch (ApiException  e)
             {
@@ -674,7 +674,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Updated user
-    apiInstance.UpdateUserWithHttpInfo(username, user);
+    apiInstance.UpdateUserWithHttpInfo(user, username);
 }
 catch (ApiException e)
 {
@@ -688,8 +688,8 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **username** | **string** | name that need to be deleted |  |
 | **user** | [**User**](User.md) | Updated user object |  |
+| **username** | **string** | name that need to be deleted |  |
 
 ### Return type
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools.Test/Api/FakeApiTests.cs
@@ -193,20 +193,20 @@ namespace Org.OpenAPITools.Test.Api
         public async Task TestEndpointParametersAsyncTest()
         {
             decimal number = default;
-            double varDouble = default;
             string patternWithoutDelimiter = default;
             byte[] varByte = default;
-            Client.Option<int> integer = default;
-            Client.Option<int> int32 = default;
-            Client.Option<long> int64 = default;
-            Client.Option<float> varFloat = default;
-            Client.Option<string> varString = default;
+            double varDouble = default;
             Client.Option<System.IO.Stream> binary = default;
+            Client.Option<string> callback = default;
             Client.Option<DateTime> date = default;
             Client.Option<DateTime> dateTime = default;
+            Client.Option<int> int32 = default;
+            Client.Option<long> int64 = default;
+            Client.Option<int> integer = default;
             Client.Option<string> password = default;
-            Client.Option<string> callback = default;
-            await _instance.TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            Client.Option<float> varFloat = default;
+            Client.Option<string> varString = default;
+            await _instance.TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
         }
 
         /// <summary>
@@ -215,15 +215,15 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestEnumParametersAsyncTest()
         {
-            Client.Option<List<string>> enumHeaderStringArray = default;
-            Client.Option<string> enumHeaderString = default;
-            Client.Option<List<string>> enumQueryStringArray = default;
-            Client.Option<string> enumQueryString = default;
-            Client.Option<int> enumQueryInteger = default;
-            Client.Option<double> enumQueryDouble = default;
-            Client.Option<List<string>> enumFormStringArray = default;
             Client.Option<string> enumFormString = default;
-            await _instance.TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            Client.Option<List<string>> enumFormStringArray = default;
+            Client.Option<string> enumHeaderString = default;
+            Client.Option<List<string>> enumHeaderStringArray = default;
+            Client.Option<double> enumQueryDouble = default;
+            Client.Option<int> enumQueryInteger = default;
+            Client.Option<string> enumQueryString = default;
+            Client.Option<List<string>> enumQueryStringArray = default;
+            await _instance.TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
         }
 
         /// <summary>
@@ -232,13 +232,13 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestGroupParametersAsyncTest()
         {
-            int requiredStringGroup = default;
             bool requiredBooleanGroup = default;
             long requiredInt64Group = default;
-            Client.Option<int> stringGroup = default;
+            int requiredStringGroup = default;
             Client.Option<bool> booleanGroup = default;
             Client.Option<long> int64Group = default;
-            await _instance.TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            Client.Option<int> stringGroup = default;
+            await _instance.TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
         }
 
         /// <summary>
@@ -278,16 +278,16 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task TestQueryParameterCollectionFormatAsyncTest()
         {
-            List<string> pipe = default;
-            List<string> ioutil = default;
-            List<string> http = default;
-            List<string> url = default;
             List<string> context = default;
+            List<string> http = default;
+            List<string> ioutil = default;
+            List<string> pipe = default;
             string requiredNotNullable = default;
-            string requiredNullable = default;
+            List<string> url = default;
             Client.Option<string> notRequiredNotNullable = default;
             Client.Option<string> notRequiredNullable = default;
-            await _instance.TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            string requiredNullable = default;
+            await _instance.TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools.Test/Api/UserApiTests.cs
@@ -108,9 +108,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task LoginUserAsyncTest()
         {
-            string username = default;
             string password = default;
-            var response = await _instance.LoginUserAsync(username, password);
+            string username = default;
+            var response = await _instance.LoginUserAsync(password, username);
             var model = response.Ok();
             Assert.IsType<string>(model);
         }
@@ -130,9 +130,9 @@ namespace Org.OpenAPITools.Test.Api
         [Fact (Skip = "not implemented")]
         public async Task UpdateUserAsyncTest()
         {
-            string username = default;
             User user = default;
-            await _instance.UpdateUserAsync(username, user);
+            string username = default;
+            await _instance.UpdateUserAsync(user, username);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -312,22 +312,22 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -336,22 +336,22 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </remarks>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -360,17 +360,17 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// To test enum parameters
@@ -378,17 +378,17 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test enum parameters
         /// </remarks>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -397,15 +397,15 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -413,15 +413,15 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// Fake endpoint to test group parameters (optional)
         /// </remarks>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test inline additionalProperties
@@ -501,18 +501,18 @@ namespace Org.OpenAPITools.Api
         /// To test the collection format in query parameters
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -520,18 +520,18 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// To test the collection format in query parameters
         /// </remarks>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
+        Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// test referenced string map
@@ -3780,19 +3780,19 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEndpointParameters(ref decimal number, ref double varDouble, ref string patternWithoutDelimiter, ref byte[] varByte, ref Option<int> integer, ref Option<int> int32, ref Option<long> int64, ref Option<float> varFloat, ref Option<string> varString, ref Option<System.IO.Stream> binary, ref Option<DateTime> date, ref Option<DateTime> dateTime, ref Option<string> password, ref Option<string> callback);
+        partial void FormatTestEndpointParameters(ref decimal number, ref string patternWithoutDelimiter, ref byte[] varByte, ref double varDouble, ref Option<System.IO.Stream> binary, ref Option<string> callback, ref Option<DateTime> date, ref Option<DateTime> dateTime, ref Option<int> int32, ref Option<long> int64, ref Option<int> integer, ref Option<string> password, ref Option<float> varFloat, ref Option<string> varString);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="varString"></param>
         /// <param name="binary"></param>
-        /// <param name="password"></param>
         /// <param name="callback"></param>
+        /// <param name="password"></param>
+        /// <param name="varString"></param>
         /// <returns></returns>
-        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<string> varString, Option<System.IO.Stream> binary, Option<string> password, Option<string> callback)
+        private void ValidateTestEndpointParameters(string patternWithoutDelimiter, byte[] varByte, Option<System.IO.Stream> binary, Option<string> callback, Option<string> password, Option<string> varString)
         {
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
@@ -3800,17 +3800,17 @@ namespace Org.OpenAPITools.Api
             if (varByte == null)
                 throw new ArgumentNullException(nameof(varByte));
 
-            if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString));
-
             if (binary.IsSet && binary.Value == null)
                 throw new ArgumentNullException(nameof(binary));
+
+            if (callback.IsSet && callback.Value == null)
+                throw new ArgumentNullException(nameof(callback));
 
             if (password.IsSet && password.Value == null)
                 throw new ArgumentNullException(nameof(password));
 
-            if (callback.IsSet && callback.Value == null)
-                throw new ArgumentNullException(nameof(callback));
+            if (varString.IsSet && varString.Value == null)
+                throw new ArgumentNullException(nameof(varString));
         }
 
         /// <summary>
@@ -3818,23 +3818,23 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void AfterTestEndpointParametersDefaultImplementation(ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            AfterTestEndpointParameters(ref suppressDefaultLog, apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -3845,20 +3845,20 @@ namespace Org.OpenAPITools.Api
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void AfterTestEndpointParameters(ref bool suppressDefaultLog, ITestEndpointParametersApiResponse apiResponseLocalVar, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -3867,23 +3867,23 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback)
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        private void OnErrorTestEndpointParametersDefaultImplementation(Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+            OnErrorTestEndpointParameters(ref suppressDefaultLog, exception, pathFormat, path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -3896,45 +3896,45 @@ namespace Org.OpenAPITools.Api
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
         /// <param name="number"></param>
-        /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="varByte"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="varString"></param>
+        /// <param name="varDouble"></param>
         /// <param name="binary"></param>
+        /// <param name="callback"></param>
         /// <param name="date"></param>
         /// <param name="dateTime"></param>
+        /// <param name="int32"></param>
+        /// <param name="int64"></param>
+        /// <param name="integer"></param>
         /// <param name="password"></param>
-        /// <param name="callback"></param>
-        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer, Option<int> int32, Option<long> int64, Option<float> varFloat, Option<string> varString, Option<System.IO.Stream> binary, Option<DateTime> date, Option<DateTime> dateTime, Option<string> password, Option<string> callback);
+        /// <param name="varFloat"></param>
+        /// <param name="varString"></param>
+        partial void OnErrorTestEndpointParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary, Option<string> callback, Option<DateTime> date, Option<DateTime> dateTime, Option<int> int32, Option<long> int64, Option<int> integer, Option<string> password, Option<float> varFloat, Option<string> varString);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트  Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersOrDefaultAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEndpointParametersAsync(number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback, cancellationToken).ConfigureAwait(false);
+                return await TestEndpointParametersAsync(number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -3947,30 +3947,30 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="number">None</param>
-        /// <param name="varDouble">None</param>
         /// <param name="patternWithoutDelimiter">None</param>
         /// <param name="varByte">None</param>
-        /// <param name="integer">None (optional)</param>
-        /// <param name="int32">None (optional)</param>
-        /// <param name="int64">None (optional)</param>
-        /// <param name="varFloat">None (optional)</param>
-        /// <param name="varString">None (optional)</param>
+        /// <param name="varDouble">None</param>
         /// <param name="binary">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional, default to &quot;2010-02-01T10:20:10.111110+01:00&quot;)</param>
+        /// <param name="int32">None (optional)</param>
+        /// <param name="int64">None (optional)</param>
+        /// <param name="integer">None (optional)</param>
         /// <param name="password">None (optional)</param>
-        /// <param name="callback">None (optional)</param>
+        /// <param name="varFloat">None (optional)</param>
+        /// <param name="varString">None (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEndpointParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, double varDouble, string patternWithoutDelimiter, byte[] varByte, Option<int> integer = default, Option<int> int32 = default, Option<long> int64 = default, Option<float> varFloat = default, Option<string> varString = default, Option<System.IO.Stream> binary = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<string> password = default, Option<string> callback = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEndpointParametersApiResponse> TestEndpointParametersAsync(decimal number, string patternWithoutDelimiter, byte[] varByte, double varDouble, Option<System.IO.Stream> binary = default, Option<string> callback = default, Option<DateTime> date = default, Option<DateTime> dateTime = default, Option<int> int32 = default, Option<long> int64 = default, Option<int> integer = default, Option<string> password = default, Option<float> varFloat = default, Option<string> varString = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, varString, binary, password, callback);
+                ValidateTestEndpointParameters(patternWithoutDelimiter, varByte, binary, callback, password, varString);
 
-                FormatTestEndpointParameters(ref number, ref varDouble, ref patternWithoutDelimiter, ref varByte, ref integer, ref int32, ref int64, ref varFloat, ref varString, ref binary, ref date, ref dateTime, ref password, ref callback);
+                FormatTestEndpointParameters(ref number, ref patternWithoutDelimiter, ref varByte, ref varDouble, ref binary, ref callback, ref date, ref dateTime, ref int32, ref int64, ref integer, ref password, ref varFloat, ref varString);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -3989,29 +3989,17 @@ namespace Org.OpenAPITools.Api
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("number", ClientUtils.ParameterToString(number)));
 
-                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
-
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("pattern_without_delimiter", ClientUtils.ParameterToString(patternWithoutDelimiter)));
 
                     formParameterLocalVars.Add(new KeyValuePair<string, string>("byte", ClientUtils.ParameterToString(varByte)));
 
-                    if (integer.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
-
-                    if (int32.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
-
-                    if (int64.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
-
-                    if (varFloat.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
-
-                    if (varString.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
+                    formParameterLocalVars.Add(new KeyValuePair<string, string>("double", ClientUtils.ParameterToString(varDouble)));
 
                     if (binary.IsSet)
                         multipartContentLocalVar.Add(new StreamContent(binary.Value));
+
+                    if (callback.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
 
                     if (date.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("date", ClientUtils.ParameterToString(date.Value)));
@@ -4019,11 +4007,23 @@ namespace Org.OpenAPITools.Api
                     if (dateTime.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("dateTime", ClientUtils.ParameterToString(dateTime.Value)));
 
+                    if (int32.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int32", ClientUtils.ParameterToString(int32.Value)));
+
+                    if (int64.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("int64", ClientUtils.ParameterToString(int64.Value)));
+
+                    if (integer.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("integer", ClientUtils.ParameterToString(integer.Value)));
+
                     if (password.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("password", ClientUtils.ParameterToString(password.Value)));
 
-                    if (callback.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("callback", ClientUtils.ParameterToString(callback.Value)));
+                    if (varFloat.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("float", ClientUtils.ParameterToString(varFloat.Value)));
+
+                    if (varString.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("string", ClientUtils.ParameterToString(varString.Value)));
 
                     List<TokenBase> tokenBaseLocalVars = new List<TokenBase>();
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
@@ -4055,7 +4055,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEndpointParametersApiResponse apiResponseLocalVar = new TestEndpointParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                        AfterTestEndpointParametersDefaultImplementation(apiResponseLocalVar, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
 
                         Events.ExecuteOnTestEndpointParameters(apiResponseLocalVar);
 
@@ -4069,7 +4069,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, varDouble, patternWithoutDelimiter, varByte, integer, int32, int64, varFloat, varString, binary, date, dateTime, password, callback);
+                OnErrorTestEndpointParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, number, patternWithoutDelimiter, varByte, varDouble, binary, callback, date, dateTime, int32, int64, integer, password, varFloat, varString);
                 Events.ExecuteOnErrorTestEndpointParameters(e);
                 throw;
             }
@@ -4126,55 +4126,55 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestEnumParameters(Option<List<string>> enumHeaderStringArray, ref Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, ref Option<string> enumQueryString, ref Option<int> enumQueryInteger, ref Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, ref Option<string> enumFormString);
+        partial void FormatTestEnumParameters(ref Option<string> enumFormString, Option<List<string>> enumFormStringArray, ref Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, ref Option<double> enumQueryDouble, ref Option<int> enumQueryInteger, ref Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
         /// <returns></returns>
-        private void ValidateTestEnumParameters(Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        private void ValidateTestEnumParameters(Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
-            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderStringArray));
-
-            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderString));
-
-            if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumQueryStringArray));
-
-            if (enumQueryString.IsSet && enumQueryString.Value == null)
-                throw new ArgumentNullException(nameof(enumQueryString));
+            if (enumFormString.IsSet && enumFormString.Value == null)
+                throw new ArgumentNullException(nameof(enumFormString));
 
             if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumFormStringArray));
 
-            if (enumFormString.IsSet && enumFormString.Value == null)
-                throw new ArgumentNullException(nameof(enumFormString));
+            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderString));
+
+            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderStringArray));
+
+            if (enumQueryString.IsSet && enumQueryString.Value == null)
+                throw new ArgumentNullException(nameof(enumQueryString));
+
+            if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumQueryStringArray));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void AfterTestEnumParametersDefaultImplementation(ITestEnumParametersApiResponse apiResponseLocalVar, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            AfterTestEnumParameters(ref suppressDefaultLog, apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4184,15 +4184,15 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void AfterTestEnumParameters(ref bool suppressDefaultLog, ITestEnumParametersApiResponse apiResponseLocalVar, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4200,18 +4200,18 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString)
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        private void OnErrorTestEnumParametersDefaultImplementation(Exception exception, string pathFormat, string path, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+            OnErrorTestEnumParameters(ref suppressDefaultLog, exception, pathFormat, path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4223,34 +4223,34 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumFormStringArray"></param>
         /// <param name="enumFormString"></param>
-        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<List<string>> enumHeaderStringArray, Option<string> enumHeaderString, Option<List<string>> enumQueryStringArray, Option<string> enumQueryString, Option<int> enumQueryInteger, Option<double> enumQueryDouble, Option<List<string>> enumFormStringArray, Option<string> enumFormString);
+        /// <param name="enumFormStringArray"></param>
+        /// <param name="enumHeaderString"></param>
+        /// <param name="enumHeaderStringArray"></param>
+        /// <param name="enumQueryDouble"></param>
+        /// <param name="enumQueryInteger"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumQueryStringArray"></param>
+        partial void OnErrorTestEnumParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, Option<string> enumFormString, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<List<string>> enumHeaderStringArray, Option<double> enumQueryDouble, Option<int> enumQueryInteger, Option<string> enumQueryString, Option<List<string>> enumQueryStringArray);
 
         /// <summary>
         /// To test enum parameters To test enum parameters
         /// </summary>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersOrDefaultAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestEnumParametersAsync(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, cancellationToken).ConfigureAwait(false);
+                return await TestEnumParametersAsync(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4262,25 +4262,25 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
-        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
-        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
-        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumFormString">Form parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
+        /// <param name="enumHeaderString">Header parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
+        /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryInteger">Query parameter enum test (double) (optional)</param>
+        /// <param name="enumQueryString">Query parameter enum test (string) (optional, default to -efg)</param>
+        /// <param name="enumQueryStringArray">Query parameter enum test (string array) (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestEnumParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<List<string>> enumHeaderStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumQueryStringArray = default, Option<string> enumQueryString = default, Option<int> enumQueryInteger = default, Option<double> enumQueryDouble = default, Option<List<string>> enumFormStringArray = default, Option<string> enumFormString = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestEnumParametersApiResponse> TestEnumParametersAsync(Option<string> enumFormString = default, Option<List<string>> enumFormStringArray = default, Option<string> enumHeaderString = default, Option<List<string>> enumHeaderStringArray = default, Option<double> enumQueryDouble = default, Option<int> enumQueryInteger = default, Option<string> enumQueryString = default, Option<List<string>> enumQueryStringArray = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumFormStringArray, enumFormString);
+                ValidateTestEnumParameters(enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryString, enumQueryStringArray);
 
-                FormatTestEnumParameters(enumHeaderStringArray, ref enumHeaderString, enumQueryStringArray, ref enumQueryString, ref enumQueryInteger, ref enumQueryDouble, enumFormStringArray, ref enumFormString);
+                FormatTestEnumParameters(ref enumFormString, enumFormStringArray, ref enumHeaderString, enumHeaderStringArray, ref enumQueryDouble, ref enumQueryInteger, ref enumQueryString, enumQueryStringArray);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4291,25 +4291,25 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    if (enumQueryStringArray.IsSet)
-                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
-
-                    if (enumQueryString.IsSet)
-                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+                    if (enumQueryDouble.IsSet)
+                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
 
                     if (enumQueryInteger.IsSet)
                         parseQueryStringLocalVar["enum_query_integer"] = ClientUtils.ParameterToString(enumQueryInteger.Value);
 
-                    if (enumQueryDouble.IsSet)
-                        parseQueryStringLocalVar["enum_query_double"] = ClientUtils.ParameterToString(enumQueryDouble.Value);
+                    if (enumQueryString.IsSet)
+                        parseQueryStringLocalVar["enum_query_string"] = ClientUtils.ParameterToString(enumQueryString.Value);
+
+                    if (enumQueryStringArray.IsSet)
+                        parseQueryStringLocalVar["enum_query_string_array"] = ClientUtils.ParameterToString(enumQueryStringArray.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
-                    if (enumHeaderStringArray.IsSet)
-                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
-
                     if (enumHeaderString.IsSet)
                         httpRequestMessageLocalVar.Headers.Add("enum_header_string", ClientUtils.ParameterToString(enumHeaderString.Value));
+
+                    if (enumHeaderStringArray.IsSet)
+                        httpRequestMessageLocalVar.Headers.Add("enum_header_string_array", ClientUtils.ParameterToString(enumHeaderStringArray.Value));
 
                     MultipartContent multipartContentLocalVar = new MultipartContent();
 
@@ -4317,11 +4317,11 @@ namespace Org.OpenAPITools.Api
 
                     List<KeyValuePair<string, string>> formParameterLocalVars = new List<KeyValuePair<string, string>>();
 
-                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormStringArray.IsSet)
-                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
-
-                    if (enumFormString.IsSet)
+                    multipartContentLocalVar.Add(new FormUrlEncodedContent(formParameterLocalVars));                    if (enumFormString.IsSet)
                         formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string", ClientUtils.ParameterToString(enumFormString.Value)));
+
+                    if (enumFormStringArray.IsSet)
+                        formParameterLocalVars.Add(new KeyValuePair<string, string>("enum_form_string_array", ClientUtils.ParameterToString(enumFormStringArray.Value)));
 
                     httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
 
@@ -4346,7 +4346,7 @@ namespace Org.OpenAPITools.Api
 
                         TestEnumParametersApiResponse apiResponseLocalVar = new TestEnumParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                        AfterTestEnumParametersDefaultImplementation(apiResponseLocalVar, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
 
                         Events.ExecuteOnTestEnumParameters(apiResponseLocalVar);
 
@@ -4356,7 +4356,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+                OnErrorTestEnumParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, enumFormString, enumFormStringArray, enumHeaderString, enumHeaderStringArray, enumQueryDouble, enumQueryInteger, enumQueryString, enumQueryStringArray);
                 Events.ExecuteOnErrorTestEnumParameters(e);
                 throw;
             }
@@ -4413,22 +4413,22 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestGroupParameters(ref int requiredStringGroup, ref bool requiredBooleanGroup, ref long requiredInt64Group, ref Option<int> stringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group);
+        partial void FormatTestGroupParameters(ref bool requiredBooleanGroup, ref long requiredInt64Group, ref int requiredStringGroup, ref Option<bool> booleanGroup, ref Option<long> int64Group, ref Option<int> stringGroup);
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void AfterTestGroupParametersDefaultImplementation(ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            AfterTestGroupParameters(ref suppressDefaultLog, apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -4438,13 +4438,13 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void AfterTestGroupParameters(ref bool suppressDefaultLog, ITestGroupParametersApiResponse apiResponseLocalVar, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -4452,16 +4452,16 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group)
+        /// <param name="stringGroup"></param>
+        private void OnErrorTestGroupParametersDefaultImplementation(Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+            OnErrorTestGroupParameters(ref suppressDefaultLog, exception, pathFormat, path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -4473,30 +4473,30 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="requiredStringGroup"></param>
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="stringGroup"></param>
+        /// <param name="requiredStringGroup"></param>
         /// <param name="booleanGroup"></param>
         /// <param name="int64Group"></param>
-        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup, Option<bool> booleanGroup, Option<long> int64Group);
+        /// <param name="stringGroup"></param>
+        partial void OnErrorTestGroupParameters(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup, Option<long> int64Group, Option<int> stringGroup);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersOrDefaultAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestGroupParametersAsync(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, cancellationToken).ConfigureAwait(false);
+                return await TestGroupParametersAsync(requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -4508,21 +4508,21 @@ namespace Org.OpenAPITools.Api
         /// Fake endpoint to test group parameters (optional) Fake endpoint to test group parameters (optional)
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="requiredBooleanGroup">Required Boolean in group parameters</param>
         /// <param name="requiredInt64Group">Required Integer in group parameters</param>
-        /// <param name="stringGroup">String in group parameters (optional)</param>
+        /// <param name="requiredStringGroup">Required String in group parameters</param>
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
+        /// <param name="stringGroup">String in group parameters (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestGroupParametersApiResponse"/>&gt;</returns>
-        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, Option<int> stringGroup = default, Option<bool> booleanGroup = default, Option<long> int64Group = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestGroupParametersApiResponse> TestGroupParametersAsync(bool requiredBooleanGroup, long requiredInt64Group, int requiredStringGroup, Option<bool> booleanGroup = default, Option<long> int64Group = default, Option<int> stringGroup = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                FormatTestGroupParameters(ref requiredStringGroup, ref requiredBooleanGroup, ref requiredInt64Group, ref stringGroup, ref booleanGroup, ref int64Group);
+                FormatTestGroupParameters(ref requiredBooleanGroup, ref requiredInt64Group, ref requiredStringGroup, ref booleanGroup, ref int64Group, ref stringGroup);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -4533,14 +4533,14 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
                     parseQueryStringLocalVar["required_int64_group"] = ClientUtils.ParameterToString(requiredInt64Group);
-
-                    if (stringGroup.IsSet)
-                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
+                    parseQueryStringLocalVar["required_string_group"] = ClientUtils.ParameterToString(requiredStringGroup);
 
                     if (int64Group.IsSet)
                         parseQueryStringLocalVar["int64_group"] = ClientUtils.ParameterToString(int64Group.Value);
+
+                    if (stringGroup.IsSet)
+                        parseQueryStringLocalVar["string_group"] = ClientUtils.ParameterToString(stringGroup.Value);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -4569,7 +4569,7 @@ namespace Org.OpenAPITools.Api
 
                         TestGroupParametersApiResponse apiResponseLocalVar = new TestGroupParametersApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                        AfterTestGroupParametersDefaultImplementation(apiResponseLocalVar, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
 
                         Events.ExecuteOnTestGroupParameters(apiResponseLocalVar);
 
@@ -4583,7 +4583,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+                OnErrorTestGroupParametersDefaultImplementation(e, "/fake", uriBuilderLocalVar.Path, requiredBooleanGroup, requiredInt64Group, requiredStringGroup, booleanGroup, int64Group, stringGroup);
                 Events.ExecuteOnErrorTestGroupParameters(e);
                 throw;
             }
@@ -5219,38 +5219,38 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, ref string requiredNotNullable, ref string requiredNullable, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable);
+        partial void FormatTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, ref string requiredNotNullable, List<string> url, ref Option<string> notRequiredNotNullable, ref Option<string> notRequiredNullable, ref string requiredNullable);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <returns></returns>
-        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, Option<string> notRequiredNotNullable)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable)
         {
-            if (pipe == null)
-                throw new ArgumentNullException(nameof(pipe));
-
-            if (ioutil == null)
-                throw new ArgumentNullException(nameof(ioutil));
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
 
             if (http == null)
                 throw new ArgumentNullException(nameof(http));
 
-            if (url == null)
-                throw new ArgumentNullException(nameof(url));
+            if (ioutil == null)
+                throw new ArgumentNullException(nameof(ioutil));
 
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
+            if (pipe == null)
+                throw new ArgumentNullException(nameof(pipe));
 
             if (requiredNotNullable == null)
                 throw new ArgumentNullException(nameof(requiredNotNullable));
+
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
 
             if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
                 throw new ArgumentNullException(nameof(notRequiredNotNullable));
@@ -5260,19 +5260,19 @@ namespace Org.OpenAPITools.Api
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void AfterTestQueryParameterCollectionFormatDefaultImplementation(ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            AfterTestQueryParameterCollectionFormat(ref suppressDefaultLog, apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -5282,16 +5282,16 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void AfterTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, ITestQueryParameterCollectionFormatApiResponse apiResponseLocalVar, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -5299,19 +5299,19 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable)
+        /// <param name="requiredNullable"></param>
+        private void OnErrorTestQueryParameterCollectionFormatDefaultImplementation(Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable)
         {
             bool suppressDefaultLog = false;
-            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+            OnErrorTestQueryParameterCollectionFormat(ref suppressDefaultLog, exception, pathFormat, path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -5323,36 +5323,36 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"></param>
         /// <param name="notRequiredNullable"></param>
-        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable);
+        /// <param name="requiredNullable"></param>
+        partial void OnErrorTestQueryParameterCollectionFormat(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable, Option<string> notRequiredNullable, string requiredNullable);
 
         /// <summary>
         ///  To test the collection format in query parameters
         /// </summary>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatOrDefaultAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await TestQueryParameterCollectionFormatAsync(pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable, cancellationToken).ConfigureAwait(false);
+                return await TestQueryParameterCollectionFormatAsync(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -5364,26 +5364,26 @@ namespace Org.OpenAPITools.Api
         ///  To test the collection format in query parameters
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="http"></param>
-        /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="http"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="pipe"></param>
         /// <param name="requiredNotNullable"></param>
-        /// <param name="requiredNullable"></param>
+        /// <param name="url"></param>
         /// <param name="notRequiredNotNullable"> (optional)</param>
         /// <param name="notRequiredNullable"> (optional)</param>
+        /// <param name="requiredNullable"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ITestQueryParameterCollectionFormatApiResponse"/>&gt;</returns>
-        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, string requiredNullable = default, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ITestQueryParameterCollectionFormatApiResponse> TestQueryParameterCollectionFormatAsync(List<string> context, List<string> http, List<string> ioutil, List<string> pipe, string requiredNotNullable, List<string> url, Option<string> notRequiredNotNullable = default, Option<string> notRequiredNullable = default, string requiredNullable = default, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, notRequiredNotNullable);
+                ValidateTestQueryParameterCollectionFormat(context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable);
 
-                FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, ref requiredNotNullable, ref requiredNullable, ref notRequiredNotNullable, ref notRequiredNullable);
+                FormatTestQueryParameterCollectionFormat(context, http, ioutil, pipe, ref requiredNotNullable, url, ref notRequiredNotNullable, ref notRequiredNullable, ref requiredNullable);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -5394,12 +5394,12 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
-                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
-                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
-                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["context"] = ClientUtils.ParameterToString(context);
+                    parseQueryStringLocalVar["http"] = ClientUtils.ParameterToString(http);
+                    parseQueryStringLocalVar["ioutil"] = ClientUtils.ParameterToString(ioutil);
+                    parseQueryStringLocalVar["pipe"] = ClientUtils.ParameterToString(pipe);
                     parseQueryStringLocalVar["requiredNotNullable"] = ClientUtils.ParameterToString(requiredNotNullable);
+                    parseQueryStringLocalVar["url"] = ClientUtils.ParameterToString(url);
                     parseQueryStringLocalVar["requiredNullable"] = ClientUtils.ParameterToString(requiredNullable);
 
                     if (notRequiredNotNullable.IsSet)
@@ -5423,7 +5423,7 @@ namespace Org.OpenAPITools.Api
 
                         TestQueryParameterCollectionFormatApiResponse apiResponseLocalVar = new TestQueryParameterCollectionFormatApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/fake/test-query-parameters", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                        AfterTestQueryParameterCollectionFormatDefaultImplementation(apiResponseLocalVar, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
 
                         Events.ExecuteOnTestQueryParameterCollectionFormat(apiResponseLocalVar);
 
@@ -5433,7 +5433,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, pipe, ioutil, http, url, context, requiredNotNullable, requiredNullable, notRequiredNotNullable, notRequiredNullable);
+                OnErrorTestQueryParameterCollectionFormatDefaultImplementation(e, "/fake/test-query-parameters", uriBuilderLocalVar.Path, context, http, ioutil, pipe, requiredNotNullable, url, notRequiredNotNullable, notRequiredNullable, requiredNullable);
                 Events.ExecuteOnErrorTestQueryParameterCollectionFormat(e);
                 throw;
             }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
@@ -154,11 +154,11 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs user into the system
@@ -166,11 +166,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default);
+        Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Logs out current logged in user session
@@ -200,11 +200,11 @@ namespace Org.OpenAPITools.Api
         /// This can only be done by the logged in user.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updated user
@@ -212,11 +212,11 @@ namespace Org.OpenAPITools.Api
         /// <remarks>
         /// This can only be done by the logged in user.
         /// </remarks>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default);
+        Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default);
     }
 
     /// <summary>
@@ -1621,33 +1621,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatLoginUser(ref string username, ref string password);
+        partial void FormatLoginUser(ref string password, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="password"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateLoginUser(string username, string password)
+        private void ValidateLoginUser(string password, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (password == null)
                 throw new ArgumentNullException(nameof(password));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string username, string password)
+        /// <param name="username"></param>
+        private void AfterLoginUserDefaultImplementation(ILoginUserApiResponse apiResponseLocalVar, string password, string username)
         {
             bool suppressDefaultLog = false;
-            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, username, password);
+            AfterLoginUser(ref suppressDefaultLog, apiResponseLocalVar, password, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -1657,9 +1657,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string username, string password);
+        /// <param name="username"></param>
+        partial void AfterLoginUser(ref bool suppressDefaultLog, ILoginUserApiResponse apiResponseLocalVar, string password, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -1667,12 +1667,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, string password)
+        /// <param name="username"></param>
+        private void OnErrorLoginUserDefaultImplementation(Exception exception, string pathFormat, string path, string password, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, username, password);
+            OnErrorLoginUser(ref suppressDefaultLog, exception, pathFormat, path, password, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -1684,22 +1684,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="password"></param>
-        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, string password);
+        /// <param name="username"></param>
+        partial void OnErrorLoginUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string password, string username);
 
         /// <summary>
         /// Logs user into the system 
         /// </summary>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserOrDefaultAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await LoginUserAsync(username, password, cancellationToken).ConfigureAwait(false);
+                return await LoginUserAsync(password, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -1711,19 +1711,19 @@ namespace Org.OpenAPITools.Api
         /// Logs user into the system 
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
+        /// <param name="username">The user name for login</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="ILoginUserApiResponse"/>&gt;</returns>
-        public async Task<ILoginUserApiResponse> LoginUserAsync(string username, string password, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<ILoginUserApiResponse> LoginUserAsync(string password, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateLoginUser(username, password);
+                ValidateLoginUser(password, username);
 
-                FormatLoginUser(ref username, ref password);
+                FormatLoginUser(ref password, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1734,8 +1734,8 @@ namespace Org.OpenAPITools.Api
 
                     System.Collections.Specialized.NameValueCollection parseQueryStringLocalVar = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
                     parseQueryStringLocalVar["password"] = ClientUtils.ParameterToString(password);
+                    parseQueryStringLocalVar["username"] = ClientUtils.ParameterToString(username);
 
                     uriBuilderLocalVar.Query = parseQueryStringLocalVar.ToString();
 
@@ -1762,7 +1762,7 @@ namespace Org.OpenAPITools.Api
 
                         LoginUserApiResponse apiResponseLocalVar = new LoginUserApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/login", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, username, password);
+                        AfterLoginUserDefaultImplementation(apiResponseLocalVar, password, username);
 
                         Events.ExecuteOnLoginUser(apiResponseLocalVar);
 
@@ -1772,7 +1772,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, username, password);
+                OnErrorLoginUserDefaultImplementation(e, "/user/login", uriBuilderLocalVar.Path, password, username);
                 Events.ExecuteOnErrorLoginUser(e);
                 throw;
             }
@@ -2013,33 +2013,33 @@ namespace Org.OpenAPITools.Api
             partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
         }
 
-        partial void FormatUpdateUser(ref string username, User user);
+        partial void FormatUpdateUser(User user, ref string username);
 
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="user"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateUpdateUser(string username, User user)
+        private void ValidateUpdateUser(User user, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, string username, User user)
+        /// <param name="username"></param>
+        private void AfterUpdateUserDefaultImplementation(IUpdateUserApiResponse apiResponseLocalVar, User user, string username)
         {
             bool suppressDefaultLog = false;
-            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, username, user);
+            AfterUpdateUser(ref suppressDefaultLog, apiResponseLocalVar, user, username);
             if (!suppressDefaultLog)
                 Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
         }
@@ -2049,9 +2049,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="suppressDefaultLog"></param>
         /// <param name="apiResponseLocalVar"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, string username, User user);
+        /// <param name="username"></param>
+        partial void AfterUpdateUser(ref bool suppressDefaultLog, IUpdateUserApiResponse apiResponseLocalVar, User user, string username);
 
         /// <summary>
         /// Logs exceptions that occur while retrieving the server response
@@ -2059,12 +2059,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, string username, User user)
+        /// <param name="username"></param>
+        private void OnErrorUpdateUserDefaultImplementation(Exception exception, string pathFormat, string path, User user, string username)
         {
             bool suppressDefaultLog = false;
-            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, username, user);
+            OnErrorUpdateUser(ref suppressDefaultLog, exception, pathFormat, path, user, username);
             if (!suppressDefaultLog)
                 Logger.LogError(exception, "An error occurred while sending the request to the server.");
         }
@@ -2076,22 +2076,22 @@ namespace Org.OpenAPITools.Api
         /// <param name="exception"></param>
         /// <param name="pathFormat"></param>
         /// <param name="path"></param>
-        /// <param name="username"></param>
         /// <param name="user"></param>
-        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, string username, User user);
+        /// <param name="username"></param>
+        partial void OnErrorUpdateUser(ref bool suppressDefaultLog, Exception exception, string pathFormat, string path, User user, string username);
 
         /// <summary>
         /// Updated user This can only be done by the logged in user.
         /// </summary>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserOrDefaultAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             try
             {
-                return await UpdateUserAsync(username, user, cancellationToken).ConfigureAwait(false);
+                return await UpdateUserAsync(user, username, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -2103,19 +2103,19 @@ namespace Org.OpenAPITools.Api
         /// Updated user This can only be done by the logged in user.
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
-        /// <param name="username">name that need to be deleted</param>
         /// <param name="user">Updated user object</param>
+        /// <param name="username">name that need to be deleted</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IUpdateUserApiResponse"/>&gt;</returns>
-        public async Task<IUpdateUserApiResponse> UpdateUserAsync(string username, User user, System.Threading.CancellationToken cancellationToken = default)
+        public async Task<IUpdateUserApiResponse> UpdateUserAsync(User user, string username, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
 
             try
             {
-                ValidateUpdateUser(username, user);
+                ValidateUpdateUser(user, username);
 
-                FormatUpdateUser(ref username, user);
+                FormatUpdateUser(user, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2152,7 +2152,7 @@ namespace Org.OpenAPITools.Api
 
                         UpdateUserApiResponse apiResponseLocalVar = new UpdateUserApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/user/{username}", requestedAtLocalVar, _jsonSerializerOptions);
 
-                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, username, user);
+                        AfterUpdateUserDefaultImplementation(apiResponseLocalVar, user, username);
 
                         Events.ExecuteOnUpdateUser(apiResponseLocalVar);
 
@@ -2162,7 +2162,7 @@ namespace Org.OpenAPITools.Api
             }
             catch(Exception e)
             {
-                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, username, user);
+                OnErrorUpdateUserDefaultImplementation(e, "/user/{username}", uriBuilderLocalVar.Path, user, username);
                 Events.ExecuteOnErrorUpdateUser(e);
                 throw;
             }


### PR DESCRIPTION
Changes the default sorting of the samples so that errors will be obvious.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
