### PR TITLE
[Java] Remove extra bracket to fix compilation of Jersey clients (trivial)

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
@@ -112,7 +112,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                     attemptParsing |= (token == JsonToken.VALUE_NUMBER_FLOAT);
                     {{/isDecimal}}
                     {{#isBoolean}}
-                    attemptParsing |= (token == JsonToken.VALUE_FALSE || token == JsonToken.VALUE_TRUE));
+                    attemptParsing |= (token == JsonToken.VALUE_FALSE || token == JsonToken.VALUE_TRUE);
                     {{/isBoolean}}
                     {{#isNullable}}
                     attemptParsing |= (token == JsonToken.VALUE_NULL);

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/oneof_model.mustache
@@ -112,7 +112,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                     attemptParsing |= (token == JsonToken.VALUE_NUMBER_FLOAT);
                     {{/isDecimal}}
                     {{#isBoolean}}
-                    attemptParsing |= (token == JsonToken.VALUE_FALSE || token == JsonToken.VALUE_TRUE));
+                    attemptParsing |= (token == JsonToken.VALUE_FALSE || token == JsonToken.VALUE_TRUE);
                     {{/isBoolean}}
                     {{#isNullable}}
                     attemptParsing |= (token == JsonToken.VALUE_NULL);


### PR DESCRIPTION
The code generation template for the Jersey Java client had an extra bracket for Boolean deserialization, that made the code not compile.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @martin-mfg
