### PR TITLE
[Kotlin] Add Option to Skip Merging Spec Files

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -98,6 +98,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     outputDir.set(generate.outputDir)
                     inputSpec.set(generate.inputSpec)
                     inputSpecRootDirectory.set(generate.inputSpecRootDirectory)
+                    inputSpecRootDirectorySkipMerge.set(generate.inputSpecRootDirectorySkipMerge)
                     remoteInputSpec.set(generate.remoteInputSpec)
                     templateDir.set(generate.templateDir)
                     templateResourcePath.set(generate.templateResourcePath)

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -51,13 +51,27 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
 
     /**
      * The Open API 2.0/3.x specification location.
+     *
+     * Be default, Gradle will treat the openApiGenerate task as up-to-date based only on this file, regardless of
+     * changes to any $ref referenced files. Use the `inputSpecRootDirectory` property to have Gradle track changes to
+     * an entire directory of spec files.
      */
     val inputSpec = project.objects.property<String>()
 
     /**
-     * Local root folder with spec files
+     * Local root folder with spec files.
+     *
+     * By default, a merged spec file will be generated based on the contents of the directory. To disable this, set the
+     * `inputSpecRootDirectorySkipMerge` property.
      */
     val inputSpecRootDirectory = project.objects.property<String>()
+
+    /**
+     * Skip bundling all spec files into a merged spec file, if true.
+     *
+     * Default false.
+     */
+    val inputSpecRootDirectorySkipMerge = project.objects.property<Boolean>()
 
     /**
      * The remote Open API 2.0/3.x specification URL location.
@@ -400,6 +414,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     @Suppress("MemberVisibilityCanBePrivate")
     fun applyDefaults() {
         releaseNote.set("Minor update")
+        inputSpecRootDirectorySkipMerge.set(false)
         modelNamePrefix.set("")
         modelNameSuffix.set("")
         apiNameSuffix.set("")

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -106,6 +106,10 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
 
     /**
      * The Open API 2.0/3.x specification location.
+     *
+     * Be default, Gradle will treat the openApiGenerate task as up-to-date based only on this file, regardless of
+     * changes to any $ref referenced files. Use the `inputSpecRootDirectory` property to have Gradle track changes to
+     * an entire directory of spec files.
      */
     @Optional
     @get:InputFile
@@ -113,12 +117,22 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
     val inputSpec = project.objects.property<String>()
 
     /**
-     * Local root folder with spec files
+     * Local root folder with spec files.
+     *
+     * By default, a merged spec file will be generated based on the contents of the directory. To disable this, set the
+     * `inputSpecRootDirectorySkipMerge` property.
      */
     @Optional
     @get:InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
     val inputSpecRootDirectory = project.objects.property<String>();
+
+    /**
+     * Skip bundling all spec files into a merged spec file, if true.
+     */
+    @Input
+    @Optional
+    val inputSpecRootDirectorySkipMerge = project.objects.property<Boolean>()
 
     /**
      * Name of the file that will contain all merged specs
@@ -625,9 +639,16 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
         }
 
         inputSpecRootDirectory.ifNotEmpty { inputSpecRootDirectoryValue ->
-            run {
-                resolvedInputSpec = MergedSpecBuilder(inputSpecRootDirectoryValue, mergedFileName.getOrElse("merged")).buildMergedSpec()
-                logger.info("Merge input spec would be used - {}", resolvedInputSpec)
+            val skipMerge = inputSpecRootDirectorySkipMerge.get()
+            val runMergeSpec = !skipMerge
+            if (runMergeSpec) {
+                run {
+                    resolvedInputSpec = MergedSpecBuilder(
+                        inputSpecRootDirectoryValue,
+                        mergedFileName.getOrElse("merged")
+                    ).buildMergedSpec()
+                    logger.info("Merge input spec would be used - {}", resolvedInputSpec)
+                }
             }
         }
 


### PR DESCRIPTION
I have split my API spec YAML files across multiple files, and use the Gradle task to generate Kotlin server interfaces. The Gradle task incorrectly thinks it is UP-TO-DATE if only `inputSpec` is given because Gradle only checks that one file for changes, even though the generator is able to process the entire structure correctly. The `inputSpecRootDirectory` property is available which will tell Gradle to look at the entire directory, but _for some reason_ (I don't know) the generator is unable to process the merged file. So I've just cut out the middle step, and allowed for the best of both worlds.

Introduced a new property `inputSpecRootDirectorySkipMerge` to conditionally skip the merging step of the specification files. I chose it to be similar to `inputSpecRootDirectory` so that it can be easily found with autocomplete. But I am certainly open to choosing a different property name :)

As said above, this has the very useful side-effect of allowing the user to specify `inputSpecRootDirectory` for its Gradle `InputDirectory` annotation, without running the merge step. This means the Gradle task will run if any files in the directory have changed, rather than just the `inputSpec`.

@wing328 @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
