### PR TITLE
Added support for openapi-normalizer in the online version.

### DIFF
--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/model/GeneratorInput.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/model/GeneratorInput.java
@@ -23,6 +23,7 @@ import io.swagger.v3.parser.core.models.AuthorizationValue;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
 import java.util.Map;
 
 @Setter
@@ -31,6 +32,8 @@ public class GeneratorInput {
     @Getter private Map<String, String> options;
     private String openAPIUrl;
     @Getter private AuthorizationValue authorizationValue;
+    //FILTER=operationId:updatePet
+    @Getter private List<String> openapiNormalizer;
 
     @ApiModelProperty(example = "https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml")
     public String getOpenAPIUrl() {

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/Generator.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/Generator.java
@@ -118,11 +118,6 @@ public class Generator {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The OpenAPI specification supplied was not valid");
         }
 
-//        if(opts.getOpenapiNormalizer() != null && !opts.getOpenapiNormalizer().isEmpty()){
-//            for(String ruleString: opts.getOpenapiNormalizer()) {
-//
-//            }
-//        }
 
         // do not use opts.getOptions().get("outputFolder") as the input can contain ../../
         // to access other folders in the server
@@ -137,7 +132,6 @@ public class Generator {
         CodegenConfig codegenConfig;
         try {
             codegenConfig = CodegenConfigLoader.forName(language);
-
         } catch (RuntimeException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported target " + language + " supplied");
         }
@@ -149,7 +143,6 @@ public class Generator {
 
         if(opts.getOpenapiNormalizer() != null && !opts.getOpenapiNormalizer().isEmpty()){
             for(String rule: opts.getOpenapiNormalizer()){
-
                 String[] ruleOperands = rule.split("=");
                 if(ruleOperands.length != 2) {
                     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "In rule: " + rule + "the operands were not provided in the form of <Rule>=<Value>");

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/Generator.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/Generator.java
@@ -118,6 +118,12 @@ public class Generator {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The OpenAPI specification supplied was not valid");
         }
 
+//        if(opts.getOpenapiNormalizer() != null && !opts.getOpenapiNormalizer().isEmpty()){
+//            for(String ruleString: opts.getOpenapiNormalizer()) {
+//
+//            }
+//        }
+
         // do not use opts.getOptions().get("outputFolder") as the input can contain ../../
         // to access other folders in the server
         String destPath = language + "-" + type.getTypeName();
@@ -131,6 +137,7 @@ public class Generator {
         CodegenConfig codegenConfig;
         try {
             codegenConfig = CodegenConfigLoader.forName(language);
+
         } catch (RuntimeException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported target " + language + " supplied");
         }
@@ -138,6 +145,17 @@ public class Generator {
         if (opts.getOptions() != null) {
             codegenConfig.additionalProperties().putAll(opts.getOptions());
             codegenConfig.additionalProperties().put("openAPI", openapi);
+        }
+
+        if(opts.getOpenapiNormalizer() != null && !opts.getOpenapiNormalizer().isEmpty()){
+            for(String rule: opts.getOpenapiNormalizer()){
+
+                String[] ruleOperands = rule.split("=");
+                if(ruleOperands.length != 2) {
+                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "In rule: " + rule + "the operands were not provided in the form of <Rule>=<Value>");
+                }
+                codegenConfig.openapiNormalizer().put(ruleOperands[0],ruleOperands[1]);
+            }
         }
 
         codegenConfig.setOutputDir(outputFolder);

--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
@@ -12,8 +12,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.Assert;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;

--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
@@ -10,6 +10,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.Assert;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
@@ -132,5 +135,33 @@ public class GenApiControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"openAPIUrl\": \"" + invalidOpenAPIUrl + "\"}"))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void generateWithOpenAPINormalizer() throws Exception {
+        String withOpenAPINormalizer = "{\"openAPIUrl\":\"https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml\",\"openapiNormalizer\":[\"FILTER=operationId:updatePet\"],\"options\":{},\"spec\":{}}";
+        String withoutOpenAPINormalizer = "{\"openAPIUrl\":\"https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml\",\"options\":{},\"spec\":{}}";
+
+        String responseOfNormalized = mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(withOpenAPINormalizer))
+                .andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
+        String codeOfNormalized = new ObjectMapper().readValue(responseOfNormalized, ResponseCode.class).getCode();
+        Long lengthOfNormalized = Long.parseLong(mockMvc.perform(get("http://test.com:1234/api/gen/download/" + codeOfNormalized))
+                .andExpect(content().contentType("application/zip"))
+                .andExpect(status().isOk()).andReturn().getResponse().getHeader("Content-Length"));
+
+        String responseOfNotNormalized = mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(withoutOpenAPINormalizer))
+                .andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
+
+        String codeOfNotNormalized = new ObjectMapper().readValue(responseOfNotNormalized, ResponseCode.class).getCode();
+        Long lengthOfNotNormalized = Long.parseLong(mockMvc.perform(get("http://test.com:1234/api/gen/download/" + codeOfNotNormalized))
+                .andExpect(content().contentType("application/zip"))
+                .andExpect(status().isOk()).andReturn().getResponse().getHeader("Content-Length"));
+
+        Assert.isTrue(lengthOfNormalized <= lengthOfNotNormalized,"Using the normalizer should result in a smaller or equal file size");
+
     }
 }


### PR DESCRIPTION
Added support for openapi-normalizer in the online version with a minimal test. 
To fix #18677.

The changes done are the following:
- Added an openapiNormalizer List<String> argument to the api (if this is not a desired change i can just put it in the options object and just parse the list of strings).
- Wrote the feature in a similar manner as in the generator-cli code.
- Wrote a minimal test that checks that the normalized version code is less (or equal) in size to the not normalized version.



<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. [In my case it did not create any changes]
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed. 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
