### PR TITLE
fixes deepObject query-params with additonal properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/api.mustache
@@ -330,15 +330,22 @@ namespace {{packageName}}.{{apiPackage}}
             if ({{paramName}} != null)
             {
                 {{#isDeepObject}}
+                {{#items.hasVars}}
                 {{#items.vars}}
                 if ({{paramName}}.{{name}} != null)
                 {
                     localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{paramName}}[{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}]", {{paramName}}.{{name}}));
                 }
                 {{/items.vars}}
-                {{^items}}
-                localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("deepObject", "{{baseName}}", {{paramName}}));
-                {{/items}}
+                {{#additionalProperties}}
+                localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("deepObject", "{{paramName}}", {{paramName}}.AdditionalProperties));
+                {{/additionalProperties}}
+                {{/items.hasVars}}
+                {{^items.hasVars}}
+                {{#additionalProperties}}
+                localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("deepObject", "{{paramName}}", {{paramName}}));
+                {{/additionalProperties}}
+                {{/items.hasVars}}
                 {{/isDeepObject}}
                 {{^isDeepObject}}
                 localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", {{paramName}}));
@@ -614,15 +621,22 @@ namespace {{packageName}}.{{apiPackage}}
             if ({{paramName}} != null)
             {
                 {{#isDeepObject}}
+                {{#items.hasVars}}
                 {{#items.vars}}
                 if ({{paramName}}.{{name}} != null)
                 {
                     localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{paramName}}[{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}]", {{paramName}}.{{name}}));
                 }
                 {{/items.vars}}
-                {{^items}}
-                localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("deepObject", "{{baseName}}", {{paramName}}));
-                {{/items}}
+                {{#additionalProperties}}
+                localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("deepObject", "{{paramName}}", {{paramName}}.AdditionalProperties));
+                {{/additionalProperties}}
+                {{/items.hasVars}}
+                {{^items.hasVars}}
+                {{#additionalProperties}}
+                localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("deepObject", "{{paramName}}", {{paramName}}));
+                {{/additionalProperties}}
+                {{/items.hasVars}}
                 {{/isDeepObject}}
                 {{^isDeepObject}}
                 localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", {{paramName}}));


### PR DESCRIPTION
fixes the issue #19350. Modify the `api.mustache` template for Csharp to handle deepObject query-params for the following cases:

1. If the deep object has only defined properties like foo.
2. If the schema only supports additional properties without a defined property.
3. If the schema support defined properties as well as additional property.


### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.  @mandrean @shibayan @Blackclaws @lucamazzanti @iBicha