### PR TITLE
[Rust Server] Improve RFC 13341 compliance for multipart/related

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/generate-multipart-related.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/generate-multipart-related.mustache
@@ -39,7 +39,10 @@
 {{#-last}}
 
         // Write the body into a vec.
-        let mut body: Vec<u8> = vec![];
+        // RFC 13341 Section 7.2.1 suggests that the body should begin with a
+        // CRLF prior to the first boundary. The mime_multipart library doesn't
+        // do this, so we do it instead.
+        let mut body: Vec<u8> = vec![b'\r', b'\n'];
         write_multipart(&mut body, &boundary, &body_parts)
             .expect("Failed to write multipart body");
 {{/-last}}

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/client/mod.rs
@@ -478,7 +478,10 @@ impl<S, C> Api<C> for Client<S, C> where
         }
 
         // Write the body into a vec.
-        let mut body: Vec<u8> = vec![];
+        // RFC 13341 Section 7.2.1 suggests that the body should begin with a
+        // CRLF prior to the first boundary. The mime_multipart library doesn't
+        // do this, so we do it instead.
+        let mut body: Vec<u8> = vec![b'\r', b'\n'];
         write_multipart(&mut body, &boundary, &body_parts)
             .expect("Failed to write multipart body");
 
@@ -759,7 +762,10 @@ impl<S, C> Api<C> for Client<S, C> where
         }
 
         // Write the body into a vec.
-        let mut body: Vec<u8> = vec![];
+        // RFC 13341 Section 7.2.1 suggests that the body should begin with a
+        // CRLF prior to the first boundary. The mime_multipart library doesn't
+        // do this, so we do it instead.
+        let mut body: Vec<u8> = vec![b'\r', b'\n'];
         write_multipart(&mut body, &boundary, &body_parts)
             .expect("Failed to write multipart body");
 


### PR DESCRIPTION
RFC 13341 Section 7.2.1 suggests that the body should begin with a CRLF prior to the first boundary. The mime_multipart library doesn't do this, so we do it instead.

This improves interop with other servers

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Rust Technical Committee: @frol @farcaller @paladinzh @jacob-pro