### PR TITLE
[typescript] Unify `stringEnums` across all typescript generators

### DIFF
--- a/docs/generators/javascript-flowtyped.md
+++ b/docs/generators/javascript-flowtyped.md
@@ -36,6 +36,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshot|When setting this property to true, the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
+|stringEnums|Generate string enums instead of objects for enum values.| |false|
 |supportsES6|Generate code that conforms to ES6.| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/typescript-aurelia.md
+++ b/docs/generators/typescript-aurelia.md
@@ -35,6 +35,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshot|When setting this property to true, the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
+|stringEnums|Generate string enums instead of objects for enum values.| |false|
 |supportsES6|Generate code that conforms to ES6.| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/typescript-inversify.md
+++ b/docs/generators/typescript-inversify.md
@@ -36,6 +36,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshot|When setting this property to true, the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
+|stringEnums|Generate string enums instead of objects for enum values.| |false|
 |supportsES6|Generate code that conforms to ES6.| |false|
 |taggedUnions|Use discriminators to create tagged unions instead of extending interfaces.| |false|
 |usePromise|Setting this property to use promise instead of observable inside every service.| |false|

--- a/docs/generators/typescript-jquery.md
+++ b/docs/generators/typescript-jquery.md
@@ -37,6 +37,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshot|When setting this property to true, the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
+|stringEnums|Generate string enums instead of objects for enum values.| |false|
 |supportsES6|Generate code that conforms to ES6.| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/typescript-node.md
+++ b/docs/generators/typescript-node.md
@@ -36,6 +36,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshot|When setting this property to true, the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
+|stringEnums|Generate string enums instead of objects for enum values.| |false|
 |supportsES6|Generate code that conforms to ES6.| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/typescript-redux-query.md
+++ b/docs/generators/typescript-redux-query.md
@@ -36,6 +36,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshot|When setting this property to true, the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
+|stringEnums|Generate string enums instead of objects for enum values.| |false|
 |supportsES6|Generate code that conforms to ES6.| |false|
 |useSingleRequestParameter|Setting this property to true will generate functions with a single argument containing all API endpoint parameters instead of one argument per parameter.| |true|
 |withInterfaces|Setting this property to true will generate interfaces next to the default class implementations.| |false|

--- a/docs/generators/typescript-rxjs.md
+++ b/docs/generators/typescript-rxjs.md
@@ -36,6 +36,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshot|When setting this property to true, the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
+|stringEnums|Generate string enums instead of objects for enum values.| |false|
 |supportsES6|Generate code that conforms to ES6.| |false|
 |withProgressSubscriber|Setting this property to true will generate API controller methods with support for subscribing to request progress.| |false|
 

--- a/docs/generators/typescript.md
+++ b/docs/generators/typescript.md
@@ -40,6 +40,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshot|When setting this property to true, the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
+|stringEnums|Generate string enums instead of objects for enum values.| |false|
 |supportsES6|Generate code that conforms to ES6.| |false|
 |useInversify|Enable this to generate decorators and service identifiers for the InversifyJS inversion of control container. If you set 'deno' as 'platform', the generator will process this value as 'disable'.| |false|
 |useObjectParameters|Use aggregate parameter objects as function arguments for api operations instead of passing each parameter as a separate function argument.| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -236,6 +236,9 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
     public static final String NULL_SAFE_ADDITIONAL_PROPS = "nullSafeAdditionalProps";
     public static final String NULL_SAFE_ADDITIONAL_PROPS_DESC = "Set to make additional properties types declare that their indexer may return undefined";
 
+    public static final String STRING_ENUMS = "stringEnums";
+    public static final String STRING_ENUMS_DESC = "Generate string enums instead of objects for enum values.";
+
     // NOTE: SimpleDateFormat is not thread-safe and may not be static unless it is thread-local
     @SuppressWarnings("squid:S5164")
     protected static final ThreadLocal<SimpleDateFormat> SNAPSHOT_SUFFIX_FORMAT = ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyyMMddHHmm", Locale.ROOT));
@@ -248,6 +251,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
     protected Boolean supportsES6 = false;
     @Getter @Setter
     protected Boolean nullSafeAdditionalProps = false;
+    @Getter @Setter protected Boolean stringEnums = false;
     protected HashSet<String> languageGenericTypes;
     @Getter @Setter
     protected String npmName = null;
@@ -369,6 +373,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
                 "When setting this property to true, the version will be suffixed with -SNAPSHOT." + SNAPSHOT_SUFFIX_FORMAT.get().toPattern(),
                 false));
         this.cliOptions.add(new CliOption(NULL_SAFE_ADDITIONAL_PROPS, NULL_SAFE_ADDITIONAL_PROPS_DESC).defaultValue(String.valueOf(this.getNullSafeAdditionalProps())));
+        this.cliOptions.add(new CliOption(STRING_ENUMS, STRING_ENUMS_DESC).defaultValue(String.valueOf(this.getStringEnums())));
         this.cliOptions.add(CliOption.newBoolean(ENUM_PROPERTY_NAMING_REPLACE_SPECIAL_CHAR, ENUM_PROPERTY_NAMING_REPLACE_SPECIAL_CHAR_DESC, false));
     }
 
@@ -411,6 +416,11 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
 
         if (additionalProperties.containsKey(NULL_SAFE_ADDITIONAL_PROPS)) {
             setNullSafeAdditionalProps(Boolean.valueOf(additionalProperties.get(NULL_SAFE_ADDITIONAL_PROPS).toString()));
+        }
+
+        if (additionalProperties.containsKey(STRING_ENUMS)) {
+            setStringEnums(convertPropertyToBoolean(STRING_ENUMS));
+            additionalProperties.put("stringEnums", getStringEnums());
         }
 
         if (additionalProperties.containsKey(NPM_NAME)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -72,8 +72,6 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     public static final String MODEL_SUFFIX = "modelSuffix";
     public static final String MODEL_FILE_SUFFIX = "modelFileSuffix";
     public static final String FILE_NAMING = "fileNaming";
-    public static final String STRING_ENUMS = "stringEnums";
-    public static final String STRING_ENUMS_DESC = "Generate string enums instead of objects for enum values.";
     public static final String QUERY_PARAM_OBJECT_FORMAT = "queryParamObjectFormat";
     public static final String USE_SQUARE_BRACKETS_IN_ARRAY_NAMES = "useSquareBracketsInArrayNames";
 
@@ -86,7 +84,6 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     protected String modelSuffix = "";
     protected String modelFileSuffix = "";
     protected String fileNaming = "camelCase";
-    @Getter protected Boolean stringEnums = false;
     protected QUERY_PARAM_OBJECT_FORMAT_TYPE queryParamObjectFormat = QUERY_PARAM_OBJECT_FORMAT_TYPE.dot;
     protected PROVIDED_IN_LEVEL providedIn = PROVIDED_IN_LEVEL.root;
 
@@ -141,7 +138,6 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         this.cliOptions.add(new CliOption(MODEL_SUFFIX, "The suffix of the generated model."));
         this.cliOptions.add(new CliOption(MODEL_FILE_SUFFIX, "The suffix of the file of the generated model (model<suffix>.ts)."));
         this.cliOptions.add(new CliOption(FILE_NAMING, "Naming convention for the output files: 'camelCase', 'kebab-case'.").defaultValue(this.fileNaming));
-        this.cliOptions.add(new CliOption(STRING_ENUMS, STRING_ENUMS_DESC).defaultValue(String.valueOf(this.stringEnums)));
         this.cliOptions.add(new CliOption(QUERY_PARAM_OBJECT_FORMAT, "The format for query param objects: 'dot', 'json', 'key'.").defaultValue(this.queryParamObjectFormat.name()));
         this.cliOptions.add(CliOption.newBoolean(USE_SQUARE_BRACKETS_IN_ARRAY_NAMES, "Setting this property to true will add brackets to array attribute names, e.g. my_values[].", false));
     }
@@ -197,12 +193,8 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
             addNpmPackageGeneration(ngVersion);
         }
 
-        if (additionalProperties.containsKey(STRING_ENUMS)) {
-            setStringEnums(Boolean.parseBoolean(additionalProperties.get(STRING_ENUMS).toString()));
-            additionalProperties.put("stringEnums", getStringEnums());
-            if (getStringEnums()) {
-                classEnumSeparator = "";
-            }
+        if (additionalProperties.containsKey(STRING_ENUMS) && getStringEnums()) {
+            classEnumSeparator = "";
         }
 
         if (additionalProperties.containsKey(WITH_INTERFACES)) {
@@ -413,10 +405,6 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     private String getIndexDirectory() {
         String indexPackage = modelPackage.substring(0, Math.max(0, modelPackage.lastIndexOf('.')));
         return indexPackage.replace('.', File.separatorChar);
-    }
-
-    public void setStringEnums(boolean value) {
-        stringEnums = value;
     }
 
     public boolean getQueryParamObjectFormatDot() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -41,15 +41,12 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
     public static final String WITHOUT_PREFIX_ENUMS = "withoutPrefixEnums";
     public static final String USE_SINGLE_REQUEST_PARAMETER = "useSingleRequestParameter";
     public static final String WITH_NODE_IMPORTS = "withNodeImports";
-    public static final String STRING_ENUMS = "stringEnums";
-    public static final String STRING_ENUMS_DESC = "Generate string enums instead of objects for enum values.";
     public static final String USE_SQUARE_BRACKETS_IN_ARRAY_NAMES = "useSquareBracketsInArrayNames";
     public static final String AXIOS_VERSION = "axiosVersion";
     public static final String DEFAULT_AXIOS_VERSION = "^1.6.1";
 
     @Getter @Setter
     protected String npmRepository = null;
-    protected Boolean stringEnums = false;
 
     @Getter @Setter
     protected String axiosVersion = DEFAULT_AXIOS_VERSION;
@@ -80,7 +77,6 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
         this.cliOptions.add(new CliOption(WITHOUT_PREFIX_ENUMS, "Don't prefix enum names with class names", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(USE_SINGLE_REQUEST_PARAMETER, "Setting this property to true will generate functions with a single argument containing all API endpoint parameters instead of one argument per parameter.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(WITH_NODE_IMPORTS, "Setting this property to true adds imports for NodeJS", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
-        this.cliOptions.add(new CliOption(STRING_ENUMS, STRING_ENUMS_DESC).defaultValue(String.valueOf(this.stringEnums)));
         this.cliOptions.add(new CliOption(USE_SQUARE_BRACKETS_IN_ARRAY_NAMES, "Setting this property to true will add brackets to array attribute names, e.g. my_values[].", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(AXIOS_VERSION, "Use this property to override the axios version in package.json").defaultValue(DEFAULT_AXIOS_VERSION));
         // Templates have no mapping between formatted property names and original base names so use only "original" and remove this option
@@ -143,11 +139,6 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
                 apiTemplateFiles.put("apiInner.mustache", ".ts");
                 supportingFiles.add(new SupportingFile("modelIndex.mustache", tsModelPackage, "index.ts"));
             }
-        }
-
-        if (additionalProperties.containsKey(STRING_ENUMS)) {
-            this.stringEnums = Boolean.parseBoolean(additionalProperties.get(STRING_ENUMS).toString());
-            additionalProperties.put("stringEnums", this.stringEnums);
         }
 
         if (additionalProperties.containsKey(NPM_NAME)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -51,8 +51,6 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
     public static final String USE_SINGLE_REQUEST_PARAMETER = "useSingleRequestParameter";
     public static final String PREFIX_PARAMETER_INTERFACES = "prefixParameterInterfaces";
     public static final String WITHOUT_RUNTIME_CHECKS = "withoutRuntimeChecks";
-    public static final String STRING_ENUMS = "stringEnums";
-    public static final String STRING_ENUMS_DESC = "Generate string enums instead of objects for enum values.";
     public static final String IMPORT_FILE_EXTENSION_SWITCH = "importFileExtension";
     public static final String IMPORT_FILE_EXTENSION_SWITCH_DESC = "File extension to use with relative imports. Set it to '.js' or '.mjs' when using [ESM](https://nodejs.org/api/esm.html).";
     public static final String FILE_NAMING = "fileNaming";
@@ -70,7 +68,6 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
     protected boolean addedApiIndex = false;
     protected boolean addedModelIndex = false;
     protected boolean withoutRuntimeChecks = false;
-    protected boolean stringEnums = false;
     protected String fileNaming = PASCAL_CASE;
 
     // "Saga and Record" mode.
@@ -119,7 +116,6 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         this.cliOptions.add(new CliOption(PREFIX_PARAMETER_INTERFACES, "Setting this property to true will generate parameter interface declarations prefixed with API class name to avoid name conflicts.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(WITHOUT_RUNTIME_CHECKS, "Setting this property to true will remove any runtime checks on the request and response payloads. Payloads will be casted to their expected types.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(SAGAS_AND_RECORDS, "Setting this property to true will generate additional files for use with redux-saga and immutablejs.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
-        this.cliOptions.add(new CliOption(STRING_ENUMS, STRING_ENUMS_DESC, SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(IMPORT_FILE_EXTENSION_SWITCH, IMPORT_FILE_EXTENSION_SWITCH_DESC).defaultValue(""));
         this.cliOptions.add(new CliOption(FILE_NAMING, "Naming convention for the output files: 'PascalCase', 'camelCase', 'kebab-case'.").defaultValue(this.fileNaming));
         this.cliOptions.add(new CliOption(USE_SQUARE_BRACKETS_IN_ARRAY_NAMES, "Setting this property to true will add brackets to array attribute names, e.g. my_values[].", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
@@ -167,13 +163,6 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
 
     public void setWithoutRuntimeChecks(Boolean withoutRuntimeChecks) {
         this.withoutRuntimeChecks = withoutRuntimeChecks;
-    }
-
-    public Boolean getStringEnums() {
-        return this.stringEnums;
-    }
-    public void setStringEnums(Boolean stringEnums) {
-        this.stringEnums = stringEnums;
     }
 
     /**
@@ -262,10 +251,6 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
 
         if (additionalProperties.containsKey(WITHOUT_RUNTIME_CHECKS)) {
             this.setWithoutRuntimeChecks(convertPropertyToBoolean(WITHOUT_RUNTIME_CHECKS));
-        }
-
-        if (additionalProperties.containsKey(STRING_ENUMS)) {
-            this.setStringEnums(convertPropertyToBoolean(STRING_ENUMS));
         }
 
         if (additionalProperties.containsKey(FILE_NAMING)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNestjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNestjsClientCodegen.java
@@ -53,8 +53,6 @@ public class TypeScriptNestjsClientCodegen extends AbstractTypeScriptClientCodeg
     public static final String MODEL_SUFFIX = "modelSuffix";
     public static final String MODEL_FILE_SUFFIX = "modelFileSuffix";
     public static final String FILE_NAMING = "fileNaming";
-    public static final String STRING_ENUMS = "stringEnums";
-    public static final String STRING_ENUMS_DESC = "Generate string enums instead of objects for enum values.";
     public static final String USE_SINGLE_REQUEST_PARAMETER = "useSingleRequestParameter";
 
     protected String nestVersion = "8.0.0";
@@ -65,7 +63,6 @@ public class TypeScriptNestjsClientCodegen extends AbstractTypeScriptClientCodeg
     protected String modelSuffix = "";
     protected String modelFileSuffix = "";
     protected String fileNaming = "camelCase";
-    @Getter protected Boolean stringEnums = false;
 
     private boolean taggedUnions = false;
 
@@ -102,7 +99,6 @@ public class TypeScriptNestjsClientCodegen extends AbstractTypeScriptClientCodeg
         this.cliOptions.add(new CliOption(MODEL_SUFFIX, "The suffix of the generated model."));
         this.cliOptions.add(new CliOption(MODEL_FILE_SUFFIX, "The suffix of the file of the generated model (model<suffix>.ts)."));
         this.cliOptions.add(new CliOption(FILE_NAMING, "Naming convention for the output files: 'camelCase', 'kebab-case'.").defaultValue(this.fileNaming));
-        this.cliOptions.add(new CliOption(STRING_ENUMS, STRING_ENUMS_DESC).defaultValue(String.valueOf(this.stringEnums)));
         this.cliOptions.add(new CliOption(USE_SINGLE_REQUEST_PARAMETER, "Setting this property to true will generate functions with a single argument containing all API endpoint parameters instead of one argument per parameter.").defaultValue(Boolean.FALSE.toString()));
     }
 
@@ -152,13 +148,9 @@ public class TypeScriptNestjsClientCodegen extends AbstractTypeScriptClientCodeg
             addNpmPackageGeneration(nestVersion);
         }
 
-        if (additionalProperties.containsKey(STRING_ENUMS)) {
-            setStringEnums(Boolean.parseBoolean(additionalProperties.get(STRING_ENUMS).toString()));
-            additionalProperties.put("stringEnums", getStringEnums());
-            if (getStringEnums()) {
-                enumSuffix = "";
-                classEnumSeparator = "";
-            }
+        if (additionalProperties.containsKey(STRING_ENUMS) && getStringEnums()) {
+            enumSuffix = "";
+            classEnumSeparator = "";
         }
 
         if (additionalProperties.containsKey(WITH_INTERFACES)) {
@@ -215,10 +207,6 @@ public class TypeScriptNestjsClientCodegen extends AbstractTypeScriptClientCodeg
     private String getIndexDirectory() {
         String indexPackage = modelPackage.substring(0, Math.max(0, modelPackage.lastIndexOf('.')));
         return indexPackage.replace('.', File.separatorChar);
-    }
-
-    public void setStringEnums(boolean value) {
-        stringEnums = value;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/typescript-angularjs/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angularjs/model.mustache
@@ -23,6 +23,7 @@ export interface {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
 export namespace {{classname}} {
 {{#vars}}
 {{#isEnum}}
+{{#stringEnums}}
     export enum {{enumName}} {
     {{#allowableValues}}
     {{#enumVars}}
@@ -30,6 +31,18 @@ export namespace {{classname}} {
     {{/enumVars}}
     {{/allowableValues}}
     }
+{{/stringEnums}}
+{{^stringEnums}}
+    export type {{enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+    export const {{enumName}} = {
+    {{#allowableValues}}
+    {{#enumVars}}
+        {{name}}: {{{value}}} as {{enumName}}{{^-last}},{{/-last}}
+    {{/enumVars}}
+    {{/allowableValues}}
+    };
+{{/stringEnums}}
 {{/isEnum}}
 {{/vars}}
 }

--- a/modules/openapi-generator/src/main/resources/typescript-jquery/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-jquery/modelEnum.mustache
@@ -3,6 +3,7 @@
     * {{{.}}}
     */
 {{/description}}
+{{#stringEnums}}
 export enum {{classname}} {
 {{#allowableValues}}
 {{#enumVars}}
@@ -10,3 +11,15 @@ export enum {{classname}} {
 {{/enumVars}}
 {{/allowableValues}}
 }
+{{/stringEnums}}
+{{^stringEnums}}
+export type {{classname}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+export const {{classname}} = {
+{{#allowableValues}}
+{{#enumVars}}
+    {{name}}: {{{value}}} as {{classname}}{{^-last}},{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+};
+{{/stringEnums}}

--- a/modules/openapi-generator/src/main/resources/typescript-jquery/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-jquery/modelGeneric.mustache
@@ -16,6 +16,7 @@ export interface {{classname}} {{#parent}}extends models.{{{.}}} {{/parent}}{
 export namespace {{classname}} {
 {{#vars}}
     {{#isEnum}}
+    {{#stringEnums}}
     export enum {{enumName}} {
     {{#allowableValues}}
         {{#enumVars}}
@@ -23,6 +24,18 @@ export namespace {{classname}} {
         {{/enumVars}}
     {{/allowableValues}}
     }
+    {{/stringEnums}}
+    {{^stringEnums}}
+    export type {{enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+    export const {{enumName}} = {
+    {{#allowableValues}}
+    {{#enumVars}}
+        {{name}}: {{{value}}} as {{enumName}}{{^-last}},{{/-last}}
+    {{/enumVars}}
+    {{/allowableValues}}
+    };
+    {{/stringEnums}}
     {{/isEnum}}
 {{/vars}}
 }{{/hasEnums}}

--- a/modules/openapi-generator/src/main/resources/typescript-node/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/model.mustache
@@ -56,6 +56,7 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
 export namespace {{classname}} {
 {{#vars}}
 {{#isEnum}}
+{{#stringEnums}}
     export enum {{enumName}} {
         {{#allowableValues}}
         {{#enumVars}}
@@ -63,12 +64,25 @@ export namespace {{classname}} {
         {{/enumVars}}
         {{/allowableValues}}
     }
+{{/stringEnums}}
+{{^stringEnums}}
+    export type {{enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+    export const {{enumName}} = {
+    {{#allowableValues}}
+    {{#enumVars}}
+        {{name}}: {{{value}}} as {{enumName}}{{^-last}},{{/-last}}
+    {{/enumVars}}
+    {{/allowableValues}}
+    };
+{{/stringEnums}}
 {{/isEnum}}
 {{/vars}}
 }
 {{/hasEnums}}
 {{/isEnum}}
 {{#isEnum}}
+{{#stringEnums}}
 export enum {{classname}} {
     {{#allowableValues}}
     {{#enumVars}}
@@ -76,6 +90,18 @@ export enum {{classname}} {
     {{/enumVars}}
     {{/allowableValues}}
 }
+{{/stringEnums}}
+{{^stringEnums}}
+export type {{classname}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+export const {{classname}} = {
+{{#allowableValues}}
+{{#enumVars}}
+    {{name}}: {{{value}}} as {{classname}}{{^-last}},{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+};
+{{/stringEnums}}
 {{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
@@ -241,6 +241,7 @@ export function {{nickname}}<T>({{#allParams.0}}requestParameters: {{operationId
 {{#operation}}
 {{#allParams}}
 {{#isEnum}}
+{{#stringEnums}}
 /**
     * @export
     * @enum {string}
@@ -252,6 +253,21 @@ export enum {{operationIdCamelCase}}{{enumName}} {
     {{/enumVars}}
 {{/allowableValues}}
 }
+{{/stringEnums}}
+{{^stringEnums}}
+/**
+ * @export
+ */
+export type {{operationIdCamelCase}}{{enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+export const {{operationIdCamelCase}}{{enumName}} = {
+{{#allowableValues}}
+{{#enumVars}}
+    {{name}}: {{{value}}} as {{operationIdCamelCase}}{{enumName}}{{^-last}},{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+};
+{{/stringEnums}}
 {{/isEnum}}
 {{/allParams}}
 {{/operation}}

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/modelEnum.mustache
@@ -1,3 +1,4 @@
+{{#stringEnums}}
 /**
  * {{{description}}}
  * @export
@@ -10,6 +11,22 @@ export enum {{classname}} {
 {{/enumVars}}
 {{/allowableValues}}
 }
+{{/stringEnums}}
+{{^stringEnums}}
+/**
+ * {{{description}}}
+ * @export
+ */
+export type {{classname}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+export const {{classname}} = {
+{{#allowableValues}}
+{{#enumVars}}
+    {{name}}: {{{value}}} as {{classname}}{{^-last}},{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+};
+{{/stringEnums}}
 
 export function {{classname}}FromJSON(json: any): {{classname}} {
     return json as {{classname}};

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/modelGeneric.mustache
@@ -124,6 +124,7 @@ export function {{classname}}ToJSON(value?: {{classname}}): any {
 {{#hasEnums}}
 {{#vars}}
 {{#isEnum}}
+{{#stringEnums}}
 /**
 * @export
 * @enum {string}
@@ -135,6 +136,21 @@ export enum {{classname}}{{enumName}} {
     {{/enumVars}}
 {{/allowableValues}}
 }
+{{/stringEnums}}
+{{^stringEnums}}
+/**
+ * @export
+ */
+export type {{classname}}{{enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+export const {{classname}}{{enumName}} = {
+{{#allowableValues}}
+{{#enumVars}}
+    {{name}}: {{{value}}} as {{classname}}{{enumName}}{{^-last}},{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+};
+{{/stringEnums}}
 {{/isEnum}}
 {{/vars}}
 

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
@@ -228,6 +228,7 @@ export class {{classname}} extends BaseAPI {
 {{#operation}}
 {{#allParams}}
 {{#isEnum}}
+{{#stringEnums}}
 /**
  * @export
  * @enum {string}
@@ -239,6 +240,21 @@ export enum {{operationIdCamelCase}}{{enumName}} {
     {{/enumVars}}
 {{/allowableValues}}
 }
+{{/stringEnums}}
+{{^stringEnums}}
+/**
+ * @export
+ */
+export type {{operationIdCamelCase}}{{enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+export const {{operationIdCamelCase}}{{enumName}} = {
+{{#allowableValues}}
+{{#enumVars}}
+    {{name}}: {{{value}}} as {{operationIdCamelCase}}{{enumName}}{{^-last}},{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+};
+{{/stringEnums}}
 {{/isEnum}}
 {{/allParams}}
 {{/operation}}

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/modelEnum.mustache
@@ -1,3 +1,4 @@
+{{#stringEnums}}
 /**
  * {{{description}}}
  * @export
@@ -10,3 +11,19 @@ export enum {{classname}} {
 {{/enumVars}}
 {{/allowableValues}}
 }
+{{/stringEnums}}
+{{^stringEnums}}
+/**
+ * {{{description}}}
+ * @export
+ */
+export type {{classname}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+export const {{classname}} = {
+{{#allowableValues}}
+{{#enumVars}}
+    {{name}}: {{{value}}} as {{classname}}{{^-last}},{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+};
+{{/stringEnums}}

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/modelGeneric.mustache
@@ -27,6 +27,7 @@ export interface {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
 
 {{#vars}}
 {{#isEnum}}
+{{#stringEnums}}
 /**
  * @export
  * @enum {string}
@@ -38,6 +39,21 @@ export enum {{classname}}{{enumName}} {
     {{/enumVars}}
 {{/allowableValues}}
 }
+{{/stringEnums}}
+{{^stringEnums}}
+/**
+ * @export
+ */
+export type {{classname}}{{enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+export const {{classname}}{{enumName}} = {
+{{#allowableValues}}
+{{#enumVars}}
+    {{name}}: {{{value}}} as {{classname}}{{enumName}}{{^-last}},{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+};
+{{/stringEnums}}
 {{/isEnum}}
 {{/vars}}
 {{/hasEnums}}

--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -60,7 +60,7 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
             .replace('{' + '{{baseName}}' + '}', encodeURIComponent(String({{paramName}}))){{/pathParams}};
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.{{httpMethod}});
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, {{#stringEnums}}HttpMethod.{{/stringEnums}}{{^stringEnums}}"{{/stringEnums}}{{httpMethod}}{{^stringEnums}}"{{/stringEnums}});
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
         {{#queryParams}}
 
@@ -161,7 +161,7 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
         {{/authMethods}}
-        
+
         {{^useInversify}}
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {

--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -22,6 +22,7 @@ export * from './jquery{{importFileExtension}}';
 {{/deno}}
 {{/platforms}}
 
+{{#stringEnums}}
 /**
  * Represents an HTTP method.
  */
@@ -36,6 +37,25 @@ export enum HttpMethod {
     TRACE = "TRACE",
     PATCH = "PATCH"
 }
+{{/stringEnums}}
+{{^stringEnums}}
+/**
+ * Represents an HTTP method.
+ */
+export type HttpMethod = "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE" | "PATCH";
+
+export const HttpMethod = {
+    GET: "GET" as HttpMethod,
+    HEAD: "HEAD" as HttpMethod,
+    POST: "POST" as HttpMethod,
+    PUT: "PUT" as HttpMethod,
+    DELETE: "DELETE" as HttpMethod,
+    CONNECT: "CONNECT" as HttpMethod,
+    OPTIONS: "OPTIONS" as HttpMethod,
+    TRACE: "TRACE" as HttpMethod,
+    PATCH: "PATCH" as HttpMethod
+}
+{{/stringEnums}}
 
 /**
  * Represents an HTTP file which will be transferred from or to a server.
@@ -163,7 +183,7 @@ export class RequestContext {
     }
     {{#platforms}}
     {{#node}}
-    
+
     public setAgent(agent: http.Agent | https.Agent) {
         this.agent = agent;
     }

--- a/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
@@ -71,6 +71,7 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
 
 {{#vars}}
 {{#isEnum}}
+{{#stringEnums}}
 export enum {{classname}}{{enumName}} {
     {{#allowableValues}}
     {{#enumVars}}
@@ -78,12 +79,25 @@ export enum {{classname}}{{enumName}} {
     {{/enumVars}}
     {{/allowableValues}}
 }
+{{/stringEnums}}
+{{^stringEnums}}
+export type {{classname}}{{enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+export const {{classname}}{{enumName}} = {
+{{#allowableValues}}
+{{#enumVars}}
+    {{name}}: {{{value}}} as {{classname}}{{enumName}}{{^-last}},{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+};
+{{/stringEnums}}
 {{/isEnum}}
 {{/vars}}
 
 {{/hasEnums}}
 {{/isEnum}}
 {{#isEnum}}
+{{#stringEnums}}
 export enum {{classname}} {
     {{#allowableValues}}
     {{#enumVars}}
@@ -91,6 +105,18 @@ export enum {{classname}} {
     {{/enumVars}}
     {{/allowableValues}}
 }
+{{/stringEnums}}
+{{^stringEnums}}
+export type {{classname}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+export const {{classname}} = {
+{{#allowableValues}}
+{{#enumVars}}
+    {{name}}: {{{value}}} as {{classname}}{{^-last}},{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+};
+{{/stringEnums}}
 {{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAngularClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAngularClientOptionsProvider.java
@@ -71,7 +71,7 @@ public class TypeScriptAngularClientOptionsProvider implements OptionsProvider {
                 .put(AbstractTypeScriptClientCodegen.NULL_SAFE_ADDITIONAL_PROPS, NULL_SAFE_ADDITIONAL_PROPS_VALUE)
                 .put(AbstractTypeScriptClientCodegen.ENUM_PROPERTY_NAMING_REPLACE_SPECIAL_CHAR, ENUM_PROPERTY_NAMING_REPLACE_SPECIAL_CHAR_VALUE)
                 .put(CodegenConstants.ENUM_NAME_SUFFIX, ENUM_NAME_SUFFIX)
-                .put(TypeScriptAngularClientCodegen.STRING_ENUMS, STRING_ENUMS_VALUE)
+                .put(AbstractTypeScriptClientCodegen.STRING_ENUMS, STRING_ENUMS_VALUE)
                 .put(TypeScriptAngularClientCodegen.NPM_NAME, NPM_NAME)
                 .put(TypeScriptAngularClientCodegen.NPM_VERSION, NPM_VERSION)
                 .put(TypeScriptAngularClientCodegen.SNAPSHOT, Boolean.FALSE.toString())

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAngularJsClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAngularJsClientOptionsProvider.java
@@ -27,6 +27,7 @@ public class TypeScriptAngularJsClientOptionsProvider implements OptionsProvider
     public static final String SUPPORTS_ES6_VALUE = "false";
     public static final String NULL_SAFE_ADDITIONAL_PROPS_VALUE = "false";
     public static final String ENUM_NAME_SUFFIX = "Enum";
+    public static final String STRING_ENUMS_VALUE = "false";
     public static final String SORT_PARAMS_VALUE = "false";
     public static final String SORT_MODEL_PROPERTIES_VALUE = "false";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
@@ -50,6 +51,7 @@ public class TypeScriptAngularJsClientOptionsProvider implements OptionsProvider
                 .put(CodegenConstants.SUPPORTS_ES6, SUPPORTS_ES6_VALUE)
                 .put(AbstractTypeScriptClientCodegen.NULL_SAFE_ADDITIONAL_PROPS, NULL_SAFE_ADDITIONAL_PROPS_VALUE)
                 .put(CodegenConstants.ENUM_NAME_SUFFIX, ENUM_NAME_SUFFIX)
+                .put(AbstractTypeScriptClientCodegen.STRING_ENUMS, STRING_ENUMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING_VALUE)
                 .put(CodegenConstants.MODEL_PROPERTY_NAMING, MODEL_PROPERTY_NAMING_VALUE)

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAureliaClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAureliaClientOptionsProvider.java
@@ -31,6 +31,7 @@ public class TypeScriptAureliaClientOptionsProvider implements OptionsProvider {
     public static final Boolean SUPPORTS_ES6_VALUE = false;
     public static final Boolean NULL_SAFE_ADDITIONAL_PROPS_VALUE = false;
     public static final String ENUM_NAME_SUFFIX = "Enum";
+    public static final String STRING_ENUMS_VALUE = "false";
     public static final String ENUM_PROPERTY_NAMING_VALUE = "PascalCase";
     public static final String MODEL_PROPERTY_NAMING_VALUE = "camelCase";
     public static final String PARAM_NAMING_VALUE = "camelCase";
@@ -59,6 +60,7 @@ public class TypeScriptAureliaClientOptionsProvider implements OptionsProvider {
                 .put(AbstractTypeScriptClientCodegen.NULL_SAFE_ADDITIONAL_PROPS, String.valueOf(NULL_SAFE_ADDITIONAL_PROPS_VALUE))
                 .put(AbstractTypeScriptClientCodegen.ENUM_PROPERTY_NAMING_REPLACE_SPECIAL_CHAR, ENUM_PROPERTY_NAMING_REPLACE_SPECIAL_CHAR_VALUE)
                 .put(CodegenConstants.ENUM_NAME_SUFFIX, ENUM_NAME_SUFFIX)
+                .put(AbstractTypeScriptClientCodegen.STRING_ENUMS, STRING_ENUMS_VALUE)
                 .put(TypeScriptAureliaClientCodegen.NPM_NAME, NPM_NAME)
                 .put(TypeScriptAureliaClientCodegen.NPM_VERSION, NPM_VERSION)
                 .put(TypeScriptAureliaClientCodegen.SNAPSHOT, Boolean.FALSE.toString())

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptFetchClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptFetchClientOptionsProvider.java
@@ -84,7 +84,7 @@ public class TypeScriptFetchClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
                 .put(CodegenConstants.ENUM_UNKNOWN_DEFAULT_CASE, ENUM_UNKNOWN_DEFAULT_CASE_VALUE)
-                .put(TypeScriptFetchClientCodegen.STRING_ENUMS, STRING_ENUMS)
+                .put(AbstractTypeScriptClientCodegen.STRING_ENUMS, STRING_ENUMS)
                 .put(TypeScriptFetchClientCodegen.USE_SQUARE_BRACKETS_IN_ARRAY_NAMES, Boolean.FALSE.toString())
                 .build();
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptNestjsClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptNestjsClientOptionsProvider.java
@@ -68,7 +68,7 @@ public class TypeScriptNestjsClientOptionsProvider implements OptionsProvider {
                 .put(AbstractTypeScriptClientCodegen.NULL_SAFE_ADDITIONAL_PROPS, NULL_SAFE_ADDITIONAL_PROPS_VALUE)
                 .put(AbstractTypeScriptClientCodegen.ENUM_PROPERTY_NAMING_REPLACE_SPECIAL_CHAR, ENUM_PROPERTY_NAMING_REPLACE_SPECIAL_CHAR_VALUE)
                 .put(CodegenConstants.ENUM_NAME_SUFFIX, ENUM_NAME_SUFFIX)
-                .put(TypeScriptNestjsClientCodegen.STRING_ENUMS, STRING_ENUMS_VALUE)
+                .put(AbstractTypeScriptClientCodegen.STRING_ENUMS, STRING_ENUMS_VALUE)
                 .put(TypeScriptNestjsClientCodegen.NPM_NAME, NMP_NAME)
                 .put(TypeScriptNestjsClientCodegen.NPM_VERSION, NMP_VERSION)
                 .put(TypeScriptNestjsClientCodegen.SNAPSHOT, Boolean.FALSE.toString())

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptNodeClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptNodeClientOptionsProvider.java
@@ -29,6 +29,7 @@ public class TypeScriptNodeClientOptionsProvider implements OptionsProvider {
     public static final String SUPPORTS_ES6_VALUE = "false";
     public static final String NULL_SAFE_ADDITIONAL_PROPS_VALUE = "false";
     public static final String ENUM_NAME_SUFFIX = "Enum";
+    public static final String STRING_ENUMS_VALUE = "false";
     public static final String SORT_PARAMS_VALUE = "false";
     public static final String SORT_MODEL_PROPERTIES_VALUE = "false";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
@@ -58,6 +59,7 @@ public class TypeScriptNodeClientOptionsProvider implements OptionsProvider {
                 .put(AbstractTypeScriptClientCodegen.NULL_SAFE_ADDITIONAL_PROPS, NULL_SAFE_ADDITIONAL_PROPS_VALUE)
                 .put(AbstractTypeScriptClientCodegen.ENUM_PROPERTY_NAMING_REPLACE_SPECIAL_CHAR, ENUM_PROPERTY_NAMING_REPLACE_SPECIAL_CHAR_VALUE)
                 .put(CodegenConstants.ENUM_NAME_SUFFIX, ENUM_NAME_SUFFIX)
+                .put(AbstractTypeScriptClientCodegen.STRING_ENUMS, STRING_ENUMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING_VALUE)
                 .put(CodegenConstants.MODEL_PROPERTY_NAMING, MODEL_PROPERTY_NAMING_VALUE)

--- a/samples/client/others/typescript/builds/with-unique-items/apis/DefaultApi.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/apis/DefaultApi.ts
@@ -24,11 +24,11 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/unique-items';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/client/others/typescript/builds/with-unique-items/http/http.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/http/http.ts
@@ -5,16 +5,18 @@ export * from './isomorphic-fetch';
 /**
  * Represents an HTTP method.
  */
-export enum HttpMethod {
-    GET = "GET",
-    HEAD = "HEAD",
-    POST = "POST",
-    PUT = "PUT",
-    DELETE = "DELETE",
-    CONNECT = "CONNECT",
-    OPTIONS = "OPTIONS",
-    TRACE = "TRACE",
-    PATCH = "PATCH"
+export type HttpMethod = "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE" | "PATCH";
+
+export const HttpMethod = {
+    GET: "GET" as HttpMethod,
+    HEAD: "HEAD" as HttpMethod,
+    POST: "POST" as HttpMethod,
+    PUT: "PUT" as HttpMethod,
+    DELETE: "DELETE" as HttpMethod,
+    CONNECT: "CONNECT" as HttpMethod,
+    OPTIONS: "OPTIONS" as HttpMethod,
+    TRACE: "TRACE" as HttpMethod,
+    PATCH: "PATCH" as HttpMethod
 }
 
 /**

--- a/samples/client/petstore/typescript-jquery/default/model/ApiResponse.ts
+++ b/samples/client/petstore/typescript-jquery/default/model/ApiResponse.ts
@@ -23,3 +23,4 @@ export interface ApiResponse {
     message?: string;
 
 }
+

--- a/samples/client/petstore/typescript-jquery/default/model/Category.ts
+++ b/samples/client/petstore/typescript-jquery/default/model/Category.ts
@@ -21,3 +21,4 @@ export interface Category {
     name?: string;
 
 }
+

--- a/samples/client/petstore/typescript-jquery/default/model/Order.ts
+++ b/samples/client/petstore/typescript-jquery/default/model/Order.ts
@@ -33,9 +33,12 @@ export interface Order {
 
 }
 export namespace Order {
-    export enum StatusEnum {
-        Placed = <any> 'placed',
-        Approved = <any> 'approved',
-        Delivered = <any> 'delivered'
-    }
+    export type StatusEnum = 'placed' | 'approved' | 'delivered';
+
+    export const StatusEnum = {
+        Placed: 'placed' as StatusEnum,
+        Approved: 'approved' as StatusEnum,
+        Delivered: 'delivered' as StatusEnum
+    };
 }
+

--- a/samples/client/petstore/typescript-jquery/default/model/Pet.ts
+++ b/samples/client/petstore/typescript-jquery/default/model/Pet.ts
@@ -33,9 +33,12 @@ export interface Pet {
 
 }
 export namespace Pet {
-    export enum StatusEnum {
-        Available = <any> 'available',
-        Pending = <any> 'pending',
-        Sold = <any> 'sold'
-    }
+    export type StatusEnum = 'available' | 'pending' | 'sold';
+
+    export const StatusEnum = {
+        Available: 'available' as StatusEnum,
+        Pending: 'pending' as StatusEnum,
+        Sold: 'sold' as StatusEnum
+    };
 }
+

--- a/samples/client/petstore/typescript-jquery/default/model/Tag.ts
+++ b/samples/client/petstore/typescript-jquery/default/model/Tag.ts
@@ -21,3 +21,4 @@ export interface Tag {
     name?: string;
 
 }
+

--- a/samples/client/petstore/typescript-jquery/default/model/User.ts
+++ b/samples/client/petstore/typescript-jquery/default/model/User.ts
@@ -36,3 +36,4 @@ export interface User {
     userStatus?: number;
 
 }
+

--- a/samples/client/petstore/typescript-jquery/npm/model/ApiResponse.ts
+++ b/samples/client/petstore/typescript-jquery/npm/model/ApiResponse.ts
@@ -23,3 +23,4 @@ export interface ApiResponse {
     message?: string;
 
 }
+

--- a/samples/client/petstore/typescript-jquery/npm/model/Category.ts
+++ b/samples/client/petstore/typescript-jquery/npm/model/Category.ts
@@ -21,3 +21,4 @@ export interface Category {
     name?: string;
 
 }
+

--- a/samples/client/petstore/typescript-jquery/npm/model/Order.ts
+++ b/samples/client/petstore/typescript-jquery/npm/model/Order.ts
@@ -33,9 +33,12 @@ export interface Order {
 
 }
 export namespace Order {
-    export enum StatusEnum {
-        Placed = <any> 'placed',
-        Approved = <any> 'approved',
-        Delivered = <any> 'delivered'
-    }
+    export type StatusEnum = 'placed' | 'approved' | 'delivered';
+
+    export const StatusEnum = {
+        Placed: 'placed' as StatusEnum,
+        Approved: 'approved' as StatusEnum,
+        Delivered: 'delivered' as StatusEnum
+    };
 }
+

--- a/samples/client/petstore/typescript-jquery/npm/model/Pet.ts
+++ b/samples/client/petstore/typescript-jquery/npm/model/Pet.ts
@@ -33,9 +33,12 @@ export interface Pet {
 
 }
 export namespace Pet {
-    export enum StatusEnum {
-        Available = <any> 'available',
-        Pending = <any> 'pending',
-        Sold = <any> 'sold'
-    }
+    export type StatusEnum = 'available' | 'pending' | 'sold';
+
+    export const StatusEnum = {
+        Available: 'available' as StatusEnum,
+        Pending: 'pending' as StatusEnum,
+        Sold: 'sold' as StatusEnum
+    };
 }
+

--- a/samples/client/petstore/typescript-jquery/npm/model/Tag.ts
+++ b/samples/client/petstore/typescript-jquery/npm/model/Tag.ts
@@ -21,3 +21,4 @@ export interface Tag {
     name?: string;
 
 }
+

--- a/samples/client/petstore/typescript-jquery/npm/model/User.ts
+++ b/samples/client/petstore/typescript-jquery/npm/model/User.ts
@@ -36,3 +36,4 @@ export interface User {
     userStatus?: number;
 
 }
+

--- a/samples/client/petstore/typescript-node/default/model/order.ts
+++ b/samples/client/petstore/typescript-node/default/model/order.ts
@@ -66,9 +66,11 @@ export class Order {
 }
 
 export namespace Order {
-    export enum StatusEnum {
-        Placed = <any> 'placed',
-        Approved = <any> 'approved',
-        Delivered = <any> 'delivered'
-    }
+    export type StatusEnum = 'placed' | 'approved' | 'delivered';
+
+    export const StatusEnum = {
+        Placed: 'placed' as StatusEnum,
+        Approved: 'approved' as StatusEnum,
+        Delivered: 'delivered' as StatusEnum
+    };
 }

--- a/samples/client/petstore/typescript-node/default/model/pet.ts
+++ b/samples/client/petstore/typescript-node/default/model/pet.ts
@@ -68,9 +68,11 @@ export class Pet {
 }
 
 export namespace Pet {
-    export enum StatusEnum {
-        Available = <any> 'available',
-        Pending = <any> 'pending',
-        Sold = <any> 'sold'
-    }
+    export type StatusEnum = 'available' | 'pending' | 'sold';
+
+    export const StatusEnum = {
+        Available: 'available' as StatusEnum,
+        Pending: 'pending' as StatusEnum,
+        Sold: 'sold' as StatusEnum
+    };
 }

--- a/samples/client/petstore/typescript-node/npm/model/order.ts
+++ b/samples/client/petstore/typescript-node/npm/model/order.ts
@@ -66,9 +66,11 @@ export class Order {
 }
 
 export namespace Order {
-    export enum StatusEnum {
-        Placed = <any> 'placed',
-        Approved = <any> 'approved',
-        Delivered = <any> 'delivered'
-    }
+    export type StatusEnum = 'placed' | 'approved' | 'delivered';
+
+    export const StatusEnum = {
+        Placed: 'placed' as StatusEnum,
+        Approved: 'approved' as StatusEnum,
+        Delivered: 'delivered' as StatusEnum
+    };
 }

--- a/samples/client/petstore/typescript-node/npm/model/pet.ts
+++ b/samples/client/petstore/typescript-node/npm/model/pet.ts
@@ -68,9 +68,11 @@ export class Pet {
 }
 
 export namespace Pet {
-    export enum StatusEnum {
-        Available = <any> 'available',
-        Pending = <any> 'pending',
-        Sold = <any> 'sold'
-    }
+    export type StatusEnum = 'available' | 'pending' | 'sold';
+
+    export const StatusEnum = {
+        Available: 'available' as StatusEnum,
+        Pending: 'pending' as StatusEnum,
+        Sold: 'sold' as StatusEnum
+    };
 }

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/PetApi.ts
@@ -479,11 +479,12 @@ export function uploadFile<T>(requestParameters: UploadFileRequest, requestConfi
 
 
 /**
-    * @export
-    * @enum {string}
-    */
-export enum FindPetsByStatusStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+ * @export
+ */
+export type FindPetsByStatusStatusEnum = 'available' | 'pending' | 'sold';
+
+export const FindPetsByStatusStatusEnum = {
+    Available: 'available' as FindPetsByStatusStatusEnum,
+    Pending: 'pending' as FindPetsByStatusStatusEnum,
+    Sold: 'sold' as FindPetsByStatusStatusEnum
+};

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/models/Order.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/models/Order.ts
@@ -82,13 +82,14 @@ export function OrderToJSON(value?: Order): any {
 }
 
 /**
-* @export
-* @enum {string}
-*/
-export enum OrderStatusEnum {
-    Placed = 'placed',
-    Approved = 'approved',
-    Delivered = 'delivered'
-}
+ * @export
+ */
+export type OrderStatusEnum = 'placed' | 'approved' | 'delivered';
+
+export const OrderStatusEnum = {
+    Placed: 'placed' as OrderStatusEnum,
+    Approved: 'approved' as OrderStatusEnum,
+    Delivered: 'delivered' as OrderStatusEnum
+};
 
 

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/models/Pet.ts
@@ -91,13 +91,14 @@ export function PetToJSON(value?: Pet): any {
 }
 
 /**
-* @export
-* @enum {string}
-*/
-export enum PetStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+ * @export
+ */
+export type PetStatusEnum = 'available' | 'pending' | 'sold';
+
+export const PetStatusEnum = {
+    Available: 'available' as PetStatusEnum,
+    Pending: 'pending' as PetStatusEnum,
+    Sold: 'sold' as PetStatusEnum
+};
 
 

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
@@ -288,10 +288,11 @@ export class PetApi extends BaseAPI {
 
 /**
  * @export
- * @enum {string}
  */
-export enum FindPetsByStatusStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type FindPetsByStatusStatusEnum = 'available' | 'pending' | 'sold';
+
+export const FindPetsByStatusStatusEnum = {
+    Available: 'available' as FindPetsByStatusStatusEnum,
+    Pending: 'pending' as FindPetsByStatusStatusEnum,
+    Sold: 'sold' as FindPetsByStatusStatusEnum
+};

--- a/samples/client/petstore/typescript-rxjs/builds/default/models/Order.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/models/Order.ts
@@ -52,11 +52,12 @@ export interface Order {
 
 /**
  * @export
- * @enum {string}
  */
-export enum OrderStatusEnum {
-    Placed = 'placed',
-    Approved = 'approved',
-    Delivered = 'delivered'
-}
+export type OrderStatusEnum = 'placed' | 'approved' | 'delivered';
+
+export const OrderStatusEnum = {
+    Placed: 'placed' as OrderStatusEnum,
+    Approved: 'approved' as OrderStatusEnum,
+    Delivered: 'delivered' as OrderStatusEnum
+};
 

--- a/samples/client/petstore/typescript-rxjs/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/models/Pet.ts
@@ -57,11 +57,12 @@ export interface Pet {
 
 /**
  * @export
- * @enum {string}
  */
-export enum PetStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type PetStatusEnum = 'available' | 'pending' | 'sold';
+
+export const PetStatusEnum = {
+    Available: 'available' as PetStatusEnum,
+    Pending: 'pending' as PetStatusEnum,
+    Sold: 'sold' as PetStatusEnum
+};
 

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
@@ -288,10 +288,11 @@ export class PetApi extends BaseAPI {
 
 /**
  * @export
- * @enum {string}
  */
-export enum FindPetsByStatusStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type FindPetsByStatusStatusEnum = 'available' | 'pending' | 'sold';
+
+export const FindPetsByStatusStatusEnum = {
+    Available: 'available' as FindPetsByStatusStatusEnum,
+    Pending: 'pending' as FindPetsByStatusStatusEnum,
+    Sold: 'sold' as FindPetsByStatusStatusEnum
+};

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/models/Order.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/models/Order.ts
@@ -52,11 +52,12 @@ export interface Order {
 
 /**
  * @export
- * @enum {string}
  */
-export enum OrderStatusEnum {
-    Placed = 'placed',
-    Approved = 'approved',
-    Delivered = 'delivered'
-}
+export type OrderStatusEnum = 'placed' | 'approved' | 'delivered';
+
+export const OrderStatusEnum = {
+    Placed: 'placed' as OrderStatusEnum,
+    Approved: 'approved' as OrderStatusEnum,
+    Delivered: 'delivered' as OrderStatusEnum
+};
 

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/models/Pet.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/models/Pet.ts
@@ -57,11 +57,12 @@ export interface Pet {
 
 /**
  * @export
- * @enum {string}
  */
-export enum PetStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type PetStatusEnum = 'available' | 'pending' | 'sold';
+
+export const PetStatusEnum = {
+    Available: 'available' as PetStatusEnum,
+    Pending: 'pending' as PetStatusEnum,
+    Sold: 'sold' as PetStatusEnum
+};
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
@@ -288,10 +288,11 @@ export class PetApi extends BaseAPI {
 
 /**
  * @export
- * @enum {string}
  */
-export enum FindPetsByStatusStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type FindPetsByStatusStatusEnum = 'available' | 'pending' | 'sold';
+
+export const FindPetsByStatusStatusEnum = {
+    Available: 'available' as FindPetsByStatusStatusEnum,
+    Pending: 'pending' as FindPetsByStatusStatusEnum,
+    Sold: 'sold' as FindPetsByStatusStatusEnum
+};

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/models/Order.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/models/Order.ts
@@ -52,11 +52,12 @@ export interface Order {
 
 /**
  * @export
- * @enum {string}
  */
-export enum OrderStatusEnum {
-    Placed = 'placed',
-    Approved = 'approved',
-    Delivered = 'delivered'
-}
+export type OrderStatusEnum = 'placed' | 'approved' | 'delivered';
+
+export const OrderStatusEnum = {
+    Placed: 'placed' as OrderStatusEnum,
+    Approved: 'approved' as OrderStatusEnum,
+    Delivered: 'delivered' as OrderStatusEnum
+};
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/models/Pet.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/models/Pet.ts
@@ -57,11 +57,12 @@ export interface Pet {
 
 /**
  * @export
- * @enum {string}
  */
-export enum PetStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type PetStatusEnum = 'available' | 'pending' | 'sold';
+
+export const PetStatusEnum = {
+    Available: 'available' as PetStatusEnum,
+    Pending: 'pending' as PetStatusEnum,
+    Sold: 'sold' as PetStatusEnum
+};
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/apis/PetApi.ts
@@ -304,10 +304,11 @@ export class PetApi extends BaseAPI {
 
 /**
  * @export
- * @enum {string}
  */
-export enum FindPetsByStatusStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type FindPetsByStatusStatusEnum = 'available' | 'pending' | 'sold';
+
+export const FindPetsByStatusStatusEnum = {
+    Available: 'available' as FindPetsByStatusStatusEnum,
+    Pending: 'pending' as FindPetsByStatusStatusEnum,
+    Sold: 'sold' as FindPetsByStatusStatusEnum
+};

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/models/Order.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/models/Order.ts
@@ -52,11 +52,12 @@ export interface Order {
 
 /**
  * @export
- * @enum {string}
  */
-export enum OrderStatusEnum {
-    Placed = 'placed',
-    Approved = 'approved',
-    Delivered = 'delivered'
-}
+export type OrderStatusEnum = 'placed' | 'approved' | 'delivered';
+
+export const OrderStatusEnum = {
+    Placed: 'placed' as OrderStatusEnum,
+    Approved: 'approved' as OrderStatusEnum,
+    Delivered: 'delivered' as OrderStatusEnum
+};
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/models/Pet.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/models/Pet.ts
@@ -57,11 +57,12 @@ export interface Pet {
 
 /**
  * @export
- * @enum {string}
  */
-export enum PetStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type PetStatusEnum = 'available' | 'pending' | 'sold';
+
+export const PetStatusEnum = {
+    Available: 'available' as PetStatusEnum,
+    Pending: 'pending' as PetStatusEnum,
+    Sold: 'sold' as PetStatusEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/browser/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/apis/PetApi.ts
@@ -34,7 +34,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -57,7 +57,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -87,7 +87,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Header Params
@@ -100,7 +100,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -127,7 +127,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByStatus';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -142,7 +142,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -169,7 +169,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByTags';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -184,7 +184,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -212,7 +212,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -222,7 +222,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -249,7 +249,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PUT");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -272,7 +272,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -304,7 +304,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Form Params
@@ -343,7 +343,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -375,7 +375,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Form Params
@@ -416,7 +416,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/browser/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/apis/StoreApi.ts
@@ -34,11 +34,11 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -58,7 +58,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/inventory';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -68,7 +68,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -96,11 +96,11 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -127,7 +127,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/order';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -142,7 +142,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         );
         requestContext.setBody(serializedBody);
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/browser/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/apis/UserApi.ts
@@ -33,7 +33,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -54,7 +54,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -81,7 +81,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithArray';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -102,7 +102,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -129,7 +129,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithList';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -150,7 +150,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -178,7 +178,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -188,7 +188,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -216,11 +216,11 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -254,7 +254,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/login';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -268,7 +268,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         }
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -288,7 +288,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/logout';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -298,7 +298,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -333,7 +333,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PUT");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -354,7 +354,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/browser/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/http/http.ts
@@ -5,16 +5,18 @@ export * from './isomorphic-fetch';
 /**
  * Represents an HTTP method.
  */
-export enum HttpMethod {
-    GET = "GET",
-    HEAD = "HEAD",
-    POST = "POST",
-    PUT = "PUT",
-    DELETE = "DELETE",
-    CONNECT = "CONNECT",
-    OPTIONS = "OPTIONS",
-    TRACE = "TRACE",
-    PATCH = "PATCH"
+export type HttpMethod = "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE" | "PATCH";
+
+export const HttpMethod = {
+    GET: "GET" as HttpMethod,
+    HEAD: "HEAD" as HttpMethod,
+    POST: "POST" as HttpMethod,
+    PUT: "PUT" as HttpMethod,
+    DELETE: "DELETE" as HttpMethod,
+    CONNECT: "CONNECT" as HttpMethod,
+    OPTIONS: "OPTIONS" as HttpMethod,
+    TRACE: "TRACE" as HttpMethod,
+    PATCH: "PATCH" as HttpMethod
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Order.ts
@@ -75,9 +75,11 @@ export class Order {
 }
 
 
-export enum OrderStatusEnum {
-    Placed = 'placed',
-    Approved = 'approved',
-    Delivered = 'delivered'
-}
+export type OrderStatusEnum = 'placed' | 'approved' | 'delivered';
+
+export const OrderStatusEnum = {
+    Placed: 'placed' as OrderStatusEnum,
+    Approved: 'approved' as OrderStatusEnum,
+    Delivered: 'delivered' as OrderStatusEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/Pet.ts
@@ -77,9 +77,11 @@ export class Pet {
 }
 
 
-export enum PetStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type PetStatusEnum = 'available' | 'pending' | 'sold';
+
+export const PetStatusEnum = {
+    Available: 'available' as PetStatusEnum,
+    Pending: 'pending' as PetStatusEnum,
+    Sold: 'sold' as PetStatusEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/DefaultApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/DefaultApi.ts
@@ -28,7 +28,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/file';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -43,7 +43,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         );
         requestContext.setBody(serializedBody);
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -63,7 +63,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pets-filtered';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PATCH);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PATCH");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -78,7 +78,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         );
         requestContext.setBody(serializedBody);
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -98,7 +98,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pets';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PATCH);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PATCH");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -113,7 +113,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         );
         requestContext.setBody(serializedBody);
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
@@ -5,16 +5,18 @@ export * from './isomorphic-fetch';
 /**
  * Represents an HTTP method.
  */
-export enum HttpMethod {
-    GET = "GET",
-    HEAD = "HEAD",
-    POST = "POST",
-    PUT = "PUT",
-    DELETE = "DELETE",
-    CONNECT = "CONNECT",
-    OPTIONS = "OPTIONS",
-    TRACE = "TRACE",
-    PATCH = "PATCH"
+export type HttpMethod = "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE" | "PATCH";
+
+export const HttpMethod = {
+    GET: "GET" as HttpMethod,
+    HEAD: "HEAD" as HttpMethod,
+    POST: "POST" as HttpMethod,
+    PUT: "PUT" as HttpMethod,
+    DELETE: "DELETE" as HttpMethod,
+    CONNECT: "CONNECT" as HttpMethod,
+    OPTIONS: "OPTIONS" as HttpMethod,
+    TRACE: "TRACE" as HttpMethod,
+    PATCH: "PATCH" as HttpMethod
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Dog.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/Dog.ts
@@ -41,10 +41,12 @@ export class Dog {
 }
 
 
-export enum DogBreedEnum {
-    Dingo = 'Dingo',
-    Husky = 'Husky',
-    Retriever = 'Retriever',
-    Shepherd = 'Shepherd'
-}
+export type DogBreedEnum = 'Dingo' | 'Husky' | 'Retriever' | 'Shepherd';
+
+export const DogBreedEnum = {
+    Dingo: 'Dingo' as DogBreedEnum,
+    Husky: 'Husky' as DogBreedEnum,
+    Retriever: 'Retriever' as DogBreedEnum,
+    Shepherd: 'Shepherd' as DogBreedEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByType.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetByType.ts
@@ -41,8 +41,10 @@ export class PetByType {
 }
 
 
-export enum PetByTypePetTypeEnum {
-    Cat = 'Cat',
-    Dog = 'Dog'
-}
+export type PetByTypePetTypeEnum = 'Cat' | 'Dog';
+
+export const PetByTypePetTypeEnum = {
+    Cat: 'Cat' as PetByTypePetTypeEnum,
+    Dog: 'Dog' as PetByTypePetTypeEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsFilteredPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsFilteredPatchRequest.ts
@@ -57,8 +57,10 @@ export class PetsFilteredPatchRequest {
 }
 
 
-export enum PetsFilteredPatchRequestPetTypeEnum {
-    Cat = 'Cat',
-    Dog = 'Dog'
-}
+export type PetsFilteredPatchRequestPetTypeEnum = 'Cat' | 'Dog';
+
+export const PetsFilteredPatchRequestPetTypeEnum = {
+    Cat: 'Cat' as PetsFilteredPatchRequestPetTypeEnum,
+    Dog: 'Dog' as PetsFilteredPatchRequestPetTypeEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
@@ -58,10 +58,12 @@ export class PetsPatchRequest {
 }
 
 
-export enum PetsPatchRequestBreedEnum {
-    Dingo = 'Dingo',
-    Husky = 'Husky',
-    Retriever = 'Retriever',
-    Shepherd = 'Shepherd'
-}
+export type PetsPatchRequestBreedEnum = 'Dingo' | 'Husky' | 'Retriever' | 'Shepherd';
+
+export const PetsPatchRequestBreedEnum = {
+    Dingo: 'Dingo' as PetsPatchRequestBreedEnum,
+    Husky: 'Husky' as PetsPatchRequestBreedEnum,
+    Retriever: 'Retriever' as PetsPatchRequestBreedEnum,
+    Shepherd: 'Shepherd' as PetsPatchRequestBreedEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -36,7 +36,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -59,7 +59,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -89,7 +89,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Header Params
@@ -102,7 +102,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -129,7 +129,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByStatus';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -144,7 +144,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -171,7 +171,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByTags';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -186,7 +186,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -214,7 +214,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -224,7 +224,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -251,7 +251,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PUT");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -274,7 +274,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -306,7 +306,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Form Params
@@ -345,7 +345,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -377,7 +377,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Form Params
@@ -418,7 +418,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -36,11 +36,11 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -60,7 +60,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/inventory';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -70,7 +70,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -98,11 +98,11 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -129,7 +129,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/order';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -144,7 +144,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         );
         requestContext.setBody(serializedBody);
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -35,7 +35,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -56,7 +56,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -83,7 +83,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithArray';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -104,7 +104,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -131,7 +131,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithList';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -152,7 +152,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -180,7 +180,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -190,7 +190,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -218,11 +218,11 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -256,7 +256,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/login';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -270,7 +270,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         }
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -290,7 +290,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/logout';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -300,7 +300,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -335,7 +335,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PUT");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -356,7 +356,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
@@ -10,16 +10,18 @@ export * from './isomorphic-fetch';
 /**
  * Represents an HTTP method.
  */
-export enum HttpMethod {
-    GET = "GET",
-    HEAD = "HEAD",
-    POST = "POST",
-    PUT = "PUT",
-    DELETE = "DELETE",
-    CONNECT = "CONNECT",
-    OPTIONS = "OPTIONS",
-    TRACE = "TRACE",
-    PATCH = "PATCH"
+export type HttpMethod = "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE" | "PATCH";
+
+export const HttpMethod = {
+    GET: "GET" as HttpMethod,
+    HEAD: "HEAD" as HttpMethod,
+    POST: "POST" as HttpMethod,
+    PUT: "PUT" as HttpMethod,
+    DELETE: "DELETE" as HttpMethod,
+    CONNECT: "CONNECT" as HttpMethod,
+    OPTIONS: "OPTIONS" as HttpMethod,
+    TRACE: "TRACE" as HttpMethod,
+    PATCH: "PATCH" as HttpMethod
 }
 
 /**
@@ -128,7 +130,7 @@ export class RequestContext {
     public setHeaderParam(key: string, value: string): void  {
         this.headers[key] = value;
     }
-    
+
     public setAgent(agent: http.Agent | https.Agent) {
         this.agent = agent;
     }

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Order.ts
@@ -75,9 +75,11 @@ export class Order {
 }
 
 
-export enum OrderStatusEnum {
-    Placed = 'placed',
-    Approved = 'approved',
-    Delivered = 'delivered'
-}
+export type OrderStatusEnum = 'placed' | 'approved' | 'delivered';
+
+export const OrderStatusEnum = {
+    Placed: 'placed' as OrderStatusEnum,
+    Approved: 'approved' as OrderStatusEnum,
+    Delivered: 'delivered' as OrderStatusEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Pet.ts
@@ -77,9 +77,11 @@ export class Pet {
 }
 
 
-export enum PetStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type PetStatusEnum = 'available' | 'pending' | 'sold';
+
+export const PetStatusEnum = {
+    Available: 'available' as PetStatusEnum,
+    Pending: 'pending' as PetStatusEnum,
+    Sold: 'sold' as PetStatusEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
@@ -34,7 +34,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -57,7 +57,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -87,7 +87,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Header Params
@@ -100,7 +100,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -127,7 +127,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByStatus';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -142,7 +142,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -169,7 +169,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByTags';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -184,7 +184,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -212,7 +212,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -222,7 +222,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -249,7 +249,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PUT");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -272,7 +272,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -304,7 +304,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Form Params
@@ -343,7 +343,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -375,7 +375,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Form Params
@@ -416,7 +416,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
@@ -34,11 +34,11 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -58,7 +58,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/inventory';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -68,7 +68,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -96,11 +96,11 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -127,7 +127,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/order';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -142,7 +142,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         );
         requestContext.setBody(serializedBody);
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
@@ -33,7 +33,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -54,7 +54,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -81,7 +81,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithArray';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -102,7 +102,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -129,7 +129,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithList';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -150,7 +150,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -178,7 +178,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -188,7 +188,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -216,11 +216,11 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -254,7 +254,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/login';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -268,7 +268,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         }
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -288,7 +288,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/logout';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -298,7 +298,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -333,7 +333,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PUT");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -354,7 +354,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
@@ -4,16 +4,18 @@ import { Observable, from } from '../rxjsStub.ts';
 /**
  * Represents an HTTP method.
  */
-export enum HttpMethod {
-    GET = "GET",
-    HEAD = "HEAD",
-    POST = "POST",
-    PUT = "PUT",
-    DELETE = "DELETE",
-    CONNECT = "CONNECT",
-    OPTIONS = "OPTIONS",
-    TRACE = "TRACE",
-    PATCH = "PATCH"
+export type HttpMethod = "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE" | "PATCH";
+
+export const HttpMethod = {
+    GET: "GET" as HttpMethod,
+    HEAD: "HEAD" as HttpMethod,
+    POST: "POST" as HttpMethod,
+    PUT: "PUT" as HttpMethod,
+    DELETE: "DELETE" as HttpMethod,
+    CONNECT: "CONNECT" as HttpMethod,
+    OPTIONS: "OPTIONS" as HttpMethod,
+    TRACE: "TRACE" as HttpMethod,
+    PATCH: "PATCH" as HttpMethod
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Order.ts
@@ -75,9 +75,11 @@ export class Order {
 }
 
 
-export enum OrderStatusEnum {
-    Placed = 'placed',
-    Approved = 'approved',
-    Delivered = 'delivered'
-}
+export type OrderStatusEnum = 'placed' | 'approved' | 'delivered';
+
+export const OrderStatusEnum = {
+    Placed: 'placed' as OrderStatusEnum,
+    Approved: 'approved' as OrderStatusEnum,
+    Delivered: 'delivered' as OrderStatusEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/Pet.ts
@@ -77,9 +77,11 @@ export class Pet {
 }
 
 
-export enum PetStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type PetStatusEnum = 'available' | 'pending' | 'sold';
+
+export const PetStatusEnum = {
+    Available: 'available' as PetStatusEnum,
+    Pending: 'pending' as PetStatusEnum,
+    Sold: 'sold' as PetStatusEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
@@ -38,7 +38,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -61,7 +61,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }
@@ -87,7 +87,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Header Params
@@ -100,7 +100,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }
@@ -123,7 +123,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByStatus';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -138,7 +138,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }
@@ -161,7 +161,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByTags';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -176,7 +176,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }
@@ -200,7 +200,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -210,7 +210,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }
@@ -233,7 +233,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PUT");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -256,7 +256,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }
@@ -284,7 +284,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Form Params
@@ -323,7 +323,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }
@@ -351,7 +351,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Form Params
@@ -392,7 +392,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
@@ -38,11 +38,11 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
 
         return requestContext;
     }
@@ -58,7 +58,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/inventory';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -68,7 +68,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }
@@ -92,11 +92,11 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
 
         return requestContext;
     }
@@ -119,7 +119,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/order';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -134,7 +134,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         );
         requestContext.setBody(serializedBody);
 
-        
+
 
         return requestContext;
     }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
@@ -37,7 +37,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -58,7 +58,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }
@@ -81,7 +81,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithArray';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -102,7 +102,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }
@@ -125,7 +125,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithList';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -146,7 +146,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }
@@ -170,7 +170,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -180,7 +180,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }
@@ -204,11 +204,11 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
 
         return requestContext;
     }
@@ -238,7 +238,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/login';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -252,7 +252,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         }
 
 
-        
+
 
         return requestContext;
     }
@@ -268,7 +268,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/logout';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -278,7 +278,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }
@@ -309,7 +309,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PUT");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -330,7 +330,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
 
         return requestContext;
     }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
@@ -10,16 +10,18 @@ export * from './isomorphic-fetch';
 /**
  * Represents an HTTP method.
  */
-export enum HttpMethod {
-    GET = "GET",
-    HEAD = "HEAD",
-    POST = "POST",
-    PUT = "PUT",
-    DELETE = "DELETE",
-    CONNECT = "CONNECT",
-    OPTIONS = "OPTIONS",
-    TRACE = "TRACE",
-    PATCH = "PATCH"
+export type HttpMethod = "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE" | "PATCH";
+
+export const HttpMethod = {
+    GET: "GET" as HttpMethod,
+    HEAD: "HEAD" as HttpMethod,
+    POST: "POST" as HttpMethod,
+    PUT: "PUT" as HttpMethod,
+    DELETE: "DELETE" as HttpMethod,
+    CONNECT: "CONNECT" as HttpMethod,
+    OPTIONS: "OPTIONS" as HttpMethod,
+    TRACE: "TRACE" as HttpMethod,
+    PATCH: "PATCH" as HttpMethod
 }
 
 /**
@@ -128,7 +130,7 @@ export class RequestContext {
     public setHeaderParam(key: string, value: string): void  {
         this.headers[key] = value;
     }
-    
+
     public setAgent(agent: http.Agent | https.Agent) {
         this.agent = agent;
     }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Order.ts
@@ -75,9 +75,11 @@ export class Order {
 }
 
 
-export enum OrderStatusEnum {
-    Placed = 'placed',
-    Approved = 'approved',
-    Delivered = 'delivered'
-}
+export type OrderStatusEnum = 'placed' | 'approved' | 'delivered';
+
+export const OrderStatusEnum = {
+    Placed: 'placed' as OrderStatusEnum,
+    Approved: 'approved' as OrderStatusEnum,
+    Delivered: 'delivered' as OrderStatusEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/Pet.ts
@@ -77,9 +77,11 @@ export class Pet {
 }
 
 
-export enum PetStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type PetStatusEnum = 'available' | 'pending' | 'sold';
+
+export const PetStatusEnum = {
+    Available: 'available' as PetStatusEnum,
+    Pending: 'pending' as PetStatusEnum,
+    Sold: 'sold' as PetStatusEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -34,7 +34,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -57,7 +57,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -87,7 +87,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Header Params
@@ -100,7 +100,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -127,7 +127,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByStatus';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -142,7 +142,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -169,7 +169,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByTags';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -184,7 +184,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -212,7 +212,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -222,7 +222,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -249,7 +249,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PUT");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -272,7 +272,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -304,7 +304,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Form Params
@@ -343,7 +343,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -375,7 +375,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Form Params
@@ -416,7 +416,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -34,11 +34,11 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -58,7 +58,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/inventory';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -68,7 +68,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -96,11 +96,11 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -127,7 +127,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/order';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -142,7 +142,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         );
         requestContext.setBody(serializedBody);
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -33,7 +33,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -54,7 +54,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -81,7 +81,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithArray';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -102,7 +102,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -129,7 +129,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithList';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -150,7 +150,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -178,7 +178,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -188,7 +188,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -216,11 +216,11 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -254,7 +254,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/login';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -268,7 +268,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         }
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -288,7 +288,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/logout';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -298,7 +298,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -333,7 +333,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PUT");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -354,7 +354,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
@@ -5,16 +5,18 @@ export * from './jquery';
 /**
  * Represents an HTTP method.
  */
-export enum HttpMethod {
-    GET = "GET",
-    HEAD = "HEAD",
-    POST = "POST",
-    PUT = "PUT",
-    DELETE = "DELETE",
-    CONNECT = "CONNECT",
-    OPTIONS = "OPTIONS",
-    TRACE = "TRACE",
-    PATCH = "PATCH"
+export type HttpMethod = "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE" | "PATCH";
+
+export const HttpMethod = {
+    GET: "GET" as HttpMethod,
+    HEAD: "HEAD" as HttpMethod,
+    POST: "POST" as HttpMethod,
+    PUT: "PUT" as HttpMethod,
+    DELETE: "DELETE" as HttpMethod,
+    CONNECT: "CONNECT" as HttpMethod,
+    OPTIONS: "OPTIONS" as HttpMethod,
+    TRACE: "TRACE" as HttpMethod,
+    PATCH: "PATCH" as HttpMethod
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Order.ts
@@ -75,9 +75,11 @@ export class Order {
 }
 
 
-export enum OrderStatusEnum {
-    Placed = 'placed',
-    Approved = 'approved',
-    Delivered = 'delivered'
-}
+export type OrderStatusEnum = 'placed' | 'approved' | 'delivered';
+
+export const OrderStatusEnum = {
+    Placed: 'placed' as OrderStatusEnum,
+    Approved: 'approved' as OrderStatusEnum,
+    Delivered: 'delivered' as OrderStatusEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/Pet.ts
@@ -77,9 +77,11 @@ export class Pet {
 }
 
 
-export enum PetStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type PetStatusEnum = 'available' | 'pending' | 'sold';
+
+export const PetStatusEnum = {
+    Available: 'available' as PetStatusEnum,
+    Pending: 'pending' as PetStatusEnum,
+    Sold: 'sold' as PetStatusEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
@@ -36,7 +36,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -59,7 +59,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -89,7 +89,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Header Params
@@ -102,7 +102,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -129,7 +129,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByStatus';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -144,7 +144,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -171,7 +171,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByTags';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -186,7 +186,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -214,7 +214,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -224,7 +224,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -251,7 +251,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PUT");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -274,7 +274,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -306,7 +306,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Form Params
@@ -345,7 +345,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -377,7 +377,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Form Params
@@ -418,7 +418,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
@@ -36,11 +36,11 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -60,7 +60,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/inventory';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -70,7 +70,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -98,11 +98,11 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -129,7 +129,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/order';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -144,7 +144,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         );
         requestContext.setBody(serializedBody);
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
@@ -35,7 +35,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -56,7 +56,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -83,7 +83,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithArray';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -104,7 +104,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -131,7 +131,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithList';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "POST");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -152,7 +152,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -180,7 +180,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "DELETE");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -190,7 +190,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -218,11 +218,11 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -256,7 +256,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/login';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -270,7 +270,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         }
 
 
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -290,7 +290,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/logout';
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "GET");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -300,7 +300,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);
@@ -335,7 +335,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, "PUT");
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
 
@@ -356,7 +356,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         if (authMethod?.applySecurityAuthentication) {
             await authMethod?.applySecurityAuthentication(requestContext);
         }
-        
+
         const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
         if (defaultAuth?.applySecurityAuthentication) {
             await defaultAuth?.applySecurityAuthentication(requestContext);

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
@@ -10,16 +10,18 @@ export * from './isomorphic-fetch';
 /**
  * Represents an HTTP method.
  */
-export enum HttpMethod {
-    GET = "GET",
-    HEAD = "HEAD",
-    POST = "POST",
-    PUT = "PUT",
-    DELETE = "DELETE",
-    CONNECT = "CONNECT",
-    OPTIONS = "OPTIONS",
-    TRACE = "TRACE",
-    PATCH = "PATCH"
+export type HttpMethod = "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE" | "PATCH";
+
+export const HttpMethod = {
+    GET: "GET" as HttpMethod,
+    HEAD: "HEAD" as HttpMethod,
+    POST: "POST" as HttpMethod,
+    PUT: "PUT" as HttpMethod,
+    DELETE: "DELETE" as HttpMethod,
+    CONNECT: "CONNECT" as HttpMethod,
+    OPTIONS: "OPTIONS" as HttpMethod,
+    TRACE: "TRACE" as HttpMethod,
+    PATCH: "PATCH" as HttpMethod
 }
 
 /**
@@ -128,7 +130,7 @@ export class RequestContext {
     public setHeaderParam(key: string, value: string): void  {
         this.headers[key] = value;
     }
-    
+
     public setAgent(agent: http.Agent | https.Agent) {
         this.agent = agent;
     }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Order.ts
@@ -75,9 +75,11 @@ export class Order {
 }
 
 
-export enum OrderStatusEnum {
-    Placed = 'placed',
-    Approved = 'approved',
-    Delivered = 'delivered'
-}
+export type OrderStatusEnum = 'placed' | 'approved' | 'delivered';
+
+export const OrderStatusEnum = {
+    Placed: 'placed' as OrderStatusEnum,
+    Approved: 'approved' as OrderStatusEnum,
+    Delivered: 'delivered' as OrderStatusEnum
+};
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/Pet.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/Pet.ts
@@ -77,9 +77,11 @@ export class Pet {
 }
 
 
-export enum PetStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
-}
+export type PetStatusEnum = 'available' | 'pending' | 'sold';
+
+export const PetStatusEnum = {
+    Available: 'available' as PetStatusEnum,
+    Pending: 'pending' as PetStatusEnum,
+    Sold: 'sold' as PetStatusEnum
+};
 


### PR DESCRIPTION
Currently a few of the typescript generators have an option for choosing if enums are generated as first-class `enum`s, or as unions of strings. This PR expands that option to be standard across all the typescript family of generators.

Note: this is a breaking change with a fallback (add the `stringEnums` option).

Fixes #12718

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

TypeScript committee members: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)