### PR TITLE
[Rust] Ensure all features build as part of CI / Upgrade to Frunk 0.4

### DIFF
--- a/.github/workflows/samples-rust.yaml
+++ b/.github/workflows/samples-rust.yaml
@@ -34,4 +34,4 @@ jobs:
           toolchain: stable
       - name: Build
         working-directory: ${{ matrix.sample }}
-        run: cargo build --all-targets
+        run: cargo build --all-targets --all-features

--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -127,11 +127,11 @@ percent-encoding = {version = "2.1.0", optional = true}
 regex = {version = "1.3", optional = true}
 
 # Conversion
-frunk = { version = "0.3.0", optional = true }
-frunk_derives = { version = "0.3.0", optional = true }
-frunk_core = { version = "0.3.0", optional = true }
-frunk-enum-derive = { version = "0.2.0", optional = true }
-frunk-enum-core = { version = "0.2.0", optional = true }
+frunk = { version = "0.4.0", optional = true }
+frunk_derives = { version = "0.4.0", optional = true }
+frunk_core = { version = "0.4.0", optional = true }
+frunk-enum-derive = { version = "0.3.0", optional = true }
+frunk-enum-core = { version = "0.3.0", optional = true }
 
 # Bearer authentication
 jsonwebtoken = { version = "9.3.0", optional = false }

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -63,11 +63,11 @@ percent-encoding = {version = "2.1.0", optional = true}
 regex = {version = "1.3", optional = true}
 
 # Conversion
-frunk = { version = "0.3.0", optional = true }
-frunk_derives = { version = "0.3.0", optional = true }
-frunk_core = { version = "0.3.0", optional = true }
-frunk-enum-derive = { version = "0.2.0", optional = true }
-frunk-enum-core = { version = "0.2.0", optional = true }
+frunk = { version = "0.4.0", optional = true }
+frunk_derives = { version = "0.4.0", optional = true }
+frunk_core = { version = "0.4.0", optional = true }
+frunk-enum-derive = { version = "0.3.0", optional = true }
+frunk-enum-core = { version = "0.3.0", optional = true }
 
 # Bearer authentication
 jsonwebtoken = { version = "9.3.0", optional = false }

--- a/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
@@ -53,11 +53,11 @@ percent-encoding = {version = "2.1.0", optional = true}
 regex = {version = "1.3", optional = true}
 
 # Conversion
-frunk = { version = "0.3.0", optional = true }
-frunk_derives = { version = "0.3.0", optional = true }
-frunk_core = { version = "0.3.0", optional = true }
-frunk-enum-derive = { version = "0.2.0", optional = true }
-frunk-enum-core = { version = "0.2.0", optional = true }
+frunk = { version = "0.4.0", optional = true }
+frunk_derives = { version = "0.4.0", optional = true }
+frunk_core = { version = "0.4.0", optional = true }
+frunk-enum-derive = { version = "0.3.0", optional = true }
+frunk-enum-core = { version = "0.3.0", optional = true }
 
 # Bearer authentication
 jsonwebtoken = { version = "9.3.0", optional = false }

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -59,11 +59,11 @@ percent-encoding = {version = "2.1.0", optional = true}
 regex = {version = "1.3", optional = true}
 
 # Conversion
-frunk = { version = "0.3.0", optional = true }
-frunk_derives = { version = "0.3.0", optional = true }
-frunk_core = { version = "0.3.0", optional = true }
-frunk-enum-derive = { version = "0.2.0", optional = true }
-frunk-enum-core = { version = "0.2.0", optional = true }
+frunk = { version = "0.4.0", optional = true }
+frunk_derives = { version = "0.4.0", optional = true }
+frunk_core = { version = "0.4.0", optional = true }
+frunk-enum-derive = { version = "0.3.0", optional = true }
+frunk-enum-core = { version = "0.3.0", optional = true }
 
 # Bearer authentication
 jsonwebtoken = { version = "9.3.0", optional = false }

--- a/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
@@ -53,11 +53,11 @@ percent-encoding = {version = "2.1.0", optional = true}
 regex = {version = "1.3", optional = true}
 
 # Conversion
-frunk = { version = "0.3.0", optional = true }
-frunk_derives = { version = "0.3.0", optional = true }
-frunk_core = { version = "0.3.0", optional = true }
-frunk-enum-derive = { version = "0.2.0", optional = true }
-frunk-enum-core = { version = "0.2.0", optional = true }
+frunk = { version = "0.4.0", optional = true }
+frunk_derives = { version = "0.4.0", optional = true }
+frunk_core = { version = "0.4.0", optional = true }
+frunk-enum-derive = { version = "0.3.0", optional = true }
+frunk-enum-core = { version = "0.3.0", optional = true }
 
 # Bearer authentication
 jsonwebtoken = { version = "9.3.0", optional = false }

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -65,11 +65,11 @@ percent-encoding = {version = "2.1.0", optional = true}
 regex = {version = "1.3", optional = true}
 
 # Conversion
-frunk = { version = "0.3.0", optional = true }
-frunk_derives = { version = "0.3.0", optional = true }
-frunk_core = { version = "0.3.0", optional = true }
-frunk-enum-derive = { version = "0.2.0", optional = true }
-frunk-enum-core = { version = "0.2.0", optional = true }
+frunk = { version = "0.4.0", optional = true }
+frunk_derives = { version = "0.4.0", optional = true }
+frunk_core = { version = "0.4.0", optional = true }
+frunk-enum-derive = { version = "0.3.0", optional = true }
+frunk-enum-core = { version = "0.3.0", optional = true }
 
 # Bearer authentication
 jsonwebtoken = { version = "9.3.0", optional = false }

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
@@ -53,11 +53,11 @@ percent-encoding = {version = "2.1.0", optional = true}
 regex = {version = "1.3", optional = true}
 
 # Conversion
-frunk = { version = "0.3.0", optional = true }
-frunk_derives = { version = "0.3.0", optional = true }
-frunk_core = { version = "0.3.0", optional = true }
-frunk-enum-derive = { version = "0.2.0", optional = true }
-frunk-enum-core = { version = "0.2.0", optional = true }
+frunk = { version = "0.4.0", optional = true }
+frunk_derives = { version = "0.4.0", optional = true }
+frunk_core = { version = "0.4.0", optional = true }
+frunk-enum-derive = { version = "0.3.0", optional = true }
+frunk-enum-core = { version = "0.3.0", optional = true }
 
 # Bearer authentication
 jsonwebtoken = { version = "9.3.0", optional = false }

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -53,11 +53,11 @@ percent-encoding = {version = "2.1.0", optional = true}
 regex = {version = "1.3", optional = true}
 
 # Conversion
-frunk = { version = "0.3.0", optional = true }
-frunk_derives = { version = "0.3.0", optional = true }
-frunk_core = { version = "0.3.0", optional = true }
-frunk-enum-derive = { version = "0.2.0", optional = true }
-frunk-enum-core = { version = "0.2.0", optional = true }
+frunk = { version = "0.4.0", optional = true }
+frunk_derives = { version = "0.4.0", optional = true }
+frunk_core = { version = "0.4.0", optional = true }
+frunk-enum-derive = { version = "0.3.0", optional = true }
+frunk-enum-core = { version = "0.3.0", optional = true }
 
 # Bearer authentication
 jsonwebtoken = { version = "9.3.0", optional = false }


### PR DESCRIPTION
- Enforce that all features build as part of CI, by passing `--all-features` to the build.

- Upgrade `frunk` to `0.4`. This is required to bring in https://github.com/lloydmeta/frunk/pull/186 which is required to fix the following compile error:

```
error[E0412]: cannot find type `_uc` in module `frunk_core::labelled::chars`
   --> output/petstore-with-fake-endpoints-models-for-testing/src/models.rs:565:43
    |
565 | #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
    |                                           ^^^^^^^^^^^^^^^^^^^^^^ not found in `frunk_core::labelled::chars`
    |
    = note: this error originates in the derive macro `frunk::LabelledGeneric` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This is caused by sanitised identifiers like `r#type` which was introduced by https://github.com/OpenAPITools/openapi-generator/commit/dc7ae051b8a1a193c10045a0f7f01ce0f0b5d07a which moved to use AbstractRustCodegen, which changed the way sanitisation worked.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Rust Technical Committee: @frol @farcaller @paladinzh @jacob-pro
