### PR TITLE
[cpp-restsdk] Fix invalid code if type is referenced in schema

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
@@ -387,6 +387,8 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
                 || ModelUtils.isFileSchema(p) || ModelUtils.isUUIDSchema(p)
                 || languageSpecificPrimitives.contains(openAPIType)) {
             return toModelName(openAPIType);
+        } else if(typeMapping.containsKey(super.getSchemaType(p))) {
+            return openAPIType;
         }
 
         return "std::shared_ptr<" + openAPIType + ">";


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@ravinikam (2017/07) @stkrwork (2017/07) @etherealjoy (2018/02) @martindelille (2018/03) @muttleyxd (2019/08)

### Problem
If a (primitive?) type is included in a schema per reference, invalid code is generated by cpp-restsdk. If the type is used directly, it is working as expected.

#### Example (working)
```
                    "apiKeyIds": {
                        "type": "array",
                        "readOnly": true,
                        "items": {
                            "type": "string",
                            "format": "uuid",
                            "readOnly": true
                        }
                    }
```
For this spec, the method `getTypeDeclaration(...)` in CppRestSdkClientCodegen.java will correctly return the type `std::vector<utility::string_t>`

#### Example (not working)
```
                    "apiKeyIds": {
                        "type": "array",
                        "items": {
                            "$ref": "#/components/schemas/UUID"
                        },
                        "readOnly": true
                    }
```
and `UUID` being defined as
```
           "UUID": {
                "format": "uuid",
                "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
                "type": "string"
            },
```

This spec does no longer work with the cpp-restsdk because the type `std::vector<std::shared_ptr<utility::string_t>>` is generated. In a generated client there is an attempt to call `from_json(...)` on `utility::string_t` which obviously does not exist due to the additional shared pointer.

### Fix
The suggested fix checks whether the referenced type is a known, built-in type and uses this type instead of wrapping it in a shared pointer.

I'm not 100% sure this is the right place to fix this.

This should also fix #8456 
