### PR TITLE
Upgrade commons-io dependency to latest 2.16.1

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -147,6 +147,6 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_version"
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.35.1"
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "commons-io:commons-io:2.8.0"
+    testImplementation "commons-io:commons-io:2.16.1"
     testImplementation "ch.qos.logback:logback-classic:1.2.3"
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.sbt.mustache
@@ -32,7 +32,7 @@ lazy val root = (project in file(".")).
       "org.junit.jupiter" % "junit-jupiter-params" % "5.7.0" % "test",
       "com.github.tomakehurst" % "wiremock-jre8" % "2.35.1" % "test",
       "org.hamcrest" % "hamcrest" % "2.2" % "test",
-      "commons-io" % "commons-io" % "2.8.0" % "test",
+      "commons-io" % "commons-io" % "2.16.1" % "test",
       "com.novocode" % "junit-interface" % "0.10" % "test"
     )
   )

--- a/pom.xml
+++ b/pom.xml
@@ -1215,7 +1215,7 @@
         <archunit.version>1.3.0</archunit.version>
         <checkstyle.plugin.version>3.1.0</checkstyle.plugin.version>
         <commons-cli.version>1.5.0</commons-cli.version>
-        <commons-io.version>2.11.0</commons-io.version>
+        <commons-io.version>2.16.1</commons-io.version>
         <commons-lang.version>3.12.0</commons-lang.version>
         <commons-text.version>1.10.0</commons-text.version>
         <diffutils.version>1.3.0</diffutils.version>

--- a/samples/client/echo_api/java/feign-gson/build.gradle
+++ b/samples/client/echo_api/java/feign-gson/build.gradle
@@ -127,6 +127,6 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_version"
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.35.1"
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "commons-io:commons-io:2.8.0"
+    testImplementation "commons-io:commons-io:2.16.1"
     testImplementation "ch.qos.logback:logback-classic:1.2.3"
 }

--- a/samples/client/echo_api/java/feign-gson/build.sbt
+++ b/samples/client/echo_api/java/feign-gson/build.sbt
@@ -22,7 +22,7 @@ lazy val root = (project in file(".")).
       "org.junit.jupiter" % "junit-jupiter-params" % "5.7.0" % "test",
       "com.github.tomakehurst" % "wiremock-jre8" % "2.35.1" % "test",
       "org.hamcrest" % "hamcrest" % "2.2" % "test",
-      "commons-io" % "commons-io" % "2.8.0" % "test",
+      "commons-io" % "commons-io" % "2.16.1" % "test",
       "com.novocode" % "junit-interface" % "0.10" % "test"
     )
   )

--- a/samples/client/petstore/java/feign-no-nullable/build.gradle
+++ b/samples/client/petstore/java/feign-no-nullable/build.gradle
@@ -132,6 +132,6 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_version"
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.35.1"
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "commons-io:commons-io:2.8.0"
+    testImplementation "commons-io:commons-io:2.16.1"
     testImplementation "ch.qos.logback:logback-classic:1.2.3"
 }

--- a/samples/client/petstore/java/feign-no-nullable/build.sbt
+++ b/samples/client/petstore/java/feign-no-nullable/build.sbt
@@ -28,7 +28,7 @@ lazy val root = (project in file(".")).
       "org.junit.jupiter" % "junit-jupiter-params" % "5.7.0" % "test",
       "com.github.tomakehurst" % "wiremock-jre8" % "2.35.1" % "test",
       "org.hamcrest" % "hamcrest" % "2.2" % "test",
-      "commons-io" % "commons-io" % "2.8.0" % "test",
+      "commons-io" % "commons-io" % "2.16.1" % "test",
       "com.novocode" % "junit-interface" % "0.10" % "test"
     )
   )

--- a/samples/client/petstore/java/feign/build.gradle
+++ b/samples/client/petstore/java/feign/build.gradle
@@ -134,6 +134,6 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_version"
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.35.1"
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "commons-io:commons-io:2.8.0"
+    testImplementation "commons-io:commons-io:2.16.1"
     testImplementation "ch.qos.logback:logback-classic:1.2.3"
 }

--- a/samples/client/petstore/java/feign/build.sbt
+++ b/samples/client/petstore/java/feign/build.sbt
@@ -28,7 +28,7 @@ lazy val root = (project in file(".")).
       "org.junit.jupiter" % "junit-jupiter-params" % "5.7.0" % "test",
       "com.github.tomakehurst" % "wiremock-jre8" % "2.35.1" % "test",
       "org.hamcrest" % "hamcrest" % "2.2" % "test",
-      "commons-io" % "commons-io" % "2.8.0" % "test",
+      "commons-io" % "commons-io" % "2.16.1" % "test",
       "com.novocode" % "junit-interface" % "0.10" % "test"
     )
   )


### PR DESCRIPTION
Upgrade commons-io dependency to latest 2.16.1.
Currently the main pom.xml has [commons-io 2.11.0 released 2021](https://github.com/apache/commons-io/releases/tag/rel%2Fcommons-io-2.11.0).
Currently the modules and samples have [commons-io 2.8.0 released 2020](https://github.com/apache/commons-io/releases/tag/rel%2Fcommons-io-2.8.0).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
