### PR TITLE
[Java Spring] Fix copyOf inheritance using empty object instead of passed value

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/javaBuilder.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/javaBuilder.mustache
@@ -15,7 +15,7 @@
     }
 
     protected Builder copyOf({{classname}} value) { {{#parentModel}}
-      super.copyOf(instance);{{/parentModel}}{{#vars}}
+      super.copyOf(value);{{/parentModel}}{{#vars}}
       this.instance.{{setter}}(value.{{name}});{{/vars}}
       return this;
     }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Bar.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Bar.java
@@ -206,7 +206,7 @@ public class Bar extends Entity implements BarRefOrValue {
     }
 
     protected Builder copyOf(Bar value) { 
-      super.copyOf(instance);
+      super.copyOf(value);
       this.instance.setId(value.id);
       this.instance.setBarPropA(value.barPropA);
       this.instance.setFooPropB(value.fooPropB);

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/BarCreate.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/BarCreate.java
@@ -188,7 +188,7 @@ public class BarCreate extends Entity {
     }
 
     protected Builder copyOf(BarCreate value) { 
-      super.copyOf(instance);
+      super.copyOf(value);
       this.instance.setBarPropA(value.barPropA);
       this.instance.setFooPropB(value.fooPropB);
       this.instance.setFoo(value.foo);

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/BarRef.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/BarRef.java
@@ -122,7 +122,7 @@ public class BarRef extends EntityRef implements BarRefOrValue {
     }
 
     protected Builder copyOf(BarRef value) { 
-      super.copyOf(instance);
+      super.copyOf(value);
       return this;
     }
 

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Foo.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Foo.java
@@ -161,7 +161,7 @@ public class Foo extends Entity implements FooRefOrValue {
     }
 
     protected Builder copyOf(Foo value) { 
-      super.copyOf(instance);
+      super.copyOf(value);
       this.instance.setFooPropA(value.fooPropA);
       this.instance.setFooPropB(value.fooPropB);
       return this;

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/FooRef.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/FooRef.java
@@ -147,7 +147,7 @@ public class FooRef extends EntityRef implements FooRefOrValue {
     }
 
     protected Builder copyOf(FooRef value) { 
-      super.copyOf(instance);
+      super.copyOf(value);
       this.instance.setFoorefPropA(value.foorefPropA);
       return this;
     }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Pasta.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Pasta.java
@@ -137,7 +137,7 @@ public class Pasta extends Entity {
     }
 
     protected Builder copyOf(Pasta value) { 
-      super.copyOf(instance);
+      super.copyOf(value);
       this.instance.setVendor(value.vendor);
       return this;
     }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Pizza.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Pizza.java
@@ -146,7 +146,7 @@ public class Pizza extends Entity {
     }
 
     protected Builder copyOf(Pizza value) { 
-      super.copyOf(instance);
+      super.copyOf(value);
       this.instance.setPizzaSize(value.pizzaSize);
       return this;
     }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/PizzaSpeziale.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/PizzaSpeziale.java
@@ -143,7 +143,7 @@ public class PizzaSpeziale extends Pizza {
     }
 
     protected Builder copyOf(PizzaSpeziale value) { 
-      super.copyOf(instance);
+      super.copyOf(value);
       this.instance.setToppings(value.toppings);
       return this;
     }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
@@ -168,7 +168,7 @@ public class BigCat extends Cat {
     }
 
     protected Builder copyOf(BigCat value) { 
-      super.copyOf(instance);
+      super.copyOf(value);
       this.instance.setKind(value.kind);
       return this;
     }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
@@ -131,7 +131,7 @@ public class Cat extends Animal {
     }
 
     protected Builder copyOf(Cat value) { 
-      super.copyOf(instance);
+      super.copyOf(value);
       this.instance.setDeclawed(value.declawed);
       return this;
     }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -126,7 +126,7 @@ public class ChildWithNullable extends ParentWithNullable {
     }
 
     protected Builder copyOf(ChildWithNullable value) { 
-      super.copyOf(instance);
+      super.copyOf(value);
       this.instance.setOtherProperty(value.otherProperty);
       return this;
     }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Dog.java
@@ -123,7 +123,7 @@ public class Dog extends Animal {
     }
 
     protected Builder copyOf(Dog value) { 
-      super.copyOf(instance);
+      super.copyOf(value);
       this.instance.setBreed(value.breed);
       return this;
     }


### PR DESCRIPTION
Related issue: #19425 
contains example OpenAPI file and describes the problem 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08)
