### PR TITLE
[kotlin-client][jackson] Add missing @JsonEnumDefaultValue annotation to top-level enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -7,6 +7,9 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 {{/moshi}}
 {{#jackson}}
+{{#enumUnknownDefaultCase}}
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
+{{/enumUnknownDefaultCase}}
 import com.fasterxml.jackson.annotation.JsonProperty
 {{/jackson}}
 {{#kotlinx_serialization}}
@@ -46,7 +49,7 @@ import kotlinx.serialization.*
     @SerializedName(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})
     {{/gson}}
     {{#jackson}}
-    @JsonProperty(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})
+    @JsonProperty(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}}){{#enumUnknownDefaultCase}}{{#-last}} @JsonEnumDefaultValue{{/-last}}{{/enumUnknownDefaultCase}}
     {{/jackson}}
     {{#kotlinx_serialization}}
     @SerialName(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
@@ -16,6 +16,7 @@
 package org.openapitools.client.models
 
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
@@ -35,7 +36,7 @@ enum class StringEnumRef(val value: kotlin.String) {
     @JsonProperty(value = "unclassified")
     unclassified("unclassified"),
 
-    @JsonProperty(value = "unknown_default_open_api")
+    @JsonProperty(value = "unknown_default_open_api") @JsonEnumDefaultValue
     unknown_default_open_api("unknown_default_open_api");
 
     /**

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
@@ -16,6 +16,7 @@
 package org.openapitools.client.models
 
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
@@ -35,7 +36,7 @@ enum class StringEnumRef(val value: kotlin.String) {
     @JsonProperty(value = "unclassified")
     unclassified("unclassified"),
 
-    @JsonProperty(value = "unknown_default_open_api")
+    @JsonProperty(value = "unknown_default_open_api") @JsonEnumDefaultValue
     unknown_default_open_api("unknown_default_open_api");
 
     /**


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Support for unknown default enum values was added in #17404, but this works for only inner enums in data classes.
This PR fixes to work for top-level enums as well.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06)