### PR TITLE
[Rust Server] Sort operations so that the ones with fewest params come first

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -804,14 +804,15 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
             postProcessOperationWithModels(op, allModels);
         }
 
-	operationList.sort((one, another) -> {
-		int params_compare = ObjectUtils.compare(one.pathParams.size(), another.pathParams.size());
-	        if (params_compare == 0) {
-		    return ObjectUtils.compare(one.operationId, another.operationId);
-		} else {
-		    return params_compare;
-		}
-	});
+        operationList.sort((one, another) -> {
+            int params_compare = ObjectUtils.compare(one.pathParams.size(), another.pathParams.size());
+                if (params_compare == 0) {
+                return ObjectUtils.compare(one.operationId, another.operationId);
+            } else {
+                return params_compare;
+            }
+        });
+
         return objs;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -31,6 +31,7 @@ import io.swagger.v3.oas.models.servers.Server;
 import joptsimple.internal.Strings;
 import lombok.Setter;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.*;
@@ -803,6 +804,14 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
             postProcessOperationWithModels(op, allModels);
         }
 
+	operationList.sort((one, another) -> {
+		int params_compare = ObjectUtils.compare(one.pathParams.size(), another.pathParams.size());
+	        if (params_compare == 0) {
+		    return ObjectUtils.compare(one.operationId, another.operationId);
+		} else {
+		    return params_compare;
+		}
+	});
         return objs;
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/README.md
@@ -122,7 +122,6 @@ Method | HTTP request | Description
 [****](docs/default_api.md#) | **GET** /any-of | 
 [****](docs/default_api.md#) | **POST** /callback-with-header | 
 [****](docs/default_api.md#) | **GET** /complex-query-param | 
-[****](docs/default_api.md#) | **GET** /enum_in_path/{path_param} | 
 [****](docs/default_api.md#) | **GET** /json-complex-query-param | 
 [****](docs/default_api.md#) | **GET** /mandatory-request-header | 
 [****](docs/default_api.md#) | **GET** /merge-patch-json | 
@@ -143,6 +142,7 @@ Method | HTTP request | Description
 [****](docs/default_api.md#) | **PUT** /xml_other | 
 [****](docs/default_api.md#) | **POST** /xml | Post an array
 [****](docs/default_api.md#) | **PUT** /xml | 
+[****](docs/default_api.md#) | **GET** /enum_in_path/{path_param} | 
 [**CreateRepo**](docs/repo_api.md#CreateRepo) | **POST** /repos | 
 [**GetRepoInfo**](docs/repo_api.md#GetRepoInfo) | **GET** /repos/{repoId} | 
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
@@ -7,7 +7,6 @@ Method | HTTP request | Description
 ****](default_api.md#) | **GET** /any-of | 
 ****](default_api.md#) | **POST** /callback-with-header | 
 ****](default_api.md#) | **GET** /complex-query-param | 
-****](default_api.md#) | **GET** /enum_in_path/{path_param} | 
 ****](default_api.md#) | **GET** /json-complex-query-param | 
 ****](default_api.md#) | **GET** /mandatory-request-header | 
 ****](default_api.md#) | **GET** /merge-patch-json | 
@@ -28,6 +27,7 @@ Method | HTTP request | Description
 ****](default_api.md#) | **PUT** /xml_other | 
 ****](default_api.md#) | **POST** /xml | Post an array
 ****](default_api.md#) | **PUT** /xml | 
+****](default_api.md#) | **GET** /enum_in_path/{path_param} | 
 
 
 # ****
@@ -103,31 +103,6 @@ Optional parameters are passed through a map[string]interface{}.
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **list_of_strings** | [**String**](String.md)|  | 
-
-### Return type
-
- (empty response body)
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: Not defined
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# ****
-> (path_param)
-
-
-### Required Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **path_param** | [****](.md)|  | 
 
 ### Return type
 
@@ -673,6 +648,31 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: application/xml
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> (path_param)
+
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **path_param** | [****](.md)|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
  - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -9,7 +9,6 @@ use openapi_v3::{Api, ApiNoContext, Claims, Client, ContextWrapperExt, models,
                       AnyOfGetResponse,
                       CallbackWithHeaderPostResponse,
                       ComplexQueryParamGetResponse,
-                      EnumInPathPathParamGetResponse,
                       JsonComplexQueryParamGetResponse,
                       MandatoryRequestHeaderGetResponse,
                       MergePatchJsonGetResponse,
@@ -30,6 +29,7 @@ use openapi_v3::{Api, ApiNoContext, Claims, Client, ContextWrapperExt, models,
                       XmlOtherPutResponse,
                       XmlPostResponse,
                       XmlPutResponse,
+                      EnumInPathPathParamGetResponse,
                       CreateRepoResponse,
                       GetRepoInfoResponse,
                      };
@@ -177,14 +177,6 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        /* Disabled because there's no example.
-        Some("EnumInPathPathParamGet") => {
-            let result = rt.block_on(client.enum_in_path_path_param_get(
-                  ???
-            ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
-        },
-        */
         Some("JsonComplexQueryParamGet") => {
             let result = rt.block_on(client.json_complex_query_param_get(
                   Some(&Vec::new())
@@ -298,6 +290,14 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        /* Disabled because there's no example.
+        Some("EnumInPathPathParamGet") => {
+            let result = rt.block_on(client.enum_in_path_path_param_get(
+                  ???
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        */
         Some("CreateRepo") => {
             let result = rt.block_on(client.create_repo(
                   serde_json::from_str::<models::ObjectParam>(r#"{"requiredParam":true}"#).expect("Failed to parse JSON example")

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
@@ -105,7 +105,6 @@ use openapi_v3::{
     AnyOfGetResponse,
     CallbackWithHeaderPostResponse,
     ComplexQueryParamGetResponse,
-    EnumInPathPathParamGetResponse,
     JsonComplexQueryParamGetResponse,
     MandatoryRequestHeaderGetResponse,
     MergePatchJsonGetResponse,
@@ -126,6 +125,7 @@ use openapi_v3::{
     XmlOtherPutResponse,
     XmlPostResponse,
     XmlPutResponse,
+    EnumInPathPathParamGetResponse,
     CreateRepoResponse,
     GetRepoInfoResponse,
 };
@@ -160,15 +160,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         context: &C) -> Result<ComplexQueryParamGetResponse, ApiError>
     {
         info!("complex_query_param_get({:?}) - X-Span-ID: {:?}", list_of_strings, context.get().0.clone());
-        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
-    }
-
-    async fn enum_in_path_path_param_get(
-        &self,
-        path_param: models::StringEnum,
-        context: &C) -> Result<EnumInPathPathParamGetResponse, ApiError>
-    {
-        info!("enum_in_path_path_param_get({:?}) - X-Span-ID: {:?}", path_param, context.get().0.clone());
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 
@@ -345,6 +336,15 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         context: &C) -> Result<XmlPutResponse, ApiError>
     {
         info!("xml_put({:?}) - X-Span-ID: {:?}", xml_object, context.get().0.clone());
+        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
+    }
+
+    async fn enum_in_path_path_param_get(
+        &self,
+        path_param: models::StringEnum,
+        context: &C) -> Result<EnumInPathPathParamGetResponse, ApiError>
+    {
+        info!("enum_in_path_path_param_get({:?}) - X-Span-ID: {:?}", path_param, context.get().0.clone());
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -39,7 +39,6 @@ use crate::{Api,
      AnyOfGetResponse,
      CallbackWithHeaderPostResponse,
      ComplexQueryParamGetResponse,
-     EnumInPathPathParamGetResponse,
      JsonComplexQueryParamGetResponse,
      MandatoryRequestHeaderGetResponse,
      MergePatchJsonGetResponse,
@@ -60,6 +59,7 @@ use crate::{Api,
      XmlOtherPutResponse,
      XmlPostResponse,
      XmlPutResponse,
+     EnumInPathPathParamGetResponse,
      CreateRepoResponse,
      GetRepoInfoResponse
      };
@@ -645,76 +645,6 @@ impl<S, C> Api<C> for Client<S, C> where
             200 => {
                 Ok(
                     ComplexQueryParamGetResponse::Success
-                )
-            }
-            code => {
-                let headers = response.headers().clone();
-                let body = response.into_body()
-                       .take(100)
-                       .into_raw().await;
-                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                    code,
-                    headers,
-                    match body {
-                        Ok(body) => match String::from_utf8(body) {
-                            Ok(body) => body,
-                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
-                        },
-                        Err(e) => format!("<Failed to read body: {}>", e),
-                    }
-                )))
-            }
-        }
-    }
-
-    async fn enum_in_path_path_param_get(
-        &self,
-        param_path_param: models::StringEnum,
-        context: &C) -> Result<EnumInPathPathParamGetResponse, ApiError>
-    {
-        let mut client_service = self.client_service.clone();
-        let mut uri = format!(
-            "{}/enum_in_path/{path_param}",
-            self.base_path
-            ,path_param=utf8_percent_encode(&param_path_param.to_string(), ID_ENCODE_SET)
-        );
-
-        // Query parameters
-        let query_string = {
-            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
-            query_string.finish()
-        };
-        if !query_string.is_empty() {
-            uri += "?";
-            uri += &query_string;
-        }
-
-        let uri = match Uri::from_str(&uri) {
-            Ok(uri) => uri,
-            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
-        };
-
-        let mut request = match Request::builder()
-            .method("GET")
-            .uri(uri)
-            .body(Body::empty()) {
-                Ok(req) => req,
-                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
-        };
-
-        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
-        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
-            Ok(h) => h,
-            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
-        });
-
-        let response = client_service.call((request, context.clone()))
-            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
-
-        match response.status().as_u16() {
-            200 => {
-                Ok(
-                    EnumInPathPathParamGetResponse::Success
                 )
             }
             code => {
@@ -2575,6 +2505,76 @@ impl<S, C> Api<C> for Client<S, C> where
             400 => {
                 Ok(
                     XmlPutResponse::BadRequest
+                )
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body()
+                       .take(100)
+                       .into_raw().await;
+                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn enum_in_path_path_param_get(
+        &self,
+        param_path_param: models::StringEnum,
+        context: &C) -> Result<EnumInPathPathParamGetResponse, ApiError>
+    {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/enum_in_path/{path_param}",
+            self.base_path
+            ,path_param=utf8_percent_encode(&param_path_param.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
+        });
+
+        let response = client_service.call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
+
+        match response.status().as_u16() {
+            200 => {
+                Ok(
+                    EnumInPathPathParamGetResponse::Success
                 )
             }
             code => {

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -49,12 +49,6 @@ pub enum ComplexQueryParamGetResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub enum EnumInPathPathParamGetResponse {
-    /// Success
-    Success
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum JsonComplexQueryParamGetResponse {
     /// Success
     Success
@@ -266,6 +260,12 @@ pub enum XmlPutResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum EnumInPathPathParamGetResponse {
+    /// Success
+    Success
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum CreateRepoResponse {
     /// Success
     Success
@@ -300,11 +300,6 @@ pub trait Api<C: Send + Sync> {
         &self,
         list_of_strings: Option<&Vec<models::StringObject>>,
         context: &C) -> Result<ComplexQueryParamGetResponse, ApiError>;
-
-    async fn enum_in_path_path_param_get(
-        &self,
-        path_param: models::StringEnum,
-        context: &C) -> Result<EnumInPathPathParamGetResponse, ApiError>;
 
     async fn json_complex_query_param_get(
         &self,
@@ -402,6 +397,11 @@ pub trait Api<C: Send + Sync> {
         xml_object: Option<models::XmlObject>,
         context: &C) -> Result<XmlPutResponse, ApiError>;
 
+    async fn enum_in_path_path_param_get(
+        &self,
+        path_param: models::StringEnum,
+        context: &C) -> Result<EnumInPathPathParamGetResponse, ApiError>;
+
     async fn create_repo(
         &self,
         object_param: models::ObjectParam,
@@ -437,11 +437,6 @@ pub trait ApiNoContext<C: Send + Sync> {
         &self,
         list_of_strings: Option<&Vec<models::StringObject>>,
         ) -> Result<ComplexQueryParamGetResponse, ApiError>;
-
-    async fn enum_in_path_path_param_get(
-        &self,
-        path_param: models::StringEnum,
-        ) -> Result<EnumInPathPathParamGetResponse, ApiError>;
 
     async fn json_complex_query_param_get(
         &self,
@@ -539,6 +534,11 @@ pub trait ApiNoContext<C: Send + Sync> {
         xml_object: Option<models::XmlObject>,
         ) -> Result<XmlPutResponse, ApiError>;
 
+    async fn enum_in_path_path_param_get(
+        &self,
+        path_param: models::StringEnum,
+        ) -> Result<EnumInPathPathParamGetResponse, ApiError>;
+
     async fn create_repo(
         &self,
         object_param: models::ObjectParam,
@@ -599,15 +599,6 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     {
         let context = self.context().clone();
         self.api().complex_query_param_get(list_of_strings, &context).await
-    }
-
-    async fn enum_in_path_path_param_get(
-        &self,
-        path_param: models::StringEnum,
-        ) -> Result<EnumInPathPathParamGetResponse, ApiError>
-    {
-        let context = self.context().clone();
-        self.api().enum_in_path_path_param_get(path_param, &context).await
     }
 
     async fn json_complex_query_param_get(
@@ -784,6 +775,15 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     {
         let context = self.context().clone();
         self.api().xml_put(xml_object, &context).await
+    }
+
+    async fn enum_in_path_path_param_get(
+        &self,
+        path_param: models::StringEnum,
+        ) -> Result<EnumInPathPathParamGetResponse, ApiError>
+    {
+        let context = self.context().clone();
+        self.api().enum_in_path_path_param_get(path_param, &context).await
     }
 
     async fn create_repo(

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -24,7 +24,6 @@ use crate::{Api,
      AnyOfGetResponse,
      CallbackWithHeaderPostResponse,
      ComplexQueryParamGetResponse,
-     EnumInPathPathParamGetResponse,
      JsonComplexQueryParamGetResponse,
      MandatoryRequestHeaderGetResponse,
      MergePatchJsonGetResponse,
@@ -45,6 +44,7 @@ use crate::{Api,
      XmlOtherPutResponse,
      XmlPostResponse,
      XmlPutResponse,
+     EnumInPathPathParamGetResponse,
      CreateRepoResponse,
      GetRepoInfoResponse
 };
@@ -387,60 +387,6 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                         match result {
                                             Ok(rsp) => match rsp {
                                                 ComplexQueryParamGetResponse::Success
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
-
-                                                },
-                                            },
-                                            Err(_) => {
-                                                // Application code returned an error. This should not happen, as the implementation should
-                                                // return a valid response.
-                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                                *response.body_mut() = Body::from("An internal error occurred");
-                                            },
-                                        }
-
-                                        Ok(response)
-            },
-
-            // EnumInPathPathParamGet - GET /enum_in_path/{path_param}
-            hyper::Method::GET if path.matched(paths::ID_ENUM_IN_PATH_PATH_PARAM) => {
-                // Path parameters
-                let path: &str = uri.path();
-                let path_params =
-                    paths::REGEX_ENUM_IN_PATH_PATH_PARAM
-                    .captures(path)
-                    .unwrap_or_else(||
-                        panic!("Path {} matched RE ENUM_IN_PATH_PATH_PARAM in set but failed match against \"{}\"", path, paths::REGEX_ENUM_IN_PATH_PATH_PARAM.as_str())
-                    );
-
-                let param_path_param = match percent_encoding::percent_decode(path_params["path_param"].as_bytes()).decode_utf8() {
-                    Ok(param_path_param) => match param_path_param.parse::<models::StringEnum>() {
-                        Ok(param_path_param) => param_path_param,
-                        Err(e) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't parse path parameter path_param: {}", e)))
-                                        .expect("Unable to create Bad Request response for invalid path parameter")),
-                    },
-                    Err(_) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["path_param"])))
-                                        .expect("Unable to create Bad Request response for invalid percent decode"))
-                };
-
-                                let result = api_impl.enum_in_path_path_param_get(
-                                            param_path_param,
-                                        &context
-                                    ).await;
-                                let mut response = Response::new(Body::empty());
-                                response.headers_mut().insert(
-                                            HeaderName::from_static("x-span-id"),
-                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
-                                                .expect("Unable to create X-Span-ID header value"));
-
-                                        match result {
-                                            Ok(rsp) => match rsp {
-                                                EnumInPathPathParamGetResponse::Success
                                                 => {
                                                     *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
 
@@ -1771,6 +1717,60 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                         }
             },
 
+            // EnumInPathPathParamGet - GET /enum_in_path/{path_param}
+            hyper::Method::GET if path.matched(paths::ID_ENUM_IN_PATH_PATH_PARAM) => {
+                // Path parameters
+                let path: &str = uri.path();
+                let path_params =
+                    paths::REGEX_ENUM_IN_PATH_PATH_PARAM
+                    .captures(path)
+                    .unwrap_or_else(||
+                        panic!("Path {} matched RE ENUM_IN_PATH_PATH_PARAM in set but failed match against \"{}\"", path, paths::REGEX_ENUM_IN_PATH_PATH_PARAM.as_str())
+                    );
+
+                let param_path_param = match percent_encoding::percent_decode(path_params["path_param"].as_bytes()).decode_utf8() {
+                    Ok(param_path_param) => match param_path_param.parse::<models::StringEnum>() {
+                        Ok(param_path_param) => param_path_param,
+                        Err(e) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't parse path parameter path_param: {}", e)))
+                                        .expect("Unable to create Bad Request response for invalid path parameter")),
+                    },
+                    Err(_) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["path_param"])))
+                                        .expect("Unable to create Bad Request response for invalid percent decode"))
+                };
+
+                                let result = api_impl.enum_in_path_path_param_get(
+                                            param_path_param,
+                                        &context
+                                    ).await;
+                                let mut response = Response::new(Body::empty());
+                                response.headers_mut().insert(
+                                            HeaderName::from_static("x-span-id"),
+                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
+                                                .expect("Unable to create X-Span-ID header value"));
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                EnumInPathPathParamGetResponse::Success
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
+
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                                *response.body_mut() = Body::from("An internal error occurred");
+                                            },
+                                        }
+
+                                        Ok(response)
+            },
+
             // CreateRepo - POST /repos
             hyper::Method::POST if path.matched(paths::ID_REPOS) => {
                 // Handle body parameters (note that non-required body parameters will ignore garbage
@@ -1950,8 +1950,6 @@ impl<T> RequestParser<T> for ApiRequestParser {
             hyper::Method::POST if path.matched(paths::ID_CALLBACK_WITH_HEADER) => Some("CallbackWithHeaderPost"),
             // ComplexQueryParamGet - GET /complex-query-param
             hyper::Method::GET if path.matched(paths::ID_COMPLEX_QUERY_PARAM) => Some("ComplexQueryParamGet"),
-            // EnumInPathPathParamGet - GET /enum_in_path/{path_param}
-            hyper::Method::GET if path.matched(paths::ID_ENUM_IN_PATH_PATH_PARAM) => Some("EnumInPathPathParamGet"),
             // JsonComplexQueryParamGet - GET /json-complex-query-param
             hyper::Method::GET if path.matched(paths::ID_JSON_COMPLEX_QUERY_PARAM) => Some("JsonComplexQueryParamGet"),
             // MandatoryRequestHeaderGet - GET /mandatory-request-header
@@ -1992,6 +1990,8 @@ impl<T> RequestParser<T> for ApiRequestParser {
             hyper::Method::POST if path.matched(paths::ID_XML) => Some("XmlPost"),
             // XmlPut - PUT /xml
             hyper::Method::PUT if path.matched(paths::ID_XML) => Some("XmlPut"),
+            // EnumInPathPathParamGet - GET /enum_in_path/{path_param}
+            hyper::Method::GET if path.matched(paths::ID_ENUM_IN_PATH_PATH_PARAM) => Some("EnumInPathPathParamGet"),
             // CreateRepo - POST /repos
             hyper::Method::POST if path.matched(paths::ID_REPOS) => Some("CreateRepo"),
             // GetRepoInfo - GET /repos/{repoId}

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/README.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/README.md
@@ -67,25 +67,25 @@ cargo run --example client FakeOuterCompositeSerialize
 cargo run --example client FakeOuterNumberSerialize
 cargo run --example client FakeOuterStringSerialize
 cargo run --example client FakeResponseWithNumericalDescription
-cargo run --example client HyphenParam
 cargo run --example client TestEndpointParameters
 cargo run --example client TestEnumParameters
 cargo run --example client TestJsonFormData
-cargo run --example client DeletePet
+cargo run --example client HyphenParam
 cargo run --example client FindPetsByStatus
 cargo run --example client FindPetsByTags
+cargo run --example client DeletePet
 cargo run --example client GetPetById
 cargo run --example client UpdatePetWithForm
 cargo run --example client UploadFile
-cargo run --example client DeleteOrder
 cargo run --example client GetInventory
+cargo run --example client DeleteOrder
 cargo run --example client GetOrderById
 cargo run --example client CreateUsersWithArrayInput
 cargo run --example client CreateUsersWithListInput
-cargo run --example client DeleteUser
-cargo run --example client GetUserByName
 cargo run --example client LoginUser
 cargo run --example client LogoutUser
+cargo run --example client DeleteUser
+cargo run --example client GetUserByName
 ```
 
 ### HTTPS
@@ -126,33 +126,33 @@ Method | HTTP request | Description
 [**fakeOuterNumberSerialize**](docs/fake_api.md#fakeOuterNumberSerialize) | **POST** /fake/outer/number | 
 [**fakeOuterStringSerialize**](docs/fake_api.md#fakeOuterStringSerialize) | **POST** /fake/outer/string | 
 [**fake_response_with_numerical_description**](docs/fake_api.md#fake_response_with_numerical_description) | **GET** /fake/response-with-numerical-description | 
-[**hyphenParam**](docs/fake_api.md#hyphenParam) | **GET** /fake/hyphenParam/{hyphen-param} | 
 [**testBodyWithQueryParams**](docs/fake_api.md#testBodyWithQueryParams) | **PUT** /fake/body-with-query-params | 
 [**testClientModel**](docs/fake_api.md#testClientModel) | **PATCH** /fake | To test \"client\" model
 [**testEndpointParameters**](docs/fake_api.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
 [**testEnumParameters**](docs/fake_api.md#testEnumParameters) | **GET** /fake | To test enum parameters
 [**testInlineAdditionalProperties**](docs/fake_api.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](docs/fake_api.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**hyphenParam**](docs/fake_api.md#hyphenParam) | **GET** /fake/hyphenParam/{hyphen-param} | 
 [**testClassname**](docs/fake_classname_tags123_api.md#testClassname) | **PATCH** /fake_classname_test | To test class name in snake case
 [**addPet**](docs/pet_api.md#addPet) | **POST** /pet | Add a new pet to the store
-[**deletePet**](docs/pet_api.md#deletePet) | **DELETE** /pet/{petId} | Deletes a pet
 [**findPetsByStatus**](docs/pet_api.md#findPetsByStatus) | **GET** /pet/findByStatus | Finds Pets by status
 [**findPetsByTags**](docs/pet_api.md#findPetsByTags) | **GET** /pet/findByTags | Finds Pets by tags
-[**getPetById**](docs/pet_api.md#getPetById) | **GET** /pet/{petId} | Find pet by ID
 [**updatePet**](docs/pet_api.md#updatePet) | **PUT** /pet | Update an existing pet
+[**deletePet**](docs/pet_api.md#deletePet) | **DELETE** /pet/{petId} | Deletes a pet
+[**getPetById**](docs/pet_api.md#getPetById) | **GET** /pet/{petId} | Find pet by ID
 [**updatePetWithForm**](docs/pet_api.md#updatePetWithForm) | **POST** /pet/{petId} | Updates a pet in the store with form data
 [**uploadFile**](docs/pet_api.md#uploadFile) | **POST** /pet/{petId}/uploadImage | uploads an image
-[**deleteOrder**](docs/store_api.md#deleteOrder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
 [**getInventory**](docs/store_api.md#getInventory) | **GET** /store/inventory | Returns pet inventories by status
-[**getOrderById**](docs/store_api.md#getOrderById) | **GET** /store/order/{order_id} | Find purchase order by ID
 [**placeOrder**](docs/store_api.md#placeOrder) | **POST** /store/order | Place an order for a pet
+[**deleteOrder**](docs/store_api.md#deleteOrder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
+[**getOrderById**](docs/store_api.md#getOrderById) | **GET** /store/order/{order_id} | Find purchase order by ID
 [**createUser**](docs/user_api.md#createUser) | **POST** /user | Create user
 [**createUsersWithArrayInput**](docs/user_api.md#createUsersWithArrayInput) | **POST** /user/createWithArray | Creates list of users with given input array
 [**createUsersWithListInput**](docs/user_api.md#createUsersWithListInput) | **POST** /user/createWithList | Creates list of users with given input array
-[**deleteUser**](docs/user_api.md#deleteUser) | **DELETE** /user/{username} | Delete user
-[**getUserByName**](docs/user_api.md#getUserByName) | **GET** /user/{username} | Get user by user name
 [**loginUser**](docs/user_api.md#loginUser) | **GET** /user/login | Logs user into the system
 [**logoutUser**](docs/user_api.md#logoutUser) | **GET** /user/logout | Logs out current logged in user session
+[**deleteUser**](docs/user_api.md#deleteUser) | **DELETE** /user/{username} | Delete user
+[**getUserByName**](docs/user_api.md#getUserByName) | **GET** /user/{username} | Get user by user name
 [**updateUser**](docs/user_api.md#updateUser) | **PUT** /user/{username} | Updated user
 
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/fake_api.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/fake_api.md
@@ -10,13 +10,13 @@ Method | HTTP request | Description
 **fakeOuterNumberSerialize**](fake_api.md#fakeOuterNumberSerialize) | **POST** /fake/outer/number | 
 **fakeOuterStringSerialize**](fake_api.md#fakeOuterStringSerialize) | **POST** /fake/outer/string | 
 **fake_response_with_numerical_description**](fake_api.md#fake_response_with_numerical_description) | **GET** /fake/response-with-numerical-description | 
-**hyphenParam**](fake_api.md#hyphenParam) | **GET** /fake/hyphenParam/{hyphen-param} | 
 **testBodyWithQueryParams**](fake_api.md#testBodyWithQueryParams) | **PUT** /fake/body-with-query-params | 
 **testClientModel**](fake_api.md#testClientModel) | **PATCH** /fake | To test \"client\" model
 **testEndpointParameters**](fake_api.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
 **testEnumParameters**](fake_api.md#testEnumParameters) | **GET** /fake | To test enum parameters
 **testInlineAdditionalProperties**](fake_api.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 **testJsonFormData**](fake_api.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+**hyphenParam**](fake_api.md#hyphenParam) | **GET** /fake/hyphenParam/{hyphen-param} | 
 
 
 # **123example**
@@ -183,33 +183,6 @@ No authorization required
 
 ### Required Parameters
 This endpoint does not need any parameter.
-
-### Return type
-
- (empty response body)
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: Not defined
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# **hyphenParam**
-> hyphenParam(hyphen_param)
-
-
-To test hyphen in path parameter name
-
-### Required Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **hyphen_param** | **String**| Parameter with hyphen in name | 
 
 ### Return type
 
@@ -418,6 +391,33 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: application/x-www-form-urlencoded
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **hyphenParam**
+> hyphenParam(hyphen_param)
+
+
+To test hyphen in path parameter name
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **hyphen_param** | **String**| Parameter with hyphen in name | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
  - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/pet_api.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/pet_api.md
@@ -5,11 +5,11 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 **addPet**](pet_api.md#addPet) | **POST** /pet | Add a new pet to the store
-**deletePet**](pet_api.md#deletePet) | **DELETE** /pet/{petId} | Deletes a pet
 **findPetsByStatus**](pet_api.md#findPetsByStatus) | **GET** /pet/findByStatus | Finds Pets by status
 **findPetsByTags**](pet_api.md#findPetsByTags) | **GET** /pet/findByTags | Finds Pets by tags
-**getPetById**](pet_api.md#getPetById) | **GET** /pet/{petId} | Find pet by ID
 **updatePet**](pet_api.md#updatePet) | **PUT** /pet | Update an existing pet
+**deletePet**](pet_api.md#deletePet) | **DELETE** /pet/{petId} | Deletes a pet
+**getPetById**](pet_api.md#getPetById) | **GET** /pet/{petId} | Find pet by ID
 **updatePetWithForm**](pet_api.md#updatePetWithForm) | **POST** /pet/{petId} | Updates a pet in the store with form data
 **uploadFile**](pet_api.md#uploadFile) | **POST** /pet/{petId}/uploadImage | uploads an image
 
@@ -36,41 +36,6 @@ Name | Type | Description  | Notes
 ### HTTP request headers
 
  - **Content-Type**: application/json, application/xml
- - **Accept**: Not defined
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# **deletePet**
-> deletePet(ctx, pet_id, optional)
-Deletes a pet
-
-### Required Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **pet_id** | **i64**| Pet id to delete | 
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
-
-### Optional Parameters
-Optional parameters are passed through a map[string]interface{}.
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **i64**| Pet id to delete | 
- **api_key** | **String**|  | 
-
-### Return type
-
- (empty response body)
-
-### Authorization
-
-[petstore_auth](../README.md#petstore_auth)
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
  - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
@@ -131,6 +96,67 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
+# **updatePet**
+> updatePet(ctx, body)
+Update an existing pet
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context containing the authentication | nil if no authentication
+  **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+[petstore_auth](../README.md#petstore_auth)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json, application/xml
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **deletePet**
+> deletePet(ctx, pet_id, optional)
+Deletes a pet
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context containing the authentication | nil if no authentication
+  **pet_id** | **i64**| Pet id to delete | 
+ **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a map[string]interface{}.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pet_id** | **i64**| Pet id to delete | 
+ **api_key** | **String**|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+[petstore_auth](../README.md#petstore_auth)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
 # **getPetById**
 > models::Pet getPetById(ctx, pet_id)
 Find pet by ID
@@ -156,32 +182,6 @@ Name | Type | Description  | Notes
 
  - **Content-Type**: Not defined
  - **Accept**: application/json, application/xml
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# **updatePet**
-> updatePet(ctx, body)
-Update an existing pet
-
-### Required Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
-
-### Return type
-
- (empty response body)
-
-### Authorization
-
-[petstore_auth](../README.md#petstore_auth)
-
-### HTTP request headers
-
- - **Content-Type**: application/json, application/xml
- - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/store_api.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/store_api.md
@@ -4,11 +4,60 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-**deleteOrder**](store_api.md#deleteOrder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
 **getInventory**](store_api.md#getInventory) | **GET** /store/inventory | Returns pet inventories by status
-**getOrderById**](store_api.md#getOrderById) | **GET** /store/order/{order_id} | Find purchase order by ID
 **placeOrder**](store_api.md#placeOrder) | **POST** /store/order | Place an order for a pet
+**deleteOrder**](store_api.md#deleteOrder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
+**getOrderById**](store_api.md#getOrderById) | **GET** /store/order/{order_id} | Find purchase order by ID
 
+
+# **getInventory**
+> std::collections::HashMap<String, i32> getInventory(ctx, )
+Returns pet inventories by status
+
+Returns a map of status codes to quantities
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**std::collections::HashMap<String, i32>**](integer.md)
+
+### Authorization
+
+[api_key](../README.md#api_key)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **placeOrder**
+> models::Order placeOrder(body)
+Place an order for a pet
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **body** | [**Order**](Order.md)| order placed for purchasing the pet | 
+
+### Return type
+
+[**models::Order**](Order.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json, application/xml
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **deleteOrder**
 > deleteOrder(order_id)
@@ -37,30 +86,6 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **getInventory**
-> std::collections::HashMap<String, i32> getInventory(ctx, )
-Returns pet inventories by status
-
-Returns a map of status codes to quantities
-
-### Required Parameters
-This endpoint does not need any parameter.
-
-### Return type
-
-[**std::collections::HashMap<String, i32>**](integer.md)
-
-### Authorization
-
-[api_key](../README.md#api_key)
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: application/json
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
 # **getOrderById**
 > models::Order getOrderById(order_id)
 Find purchase order by ID
@@ -72,31 +97,6 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
   **order_id** | **i64**| ID of pet that needs to be fetched | 
-
-### Return type
-
-[**models::Order**](Order.md)
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: application/json, application/xml
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# **placeOrder**
-> models::Order placeOrder(body)
-Place an order for a pet
-
-### Required Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **body** | [**Order**](Order.md)| order placed for purchasing the pet | 
 
 ### Return type
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/user_api.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/user_api.md
@@ -7,10 +7,10 @@ Method | HTTP request | Description
 **createUser**](user_api.md#createUser) | **POST** /user | Create user
 **createUsersWithArrayInput**](user_api.md#createUsersWithArrayInput) | **POST** /user/createWithArray | Creates list of users with given input array
 **createUsersWithListInput**](user_api.md#createUsersWithListInput) | **POST** /user/createWithList | Creates list of users with given input array
-**deleteUser**](user_api.md#deleteUser) | **DELETE** /user/{username} | Delete user
-**getUserByName**](user_api.md#getUserByName) | **GET** /user/{username} | Get user by user name
 **loginUser**](user_api.md#loginUser) | **GET** /user/login | Logs user into the system
 **logoutUser**](user_api.md#logoutUser) | **GET** /user/logout | Logs out current logged in user session
+**deleteUser**](user_api.md#deleteUser) | **DELETE** /user/{username} | Delete user
+**getUserByName**](user_api.md#getUserByName) | **GET** /user/{username} | Get user by user name
 **updateUser**](user_api.md#updateUser) | **PUT** /user/{username} | Updated user
 
 
@@ -91,6 +91,54 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
+# **loginUser**
+> String loginUser(username, password)
+Logs user into the system
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **username** | **String**| The user name for login | 
+  **password** | **String**| The password for login in clear text | 
+
+### Return type
+
+[**String**](string.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json, application/xml
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **logoutUser**
+> logoutUser()
+Logs out current logged in user session
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
 # **deleteUser**
 > deleteUser(username)
 Delete user
@@ -140,54 +188,6 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: application/json, application/xml
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# **loginUser**
-> String loginUser(username, password)
-Logs user into the system
-
-### Required Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **username** | **String**| The user name for login | 
-  **password** | **String**| The password for login in clear text | 
-
-### Return type
-
-[**String**](string.md)
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: application/json, application/xml
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# **logoutUser**
-> logoutUser()
-Logs out current logged in user session
-
-### Required Parameters
-This endpoint does not need any parameter.
-
-### Return type
-
- (empty response body)
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
@@ -12,33 +12,33 @@ use petstore_with_fake_endpoints_models_for_testing::{Api, ApiNoContext, Claims,
                       FakeOuterNumberSerializeResponse,
                       FakeOuterStringSerializeResponse,
                       FakeResponseWithNumericalDescriptionResponse,
-                      HyphenParamResponse,
                       TestBodyWithQueryParamsResponse,
                       TestClientModelResponse,
                       TestEndpointParametersResponse,
                       TestEnumParametersResponse,
                       TestInlineAdditionalPropertiesResponse,
                       TestJsonFormDataResponse,
+                      HyphenParamResponse,
                       TestClassnameResponse,
                       AddPetResponse,
-                      DeletePetResponse,
                       FindPetsByStatusResponse,
                       FindPetsByTagsResponse,
-                      GetPetByIdResponse,
                       UpdatePetResponse,
+                      DeletePetResponse,
+                      GetPetByIdResponse,
                       UpdatePetWithFormResponse,
                       UploadFileResponse,
-                      DeleteOrderResponse,
                       GetInventoryResponse,
-                      GetOrderByIdResponse,
                       PlaceOrderResponse,
+                      DeleteOrderResponse,
+                      GetOrderByIdResponse,
                       CreateUserResponse,
                       CreateUsersWithArrayInputResponse,
                       CreateUsersWithListInputResponse,
-                      DeleteUserResponse,
-                      GetUserByNameResponse,
                       LoginUserResponse,
                       LogoutUserResponse,
+                      DeleteUserResponse,
+                      GetUserByNameResponse,
                       UpdateUserResponse,
                      };
 use clap::{App, Arg};
@@ -74,25 +74,25 @@ fn main() {
                 "FakeOuterNumberSerialize",
                 "FakeOuterStringSerialize",
                 "FakeResponseWithNumericalDescription",
-                "HyphenParam",
                 "TestEndpointParameters",
                 "TestEnumParameters",
                 "TestJsonFormData",
-                "DeletePet",
+                "HyphenParam",
                 "FindPetsByStatus",
                 "FindPetsByTags",
+                "DeletePet",
                 "GetPetById",
                 "UpdatePetWithForm",
                 "UploadFile",
-                "DeleteOrder",
                 "GetInventory",
+                "DeleteOrder",
                 "GetOrderById",
                 "CreateUsersWithArrayInput",
                 "CreateUsersWithListInput",
-                "DeleteUser",
-                "GetUserByName",
                 "LoginUser",
                 "LogoutUser",
+                "DeleteUser",
+                "GetUserByName",
             ])
             .required(true)
             .index(1))
@@ -206,12 +206,6 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        Some("HyphenParam") => {
-            let result = rt.block_on(client.hyphen_param(
-                  "hyphen_param_example".to_string()
-            ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
-        },
         /* Disabled because there's no example.
         Some("TestBodyWithQueryParams") => {
             let result = rt.block_on(client.test_body_with_query_params(
@@ -275,6 +269,12 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        Some("HyphenParam") => {
+            let result = rt.block_on(client.hyphen_param(
+                  "hyphen_param_example".to_string()
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
         /* Disabled because there's no example.
         Some("TestClassname") => {
             let result = rt.block_on(client.test_classname(
@@ -291,13 +291,6 @@ fn main() {
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
-        Some("DeletePet") => {
-            let result = rt.block_on(client.delete_pet(
-                  789,
-                  Some("api_key_example".to_string())
-            ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
-        },
         Some("FindPetsByStatus") => {
             let result = rt.block_on(client.find_pets_by_status(
                   &Vec::new()
@@ -310,12 +303,6 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        Some("GetPetById") => {
-            let result = rt.block_on(client.get_pet_by_id(
-                  789
-            ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
-        },
         /* Disabled because there's no example.
         Some("UpdatePet") => {
             let result = rt.block_on(client.update_pet(
@@ -324,6 +311,19 @@ fn main() {
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
+        Some("DeletePet") => {
+            let result = rt.block_on(client.delete_pet(
+                  789,
+                  Some("api_key_example".to_string())
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        Some("GetPetById") => {
+            let result = rt.block_on(client.get_pet_by_id(
+                  789
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
         Some("UpdatePetWithForm") => {
             let result = rt.block_on(client.update_pet_with_form(
                   789,
@@ -340,20 +340,8 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        Some("DeleteOrder") => {
-            let result = rt.block_on(client.delete_order(
-                  "order_id_example".to_string()
-            ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
-        },
         Some("GetInventory") => {
             let result = rt.block_on(client.get_inventory(
-            ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
-        },
-        Some("GetOrderById") => {
-            let result = rt.block_on(client.get_order_by_id(
-                  789
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
@@ -365,6 +353,18 @@ fn main() {
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
+        Some("DeleteOrder") => {
+            let result = rt.block_on(client.delete_order(
+                  "order_id_example".to_string()
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        Some("GetOrderById") => {
+            let result = rt.block_on(client.get_order_by_id(
+                  789
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
         /* Disabled because there's no example.
         Some("CreateUser") => {
             let result = rt.block_on(client.create_user(
@@ -385,18 +385,6 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        Some("DeleteUser") => {
-            let result = rt.block_on(client.delete_user(
-                  "username_example".to_string()
-            ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
-        },
-        Some("GetUserByName") => {
-            let result = rt.block_on(client.get_user_by_name(
-                  "username_example".to_string()
-            ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
-        },
         Some("LoginUser") => {
             let result = rt.block_on(client.login_user(
                   "username_example".to_string(),
@@ -406,6 +394,18 @@ fn main() {
         },
         Some("LogoutUser") => {
             let result = rt.block_on(client.logout_user(
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        Some("DeleteUser") => {
+            let result = rt.block_on(client.delete_user(
+                  "username_example".to_string()
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        Some("GetUserByName") => {
+            let result = rt.block_on(client.get_user_by_name(
+                  "username_example".to_string()
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server/server.rs
@@ -109,33 +109,33 @@ use petstore_with_fake_endpoints_models_for_testing::{
     FakeOuterNumberSerializeResponse,
     FakeOuterStringSerializeResponse,
     FakeResponseWithNumericalDescriptionResponse,
-    HyphenParamResponse,
     TestBodyWithQueryParamsResponse,
     TestClientModelResponse,
     TestEndpointParametersResponse,
     TestEnumParametersResponse,
     TestInlineAdditionalPropertiesResponse,
     TestJsonFormDataResponse,
+    HyphenParamResponse,
     TestClassnameResponse,
     AddPetResponse,
-    DeletePetResponse,
     FindPetsByStatusResponse,
     FindPetsByTagsResponse,
-    GetPetByIdResponse,
     UpdatePetResponse,
+    DeletePetResponse,
+    GetPetByIdResponse,
     UpdatePetWithFormResponse,
     UploadFileResponse,
-    DeleteOrderResponse,
     GetInventoryResponse,
-    GetOrderByIdResponse,
     PlaceOrderResponse,
+    DeleteOrderResponse,
+    GetOrderByIdResponse,
     CreateUserResponse,
     CreateUsersWithArrayInputResponse,
     CreateUsersWithListInputResponse,
-    DeleteUserResponse,
-    GetUserByNameResponse,
     LoginUserResponse,
     LogoutUserResponse,
+    DeleteUserResponse,
+    GetUserByNameResponse,
     UpdateUserResponse,
 };
 use petstore_with_fake_endpoints_models_for_testing::server::MakeService;
@@ -204,15 +204,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         context: &C) -> Result<FakeResponseWithNumericalDescriptionResponse, ApiError>
     {
         info!("fake_response_with_numerical_description() - X-Span-ID: {:?}", context.get().0.clone());
-        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
-    }
-
-    async fn hyphen_param(
-        &self,
-        hyphen_param: String,
-        context: &C) -> Result<HyphenParamResponse, ApiError>
-    {
-        info!("hyphen_param(\"{}\") - X-Span-ID: {:?}", hyphen_param, context.get().0.clone());
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 
@@ -296,6 +287,15 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 
+    async fn hyphen_param(
+        &self,
+        hyphen_param: String,
+        context: &C) -> Result<HyphenParamResponse, ApiError>
+    {
+        info!("hyphen_param(\"{}\") - X-Span-ID: {:?}", hyphen_param, context.get().0.clone());
+        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
+    }
+
     /// To test class name in snake case
     async fn test_classname(
         &self,
@@ -313,17 +313,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         context: &C) -> Result<AddPetResponse, ApiError>
     {
         info!("add_pet({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
-        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
-    }
-
-    /// Deletes a pet
-    async fn delete_pet(
-        &self,
-        pet_id: i64,
-        api_key: Option<String>,
-        context: &C) -> Result<DeletePetResponse, ApiError>
-    {
-        info!("delete_pet({}, {:?}) - X-Span-ID: {:?}", pet_id, api_key, context.get().0.clone());
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 
@@ -347,16 +336,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 
-    /// Find pet by ID
-    async fn get_pet_by_id(
-        &self,
-        pet_id: i64,
-        context: &C) -> Result<GetPetByIdResponse, ApiError>
-    {
-        info!("get_pet_by_id({}) - X-Span-ID: {:?}", pet_id, context.get().0.clone());
-        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
-    }
-
     /// Update an existing pet
     async fn update_pet(
         &self,
@@ -364,6 +343,27 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         context: &C) -> Result<UpdatePetResponse, ApiError>
     {
         info!("update_pet({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
+        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
+    }
+
+    /// Deletes a pet
+    async fn delete_pet(
+        &self,
+        pet_id: i64,
+        api_key: Option<String>,
+        context: &C) -> Result<DeletePetResponse, ApiError>
+    {
+        info!("delete_pet({}, {:?}) - X-Span-ID: {:?}", pet_id, api_key, context.get().0.clone());
+        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
+    }
+
+    /// Find pet by ID
+    async fn get_pet_by_id(
+        &self,
+        pet_id: i64,
+        context: &C) -> Result<GetPetByIdResponse, ApiError>
+    {
+        info!("get_pet_by_id({}) - X-Span-ID: {:?}", pet_id, context.get().0.clone());
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 
@@ -391,32 +391,12 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 
-    /// Delete purchase order by ID
-    async fn delete_order(
-        &self,
-        order_id: String,
-        context: &C) -> Result<DeleteOrderResponse, ApiError>
-    {
-        info!("delete_order(\"{}\") - X-Span-ID: {:?}", order_id, context.get().0.clone());
-        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
-    }
-
     /// Returns pet inventories by status
     async fn get_inventory(
         &self,
         context: &C) -> Result<GetInventoryResponse, ApiError>
     {
         info!("get_inventory() - X-Span-ID: {:?}", context.get().0.clone());
-        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
-    }
-
-    /// Find purchase order by ID
-    async fn get_order_by_id(
-        &self,
-        order_id: i64,
-        context: &C) -> Result<GetOrderByIdResponse, ApiError>
-    {
-        info!("get_order_by_id({}) - X-Span-ID: {:?}", order_id, context.get().0.clone());
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 
@@ -427,6 +407,26 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         context: &C) -> Result<PlaceOrderResponse, ApiError>
     {
         info!("place_order({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
+        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
+    }
+
+    /// Delete purchase order by ID
+    async fn delete_order(
+        &self,
+        order_id: String,
+        context: &C) -> Result<DeleteOrderResponse, ApiError>
+    {
+        info!("delete_order(\"{}\") - X-Span-ID: {:?}", order_id, context.get().0.clone());
+        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
+    }
+
+    /// Find purchase order by ID
+    async fn get_order_by_id(
+        &self,
+        order_id: i64,
+        context: &C) -> Result<GetOrderByIdResponse, ApiError>
+    {
+        info!("get_order_by_id({}) - X-Span-ID: {:?}", order_id, context.get().0.clone());
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 
@@ -460,26 +460,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 
-    /// Delete user
-    async fn delete_user(
-        &self,
-        username: String,
-        context: &C) -> Result<DeleteUserResponse, ApiError>
-    {
-        info!("delete_user(\"{}\") - X-Span-ID: {:?}", username, context.get().0.clone());
-        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
-    }
-
-    /// Get user by user name
-    async fn get_user_by_name(
-        &self,
-        username: String,
-        context: &C) -> Result<GetUserByNameResponse, ApiError>
-    {
-        info!("get_user_by_name(\"{}\") - X-Span-ID: {:?}", username, context.get().0.clone());
-        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
-    }
-
     /// Logs user into the system
     async fn login_user(
         &self,
@@ -497,6 +477,26 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         context: &C) -> Result<LogoutUserResponse, ApiError>
     {
         info!("logout_user() - X-Span-ID: {:?}", context.get().0.clone());
+        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
+    }
+
+    /// Delete user
+    async fn delete_user(
+        &self,
+        username: String,
+        context: &C) -> Result<DeleteUserResponse, ApiError>
+    {
+        info!("delete_user(\"{}\") - X-Span-ID: {:?}", username, context.get().0.clone());
+        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
+    }
+
+    /// Get user by user name
+    async fn get_user_by_name(
+        &self,
+        username: String,
+        context: &C) -> Result<GetUserByNameResponse, ApiError>
+    {
+        info!("get_user_by_name(\"{}\") - X-Span-ID: {:?}", username, context.get().0.clone());
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
@@ -46,33 +46,33 @@ use crate::{Api,
      FakeOuterNumberSerializeResponse,
      FakeOuterStringSerializeResponse,
      FakeResponseWithNumericalDescriptionResponse,
-     HyphenParamResponse,
      TestBodyWithQueryParamsResponse,
      TestClientModelResponse,
      TestEndpointParametersResponse,
      TestEnumParametersResponse,
      TestInlineAdditionalPropertiesResponse,
      TestJsonFormDataResponse,
+     HyphenParamResponse,
      TestClassnameResponse,
      AddPetResponse,
-     DeletePetResponse,
      FindPetsByStatusResponse,
      FindPetsByTagsResponse,
-     GetPetByIdResponse,
      UpdatePetResponse,
+     DeletePetResponse,
+     GetPetByIdResponse,
      UpdatePetWithFormResponse,
      UploadFileResponse,
-     DeleteOrderResponse,
      GetInventoryResponse,
-     GetOrderByIdResponse,
      PlaceOrderResponse,
+     DeleteOrderResponse,
+     GetOrderByIdResponse,
      CreateUserResponse,
      CreateUsersWithArrayInputResponse,
      CreateUsersWithListInputResponse,
-     DeleteUserResponse,
-     GetUserByNameResponse,
      LoginUserResponse,
      LogoutUserResponse,
+     DeleteUserResponse,
+     GetUserByNameResponse,
      UpdateUserResponse
      };
 
@@ -1016,76 +1016,6 @@ impl<S, C> Api<C> for Client<S, C> where
         }
     }
 
-    async fn hyphen_param(
-        &self,
-        param_hyphen_param: String,
-        context: &C) -> Result<HyphenParamResponse, ApiError>
-    {
-        let mut client_service = self.client_service.clone();
-        let mut uri = format!(
-            "{}/v2/fake/hyphenParam/{hyphen_param}",
-            self.base_path
-            ,hyphen_param=utf8_percent_encode(&param_hyphen_param.to_string(), ID_ENCODE_SET)
-        );
-
-        // Query parameters
-        let query_string = {
-            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
-            query_string.finish()
-        };
-        if !query_string.is_empty() {
-            uri += "?";
-            uri += &query_string;
-        }
-
-        let uri = match Uri::from_str(&uri) {
-            Ok(uri) => uri,
-            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
-        };
-
-        let mut request = match Request::builder()
-            .method("GET")
-            .uri(uri)
-            .body(Body::empty()) {
-                Ok(req) => req,
-                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
-        };
-
-        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
-        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
-            Ok(h) => h,
-            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
-        });
-
-        let response = client_service.call((request, context.clone()))
-            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
-
-        match response.status().as_u16() {
-            200 => {
-                Ok(
-                    HyphenParamResponse::Success
-                )
-            }
-            code => {
-                let headers = response.headers().clone();
-                let body = response.into_body()
-                       .take(100)
-                       .into_raw().await;
-                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                    code,
-                    headers,
-                    match body {
-                        Ok(body) => match String::from_utf8(body) {
-                            Ok(body) => body,
-                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
-                        },
-                        Err(e) => format!("<Failed to read body: {}>", e),
-                    }
-                )))
-            }
-        }
-    }
-
     async fn test_body_with_query_params(
         &self,
         param_query: String,
@@ -1703,6 +1633,76 @@ impl<S, C> Api<C> for Client<S, C> where
         }
     }
 
+    async fn hyphen_param(
+        &self,
+        param_hyphen_param: String,
+        context: &C) -> Result<HyphenParamResponse, ApiError>
+    {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/v2/fake/hyphenParam/{hyphen_param}",
+            self.base_path
+            ,hyphen_param=utf8_percent_encode(&param_hyphen_param.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
+        });
+
+        let response = client_service.call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
+
+        match response.status().as_u16() {
+            200 => {
+                Ok(
+                    HyphenParamResponse::Success
+                )
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body()
+                       .take(100)
+                       .into_raw().await;
+                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
     async fn test_classname(
         &self,
         param_body: models::Client,
@@ -1883,114 +1883,6 @@ impl<S, C> Api<C> for Client<S, C> where
             405 => {
                 Ok(
                     AddPetResponse::InvalidInput
-                )
-            }
-            code => {
-                let headers = response.headers().clone();
-                let body = response.into_body()
-                       .take(100)
-                       .into_raw().await;
-                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                    code,
-                    headers,
-                    match body {
-                        Ok(body) => match String::from_utf8(body) {
-                            Ok(body) => body,
-                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
-                        },
-                        Err(e) => format!("<Failed to read body: {}>", e),
-                    }
-                )))
-            }
-        }
-    }
-
-    async fn delete_pet(
-        &self,
-        param_pet_id: i64,
-        param_api_key: Option<String>,
-        context: &C) -> Result<DeletePetResponse, ApiError>
-    {
-        let mut client_service = self.client_service.clone();
-        let mut uri = format!(
-            "{}/v2/pet/{pet_id}",
-            self.base_path
-            ,pet_id=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
-        );
-
-        // Query parameters
-        let query_string = {
-            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
-            query_string.finish()
-        };
-        if !query_string.is_empty() {
-            uri += "?";
-            uri += &query_string;
-        }
-
-        let uri = match Uri::from_str(&uri) {
-            Ok(uri) => uri,
-            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
-        };
-
-        let mut request = match Request::builder()
-            .method("DELETE")
-            .uri(uri)
-            .body(Body::empty()) {
-                Ok(req) => req,
-                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
-        };
-
-        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
-        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
-            Ok(h) => h,
-            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
-        });
-
-        #[allow(clippy::collapsible_match)]
-        if let Some(auth_data) = Has::<Option<AuthData>>::get(context).as_ref() {
-            // Currently only authentication with Basic and Bearer are supported
-            #[allow(clippy::single_match, clippy::match_single_binding)]
-            match auth_data {
-                AuthData::Bearer(bearer_header) => {
-                    let auth = swagger::auth::Header(bearer_header.clone());
-                    let header = match HeaderValue::from_str(&format!("{}", auth)) {
-                        Ok(h) => h,
-                        Err(e) => return Err(ApiError(format!("Unable to create Authorization header: {}", e)))
-                    };
-                    request.headers_mut().insert(
-                        hyper::header::AUTHORIZATION,
-                        header);
-                },
-                _ => {}
-            }
-        }
-
-        // Header parameters
-        #[allow(clippy::single_match)]
-        match param_api_key {
-            Some(param_api_key) => {
-        request.headers_mut().append(
-            HeaderName::from_static("api_key"),
-            #[allow(clippy::redundant_clone)]
-            match header::IntoHeaderValue(param_api_key.clone()).try_into() {
-                Ok(header) => header,
-                Err(e) => {
-                    return Err(ApiError(format!(
-                        "Invalid header api_key - {}", e)));
-                },
-            });
-            },
-            None => {}
-        }
-
-        let response = client_service.call((request, context.clone()))
-            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
-
-        match response.status().as_u16() {
-            400 => {
-                Ok(
-                    DeletePetResponse::InvalidPetValue
                 )
             }
             code => {
@@ -2229,108 +2121,6 @@ impl<S, C> Api<C> for Client<S, C> where
         }
     }
 
-    async fn get_pet_by_id(
-        &self,
-        param_pet_id: i64,
-        context: &C) -> Result<GetPetByIdResponse, ApiError>
-    {
-        let mut client_service = self.client_service.clone();
-        let mut uri = format!(
-            "{}/v2/pet/{pet_id}",
-            self.base_path
-            ,pet_id=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
-        );
-
-        // Query parameters
-        let query_string = {
-            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
-            query_string.finish()
-        };
-        if !query_string.is_empty() {
-            uri += "?";
-            uri += &query_string;
-        }
-
-        let uri = match Uri::from_str(&uri) {
-            Ok(uri) => uri,
-            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
-        };
-
-        let mut request = match Request::builder()
-            .method("GET")
-            .uri(uri)
-            .body(Body::empty()) {
-                Ok(req) => req,
-                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
-        };
-
-        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
-        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
-            Ok(h) => h,
-            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
-        });
-
-        #[allow(clippy::collapsible_match)]
-        if let Some(auth_data) = Has::<Option<AuthData>>::get(context).as_ref() {
-            // Currently only authentication with Basic and Bearer are supported
-            #[allow(clippy::single_match, clippy::match_single_binding)]
-            match auth_data {
-                _ => {}
-            }
-        }
-
-        let response = client_service.call((request, context.clone()))
-            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
-
-        match response.status().as_u16() {
-            200 => {
-                let body = response.into_body();
-                let body = body
-                        .into_raw()
-                        .map_err(|e| ApiError(format!("Failed to read response: {}", e))).await?;
-
-                let body = str::from_utf8(&body)
-                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
-                // ToDo: this will move to swagger-rs and become a standard From conversion trait
-                // once https://github.com/RReverser/serde-xml-rs/pull/45 is accepted upstream
-                let body = serde_xml_rs::from_str::<models::Pet>(body)
-                    .map_err(|e| ApiError(format!("Response body did not match the schema: {}", e)))?;
-
-
-                Ok(GetPetByIdResponse::SuccessfulOperation
-                    (body)
-                )
-            }
-            400 => {
-                Ok(
-                    GetPetByIdResponse::InvalidIDSupplied
-                )
-            }
-            404 => {
-                Ok(
-                    GetPetByIdResponse::PetNotFound
-                )
-            }
-            code => {
-                let headers = response.headers().clone();
-                let body = response.into_body()
-                       .take(100)
-                       .into_raw().await;
-                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                    code,
-                    headers,
-                    match body {
-                        Ok(body) => match String::from_utf8(body) {
-                            Ok(body) => body,
-                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
-                        },
-                        Err(e) => format!("<Failed to read body: {}>", e),
-                    }
-                )))
-            }
-        }
-    }
-
     async fn update_pet(
         &self,
         param_body: models::Pet,
@@ -2418,6 +2208,216 @@ impl<S, C> Api<C> for Client<S, C> where
             405 => {
                 Ok(
                     UpdatePetResponse::ValidationException
+                )
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body()
+                       .take(100)
+                       .into_raw().await;
+                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn delete_pet(
+        &self,
+        param_pet_id: i64,
+        param_api_key: Option<String>,
+        context: &C) -> Result<DeletePetResponse, ApiError>
+    {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/v2/pet/{pet_id}",
+            self.base_path
+            ,pet_id=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("DELETE")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
+        });
+
+        #[allow(clippy::collapsible_match)]
+        if let Some(auth_data) = Has::<Option<AuthData>>::get(context).as_ref() {
+            // Currently only authentication with Basic and Bearer are supported
+            #[allow(clippy::single_match, clippy::match_single_binding)]
+            match auth_data {
+                AuthData::Bearer(bearer_header) => {
+                    let auth = swagger::auth::Header(bearer_header.clone());
+                    let header = match HeaderValue::from_str(&format!("{}", auth)) {
+                        Ok(h) => h,
+                        Err(e) => return Err(ApiError(format!("Unable to create Authorization header: {}", e)))
+                    };
+                    request.headers_mut().insert(
+                        hyper::header::AUTHORIZATION,
+                        header);
+                },
+                _ => {}
+            }
+        }
+
+        // Header parameters
+        #[allow(clippy::single_match)]
+        match param_api_key {
+            Some(param_api_key) => {
+        request.headers_mut().append(
+            HeaderName::from_static("api_key"),
+            #[allow(clippy::redundant_clone)]
+            match header::IntoHeaderValue(param_api_key.clone()).try_into() {
+                Ok(header) => header,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Invalid header api_key - {}", e)));
+                },
+            });
+            },
+            None => {}
+        }
+
+        let response = client_service.call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
+
+        match response.status().as_u16() {
+            400 => {
+                Ok(
+                    DeletePetResponse::InvalidPetValue
+                )
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body()
+                       .take(100)
+                       .into_raw().await;
+                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn get_pet_by_id(
+        &self,
+        param_pet_id: i64,
+        context: &C) -> Result<GetPetByIdResponse, ApiError>
+    {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/v2/pet/{pet_id}",
+            self.base_path
+            ,pet_id=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
+        });
+
+        #[allow(clippy::collapsible_match)]
+        if let Some(auth_data) = Has::<Option<AuthData>>::get(context).as_ref() {
+            // Currently only authentication with Basic and Bearer are supported
+            #[allow(clippy::single_match, clippy::match_single_binding)]
+            match auth_data {
+                _ => {}
+            }
+        }
+
+        let response = client_service.call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
+
+        match response.status().as_u16() {
+            200 => {
+                let body = response.into_body();
+                let body = body
+                        .into_raw()
+                        .map_err(|e| ApiError(format!("Failed to read response: {}", e))).await?;
+
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                // ToDo: this will move to swagger-rs and become a standard From conversion trait
+                // once https://github.com/RReverser/serde-xml-rs/pull/45 is accepted upstream
+                let body = serde_xml_rs::from_str::<models::Pet>(body)
+                    .map_err(|e| ApiError(format!("Response body did not match the schema: {}", e)))?;
+
+
+                Ok(GetPetByIdResponse::SuccessfulOperation
+                    (body)
+                )
+            }
+            400 => {
+                Ok(
+                    GetPetByIdResponse::InvalidIDSupplied
+                )
+            }
+            404 => {
+                Ok(
+                    GetPetByIdResponse::PetNotFound
                 )
             }
             code => {
@@ -2705,81 +2705,6 @@ impl<S, C> Api<C> for Client<S, C> where
         }
     }
 
-    async fn delete_order(
-        &self,
-        param_order_id: String,
-        context: &C) -> Result<DeleteOrderResponse, ApiError>
-    {
-        let mut client_service = self.client_service.clone();
-        let mut uri = format!(
-            "{}/v2/store/order/{order_id}",
-            self.base_path
-            ,order_id=utf8_percent_encode(&param_order_id.to_string(), ID_ENCODE_SET)
-        );
-
-        // Query parameters
-        let query_string = {
-            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
-            query_string.finish()
-        };
-        if !query_string.is_empty() {
-            uri += "?";
-            uri += &query_string;
-        }
-
-        let uri = match Uri::from_str(&uri) {
-            Ok(uri) => uri,
-            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
-        };
-
-        let mut request = match Request::builder()
-            .method("DELETE")
-            .uri(uri)
-            .body(Body::empty()) {
-                Ok(req) => req,
-                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
-        };
-
-        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
-        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
-            Ok(h) => h,
-            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
-        });
-
-        let response = client_service.call((request, context.clone()))
-            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
-
-        match response.status().as_u16() {
-            400 => {
-                Ok(
-                    DeleteOrderResponse::InvalidIDSupplied
-                )
-            }
-            404 => {
-                Ok(
-                    DeleteOrderResponse::OrderNotFound
-                )
-            }
-            code => {
-                let headers = response.headers().clone();
-                let body = response.into_body()
-                       .take(100)
-                       .into_raw().await;
-                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                    code,
-                    headers,
-                    match body {
-                        Ok(body) => match String::from_utf8(body) {
-                            Ok(body) => body,
-                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
-                        },
-                        Err(e) => format!("<Failed to read body: {}>", e),
-                    }
-                )))
-            }
-        }
-    }
-
     async fn get_inventory(
         &self,
         context: &C) -> Result<GetInventoryResponse, ApiError>
@@ -2846,99 +2771,6 @@ impl<S, C> Api<C> for Client<S, C> where
 
                 Ok(GetInventoryResponse::SuccessfulOperation
                     (body)
-                )
-            }
-            code => {
-                let headers = response.headers().clone();
-                let body = response.into_body()
-                       .take(100)
-                       .into_raw().await;
-                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                    code,
-                    headers,
-                    match body {
-                        Ok(body) => match String::from_utf8(body) {
-                            Ok(body) => body,
-                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
-                        },
-                        Err(e) => format!("<Failed to read body: {}>", e),
-                    }
-                )))
-            }
-        }
-    }
-
-    async fn get_order_by_id(
-        &self,
-        param_order_id: i64,
-        context: &C) -> Result<GetOrderByIdResponse, ApiError>
-    {
-        let mut client_service = self.client_service.clone();
-        let mut uri = format!(
-            "{}/v2/store/order/{order_id}",
-            self.base_path
-            ,order_id=utf8_percent_encode(&param_order_id.to_string(), ID_ENCODE_SET)
-        );
-
-        // Query parameters
-        let query_string = {
-            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
-            query_string.finish()
-        };
-        if !query_string.is_empty() {
-            uri += "?";
-            uri += &query_string;
-        }
-
-        let uri = match Uri::from_str(&uri) {
-            Ok(uri) => uri,
-            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
-        };
-
-        let mut request = match Request::builder()
-            .method("GET")
-            .uri(uri)
-            .body(Body::empty()) {
-                Ok(req) => req,
-                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
-        };
-
-        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
-        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
-            Ok(h) => h,
-            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
-        });
-
-        let response = client_service.call((request, context.clone()))
-            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
-
-        match response.status().as_u16() {
-            200 => {
-                let body = response.into_body();
-                let body = body
-                        .into_raw()
-                        .map_err(|e| ApiError(format!("Failed to read response: {}", e))).await?;
-
-                let body = str::from_utf8(&body)
-                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
-                // ToDo: this will move to swagger-rs and become a standard From conversion trait
-                // once https://github.com/RReverser/serde-xml-rs/pull/45 is accepted upstream
-                let body = serde_xml_rs::from_str::<models::Order>(body)
-                    .map_err(|e| ApiError(format!("Response body did not match the schema: {}", e)))?;
-
-
-                Ok(GetOrderByIdResponse::SuccessfulOperation
-                    (body)
-                )
-            }
-            400 => {
-                Ok(
-                    GetOrderByIdResponse::InvalidIDSupplied
-                )
-            }
-            404 => {
-                Ok(
-                    GetOrderByIdResponse::OrderNotFound
                 )
             }
             code => {
@@ -3037,6 +2869,174 @@ impl<S, C> Api<C> for Client<S, C> where
             400 => {
                 Ok(
                     PlaceOrderResponse::InvalidOrder
+                )
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body()
+                       .take(100)
+                       .into_raw().await;
+                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn delete_order(
+        &self,
+        param_order_id: String,
+        context: &C) -> Result<DeleteOrderResponse, ApiError>
+    {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/v2/store/order/{order_id}",
+            self.base_path
+            ,order_id=utf8_percent_encode(&param_order_id.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("DELETE")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
+        });
+
+        let response = client_service.call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
+
+        match response.status().as_u16() {
+            400 => {
+                Ok(
+                    DeleteOrderResponse::InvalidIDSupplied
+                )
+            }
+            404 => {
+                Ok(
+                    DeleteOrderResponse::OrderNotFound
+                )
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body()
+                       .take(100)
+                       .into_raw().await;
+                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn get_order_by_id(
+        &self,
+        param_order_id: i64,
+        context: &C) -> Result<GetOrderByIdResponse, ApiError>
+    {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/v2/store/order/{order_id}",
+            self.base_path
+            ,order_id=utf8_percent_encode(&param_order_id.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
+        });
+
+        let response = client_service.call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
+
+        match response.status().as_u16() {
+            200 => {
+                let body = response.into_body();
+                let body = body
+                        .into_raw()
+                        .map_err(|e| ApiError(format!("Failed to read response: {}", e))).await?;
+
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                // ToDo: this will move to swagger-rs and become a standard From conversion trait
+                // once https://github.com/RReverser/serde-xml-rs/pull/45 is accepted upstream
+                let body = serde_xml_rs::from_str::<models::Order>(body)
+                    .map_err(|e| ApiError(format!("Response body did not match the schema: {}", e)))?;
+
+
+                Ok(GetOrderByIdResponse::SuccessfulOperation
+                    (body)
+                )
+            }
+            400 => {
+                Ok(
+                    GetOrderByIdResponse::InvalidIDSupplied
+                )
+            }
+            404 => {
+                Ok(
+                    GetOrderByIdResponse::OrderNotFound
                 )
             }
             code => {
@@ -3299,174 +3299,6 @@ impl<S, C> Api<C> for Client<S, C> where
         }
     }
 
-    async fn delete_user(
-        &self,
-        param_username: String,
-        context: &C) -> Result<DeleteUserResponse, ApiError>
-    {
-        let mut client_service = self.client_service.clone();
-        let mut uri = format!(
-            "{}/v2/user/{username}",
-            self.base_path
-            ,username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
-        );
-
-        // Query parameters
-        let query_string = {
-            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
-            query_string.finish()
-        };
-        if !query_string.is_empty() {
-            uri += "?";
-            uri += &query_string;
-        }
-
-        let uri = match Uri::from_str(&uri) {
-            Ok(uri) => uri,
-            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
-        };
-
-        let mut request = match Request::builder()
-            .method("DELETE")
-            .uri(uri)
-            .body(Body::empty()) {
-                Ok(req) => req,
-                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
-        };
-
-        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
-        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
-            Ok(h) => h,
-            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
-        });
-
-        let response = client_service.call((request, context.clone()))
-            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
-
-        match response.status().as_u16() {
-            400 => {
-                Ok(
-                    DeleteUserResponse::InvalidUsernameSupplied
-                )
-            }
-            404 => {
-                Ok(
-                    DeleteUserResponse::UserNotFound
-                )
-            }
-            code => {
-                let headers = response.headers().clone();
-                let body = response.into_body()
-                       .take(100)
-                       .into_raw().await;
-                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                    code,
-                    headers,
-                    match body {
-                        Ok(body) => match String::from_utf8(body) {
-                            Ok(body) => body,
-                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
-                        },
-                        Err(e) => format!("<Failed to read body: {}>", e),
-                    }
-                )))
-            }
-        }
-    }
-
-    async fn get_user_by_name(
-        &self,
-        param_username: String,
-        context: &C) -> Result<GetUserByNameResponse, ApiError>
-    {
-        let mut client_service = self.client_service.clone();
-        let mut uri = format!(
-            "{}/v2/user/{username}",
-            self.base_path
-            ,username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
-        );
-
-        // Query parameters
-        let query_string = {
-            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
-            query_string.finish()
-        };
-        if !query_string.is_empty() {
-            uri += "?";
-            uri += &query_string;
-        }
-
-        let uri = match Uri::from_str(&uri) {
-            Ok(uri) => uri,
-            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
-        };
-
-        let mut request = match Request::builder()
-            .method("GET")
-            .uri(uri)
-            .body(Body::empty()) {
-                Ok(req) => req,
-                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
-        };
-
-        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
-        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
-            Ok(h) => h,
-            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
-        });
-
-        let response = client_service.call((request, context.clone()))
-            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
-
-        match response.status().as_u16() {
-            200 => {
-                let body = response.into_body();
-                let body = body
-                        .into_raw()
-                        .map_err(|e| ApiError(format!("Failed to read response: {}", e))).await?;
-
-                let body = str::from_utf8(&body)
-                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
-                // ToDo: this will move to swagger-rs and become a standard From conversion trait
-                // once https://github.com/RReverser/serde-xml-rs/pull/45 is accepted upstream
-                let body = serde_xml_rs::from_str::<models::User>(body)
-                    .map_err(|e| ApiError(format!("Response body did not match the schema: {}", e)))?;
-
-
-                Ok(GetUserByNameResponse::SuccessfulOperation
-                    (body)
-                )
-            }
-            400 => {
-                Ok(
-                    GetUserByNameResponse::InvalidUsernameSupplied
-                )
-            }
-            404 => {
-                Ok(
-                    GetUserByNameResponse::UserNotFound
-                )
-            }
-            code => {
-                let headers = response.headers().clone();
-                let body = response.into_body()
-                       .take(100)
-                       .into_raw().await;
-                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                    code,
-                    headers,
-                    match body {
-                        Ok(body) => match String::from_utf8(body) {
-                            Ok(body) => body,
-                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
-                        },
-                        Err(e) => format!("<Failed to read body: {}>", e),
-                    }
-                )))
-            }
-        }
-    }
-
     async fn login_user(
         &self,
         param_username: String,
@@ -3637,6 +3469,174 @@ impl<S, C> Api<C> for Client<S, C> where
             0 => {
                 Ok(
                     LogoutUserResponse::SuccessfulOperation
+                )
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body()
+                       .take(100)
+                       .into_raw().await;
+                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn delete_user(
+        &self,
+        param_username: String,
+        context: &C) -> Result<DeleteUserResponse, ApiError>
+    {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/v2/user/{username}",
+            self.base_path
+            ,username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("DELETE")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
+        });
+
+        let response = client_service.call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
+
+        match response.status().as_u16() {
+            400 => {
+                Ok(
+                    DeleteUserResponse::InvalidUsernameSupplied
+                )
+            }
+            404 => {
+                Ok(
+                    DeleteUserResponse::UserNotFound
+                )
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body()
+                       .take(100)
+                       .into_raw().await;
+                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn get_user_by_name(
+        &self,
+        param_username: String,
+        context: &C) -> Result<GetUserByNameResponse, ApiError>
+    {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/v2/user/{username}",
+            self.base_path
+            ,username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
+        });
+
+        let response = client_service.call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
+
+        match response.status().as_u16() {
+            200 => {
+                let body = response.into_body();
+                let body = body
+                        .into_raw()
+                        .map_err(|e| ApiError(format!("Failed to read response: {}", e))).await?;
+
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                // ToDo: this will move to swagger-rs and become a standard From conversion trait
+                // once https://github.com/RReverser/serde-xml-rs/pull/45 is accepted upstream
+                let body = serde_xml_rs::from_str::<models::User>(body)
+                    .map_err(|e| ApiError(format!("Response body did not match the schema: {}", e)))?;
+
+
+                Ok(GetUserByNameResponse::SuccessfulOperation
+                    (body)
+                )
+            }
+            400 => {
+                Ok(
+                    GetUserByNameResponse::InvalidUsernameSupplied
+                )
+            }
+            404 => {
+                Ok(
+                    GetUserByNameResponse::UserNotFound
                 )
             }
             code => {

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -68,12 +68,6 @@ pub enum FakeResponseWithNumericalDescriptionResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub enum HyphenParamResponse {
-    /// Success
-    Success
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum TestBodyWithQueryParamsResponse {
     /// Success
     Success
@@ -119,6 +113,12 @@ pub enum TestJsonFormDataResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum HyphenParamResponse {
+    /// Success
+    Success
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum TestClassnameResponse {
     /// successful operation
     SuccessfulOperation
@@ -129,12 +129,6 @@ pub enum TestClassnameResponse {
 pub enum AddPetResponse {
     /// Invalid input
     InvalidInput
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub enum DeletePetResponse {
-    /// Invalid pet value
-    InvalidPetValue
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -161,6 +155,25 @@ pub enum FindPetsByTagsResponse {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
+pub enum UpdatePetResponse {
+    /// Invalid ID supplied
+    InvalidIDSupplied
+    ,
+    /// Pet not found
+    PetNotFound
+    ,
+    /// Validation exception
+    ValidationException
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum DeletePetResponse {
+    /// Invalid pet value
+    InvalidPetValue
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
 pub enum GetPetByIdResponse {
     /// successful operation
     SuccessfulOperation
@@ -171,19 +184,6 @@ pub enum GetPetByIdResponse {
     ,
     /// Pet not found
     PetNotFound
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[must_use]
-pub enum UpdatePetResponse {
-    /// Invalid ID supplied
-    InvalidIDSupplied
-    ,
-    /// Pet not found
-    PetNotFound
-    ,
-    /// Validation exception
-    ValidationException
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -200,6 +200,24 @@ pub enum UploadFileResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum GetInventoryResponse {
+    /// successful operation
+    SuccessfulOperation
+    (std::collections::HashMap<String, i32>)
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
+pub enum PlaceOrderResponse {
+    /// successful operation
+    SuccessfulOperation
+    (models::Order)
+    ,
+    /// Invalid Order
+    InvalidOrder
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
 pub enum DeleteOrderResponse {
     /// Invalid ID supplied
@@ -207,13 +225,6 @@ pub enum DeleteOrderResponse {
     ,
     /// Order not found
     OrderNotFound
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub enum GetInventoryResponse {
-    /// successful operation
-    SuccessfulOperation
-    (std::collections::HashMap<String, i32>)
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -228,17 +239,6 @@ pub enum GetOrderByIdResponse {
     ,
     /// Order not found
     OrderNotFound
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[must_use]
-pub enum PlaceOrderResponse {
-    /// successful operation
-    SuccessfulOperation
-    (models::Order)
-    ,
-    /// Invalid Order
-    InvalidOrder
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -257,30 +257,6 @@ pub enum CreateUsersWithArrayInputResponse {
 pub enum CreateUsersWithListInputResponse {
     /// successful operation
     SuccessfulOperation
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[must_use]
-pub enum DeleteUserResponse {
-    /// Invalid username supplied
-    InvalidUsernameSupplied
-    ,
-    /// User not found
-    UserNotFound
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[must_use]
-pub enum GetUserByNameResponse {
-    /// successful operation
-    SuccessfulOperation
-    (models::User)
-    ,
-    /// Invalid username supplied
-    InvalidUsernameSupplied
-    ,
-    /// User not found
-    UserNotFound
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -309,6 +285,30 @@ pub enum LoginUserResponse {
 pub enum LogoutUserResponse {
     /// successful operation
     SuccessfulOperation
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
+pub enum DeleteUserResponse {
+    /// Invalid username supplied
+    InvalidUsernameSupplied
+    ,
+    /// User not found
+    UserNotFound
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
+pub enum GetUserByNameResponse {
+    /// successful operation
+    SuccessfulOperation
+    (models::User)
+    ,
+    /// Invalid username supplied
+    InvalidUsernameSupplied
+    ,
+    /// User not found
+    UserNotFound
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -362,11 +362,6 @@ pub trait Api<C: Send + Sync> {
     async fn fake_response_with_numerical_description(
         &self,
         context: &C) -> Result<FakeResponseWithNumericalDescriptionResponse, ApiError>;
-
-    async fn hyphen_param(
-        &self,
-        hyphen_param: String,
-        context: &C) -> Result<HyphenParamResponse, ApiError>;
 
     async fn test_body_with_query_params(
         &self,
@@ -424,6 +419,11 @@ pub trait Api<C: Send + Sync> {
         param2: String,
         context: &C) -> Result<TestJsonFormDataResponse, ApiError>;
 
+    async fn hyphen_param(
+        &self,
+        hyphen_param: String,
+        context: &C) -> Result<HyphenParamResponse, ApiError>;
+
     /// To test class name in snake case
     async fn test_classname(
         &self,
@@ -435,13 +435,6 @@ pub trait Api<C: Send + Sync> {
         &self,
         body: models::Pet,
         context: &C) -> Result<AddPetResponse, ApiError>;
-
-    /// Deletes a pet
-    async fn delete_pet(
-        &self,
-        pet_id: i64,
-        api_key: Option<String>,
-        context: &C) -> Result<DeletePetResponse, ApiError>;
 
     /// Finds Pets by status
     async fn find_pets_by_status(
@@ -455,17 +448,24 @@ pub trait Api<C: Send + Sync> {
         tags: &Vec<String>,
         context: &C) -> Result<FindPetsByTagsResponse, ApiError>;
 
-    /// Find pet by ID
-    async fn get_pet_by_id(
-        &self,
-        pet_id: i64,
-        context: &C) -> Result<GetPetByIdResponse, ApiError>;
-
     /// Update an existing pet
     async fn update_pet(
         &self,
         body: models::Pet,
         context: &C) -> Result<UpdatePetResponse, ApiError>;
+
+    /// Deletes a pet
+    async fn delete_pet(
+        &self,
+        pet_id: i64,
+        api_key: Option<String>,
+        context: &C) -> Result<DeletePetResponse, ApiError>;
+
+    /// Find pet by ID
+    async fn get_pet_by_id(
+        &self,
+        pet_id: i64,
+        context: &C) -> Result<GetPetByIdResponse, ApiError>;
 
     /// Updates a pet in the store with form data
     async fn update_pet_with_form(
@@ -483,28 +483,28 @@ pub trait Api<C: Send + Sync> {
         file: Option<swagger::ByteArray>,
         context: &C) -> Result<UploadFileResponse, ApiError>;
 
-    /// Delete purchase order by ID
-    async fn delete_order(
-        &self,
-        order_id: String,
-        context: &C) -> Result<DeleteOrderResponse, ApiError>;
-
     /// Returns pet inventories by status
     async fn get_inventory(
         &self,
         context: &C) -> Result<GetInventoryResponse, ApiError>;
-
-    /// Find purchase order by ID
-    async fn get_order_by_id(
-        &self,
-        order_id: i64,
-        context: &C) -> Result<GetOrderByIdResponse, ApiError>;
 
     /// Place an order for a pet
     async fn place_order(
         &self,
         body: models::Order,
         context: &C) -> Result<PlaceOrderResponse, ApiError>;
+
+    /// Delete purchase order by ID
+    async fn delete_order(
+        &self,
+        order_id: String,
+        context: &C) -> Result<DeleteOrderResponse, ApiError>;
+
+    /// Find purchase order by ID
+    async fn get_order_by_id(
+        &self,
+        order_id: i64,
+        context: &C) -> Result<GetOrderByIdResponse, ApiError>;
 
     /// Create user
     async fn create_user(
@@ -524,18 +524,6 @@ pub trait Api<C: Send + Sync> {
         body: &Vec<models::User>,
         context: &C) -> Result<CreateUsersWithListInputResponse, ApiError>;
 
-    /// Delete user
-    async fn delete_user(
-        &self,
-        username: String,
-        context: &C) -> Result<DeleteUserResponse, ApiError>;
-
-    /// Get user by user name
-    async fn get_user_by_name(
-        &self,
-        username: String,
-        context: &C) -> Result<GetUserByNameResponse, ApiError>;
-
     /// Logs user into the system
     async fn login_user(
         &self,
@@ -547,6 +535,18 @@ pub trait Api<C: Send + Sync> {
     async fn logout_user(
         &self,
         context: &C) -> Result<LogoutUserResponse, ApiError>;
+
+    /// Delete user
+    async fn delete_user(
+        &self,
+        username: String,
+        context: &C) -> Result<DeleteUserResponse, ApiError>;
+
+    /// Get user by user name
+    async fn get_user_by_name(
+        &self,
+        username: String,
+        context: &C) -> Result<GetUserByNameResponse, ApiError>;
 
     /// Updated user
     async fn update_user(
@@ -599,11 +599,6 @@ pub trait ApiNoContext<C: Send + Sync> {
     async fn fake_response_with_numerical_description(
         &self,
         ) -> Result<FakeResponseWithNumericalDescriptionResponse, ApiError>;
-
-    async fn hyphen_param(
-        &self,
-        hyphen_param: String,
-        ) -> Result<HyphenParamResponse, ApiError>;
 
     async fn test_body_with_query_params(
         &self,
@@ -661,6 +656,11 @@ pub trait ApiNoContext<C: Send + Sync> {
         param2: String,
         ) -> Result<TestJsonFormDataResponse, ApiError>;
 
+    async fn hyphen_param(
+        &self,
+        hyphen_param: String,
+        ) -> Result<HyphenParamResponse, ApiError>;
+
     /// To test class name in snake case
     async fn test_classname(
         &self,
@@ -672,13 +672,6 @@ pub trait ApiNoContext<C: Send + Sync> {
         &self,
         body: models::Pet,
         ) -> Result<AddPetResponse, ApiError>;
-
-    /// Deletes a pet
-    async fn delete_pet(
-        &self,
-        pet_id: i64,
-        api_key: Option<String>,
-        ) -> Result<DeletePetResponse, ApiError>;
 
     /// Finds Pets by status
     async fn find_pets_by_status(
@@ -692,17 +685,24 @@ pub trait ApiNoContext<C: Send + Sync> {
         tags: &Vec<String>,
         ) -> Result<FindPetsByTagsResponse, ApiError>;
 
-    /// Find pet by ID
-    async fn get_pet_by_id(
-        &self,
-        pet_id: i64,
-        ) -> Result<GetPetByIdResponse, ApiError>;
-
     /// Update an existing pet
     async fn update_pet(
         &self,
         body: models::Pet,
         ) -> Result<UpdatePetResponse, ApiError>;
+
+    /// Deletes a pet
+    async fn delete_pet(
+        &self,
+        pet_id: i64,
+        api_key: Option<String>,
+        ) -> Result<DeletePetResponse, ApiError>;
+
+    /// Find pet by ID
+    async fn get_pet_by_id(
+        &self,
+        pet_id: i64,
+        ) -> Result<GetPetByIdResponse, ApiError>;
 
     /// Updates a pet in the store with form data
     async fn update_pet_with_form(
@@ -720,28 +720,28 @@ pub trait ApiNoContext<C: Send + Sync> {
         file: Option<swagger::ByteArray>,
         ) -> Result<UploadFileResponse, ApiError>;
 
-    /// Delete purchase order by ID
-    async fn delete_order(
-        &self,
-        order_id: String,
-        ) -> Result<DeleteOrderResponse, ApiError>;
-
     /// Returns pet inventories by status
     async fn get_inventory(
         &self,
         ) -> Result<GetInventoryResponse, ApiError>;
-
-    /// Find purchase order by ID
-    async fn get_order_by_id(
-        &self,
-        order_id: i64,
-        ) -> Result<GetOrderByIdResponse, ApiError>;
 
     /// Place an order for a pet
     async fn place_order(
         &self,
         body: models::Order,
         ) -> Result<PlaceOrderResponse, ApiError>;
+
+    /// Delete purchase order by ID
+    async fn delete_order(
+        &self,
+        order_id: String,
+        ) -> Result<DeleteOrderResponse, ApiError>;
+
+    /// Find purchase order by ID
+    async fn get_order_by_id(
+        &self,
+        order_id: i64,
+        ) -> Result<GetOrderByIdResponse, ApiError>;
 
     /// Create user
     async fn create_user(
@@ -761,18 +761,6 @@ pub trait ApiNoContext<C: Send + Sync> {
         body: &Vec<models::User>,
         ) -> Result<CreateUsersWithListInputResponse, ApiError>;
 
-    /// Delete user
-    async fn delete_user(
-        &self,
-        username: String,
-        ) -> Result<DeleteUserResponse, ApiError>;
-
-    /// Get user by user name
-    async fn get_user_by_name(
-        &self,
-        username: String,
-        ) -> Result<GetUserByNameResponse, ApiError>;
-
     /// Logs user into the system
     async fn login_user(
         &self,
@@ -784,6 +772,18 @@ pub trait ApiNoContext<C: Send + Sync> {
     async fn logout_user(
         &self,
         ) -> Result<LogoutUserResponse, ApiError>;
+
+    /// Delete user
+    async fn delete_user(
+        &self,
+        username: String,
+        ) -> Result<DeleteUserResponse, ApiError>;
+
+    /// Get user by user name
+    async fn get_user_by_name(
+        &self,
+        username: String,
+        ) -> Result<GetUserByNameResponse, ApiError>;
 
     /// Updated user
     async fn update_user(
@@ -879,15 +879,6 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
         self.api().fake_response_with_numerical_description(&context).await
     }
 
-    async fn hyphen_param(
-        &self,
-        hyphen_param: String,
-        ) -> Result<HyphenParamResponse, ApiError>
-    {
-        let context = self.context().clone();
-        self.api().hyphen_param(hyphen_param, &context).await
-    }
-
     async fn test_body_with_query_params(
         &self,
         query: String,
@@ -968,6 +959,15 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
         self.api().test_json_form_data(param, param2, &context).await
     }
 
+    async fn hyphen_param(
+        &self,
+        hyphen_param: String,
+        ) -> Result<HyphenParamResponse, ApiError>
+    {
+        let context = self.context().clone();
+        self.api().hyphen_param(hyphen_param, &context).await
+    }
+
     /// To test class name in snake case
     async fn test_classname(
         &self,
@@ -986,17 +986,6 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     {
         let context = self.context().clone();
         self.api().add_pet(body, &context).await
-    }
-
-    /// Deletes a pet
-    async fn delete_pet(
-        &self,
-        pet_id: i64,
-        api_key: Option<String>,
-        ) -> Result<DeletePetResponse, ApiError>
-    {
-        let context = self.context().clone();
-        self.api().delete_pet(pet_id, api_key, &context).await
     }
 
     /// Finds Pets by status
@@ -1019,16 +1008,6 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
         self.api().find_pets_by_tags(tags, &context).await
     }
 
-    /// Find pet by ID
-    async fn get_pet_by_id(
-        &self,
-        pet_id: i64,
-        ) -> Result<GetPetByIdResponse, ApiError>
-    {
-        let context = self.context().clone();
-        self.api().get_pet_by_id(pet_id, &context).await
-    }
-
     /// Update an existing pet
     async fn update_pet(
         &self,
@@ -1037,6 +1016,27 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     {
         let context = self.context().clone();
         self.api().update_pet(body, &context).await
+    }
+
+    /// Deletes a pet
+    async fn delete_pet(
+        &self,
+        pet_id: i64,
+        api_key: Option<String>,
+        ) -> Result<DeletePetResponse, ApiError>
+    {
+        let context = self.context().clone();
+        self.api().delete_pet(pet_id, api_key, &context).await
+    }
+
+    /// Find pet by ID
+    async fn get_pet_by_id(
+        &self,
+        pet_id: i64,
+        ) -> Result<GetPetByIdResponse, ApiError>
+    {
+        let context = self.context().clone();
+        self.api().get_pet_by_id(pet_id, &context).await
     }
 
     /// Updates a pet in the store with form data
@@ -1063,16 +1063,6 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
         self.api().upload_file(pet_id, additional_metadata, file, &context).await
     }
 
-    /// Delete purchase order by ID
-    async fn delete_order(
-        &self,
-        order_id: String,
-        ) -> Result<DeleteOrderResponse, ApiError>
-    {
-        let context = self.context().clone();
-        self.api().delete_order(order_id, &context).await
-    }
-
     /// Returns pet inventories by status
     async fn get_inventory(
         &self,
@@ -1080,16 +1070,6 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     {
         let context = self.context().clone();
         self.api().get_inventory(&context).await
-    }
-
-    /// Find purchase order by ID
-    async fn get_order_by_id(
-        &self,
-        order_id: i64,
-        ) -> Result<GetOrderByIdResponse, ApiError>
-    {
-        let context = self.context().clone();
-        self.api().get_order_by_id(order_id, &context).await
     }
 
     /// Place an order for a pet
@@ -1100,6 +1080,26 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     {
         let context = self.context().clone();
         self.api().place_order(body, &context).await
+    }
+
+    /// Delete purchase order by ID
+    async fn delete_order(
+        &self,
+        order_id: String,
+        ) -> Result<DeleteOrderResponse, ApiError>
+    {
+        let context = self.context().clone();
+        self.api().delete_order(order_id, &context).await
+    }
+
+    /// Find purchase order by ID
+    async fn get_order_by_id(
+        &self,
+        order_id: i64,
+        ) -> Result<GetOrderByIdResponse, ApiError>
+    {
+        let context = self.context().clone();
+        self.api().get_order_by_id(order_id, &context).await
     }
 
     /// Create user
@@ -1132,26 +1132,6 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
         self.api().create_users_with_list_input(body, &context).await
     }
 
-    /// Delete user
-    async fn delete_user(
-        &self,
-        username: String,
-        ) -> Result<DeleteUserResponse, ApiError>
-    {
-        let context = self.context().clone();
-        self.api().delete_user(username, &context).await
-    }
-
-    /// Get user by user name
-    async fn get_user_by_name(
-        &self,
-        username: String,
-        ) -> Result<GetUserByNameResponse, ApiError>
-    {
-        let context = self.context().clone();
-        self.api().get_user_by_name(username, &context).await
-    }
-
     /// Logs user into the system
     async fn login_user(
         &self,
@@ -1170,6 +1150,26 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     {
         let context = self.context().clone();
         self.api().logout_user(&context).await
+    }
+
+    /// Delete user
+    async fn delete_user(
+        &self,
+        username: String,
+        ) -> Result<DeleteUserResponse, ApiError>
+    {
+        let context = self.context().clone();
+        self.api().delete_user(username, &context).await
+    }
+
+    /// Get user by user name
+    async fn get_user_by_name(
+        &self,
+        username: String,
+        ) -> Result<GetUserByNameResponse, ApiError>
+    {
+        let context = self.context().clone();
+        self.api().get_user_by_name(username, &context).await
     }
 
     /// Updated user

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -30,33 +30,33 @@ use crate::{Api,
      FakeOuterNumberSerializeResponse,
      FakeOuterStringSerializeResponse,
      FakeResponseWithNumericalDescriptionResponse,
-     HyphenParamResponse,
      TestBodyWithQueryParamsResponse,
      TestClientModelResponse,
      TestEndpointParametersResponse,
      TestEnumParametersResponse,
      TestInlineAdditionalPropertiesResponse,
      TestJsonFormDataResponse,
+     HyphenParamResponse,
      TestClassnameResponse,
      AddPetResponse,
-     DeletePetResponse,
      FindPetsByStatusResponse,
      FindPetsByTagsResponse,
-     GetPetByIdResponse,
      UpdatePetResponse,
+     DeletePetResponse,
+     GetPetByIdResponse,
      UpdatePetWithFormResponse,
      UploadFileResponse,
-     DeleteOrderResponse,
      GetInventoryResponse,
-     GetOrderByIdResponse,
      PlaceOrderResponse,
+     DeleteOrderResponse,
+     GetOrderByIdResponse,
      CreateUserResponse,
      CreateUsersWithArrayInputResponse,
      CreateUsersWithListInputResponse,
-     DeleteUserResponse,
-     GetUserByNameResponse,
      LoginUserResponse,
      LogoutUserResponse,
+     DeleteUserResponse,
+     GetUserByNameResponse,
      UpdateUserResponse
 };
 
@@ -690,60 +690,6 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                         Ok(response)
             },
 
-            // HyphenParam - GET /fake/hyphenParam/{hyphen-param}
-            hyper::Method::GET if path.matched(paths::ID_FAKE_HYPHENPARAM_HYPHEN_PARAM) => {
-                // Path parameters
-                let path: &str = uri.path();
-                let path_params =
-                    paths::REGEX_FAKE_HYPHENPARAM_HYPHEN_PARAM
-                    .captures(path)
-                    .unwrap_or_else(||
-                        panic!("Path {} matched RE FAKE_HYPHENPARAM_HYPHEN_PARAM in set but failed match against \"{}\"", path, paths::REGEX_FAKE_HYPHENPARAM_HYPHEN_PARAM.as_str())
-                    );
-
-                let param_hyphen_param = match percent_encoding::percent_decode(path_params["hyphen-param"].as_bytes()).decode_utf8() {
-                    Ok(param_hyphen_param) => match param_hyphen_param.parse::<String>() {
-                        Ok(param_hyphen_param) => param_hyphen_param,
-                        Err(e) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't parse path parameter hyphen-param: {}", e)))
-                                        .expect("Unable to create Bad Request response for invalid path parameter")),
-                    },
-                    Err(_) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["hyphen-param"])))
-                                        .expect("Unable to create Bad Request response for invalid percent decode"))
-                };
-
-                                let result = api_impl.hyphen_param(
-                                            param_hyphen_param,
-                                        &context
-                                    ).await;
-                                let mut response = Response::new(Body::empty());
-                                response.headers_mut().insert(
-                                            HeaderName::from_static("x-span-id"),
-                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
-                                                .expect("Unable to create X-Span-ID header value"));
-
-                                        match result {
-                                            Ok(rsp) => match rsp {
-                                                HyphenParamResponse::Success
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
-
-                                                },
-                                            },
-                                            Err(_) => {
-                                                // Application code returned an error. This should not happen, as the implementation should
-                                                // return a valid response.
-                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                                *response.body_mut() = Body::from("An internal error occurred");
-                                            },
-                                        }
-
-                                        Ok(response)
-            },
-
             // TestBodyWithQueryParams - PUT /fake/body-with-query-params
             hyper::Method::PUT if path.matched(paths::ID_FAKE_BODY_WITH_QUERY_PARAMS) => {
                 // Query parameters (note that non-required or collection query parameters will ignore garbage values, rather than causing a 400 response)
@@ -1314,6 +1260,60 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                         }
             },
 
+            // HyphenParam - GET /fake/hyphenParam/{hyphen-param}
+            hyper::Method::GET if path.matched(paths::ID_FAKE_HYPHENPARAM_HYPHEN_PARAM) => {
+                // Path parameters
+                let path: &str = uri.path();
+                let path_params =
+                    paths::REGEX_FAKE_HYPHENPARAM_HYPHEN_PARAM
+                    .captures(path)
+                    .unwrap_or_else(||
+                        panic!("Path {} matched RE FAKE_HYPHENPARAM_HYPHEN_PARAM in set but failed match against \"{}\"", path, paths::REGEX_FAKE_HYPHENPARAM_HYPHEN_PARAM.as_str())
+                    );
+
+                let param_hyphen_param = match percent_encoding::percent_decode(path_params["hyphen-param"].as_bytes()).decode_utf8() {
+                    Ok(param_hyphen_param) => match param_hyphen_param.parse::<String>() {
+                        Ok(param_hyphen_param) => param_hyphen_param,
+                        Err(e) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't parse path parameter hyphen-param: {}", e)))
+                                        .expect("Unable to create Bad Request response for invalid path parameter")),
+                    },
+                    Err(_) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["hyphen-param"])))
+                                        .expect("Unable to create Bad Request response for invalid percent decode"))
+                };
+
+                                let result = api_impl.hyphen_param(
+                                            param_hyphen_param,
+                                        &context
+                                    ).await;
+                                let mut response = Response::new(Body::empty());
+                                response.headers_mut().insert(
+                                            HeaderName::from_static("x-span-id"),
+                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
+                                                .expect("Unable to create X-Span-ID header value"));
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                HyphenParamResponse::Success
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
+
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                                *response.body_mut() = Body::from("An internal error occurred");
+                                            },
+                                        }
+
+                                        Ok(response)
+            },
+
             // TestClassname - PATCH /fake_classname_test
             hyper::Method::PATCH if path.matched(paths::ID_FAKE_CLASSNAME_TEST) => {
                 {
@@ -1510,111 +1510,6 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                         }
             },
 
-            // DeletePet - DELETE /pet/{petId}
-            hyper::Method::DELETE if path.matched(paths::ID_PET_PETID) => {
-                {
-                    let authorization = match *(&context as &dyn Has<Option<Authorization>>).get() {
-                        Some(ref authorization) => authorization,
-                        None => return Ok(Response::builder()
-                                                .status(StatusCode::FORBIDDEN)
-                                                .body(Body::from("Unauthenticated"))
-                                                .expect("Unable to create Authentication Forbidden response")),
-                    };
-
-                    // Authorization
-                    if let Scopes::Some(ref scopes) = authorization.scopes {
-                        let required_scopes: std::collections::BTreeSet<String> = vec![
-                            "write:pets".to_string(), // modify pets in your account
-                            "read:pets".to_string(), // read your pets
-                        ].into_iter().collect();
-
-                        if !required_scopes.is_subset(scopes) {
-                            let missing_scopes = required_scopes.difference(scopes);
-                            return Ok(Response::builder()
-                                .status(StatusCode::FORBIDDEN)
-                                .body(Body::from(missing_scopes.fold(
-                                    "Insufficient authorization, missing scopes".to_string(),
-                                    |s, scope| format!("{} {}", s, scope))
-                                ))
-                                .expect("Unable to create Authentication Insufficient response")
-                            );
-                        }
-                    }
-                }
-
-                // Path parameters
-                let path: &str = uri.path();
-                let path_params =
-                    paths::REGEX_PET_PETID
-                    .captures(path)
-                    .unwrap_or_else(||
-                        panic!("Path {} matched RE PET_PETID in set but failed match against \"{}\"", path, paths::REGEX_PET_PETID.as_str())
-                    );
-
-                let param_pet_id = match percent_encoding::percent_decode(path_params["petId"].as_bytes()).decode_utf8() {
-                    Ok(param_pet_id) => match param_pet_id.parse::<i64>() {
-                        Ok(param_pet_id) => param_pet_id,
-                        Err(e) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't parse path parameter petId: {}", e)))
-                                        .expect("Unable to create Bad Request response for invalid path parameter")),
-                    },
-                    Err(_) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["petId"])))
-                                        .expect("Unable to create Bad Request response for invalid percent decode"))
-                };
-
-                // Header parameters
-                let param_api_key = headers.get(HeaderName::from_static("api_key"));
-
-                let param_api_key = match param_api_key {
-                    Some(v) => match header::IntoHeaderValue::<String>::try_from((*v).clone()) {
-                        Ok(result) =>
-                            Some(result.0),
-                        Err(err) => {
-                            return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Invalid header api_key - {}", err)))
-                                        .expect("Unable to create Bad Request response for invalid header api_key"));
-
-                        },
-                    },
-                    None => {
-                        None
-                    }
-                };
-
-                                let result = api_impl.delete_pet(
-                                            param_pet_id,
-                                            param_api_key,
-                                        &context
-                                    ).await;
-                                let mut response = Response::new(Body::empty());
-                                response.headers_mut().insert(
-                                            HeaderName::from_static("x-span-id"),
-                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
-                                                .expect("Unable to create X-Span-ID header value"));
-
-                                        match result {
-                                            Ok(rsp) => match rsp {
-                                                DeletePetResponse::InvalidPetValue
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
-
-                                                },
-                                            },
-                                            Err(_) => {
-                                                // Application code returned an error. This should not happen, as the implementation should
-                                                // return a valid response.
-                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                                *response.body_mut() = Body::from("An internal error occurred");
-                                            },
-                                        }
-
-                                        Ok(response)
-            },
-
             // FindPetsByStatus - GET /pet/findByStatus
             hyper::Method::GET if path.matched(paths::ID_PET_FINDBYSTATUS) => {
                 {
@@ -1775,88 +1670,6 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                         Ok(response)
             },
 
-            // GetPetById - GET /pet/{petId}
-            hyper::Method::GET if path.matched(paths::ID_PET_PETID) => {
-                {
-                    let authorization = match *(&context as &dyn Has<Option<Authorization>>).get() {
-                        Some(ref authorization) => authorization,
-                        None => return Ok(Response::builder()
-                                                .status(StatusCode::FORBIDDEN)
-                                                .body(Body::from("Unauthenticated"))
-                                                .expect("Unable to create Authentication Forbidden response")),
-                    };
-                }
-
-                // Path parameters
-                let path: &str = uri.path();
-                let path_params =
-                    paths::REGEX_PET_PETID
-                    .captures(path)
-                    .unwrap_or_else(||
-                        panic!("Path {} matched RE PET_PETID in set but failed match against \"{}\"", path, paths::REGEX_PET_PETID.as_str())
-                    );
-
-                let param_pet_id = match percent_encoding::percent_decode(path_params["petId"].as_bytes()).decode_utf8() {
-                    Ok(param_pet_id) => match param_pet_id.parse::<i64>() {
-                        Ok(param_pet_id) => param_pet_id,
-                        Err(e) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't parse path parameter petId: {}", e)))
-                                        .expect("Unable to create Bad Request response for invalid path parameter")),
-                    },
-                    Err(_) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["petId"])))
-                                        .expect("Unable to create Bad Request response for invalid percent decode"))
-                };
-
-                                let result = api_impl.get_pet_by_id(
-                                            param_pet_id,
-                                        &context
-                                    ).await;
-                                let mut response = Response::new(Body::empty());
-                                response.headers_mut().insert(
-                                            HeaderName::from_static("x-span-id"),
-                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
-                                                .expect("Unable to create X-Span-ID header value"));
-
-                                        match result {
-                                            Ok(rsp) => match rsp {
-                                                GetPetByIdResponse::SuccessfulOperation
-                                                    (body)
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
-                                                    response.headers_mut().insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_str("application/xml")
-                                                            .expect("Unable to create Content-Type header for application/xml"));
-                                                    // XML Body
-                                                    let body = serde_xml_rs::to_string(&body).expect("impossible to fail to serialize");
-                                                    *response.body_mut() = Body::from(body);
-
-                                                },
-                                                GetPetByIdResponse::InvalidIDSupplied
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
-
-                                                },
-                                                GetPetByIdResponse::PetNotFound
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(404).expect("Unable to turn 404 into a StatusCode");
-
-                                                },
-                                            },
-                                            Err(_) => {
-                                                // Application code returned an error. This should not happen, as the implementation should
-                                                // return a valid response.
-                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                                *response.body_mut() = Body::from("An internal error occurred");
-                                            },
-                                        }
-
-                                        Ok(response)
-            },
-
             // UpdatePet - PUT /pet
             hyper::Method::PUT if path.matched(paths::ID_PET) => {
                 {
@@ -1969,6 +1782,193 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                 .body(Body::from(format!("Unable to read body: {}", e)))
                                                 .expect("Unable to create Bad Request response due to unable to read body")),
                         }
+            },
+
+            // DeletePet - DELETE /pet/{petId}
+            hyper::Method::DELETE if path.matched(paths::ID_PET_PETID) => {
+                {
+                    let authorization = match *(&context as &dyn Has<Option<Authorization>>).get() {
+                        Some(ref authorization) => authorization,
+                        None => return Ok(Response::builder()
+                                                .status(StatusCode::FORBIDDEN)
+                                                .body(Body::from("Unauthenticated"))
+                                                .expect("Unable to create Authentication Forbidden response")),
+                    };
+
+                    // Authorization
+                    if let Scopes::Some(ref scopes) = authorization.scopes {
+                        let required_scopes: std::collections::BTreeSet<String> = vec![
+                            "write:pets".to_string(), // modify pets in your account
+                            "read:pets".to_string(), // read your pets
+                        ].into_iter().collect();
+
+                        if !required_scopes.is_subset(scopes) {
+                            let missing_scopes = required_scopes.difference(scopes);
+                            return Ok(Response::builder()
+                                .status(StatusCode::FORBIDDEN)
+                                .body(Body::from(missing_scopes.fold(
+                                    "Insufficient authorization, missing scopes".to_string(),
+                                    |s, scope| format!("{} {}", s, scope))
+                                ))
+                                .expect("Unable to create Authentication Insufficient response")
+                            );
+                        }
+                    }
+                }
+
+                // Path parameters
+                let path: &str = uri.path();
+                let path_params =
+                    paths::REGEX_PET_PETID
+                    .captures(path)
+                    .unwrap_or_else(||
+                        panic!("Path {} matched RE PET_PETID in set but failed match against \"{}\"", path, paths::REGEX_PET_PETID.as_str())
+                    );
+
+                let param_pet_id = match percent_encoding::percent_decode(path_params["petId"].as_bytes()).decode_utf8() {
+                    Ok(param_pet_id) => match param_pet_id.parse::<i64>() {
+                        Ok(param_pet_id) => param_pet_id,
+                        Err(e) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't parse path parameter petId: {}", e)))
+                                        .expect("Unable to create Bad Request response for invalid path parameter")),
+                    },
+                    Err(_) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["petId"])))
+                                        .expect("Unable to create Bad Request response for invalid percent decode"))
+                };
+
+                // Header parameters
+                let param_api_key = headers.get(HeaderName::from_static("api_key"));
+
+                let param_api_key = match param_api_key {
+                    Some(v) => match header::IntoHeaderValue::<String>::try_from((*v).clone()) {
+                        Ok(result) =>
+                            Some(result.0),
+                        Err(err) => {
+                            return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Invalid header api_key - {}", err)))
+                                        .expect("Unable to create Bad Request response for invalid header api_key"));
+
+                        },
+                    },
+                    None => {
+                        None
+                    }
+                };
+
+                                let result = api_impl.delete_pet(
+                                            param_pet_id,
+                                            param_api_key,
+                                        &context
+                                    ).await;
+                                let mut response = Response::new(Body::empty());
+                                response.headers_mut().insert(
+                                            HeaderName::from_static("x-span-id"),
+                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
+                                                .expect("Unable to create X-Span-ID header value"));
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                DeletePetResponse::InvalidPetValue
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
+
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                                *response.body_mut() = Body::from("An internal error occurred");
+                                            },
+                                        }
+
+                                        Ok(response)
+            },
+
+            // GetPetById - GET /pet/{petId}
+            hyper::Method::GET if path.matched(paths::ID_PET_PETID) => {
+                {
+                    let authorization = match *(&context as &dyn Has<Option<Authorization>>).get() {
+                        Some(ref authorization) => authorization,
+                        None => return Ok(Response::builder()
+                                                .status(StatusCode::FORBIDDEN)
+                                                .body(Body::from("Unauthenticated"))
+                                                .expect("Unable to create Authentication Forbidden response")),
+                    };
+                }
+
+                // Path parameters
+                let path: &str = uri.path();
+                let path_params =
+                    paths::REGEX_PET_PETID
+                    .captures(path)
+                    .unwrap_or_else(||
+                        panic!("Path {} matched RE PET_PETID in set but failed match against \"{}\"", path, paths::REGEX_PET_PETID.as_str())
+                    );
+
+                let param_pet_id = match percent_encoding::percent_decode(path_params["petId"].as_bytes()).decode_utf8() {
+                    Ok(param_pet_id) => match param_pet_id.parse::<i64>() {
+                        Ok(param_pet_id) => param_pet_id,
+                        Err(e) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't parse path parameter petId: {}", e)))
+                                        .expect("Unable to create Bad Request response for invalid path parameter")),
+                    },
+                    Err(_) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["petId"])))
+                                        .expect("Unable to create Bad Request response for invalid percent decode"))
+                };
+
+                                let result = api_impl.get_pet_by_id(
+                                            param_pet_id,
+                                        &context
+                                    ).await;
+                                let mut response = Response::new(Body::empty());
+                                response.headers_mut().insert(
+                                            HeaderName::from_static("x-span-id"),
+                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
+                                                .expect("Unable to create X-Span-ID header value"));
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                GetPetByIdResponse::SuccessfulOperation
+                                                    (body)
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
+                                                    response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/xml")
+                                                            .expect("Unable to create Content-Type header for application/xml"));
+                                                    // XML Body
+                                                    let body = serde_xml_rs::to_string(&body).expect("impossible to fail to serialize");
+                                                    *response.body_mut() = Body::from(body);
+
+                                                },
+                                                GetPetByIdResponse::InvalidIDSupplied
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
+
+                                                },
+                                                GetPetByIdResponse::PetNotFound
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(404).expect("Unable to turn 404 into a StatusCode");
+
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                                *response.body_mut() = Body::from("An internal error occurred");
+                                            },
+                                        }
+
+                                        Ok(response)
             },
 
             // UpdatePetWithForm - POST /pet/{petId}
@@ -2254,65 +2254,6 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                         }
             },
 
-            // DeleteOrder - DELETE /store/order/{order_id}
-            hyper::Method::DELETE if path.matched(paths::ID_STORE_ORDER_ORDER_ID) => {
-                // Path parameters
-                let path: &str = uri.path();
-                let path_params =
-                    paths::REGEX_STORE_ORDER_ORDER_ID
-                    .captures(path)
-                    .unwrap_or_else(||
-                        panic!("Path {} matched RE STORE_ORDER_ORDER_ID in set but failed match against \"{}\"", path, paths::REGEX_STORE_ORDER_ORDER_ID.as_str())
-                    );
-
-                let param_order_id = match percent_encoding::percent_decode(path_params["order_id"].as_bytes()).decode_utf8() {
-                    Ok(param_order_id) => match param_order_id.parse::<String>() {
-                        Ok(param_order_id) => param_order_id,
-                        Err(e) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't parse path parameter order_id: {}", e)))
-                                        .expect("Unable to create Bad Request response for invalid path parameter")),
-                    },
-                    Err(_) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["order_id"])))
-                                        .expect("Unable to create Bad Request response for invalid percent decode"))
-                };
-
-                                let result = api_impl.delete_order(
-                                            param_order_id,
-                                        &context
-                                    ).await;
-                                let mut response = Response::new(Body::empty());
-                                response.headers_mut().insert(
-                                            HeaderName::from_static("x-span-id"),
-                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
-                                                .expect("Unable to create X-Span-ID header value"));
-
-                                        match result {
-                                            Ok(rsp) => match rsp {
-                                                DeleteOrderResponse::InvalidIDSupplied
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
-
-                                                },
-                                                DeleteOrderResponse::OrderNotFound
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(404).expect("Unable to turn 404 into a StatusCode");
-
-                                                },
-                                            },
-                                            Err(_) => {
-                                                // Application code returned an error. This should not happen, as the implementation should
-                                                // return a valid response.
-                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                                *response.body_mut() = Body::from("An internal error occurred");
-                                            },
-                                        }
-
-                                        Ok(response)
-            },
-
             // GetInventory - GET /store/inventory
             hyper::Method::GET if path.matched(paths::ID_STORE_INVENTORY) => {
                 {
@@ -2347,78 +2288,6 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                     // JSON Body
                                                     let body = serde_json::to_string(&body).expect("impossible to fail to serialize");
                                                     *response.body_mut() = Body::from(body);
-
-                                                },
-                                            },
-                                            Err(_) => {
-                                                // Application code returned an error. This should not happen, as the implementation should
-                                                // return a valid response.
-                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                                *response.body_mut() = Body::from("An internal error occurred");
-                                            },
-                                        }
-
-                                        Ok(response)
-            },
-
-            // GetOrderById - GET /store/order/{order_id}
-            hyper::Method::GET if path.matched(paths::ID_STORE_ORDER_ORDER_ID) => {
-                // Path parameters
-                let path: &str = uri.path();
-                let path_params =
-                    paths::REGEX_STORE_ORDER_ORDER_ID
-                    .captures(path)
-                    .unwrap_or_else(||
-                        panic!("Path {} matched RE STORE_ORDER_ORDER_ID in set but failed match against \"{}\"", path, paths::REGEX_STORE_ORDER_ORDER_ID.as_str())
-                    );
-
-                let param_order_id = match percent_encoding::percent_decode(path_params["order_id"].as_bytes()).decode_utf8() {
-                    Ok(param_order_id) => match param_order_id.parse::<i64>() {
-                        Ok(param_order_id) => param_order_id,
-                        Err(e) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't parse path parameter order_id: {}", e)))
-                                        .expect("Unable to create Bad Request response for invalid path parameter")),
-                    },
-                    Err(_) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["order_id"])))
-                                        .expect("Unable to create Bad Request response for invalid percent decode"))
-                };
-
-                                let result = api_impl.get_order_by_id(
-                                            param_order_id,
-                                        &context
-                                    ).await;
-                                let mut response = Response::new(Body::empty());
-                                response.headers_mut().insert(
-                                            HeaderName::from_static("x-span-id"),
-                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
-                                                .expect("Unable to create X-Span-ID header value"));
-
-                                        match result {
-                                            Ok(rsp) => match rsp {
-                                                GetOrderByIdResponse::SuccessfulOperation
-                                                    (body)
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
-                                                    response.headers_mut().insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_str("application/xml")
-                                                            .expect("Unable to create Content-Type header for application/xml"));
-                                                    // XML Body
-                                                    let body = serde_xml_rs::to_string(&body).expect("impossible to fail to serialize");
-                                                    *response.body_mut() = Body::from(body);
-
-                                                },
-                                                GetOrderByIdResponse::InvalidIDSupplied
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
-
-                                                },
-                                                GetOrderByIdResponse::OrderNotFound
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(404).expect("Unable to turn 404 into a StatusCode");
 
                                                 },
                                             },
@@ -2518,6 +2387,137 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                 .body(Body::from(format!("Unable to read body: {}", e)))
                                                 .expect("Unable to create Bad Request response due to unable to read body")),
                         }
+            },
+
+            // DeleteOrder - DELETE /store/order/{order_id}
+            hyper::Method::DELETE if path.matched(paths::ID_STORE_ORDER_ORDER_ID) => {
+                // Path parameters
+                let path: &str = uri.path();
+                let path_params =
+                    paths::REGEX_STORE_ORDER_ORDER_ID
+                    .captures(path)
+                    .unwrap_or_else(||
+                        panic!("Path {} matched RE STORE_ORDER_ORDER_ID in set but failed match against \"{}\"", path, paths::REGEX_STORE_ORDER_ORDER_ID.as_str())
+                    );
+
+                let param_order_id = match percent_encoding::percent_decode(path_params["order_id"].as_bytes()).decode_utf8() {
+                    Ok(param_order_id) => match param_order_id.parse::<String>() {
+                        Ok(param_order_id) => param_order_id,
+                        Err(e) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't parse path parameter order_id: {}", e)))
+                                        .expect("Unable to create Bad Request response for invalid path parameter")),
+                    },
+                    Err(_) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["order_id"])))
+                                        .expect("Unable to create Bad Request response for invalid percent decode"))
+                };
+
+                                let result = api_impl.delete_order(
+                                            param_order_id,
+                                        &context
+                                    ).await;
+                                let mut response = Response::new(Body::empty());
+                                response.headers_mut().insert(
+                                            HeaderName::from_static("x-span-id"),
+                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
+                                                .expect("Unable to create X-Span-ID header value"));
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                DeleteOrderResponse::InvalidIDSupplied
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
+
+                                                },
+                                                DeleteOrderResponse::OrderNotFound
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(404).expect("Unable to turn 404 into a StatusCode");
+
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                                *response.body_mut() = Body::from("An internal error occurred");
+                                            },
+                                        }
+
+                                        Ok(response)
+            },
+
+            // GetOrderById - GET /store/order/{order_id}
+            hyper::Method::GET if path.matched(paths::ID_STORE_ORDER_ORDER_ID) => {
+                // Path parameters
+                let path: &str = uri.path();
+                let path_params =
+                    paths::REGEX_STORE_ORDER_ORDER_ID
+                    .captures(path)
+                    .unwrap_or_else(||
+                        panic!("Path {} matched RE STORE_ORDER_ORDER_ID in set but failed match against \"{}\"", path, paths::REGEX_STORE_ORDER_ORDER_ID.as_str())
+                    );
+
+                let param_order_id = match percent_encoding::percent_decode(path_params["order_id"].as_bytes()).decode_utf8() {
+                    Ok(param_order_id) => match param_order_id.parse::<i64>() {
+                        Ok(param_order_id) => param_order_id,
+                        Err(e) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't parse path parameter order_id: {}", e)))
+                                        .expect("Unable to create Bad Request response for invalid path parameter")),
+                    },
+                    Err(_) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["order_id"])))
+                                        .expect("Unable to create Bad Request response for invalid percent decode"))
+                };
+
+                                let result = api_impl.get_order_by_id(
+                                            param_order_id,
+                                        &context
+                                    ).await;
+                                let mut response = Response::new(Body::empty());
+                                response.headers_mut().insert(
+                                            HeaderName::from_static("x-span-id"),
+                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
+                                                .expect("Unable to create X-Span-ID header value"));
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                GetOrderByIdResponse::SuccessfulOperation
+                                                    (body)
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
+                                                    response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/xml")
+                                                            .expect("Unable to create Content-Type header for application/xml"));
+                                                    // XML Body
+                                                    let body = serde_xml_rs::to_string(&body).expect("impossible to fail to serialize");
+                                                    *response.body_mut() = Body::from(body);
+
+                                                },
+                                                GetOrderByIdResponse::InvalidIDSupplied
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
+
+                                                },
+                                                GetOrderByIdResponse::OrderNotFound
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(404).expect("Unable to turn 404 into a StatusCode");
+
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                                *response.body_mut() = Body::from("An internal error occurred");
+                                            },
+                                        }
+
+                                        Ok(response)
             },
 
             // CreateUser - POST /user
@@ -2742,137 +2742,6 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                         }
             },
 
-            // DeleteUser - DELETE /user/{username}
-            hyper::Method::DELETE if path.matched(paths::ID_USER_USERNAME) => {
-                // Path parameters
-                let path: &str = uri.path();
-                let path_params =
-                    paths::REGEX_USER_USERNAME
-                    .captures(path)
-                    .unwrap_or_else(||
-                        panic!("Path {} matched RE USER_USERNAME in set but failed match against \"{}\"", path, paths::REGEX_USER_USERNAME.as_str())
-                    );
-
-                let param_username = match percent_encoding::percent_decode(path_params["username"].as_bytes()).decode_utf8() {
-                    Ok(param_username) => match param_username.parse::<String>() {
-                        Ok(param_username) => param_username,
-                        Err(e) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't parse path parameter username: {}", e)))
-                                        .expect("Unable to create Bad Request response for invalid path parameter")),
-                    },
-                    Err(_) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["username"])))
-                                        .expect("Unable to create Bad Request response for invalid percent decode"))
-                };
-
-                                let result = api_impl.delete_user(
-                                            param_username,
-                                        &context
-                                    ).await;
-                                let mut response = Response::new(Body::empty());
-                                response.headers_mut().insert(
-                                            HeaderName::from_static("x-span-id"),
-                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
-                                                .expect("Unable to create X-Span-ID header value"));
-
-                                        match result {
-                                            Ok(rsp) => match rsp {
-                                                DeleteUserResponse::InvalidUsernameSupplied
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
-
-                                                },
-                                                DeleteUserResponse::UserNotFound
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(404).expect("Unable to turn 404 into a StatusCode");
-
-                                                },
-                                            },
-                                            Err(_) => {
-                                                // Application code returned an error. This should not happen, as the implementation should
-                                                // return a valid response.
-                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                                *response.body_mut() = Body::from("An internal error occurred");
-                                            },
-                                        }
-
-                                        Ok(response)
-            },
-
-            // GetUserByName - GET /user/{username}
-            hyper::Method::GET if path.matched(paths::ID_USER_USERNAME) => {
-                // Path parameters
-                let path: &str = uri.path();
-                let path_params =
-                    paths::REGEX_USER_USERNAME
-                    .captures(path)
-                    .unwrap_or_else(||
-                        panic!("Path {} matched RE USER_USERNAME in set but failed match against \"{}\"", path, paths::REGEX_USER_USERNAME.as_str())
-                    );
-
-                let param_username = match percent_encoding::percent_decode(path_params["username"].as_bytes()).decode_utf8() {
-                    Ok(param_username) => match param_username.parse::<String>() {
-                        Ok(param_username) => param_username,
-                        Err(e) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't parse path parameter username: {}", e)))
-                                        .expect("Unable to create Bad Request response for invalid path parameter")),
-                    },
-                    Err(_) => return Ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["username"])))
-                                        .expect("Unable to create Bad Request response for invalid percent decode"))
-                };
-
-                                let result = api_impl.get_user_by_name(
-                                            param_username,
-                                        &context
-                                    ).await;
-                                let mut response = Response::new(Body::empty());
-                                response.headers_mut().insert(
-                                            HeaderName::from_static("x-span-id"),
-                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
-                                                .expect("Unable to create X-Span-ID header value"));
-
-                                        match result {
-                                            Ok(rsp) => match rsp {
-                                                GetUserByNameResponse::SuccessfulOperation
-                                                    (body)
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
-                                                    response.headers_mut().insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_str("application/xml")
-                                                            .expect("Unable to create Content-Type header for application/xml"));
-                                                    // XML Body
-                                                    let body = serde_xml_rs::to_string(&body).expect("impossible to fail to serialize");
-                                                    *response.body_mut() = Body::from(body);
-
-                                                },
-                                                GetUserByNameResponse::InvalidUsernameSupplied
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
-
-                                                },
-                                                GetUserByNameResponse::UserNotFound
-                                                => {
-                                                    *response.status_mut() = StatusCode::from_u16(404).expect("Unable to turn 404 into a StatusCode");
-
-                                                },
-                                            },
-                                            Err(_) => {
-                                                // Application code returned an error. This should not happen, as the implementation should
-                                                // return a valid response.
-                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                                *response.body_mut() = Body::from("An internal error occurred");
-                                            },
-                                        }
-
-                                        Ok(response)
-            },
-
             // LoginUser - GET /user/login
             hyper::Method::GET if path.matched(paths::ID_USER_LOGIN) => {
                 // Query parameters (note that non-required or collection query parameters will ignore garbage values, rather than causing a 400 response)
@@ -3023,6 +2892,137 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                 LogoutUserResponse::SuccessfulOperation
                                                 => {
                                                     *response.status_mut() = StatusCode::from_u16(0).expect("Unable to turn 0 into a StatusCode");
+
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                                *response.body_mut() = Body::from("An internal error occurred");
+                                            },
+                                        }
+
+                                        Ok(response)
+            },
+
+            // DeleteUser - DELETE /user/{username}
+            hyper::Method::DELETE if path.matched(paths::ID_USER_USERNAME) => {
+                // Path parameters
+                let path: &str = uri.path();
+                let path_params =
+                    paths::REGEX_USER_USERNAME
+                    .captures(path)
+                    .unwrap_or_else(||
+                        panic!("Path {} matched RE USER_USERNAME in set but failed match against \"{}\"", path, paths::REGEX_USER_USERNAME.as_str())
+                    );
+
+                let param_username = match percent_encoding::percent_decode(path_params["username"].as_bytes()).decode_utf8() {
+                    Ok(param_username) => match param_username.parse::<String>() {
+                        Ok(param_username) => param_username,
+                        Err(e) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't parse path parameter username: {}", e)))
+                                        .expect("Unable to create Bad Request response for invalid path parameter")),
+                    },
+                    Err(_) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["username"])))
+                                        .expect("Unable to create Bad Request response for invalid percent decode"))
+                };
+
+                                let result = api_impl.delete_user(
+                                            param_username,
+                                        &context
+                                    ).await;
+                                let mut response = Response::new(Body::empty());
+                                response.headers_mut().insert(
+                                            HeaderName::from_static("x-span-id"),
+                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
+                                                .expect("Unable to create X-Span-ID header value"));
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                DeleteUserResponse::InvalidUsernameSupplied
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
+
+                                                },
+                                                DeleteUserResponse::UserNotFound
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(404).expect("Unable to turn 404 into a StatusCode");
+
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                                *response.body_mut() = Body::from("An internal error occurred");
+                                            },
+                                        }
+
+                                        Ok(response)
+            },
+
+            // GetUserByName - GET /user/{username}
+            hyper::Method::GET if path.matched(paths::ID_USER_USERNAME) => {
+                // Path parameters
+                let path: &str = uri.path();
+                let path_params =
+                    paths::REGEX_USER_USERNAME
+                    .captures(path)
+                    .unwrap_or_else(||
+                        panic!("Path {} matched RE USER_USERNAME in set but failed match against \"{}\"", path, paths::REGEX_USER_USERNAME.as_str())
+                    );
+
+                let param_username = match percent_encoding::percent_decode(path_params["username"].as_bytes()).decode_utf8() {
+                    Ok(param_username) => match param_username.parse::<String>() {
+                        Ok(param_username) => param_username,
+                        Err(e) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't parse path parameter username: {}", e)))
+                                        .expect("Unable to create Bad Request response for invalid path parameter")),
+                    },
+                    Err(_) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["username"])))
+                                        .expect("Unable to create Bad Request response for invalid percent decode"))
+                };
+
+                                let result = api_impl.get_user_by_name(
+                                            param_username,
+                                        &context
+                                    ).await;
+                                let mut response = Response::new(Body::empty());
+                                response.headers_mut().insert(
+                                            HeaderName::from_static("x-span-id"),
+                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
+                                                .expect("Unable to create X-Span-ID header value"));
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                GetUserByNameResponse::SuccessfulOperation
+                                                    (body)
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
+                                                    response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/xml")
+                                                            .expect("Unable to create Content-Type header for application/xml"));
+                                                    // XML Body
+                                                    let body = serde_xml_rs::to_string(&body).expect("impossible to fail to serialize");
+                                                    *response.body_mut() = Body::from(body);
+
+                                                },
+                                                GetUserByNameResponse::InvalidUsernameSupplied
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
+
+                                                },
+                                                GetUserByNameResponse::UserNotFound
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(404).expect("Unable to turn 404 into a StatusCode");
 
                                                 },
                                             },
@@ -3194,8 +3194,6 @@ impl<T> RequestParser<T> for ApiRequestParser {
             hyper::Method::POST if path.matched(paths::ID_FAKE_OUTER_STRING) => Some("FakeOuterStringSerialize"),
             // FakeResponseWithNumericalDescription - GET /fake/response-with-numerical-description
             hyper::Method::GET if path.matched(paths::ID_FAKE_RESPONSE_WITH_NUMERICAL_DESCRIPTION) => Some("FakeResponseWithNumericalDescription"),
-            // HyphenParam - GET /fake/hyphenParam/{hyphen-param}
-            hyper::Method::GET if path.matched(paths::ID_FAKE_HYPHENPARAM_HYPHEN_PARAM) => Some("HyphenParam"),
             // TestBodyWithQueryParams - PUT /fake/body-with-query-params
             hyper::Method::PUT if path.matched(paths::ID_FAKE_BODY_WITH_QUERY_PARAMS) => Some("TestBodyWithQueryParams"),
             // TestClientModel - PATCH /fake
@@ -3208,46 +3206,48 @@ impl<T> RequestParser<T> for ApiRequestParser {
             hyper::Method::POST if path.matched(paths::ID_FAKE_INLINE_ADDITIONALPROPERTIES) => Some("TestInlineAdditionalProperties"),
             // TestJsonFormData - GET /fake/jsonFormData
             hyper::Method::GET if path.matched(paths::ID_FAKE_JSONFORMDATA) => Some("TestJsonFormData"),
+            // HyphenParam - GET /fake/hyphenParam/{hyphen-param}
+            hyper::Method::GET if path.matched(paths::ID_FAKE_HYPHENPARAM_HYPHEN_PARAM) => Some("HyphenParam"),
             // TestClassname - PATCH /fake_classname_test
             hyper::Method::PATCH if path.matched(paths::ID_FAKE_CLASSNAME_TEST) => Some("TestClassname"),
             // AddPet - POST /pet
             hyper::Method::POST if path.matched(paths::ID_PET) => Some("AddPet"),
-            // DeletePet - DELETE /pet/{petId}
-            hyper::Method::DELETE if path.matched(paths::ID_PET_PETID) => Some("DeletePet"),
             // FindPetsByStatus - GET /pet/findByStatus
             hyper::Method::GET if path.matched(paths::ID_PET_FINDBYSTATUS) => Some("FindPetsByStatus"),
             // FindPetsByTags - GET /pet/findByTags
             hyper::Method::GET if path.matched(paths::ID_PET_FINDBYTAGS) => Some("FindPetsByTags"),
-            // GetPetById - GET /pet/{petId}
-            hyper::Method::GET if path.matched(paths::ID_PET_PETID) => Some("GetPetById"),
             // UpdatePet - PUT /pet
             hyper::Method::PUT if path.matched(paths::ID_PET) => Some("UpdatePet"),
+            // DeletePet - DELETE /pet/{petId}
+            hyper::Method::DELETE if path.matched(paths::ID_PET_PETID) => Some("DeletePet"),
+            // GetPetById - GET /pet/{petId}
+            hyper::Method::GET if path.matched(paths::ID_PET_PETID) => Some("GetPetById"),
             // UpdatePetWithForm - POST /pet/{petId}
             hyper::Method::POST if path.matched(paths::ID_PET_PETID) => Some("UpdatePetWithForm"),
             // UploadFile - POST /pet/{petId}/uploadImage
             hyper::Method::POST if path.matched(paths::ID_PET_PETID_UPLOADIMAGE) => Some("UploadFile"),
-            // DeleteOrder - DELETE /store/order/{order_id}
-            hyper::Method::DELETE if path.matched(paths::ID_STORE_ORDER_ORDER_ID) => Some("DeleteOrder"),
             // GetInventory - GET /store/inventory
             hyper::Method::GET if path.matched(paths::ID_STORE_INVENTORY) => Some("GetInventory"),
-            // GetOrderById - GET /store/order/{order_id}
-            hyper::Method::GET if path.matched(paths::ID_STORE_ORDER_ORDER_ID) => Some("GetOrderById"),
             // PlaceOrder - POST /store/order
             hyper::Method::POST if path.matched(paths::ID_STORE_ORDER) => Some("PlaceOrder"),
+            // DeleteOrder - DELETE /store/order/{order_id}
+            hyper::Method::DELETE if path.matched(paths::ID_STORE_ORDER_ORDER_ID) => Some("DeleteOrder"),
+            // GetOrderById - GET /store/order/{order_id}
+            hyper::Method::GET if path.matched(paths::ID_STORE_ORDER_ORDER_ID) => Some("GetOrderById"),
             // CreateUser - POST /user
             hyper::Method::POST if path.matched(paths::ID_USER) => Some("CreateUser"),
             // CreateUsersWithArrayInput - POST /user/createWithArray
             hyper::Method::POST if path.matched(paths::ID_USER_CREATEWITHARRAY) => Some("CreateUsersWithArrayInput"),
             // CreateUsersWithListInput - POST /user/createWithList
             hyper::Method::POST if path.matched(paths::ID_USER_CREATEWITHLIST) => Some("CreateUsersWithListInput"),
-            // DeleteUser - DELETE /user/{username}
-            hyper::Method::DELETE if path.matched(paths::ID_USER_USERNAME) => Some("DeleteUser"),
-            // GetUserByName - GET /user/{username}
-            hyper::Method::GET if path.matched(paths::ID_USER_USERNAME) => Some("GetUserByName"),
             // LoginUser - GET /user/login
             hyper::Method::GET if path.matched(paths::ID_USER_LOGIN) => Some("LoginUser"),
             // LogoutUser - GET /user/logout
             hyper::Method::GET if path.matched(paths::ID_USER_LOGOUT) => Some("LogoutUser"),
+            // DeleteUser - DELETE /user/{username}
+            hyper::Method::DELETE if path.matched(paths::ID_USER_USERNAME) => Some("DeleteUser"),
+            // GetUserByName - GET /user/{username}
+            hyper::Method::GET if path.matched(paths::ID_USER_USERNAME) => Some("GetUserByName"),
             // UpdateUser - PUT /user/{username}
             hyper::Method::PUT if path.matched(paths::ID_USER_USERNAME) => Some("UpdateUser"),
             _ => None,


### PR DESCRIPTION
In the generated Rust Server code, the order of the operations list determines the order of cases in a match statement.

This meant that if we had two operations (say, `/foo/bar/` and `/foo/{something}`) where a given path (`/foo/bar`) could match both, it matched the operation whose `operationId` was alphabetically first, rather than following https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#pathsObject which says:

> When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts.

This sorts the operations so that the ones with fewest path parameters come first, which does meet that requirement.

This fix was contributed by @rkd-msw

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Rust Technical Committee: @frol @farcaller @paladinzh @jacob-pro
