### PR TITLE
python-asyncio: update retry factors for actual exponential retries

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -79,8 +79,8 @@ class RESTClientObject:
                 client_session=self.pool_manager,
                 retry_options=aiohttp_retry.ExponentialRetry(
                     attempts=retries,
-                    factor=0.0,
-                    start_timeout=0.0,
+                    factor=2.0,
+                    start_timeout=0.1,
                     max_timeout=120.0
                 )
             )

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
@@ -89,8 +89,8 @@ class RESTClientObject:
                 client_session=self.pool_manager,
                 retry_options=aiohttp_retry.ExponentialRetry(
                     attempts=retries,
-                    factor=0.0,
-                    start_timeout=0.0,
+                    factor=2.0,
+                    start_timeout=0.1,
                     max_timeout=120.0
                 )
             )


### PR DESCRIPTION
As per the `aiohttp-retry` library's code[^1], the timeout is

```python
timeout = self._start_timeout * (self._factor ** attempt)
```

This means the previous setting with "start_timeout=0.0" would have always just retried right away (0 timeout) regardless of the "factor" value, and also, "factor=0.0" would never have increased the timeout, rather it would have resulted in a 0 timeout regardless of the value of "start_timeout".

This double-zeroing effectively rendered exponential backoff to nothing (rather than "retries" number of retries in quick succession.

The update is a quick fix to set the same default as in `aiohttp-retry`. In the future this should likely be configurable (through extra Configuration settings perhaps?), as not all APIs are created equal, but this works as a quick fix for making retries more effective.

[^1]: https://github.com/inyutin/aiohttp_retry/blob/ba2169891f5b32a5c59e48ca185dd8e68e44ded7/aiohttp_retry/retry_options.py#L38-L65

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Connects to #17011

CC: @cbornet @tomplus @krjakbrjak @fa0311 @multani

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
