### PR TITLE
Remove the deprecated suppressImplicitAnyIndexErrors tsconfig flag

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/tsconfig.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/tsconfig.mustache
@@ -3,7 +3,6 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "{{#supportsES6}}es6{{/supportsES6}}{{^supportsES6}}es5{{/supportsES6}}",
         "module": "{{#supportsES6}}es6{{/supportsES6}}{{^supportsES6}}commonjs{{/supportsES6}}",
         "moduleResolution": "node",

--- a/modules/openapi-generator/src/main/resources/typescript-inversify/tsconfig.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-inversify/tsconfig.mustache
@@ -3,7 +3,6 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "{{#supportsES6}}es6{{/supportsES6}}{{^supportsES6}}es5{{/supportsES6}}",
         "module": "{{#supportsES6}}es6{{/supportsES6}}{{^supportsES6}}commonjs{{/supportsES6}}",
         "moduleResolution": "node",

--- a/modules/openapi-generator/src/main/resources/typescript-jquery/tsconfig.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-jquery/tsconfig.mustache
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "module": "commonjs",
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "{{#supportsES6}}ES6{{/supportsES6}}{{^supportsES6}}ES5{{/supportsES6}}",
         "moduleResolution": "node",
         "removeComments": true,

--- a/modules/openapi-generator/src/main/resources/typescript-node/tsconfig.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/tsconfig.mustache
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "module": "commonjs",
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "{{#supportsES6}}ES6{{/supportsES6}}{{^supportsES6}}ES5{{/supportsES6}}",
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/tsconfig.json
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/tsconfig.json
@@ -3,7 +3,6 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "es5",
         "module": "commonjs",
         "moduleResolution": "node",

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/tsconfig.json
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/tsconfig.json
@@ -3,7 +3,6 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "es5",
         "module": "commonjs",
         "moduleResolution": "node",

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/tsconfig.json
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/tsconfig.json
@@ -3,7 +3,6 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "es5",
         "module": "commonjs",
         "moduleResolution": "node",

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/node-es5-expected/tsconfig.json
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/node-es5-expected/tsconfig.json
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "module": "commonjs",
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "ES5",
         "moduleResolution": "node",
         "removeComments": true,

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/objectsWithEnums-expected/tsconfig.json
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/objectsWithEnums-expected/tsconfig.json
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "module": "commonjs",
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "ES5",
         "strict": true,
         "moduleResolution": "node",

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/tsconfig.json
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/tsconfig.json
@@ -3,7 +3,6 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "es5",
         "module": "commonjs",
         "moduleResolution": "node",

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/tsconfig.json
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/tsconfig.json
@@ -3,7 +3,6 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "es5",
         "module": "commonjs",
         "moduleResolution": "node",

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/tsconfig.json
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/tsconfig.json
@@ -3,7 +3,6 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "es6",
         "module": "es6",
         "moduleResolution": "node",

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/with-npm/tsconfig.json
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/with-npm/tsconfig.json
@@ -3,7 +3,6 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "es6",
         "module": "es6",
         "moduleResolution": "node",

--- a/samples/client/petstore/typescript-jquery/npm/tsconfig.json
+++ b/samples/client/petstore/typescript-jquery/npm/tsconfig.json
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "module": "commonjs",
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "ES5",
         "moduleResolution": "node",
         "removeComments": true,

--- a/samples/client/petstore/typescript-node/npm/tsconfig.json
+++ b/samples/client/petstore/typescript-node/npm/tsconfig.json
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "module": "commonjs",
         "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
         "target": "ES5",
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,


### PR DESCRIPTION
This solves the error `Option 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.`

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka