### PR TITLE
[Rust Server] Use swagger/multipart_related support

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -41,7 +41,7 @@ client = [
     "multipart", "multipart/client", "swagger/multipart_form",
 {{/apiUsesMultipartFormData}}
 {{#apiUsesMultipartRelated}}
-    "hyper_0_10", "mime_multipart",
+    "hyper_0_10", "mime_multipart", "swagger/multipart_related",
 {{/apiUsesMultipartRelated}}
 {{#usesUrlEncodedForm}}
     "serde_urlencoded",
@@ -60,7 +60,7 @@ server = [
     "multipart", "multipart/server", "swagger/multipart_form",
 {{/apiUsesMultipartFormData}}
 {{#apiUsesMultipartRelated}}
-    "hyper_0_10", "mime_multipart",
+    "hyper_0_10", "mime_multipart", "swagger/multipart_related",
 {{/apiUsesMultipartRelated}}
 {{#hasCallbacks}}
     "native-tls", "hyper-openssl", "hyper-tls", "openssl",

--- a/modules/openapi-generator/src/main/resources/rust-server/client-imports.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-imports.mustache
@@ -26,7 +26,7 @@ use multipart::client::lazy::Multipart;
 {{/apiUsesMultipartFormData}}
 {{#apiUsesMultipartRelated}}
 use hyper_0_10::header::{Headers, ContentType};
-use mime_multipart::{Node, Part, generate_boundary, write_multipart};
+use mime_multipart::{Node, Part, write_multipart};
 {{/apiUsesMultipartRelated}}
 
 use crate::models;

--- a/modules/openapi-generator/src/main/resources/rust-server/generate-multipart-related.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/generate-multipart-related.mustache
@@ -1,14 +1,5 @@
 {{#-first}}
-        // Construct the Body for a multipart/related request. The mime 0.2.6 library
-        // does not parse quoted-string parameters correctly. The boundary doesn't
-        // need to be a quoted string if it does not contain a '/', hence ensure
-        // no such boundary is used.
-        let mut boundary = generate_boundary();
-        for b in boundary.iter_mut() {
-            if b == &(b'/') {
-                *b = b'=';
-            }
-        }
+        let boundary = swagger::multipart::related::generate_boundary();
         let mut body_parts = vec![];
 
 {{/-first}}

--- a/modules/openapi-generator/src/main/resources/rust-server/server-request-body-multipart-related.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-request-body-multipart-related.mustache
@@ -1,29 +1,19 @@
                                 // Get multipart chunks.
 
-                                // Extract the top-level content type header.
-                                let content_type_mime = headers
-                                    .get(CONTENT_TYPE)
-                                    .ok_or_else(|| "Missing content-type header".to_string())
-                                    .and_then(|v| v.to_str().map_err(|e| format!("Couldn't read content-type header value for {{operationId}}: {}", e)))
-                                    .and_then(|v| v.parse::<Mime2>().map_err(|_e| "Couldn't parse content-type header value for {{operationId}}".to_string()));
-
-                                // Insert top-level content type header into a Headers object.
-                                let mut multi_part_headers = Headers::new();
-                                match content_type_mime {
-                                    Ok(content_type_mime) => {
-                                        multi_part_headers.set(ContentType(content_type_mime));
-                                    },
+                                // Create headers from top-level content type header.
+                                let multipart_headers = match swagger::multipart::related::create_multipart_headers(headers.get(CONTENT_TYPE)) {
+                                    Ok(headers) => headers,
                                     Err(e) => {
                                         return Ok(Response::builder()
                                                 .status(StatusCode::BAD_REQUEST)
                                                 .body(Body::from(e))
                                                 .expect("Unable to create Bad Request response due to unable to read content-type header for {{operationId}}"));
                                     }
-                                }
+                                };
 
                                 // &*body expresses the body as a byteslice, &mut provides a
                                 // mutable reference to that byteslice.
-                                let nodes = match read_multipart_body(&mut&*body, &multi_part_headers, false) {
+                                let nodes = match read_multipart_body(&mut&*body, &multipart_headers, false) {
                                     Ok(nodes) => nodes,
                                     Err(e) => {
                                         return Ok(Response::builder()

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -12,13 +12,13 @@ default = ["client", "server"]
 client = [
     "mime_0_2",
     "multipart", "multipart/client", "swagger/multipart_form",
-    "hyper_0_10", "mime_multipart",
+    "hyper_0_10", "mime_multipart", "swagger/multipart_related",
     "hyper", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]
 server = [
     "mime_0_2",
     "multipart", "multipart/server", "swagger/multipart_form",
-    "hyper_0_10", "mime_multipart",
+    "hyper_0_10", "mime_multipart", "swagger/multipart_related",
    "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
 ]
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/client/mod.rs
@@ -23,7 +23,7 @@ use mime::Mime;
 use std::io::Cursor;
 use multipart::client::lazy::Multipart;
 use hyper_0_10::header::{Headers, ContentType};
-use mime_multipart::{Node, Part, generate_boundary, write_multipart};
+use mime_multipart::{Node, Part, write_multipart};
 
 use crate::models;
 use crate::header;
@@ -424,16 +424,7 @@ impl<S, C> Api<C> for Client<S, C> where
         };
 
         // Consumes multipart/related body
-        // Construct the Body for a multipart/related request. The mime 0.2.6 library
-        // does not parse quoted-string parameters correctly. The boundary doesn't
-        // need to be a quoted string if it does not contain a '/', hence ensure
-        // no such boundary is used.
-        let mut boundary = generate_boundary();
-        for b in boundary.iter_mut() {
-            if b == &(b'/') {
-                *b = b'=';
-            }
-        }
+        let boundary = swagger::multipart::related::generate_boundary();
         let mut body_parts = vec![];
 
         if let Some(object_field) = param_object_field {
@@ -720,16 +711,7 @@ impl<S, C> Api<C> for Client<S, C> where
         };
 
         // Consumes multipart/related body
-        // Construct the Body for a multipart/related request. The mime 0.2.6 library
-        // does not parse quoted-string parameters correctly. The boundary doesn't
-        // need to be a quoted string if it does not contain a '/', hence ensure
-        // no such boundary is used.
-        let mut boundary = generate_boundary();
-        for b in boundary.iter_mut() {
-            if b == &(b'/') {
-                *b = b'=';
-            }
-        }
+        let boundary = swagger::multipart::related::generate_boundary();
         let mut body_parts = vec![];
 
         if let Some(binary1) = param_binary1 {

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/server/mod.rs
@@ -164,30 +164,20 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements : Vec<String> = vec![];
                                 // Get multipart chunks.
 
-                                // Extract the top-level content type header.
-                                let content_type_mime = headers
-                                    .get(CONTENT_TYPE)
-                                    .ok_or_else(|| "Missing content-type header".to_string())
-                                    .and_then(|v| v.to_str().map_err(|e| format!("Couldn't read content-type header value for MultipartRelatedRequestPost: {}", e)))
-                                    .and_then(|v| v.parse::<Mime2>().map_err(|_e| "Couldn't parse content-type header value for MultipartRelatedRequestPost".to_string()));
-
-                                // Insert top-level content type header into a Headers object.
-                                let mut multi_part_headers = Headers::new();
-                                match content_type_mime {
-                                    Ok(content_type_mime) => {
-                                        multi_part_headers.set(ContentType(content_type_mime));
-                                    },
+                                // Create headers from top-level content type header.
+                                let multipart_headers = match swagger::multipart::related::create_multipart_headers(headers.get(CONTENT_TYPE)) {
+                                    Ok(headers) => headers,
                                     Err(e) => {
                                         return Ok(Response::builder()
                                                 .status(StatusCode::BAD_REQUEST)
                                                 .body(Body::from(e))
                                                 .expect("Unable to create Bad Request response due to unable to read content-type header for MultipartRelatedRequestPost"));
                                     }
-                                }
+                                };
 
                                 // &*body expresses the body as a byteslice, &mut provides a
                                 // mutable reference to that byteslice.
-                                let nodes = match read_multipart_body(&mut&*body, &multi_part_headers, false) {
+                                let nodes = match read_multipart_body(&mut&*body, &multipart_headers, false) {
                                     Ok(nodes) => nodes,
                                     Err(e) => {
                                         return Ok(Response::builder()
@@ -465,30 +455,20 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements : Vec<String> = vec![];
                                 // Get multipart chunks.
 
-                                // Extract the top-level content type header.
-                                let content_type_mime = headers
-                                    .get(CONTENT_TYPE)
-                                    .ok_or_else(|| "Missing content-type header".to_string())
-                                    .and_then(|v| v.to_str().map_err(|e| format!("Couldn't read content-type header value for MultipleIdenticalMimeTypesPost: {}", e)))
-                                    .and_then(|v| v.parse::<Mime2>().map_err(|_e| "Couldn't parse content-type header value for MultipleIdenticalMimeTypesPost".to_string()));
-
-                                // Insert top-level content type header into a Headers object.
-                                let mut multi_part_headers = Headers::new();
-                                match content_type_mime {
-                                    Ok(content_type_mime) => {
-                                        multi_part_headers.set(ContentType(content_type_mime));
-                                    },
+                                // Create headers from top-level content type header.
+                                let multipart_headers = match swagger::multipart::related::create_multipart_headers(headers.get(CONTENT_TYPE)) {
+                                    Ok(headers) => headers,
                                     Err(e) => {
                                         return Ok(Response::builder()
                                                 .status(StatusCode::BAD_REQUEST)
                                                 .body(Body::from(e))
                                                 .expect("Unable to create Bad Request response due to unable to read content-type header for MultipleIdenticalMimeTypesPost"));
                                     }
-                                }
+                                };
 
                                 // &*body expresses the body as a byteslice, &mut provides a
                                 // mutable reference to that byteslice.
-                                let nodes = match read_multipart_body(&mut&*body, &multi_part_headers, false) {
+                                let nodes = match read_multipart_body(&mut&*body, &multipart_headers, false) {
                                     Ok(nodes) => nodes,
                                     Err(e) => {
                                         return Ok(Response::builder()


### PR DESCRIPTION
Use functions from the https://github.com/Metaswitch/swagger-rs crate for multipart/related helper functions, rather than including the logic in every generated crate.

This updates the generated code to use functions from the swagger-rs crate, rather than having hand rolled code in each crate. Code in the support crate is easier to test, update and bug fix, rather than generated code which requires each generated crate to be updated.

Support was added in 5.0 - the generated code already uses the swagger-rs 6

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Rust Technical Committee: @frol @farcaller @paladinzh @jacob-pro
