### PR TITLE
fix invalid syntax in gitignore

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/gitignore.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/gitignore.mustache
@@ -3,7 +3,9 @@
 .dart_tool/
 .packages
 build/
-pubspec.lock  # Except for application packages
+
+# Except for application packages
+pubspec.lock
 
 doc/api/
 


### PR DESCRIPTION
gitignore only supports line comments, not in-line comments
