### PR TITLE
docker-entrypoint.sh fix mixed indent + move do to same line as start of loop 

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,12 +15,11 @@ codegen="${cli}/target/openapi-generator-cli.jar"
 commands="config-help,generate,batch,help,list,meta,validate,version"
 
 if [ $# == 0 ]; then
-	echo "No command specified. Available commands:"
-	for i in $(echo $commands | sed "s/,/ /g")
-	do
-		echo "  $i"
-	done
-	exit
+    echo "No command specified. Available commands:"
+    for i in $(echo $commands | sed "s/,/ /g"); do
+        echo "  $i"
+    done
+    exit
 fi
 
 # if CLI jar exists, check $1 against completions available in the CLI


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


---

Hi! This is nothing serious. The file was changed to have the same indent style (4 spaces). Also the do start of the loop was in a separate line when the rest of the file followed more popular convention with ifs

```
if ...; then
    code
```
instead of
```
if ...
  then
  code
```

EDIT: Grammar