### PR TITLE
[Java Libraries] Jakarta Validation API support useJakartaEe flag

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/BeanValidationException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/BeanValidationException.mustache
@@ -4,8 +4,8 @@ package {{invokerPackage}};
 
 import java.util.Set;
 
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.ValidationException;
+import {{javaxPackage}}.validation.ConstraintViolation;
+import {{javaxPackage}}.validation.ValidationException;
 
 public class BeanValidationException extends ValidationException {
     /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/api.mustache
@@ -24,8 +24,8 @@ import java.util.Map;
 import java.util.StringJoiner;
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 {{>generatedAnnotation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/api_test.mustache
@@ -17,8 +17,8 @@ import java.util.List;
 import java.util.Map;
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
@@ -358,13 +358,12 @@
         {{/openApiNullable}}
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         {{/useJakartaEe}}
         {{^useJakartaEe}}
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         {{/useJakartaEe}}
-        {{#useBeanValidation}}
-        <beanvalidation-version>3.0.2</beanvalidation-version>
-        {{/useBeanValidation}}
         <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/api.mustache
@@ -15,8 +15,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 import feign.*;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/api_test.mustache
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.Map;
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/model.mustache
@@ -59,8 +59,8 @@ import android.os.Parcelable;
 import android.os.Parcel;
 {{/parcelableModel}}
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
 import org.hibernate.validator.constraints.*;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
@@ -403,13 +403,12 @@
         {{/openApiNullable}}
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         {{/useJakartaEe}}
         {{^useJakartaEe}}
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         {{/useJakartaEe}}
-        {{#useBeanValidation}}
-        <beanvalidation-version>3.0.2</beanvalidation-version>
-        {{/useBeanValidation}}
         <junit-version>5.10.0</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <scribejava-version>8.3.3</scribejava-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -12,8 +12,8 @@ import {{javaxPackage}}.ws.rs.core.GenericType;
 {{/imports}}
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 import java.util.ArrayList;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api_test.mustache
@@ -17,8 +17,8 @@ import java.util.List;
 import java.util.Map;
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/model.mustache
@@ -42,8 +42,8 @@ import android.os.Parcelable;
 import android.os.Parcel;
 {{/parcelableModel}}
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
 import org.hibernate.validator.constraints.*;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -401,13 +401,12 @@
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         {{/useJakartaEe}}
         {{^useJakartaEe}}
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         {{/useJakartaEe}}
-        {{#useBeanValidation}}
-        <beanvalidation-version>3.0.2</beanvalidation-version>
-        {{/useBeanValidation}}
         <junit-version>5.10.0</junit-version>
         {{#hasHttpSignatureMethods}}
         <http-signature-version>1.8</http-signature-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pom.mustache
@@ -400,9 +400,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
-        {{#useBeanValidation}}
         <beanvalidation-version>3.0.2</beanvalidation-version>
-        {{/useBeanValidation}}
         <junit-version>5.10.0</junit-version>
         {{#hasHttpSignatureMethods}}
         <http-signature-version>1.8</http-signature-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -14,8 +14,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 {{#hasFormParamsInSpec}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api_test.mustache
@@ -19,8 +19,8 @@ import java.util.concurrent.CompletableFuture;
 {{/asyncNative}}
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/model.mustache
@@ -47,8 +47,8 @@ import android.os.Parcelable;
 import android.os.Parcel;
 {{/parcelableModel}}
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
 import org.hibernate.validator.constraints.*;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
@@ -295,13 +295,12 @@
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         {{/useJakartaEe}}
         {{^useJakartaEe}}
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         {{/useJakartaEe}}
-        {{#useBeanValidation}}
-        <beanvalidation-version>3.0.2</beanvalidation-version>
-        {{/useBeanValidation}}
         {{#hasFormParamsInSpec}}
         <httpmime-version>4.5.14</httpmime-version>
         {{/hasFormParamsInSpec}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -26,14 +26,14 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import java.io.IOException;
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.Validation;
-import jakarta.validation.ValidatorFactory;
-import jakarta.validation.executable.ExecutableValidator;
+import {{javaxPackage}}.validation.ConstraintViolation;
+import {{javaxPackage}}.validation.Validation;
+import {{javaxPackage}}.validation.ValidatorFactory;
+import {{javaxPackage}}.validation.executable.ExecutableValidator;
 import java.util.Set;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api_test.mustache
@@ -17,8 +17,8 @@ import java.io.InputStream;
 {{/supportStreaming}}
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/model.mustache
@@ -21,8 +21,8 @@ import android.os.Parcelable;
 import android.os.Parcel;
 {{/parcelableModel}}
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
 import org.hibernate.validator.constraints.*;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -423,16 +423,15 @@
         {{/joda}}
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         {{/useJakartaEe}}
         {{^useJakartaEe}}
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         {{/useJakartaEe}}
         {{#performBeanValidation}}
         <jakarta.el-version>3.0.3</jakarta.el-version>
         {{/performBeanValidation}}
-        {{#useBeanValidation}}
-        <beanvalidation-version>3.0.2</beanvalidation-version>
-        {{/useBeanValidation}}
         <junit-version>5.10.3</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
         <jakarta.ws.rs-api-version>2.1.6</jakarta.ws.rs-api-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
@@ -33,8 +33,8 @@ import io.swagger.v3.oas.annotations.security.*;
 {{/swagger2AnnotationLibrary}}
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 import java.lang.reflect.Type;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api_test.mustache
@@ -20,8 +20,8 @@ import java.util.List;
 import java.util.Map;
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 import static io.restassured.config.ObjectMapperConfig.objectMapperConfig;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
@@ -358,13 +358,12 @@
         {{/jackson}}
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         {{/useJakartaEe}}
         {{^useJakartaEe}}
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         {{/useJakartaEe}}
-        {{#useBeanValidation}}
-        <beanvalidation-version>3.0.2</beanvalidation-version>
-        {{/useBeanValidation}}
         <okio-version>3.6.0</okio-version>
         <junit-version>5.10.3</junit-version>
     </properties>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/api.mustache
@@ -11,6 +11,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+{{#useBeanValidation}}
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
+
+{{/useBeanValidation}}
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/api_test.mustache
@@ -4,8 +4,8 @@ package {{package}};
 
 {{#imports}}import {{import}};
 {{/imports}}
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -13,10 +13,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+{{#useBeanValidation}}
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
+
+{{/useBeanValidation}}
 /**
  * API tests for {{classname}}
  */
-@Ignore
+@Disabled
 public class {{classname}}Test {
 
     private final {{classname}} api = new {{classname}}();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pom.mustache
@@ -362,9 +362,7 @@
         {{#joda}}
         <jodatime-version>2.9.9</jodatime-version>
         {{/joda}}
-        {{#useBeanValidation}}
         <beanvalidation-version>3.0.2</beanvalidation-version>
-        {{/useBeanValidation}}
         {{#performBeanValidation}}
         <hibernate-validator-version>5.4.3.Final</hibernate-validator-version>
         {{/performBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api.mustache
@@ -14,8 +14,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 import org.springframework.beans.factory.annotation.Autowired;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api_test.mustache
@@ -16,8 +16,8 @@ import java.util.List;
 import java.util.Map;
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -123,10 +123,12 @@ ext {
     {{#useJakartaEe}}
     spring_web_version = "6.1.5"
     jakarta_annotation_version = "2.1.1"
+    beanvalidation_version = "3.0.2"
     {{/useJakartaEe}}
     {{^useJakartaEe}}
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
+    beanvalidation_version = "2.0.2"
     {{/useJakartaEe}}
     jodatime_version = "2.9.9"
     junit_version = "5.10.2"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -367,29 +367,24 @@
         {{#swagger2AnnotationLibrary}}
         <swagger-annotations-version>2.2.15</swagger-annotations-version>
         {{/swagger2AnnotationLibrary}}
-        {{#useJakartaEe}}
-        <spring-web-version>6.1.5</spring-web-version>
-        {{/useJakartaEe}}
-        {{^useJakartaEe}}
-        <spring-web-version>5.3.33</spring-web-version>
-        {{/useJakartaEe}}
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-version>2.17.1</jackson-databind-version>
         {{#openApiNullable}}
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         {{/openApiNullable}}
         {{#useJakartaEe}}
+        <spring-web-version>6.1.5</spring-web-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         {{/useJakartaEe}}
         {{^useJakartaEe}}
+        <spring-web-version>5.3.33</spring-web-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         {{/useJakartaEe}}
         {{#joda}}
         <jodatime-version>2.9.9</jodatime-version>
         {{/joda}}
-        {{#useBeanValidation}}
-        <beanvalidation-version>3.0.2</beanvalidation-version>
-        {{/useBeanValidation}}
         {{#performBeanValidation}}
         <hibernate-validator-version>5.4.3.Final</hibernate-validator-version>
         {{/performBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/api.mustache
@@ -35,8 +35,8 @@ import java.util.Map;
 import java.util.Set;
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/api_test.mustache
@@ -15,8 +15,8 @@ import java.util.List;
 import java.util.Map;
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play26/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play26/api.mustache
@@ -18,8 +18,8 @@ import okhttp3.MultipartBody;
 {{/imports}}
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 import java.util.ArrayList;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -405,13 +405,12 @@
         {{/joda}}
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         {{/useJakartaEe}}
         {{^useJakartaEe}}
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         {{/useJakartaEe}}
-        {{#useBeanValidation}}
-        <beanvalidation-version>3.0.2</beanvalidation-version>
-        {{/useBeanValidation}}
         <oltu-version>1.0.1</oltu-version>
         <junit-version>5.10.3</junit-version>
     </properties>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/api.mustache
@@ -12,8 +12,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 import org.springframework.beans.factory.annotation.Autowired;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/api_test.mustache
@@ -15,8 +15,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
 /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
@@ -133,12 +133,14 @@ ext {
     {{#useJakartaEe}}
     spring_boot_version = "3.0.12"
     jakarta_annotation_version = "2.1.1"
+    beanvalidation_version = "3.0.2"
     reactor_version = "3.5.12"
     reactor_netty_version = "1.1.13"
     {{/useJakartaEe}}
     {{^useJakartaEe}}
     spring_boot_version = "2.7.17"
     jakarta_annotation_version = "1.3.5"
+    beanvalidation_version = "2.0.2"
     reactor_version = "3.4.34"
     reactor_netty_version = "1.0.39"
     {{/useJakartaEe}}

--- a/modules/openapi-generator/src/main/resources/Java/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/model.mustache
@@ -49,8 +49,8 @@ import android.os.Parcelable;
 import android.os.Parcel;
 {{/parcelableModel}}
 {{#useBeanValidation}}
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
 import org.hibernate.validator.constraints.*;

--- a/modules/openapi-generator/src/main/resources/Java/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pom.mustache
@@ -368,13 +368,12 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         {{/useJakartaEe}}
         {{^useJakartaEe}}
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         {{/useJakartaEe}}
-{{#useBeanValidation}}
-        <beanvalidation-version>3.0.2</beanvalidation-version>
-{{/useBeanValidation}}
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>

--- a/samples/client/echo_api/java/apache-httpclient/pom.xml
+++ b/samples/client/echo_api/java/apache-httpclient/pom.xml
@@ -274,6 +274,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/samples/client/echo_api/java/feign-gson/pom.xml
+++ b/samples/client/echo_api/java/feign-gson/pom.xml
@@ -305,6 +305,7 @@
         <gson-version>2.10.1</gson-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <scribejava-version>8.3.3</scribejava-version>

--- a/samples/client/echo_api/java/native/pom.xml
+++ b/samples/client/echo_api/java/native/pom.xml
@@ -256,6 +256,7 @@
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <httpmime-version>4.5.14</httpmime-version>
         <junit-version>5.10.2</junit-version>
         <spotless.version>2.27.2</spotless.version>

--- a/samples/client/echo_api/java/okhttp-gson-user-defined-templates/pom.xml
+++ b/samples/client/echo_api/java/okhttp-gson-user-defined-templates/pom.xml
@@ -334,6 +334,7 @@
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
         <jakarta.ws.rs-api-version>2.1.6</jakarta.ws.rs-api-version>

--- a/samples/client/echo_api/java/okhttp-gson/pom.xml
+++ b/samples/client/echo_api/java/okhttp-gson/pom.xml
@@ -329,6 +329,7 @@
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
         <jakarta.ws.rs-api-version>2.1.6</jakarta.ws.rs-api-version>

--- a/samples/client/echo_api/java/restclient/pom.xml
+++ b/samples/client/echo_api/java/restclient/pom.xml
@@ -285,6 +285,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
     </properties>

--- a/samples/client/echo_api/java/restclient/src/test/java/org/openapitools/client/api/AuthApiTest.java
+++ b/samples/client/echo_api/java/restclient/src/test/java/org/openapitools/client/api/AuthApiTest.java
@@ -13,50 +13,46 @@
 
 package org.openapitools.client.api;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * API tests for AuthApi
  */
+@Disabled
 public class AuthApiTest {
 
     private final AuthApi api = new AuthApi();
 
+    
     /**
      * To test HTTP basic authentication
      *
-     * <p>To test HTTP basic authentication
+     * To test HTTP basic authentication
      */
     @Test
-    public void testAuthHttpBasicTest() {
-        // given
-        api.getApiClient().setUsername("test_user");
-        api.getApiClient().setPassword("test_password");
-
-        // when
+    public void testAuthHttpBasicTest()  {
         String response = api.testAuthHttpBasic();
 
-        assertThat(
-                response,
-                containsString("Authorization: Basic dGVzdF91c2VyOnRlc3RfcGFzc3dvcmQ="));
+        // TODO: test validations
     }
-
+    
     /**
      * To test HTTP bearer authentication
      *
-     * <p>To test HTTP bearer authentication
+     * To test HTTP bearer authentication
      */
     @Test
-    public void testAuthHttpBearerTest() {
-        // given
-        api.getApiClient().setBearerToken("test_token");
-
-        // when
+    public void testAuthHttpBearerTest()  {
         String response = api.testAuthHttpBearer();
 
-        assertThat(response, containsString("Authorization: Bearer test_token"));
+        // TODO: test validations
     }
+    
 }

--- a/samples/client/echo_api/java/restclient/src/test/java/org/openapitools/client/api/BodyApiTest.java
+++ b/samples/client/echo_api/java/restclient/src/test/java/org/openapitools/client/api/BodyApiTest.java
@@ -10,278 +10,158 @@
  * Do not edit the class manually.
  */
 
+
 package org.openapitools.client.api;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
+import org.openapitools.client.model.Pet;
+import org.openapitools.client.model.StringEnumRef;
+import org.openapitools.client.model.Tag;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
-import org.openapitools.client.ApiClient;
-import org.openapitools.client.GifHttpMessageConverter;
-import org.openapitools.client.OctetStreamHttpMessageConverter;
-import org.openapitools.client.model.Category;
-import org.openapitools.client.model.Pet;
-import org.openapitools.client.model.Pet.StatusEnum;
-import org.openapitools.client.model.StringEnumRef;
-import org.openapitools.client.model.Tag;
+import java.util.stream.Collectors;
 
-/** API tests for BodyApi */
+/**
+ * API tests for BodyApi
+ */
+@Disabled
 public class BodyApiTest {
 
-  private final BodyApi api = new BodyApi();
+    private final BodyApi api = new BodyApi();
 
-  /**
-   * Test binary (gif) response body
-   *
-   * <p>Test binary (gif) response body
-   */
-  @Test
-  public void testBinaryGifTest() throws IOException {
-    // given
-    var restClient =
-        ApiClient.buildRestClientBuilder()
-            .messageConverters(converters -> converters.add(new GifHttpMessageConverter()))
-            .build();
-    api.setApiClient(new ApiClient(restClient));
+    
+    /**
+     * Test binary (gif) response body
+     *
+     * Test binary (gif) response body
+     */
+    @Test
+    public void testBinaryGifTest()  {
+        File response = api.testBinaryGif();
 
-    // when
-    File response = api.testBinaryGif();
+        // TODO: test validations
+    }
+    
+    /**
+     * Test body parameter(s)
+     *
+     * Test body parameter(s)
+     */
+    @Test
+    public void testBodyApplicationOctetstreamBinaryTest()  {
+        File body = null;
+        String response = api.testBodyApplicationOctetstreamBinary(body);
 
-    // then
-    assertThat(response, notNullValue());
-    assertThat(response.exists(), is(true));
-    assertThat(Files.probeContentType(response.toPath()), is("image/gif"));
-  }
+        // TODO: test validations
+    }
+    
+    /**
+     * Test array of binary in multipart mime
+     *
+     * Test array of binary in multipart mime
+     */
+    @Test
+    public void testBodyMultipartFormdataArrayOfBinaryTest()  {
+        List<File> files = null;
+        String response = api.testBodyMultipartFormdataArrayOfBinary(files);
 
-  /**
-   * Test body parameter(s)
-   *
-   * <p>Test body parameter(s)
-   */
-  @Test
-  public void testBodyApplicationOctetstreamBinaryTest() throws IOException {
-    // given
-    var restClient =
-        ApiClient.buildRestClientBuilder()
-            .messageConverters(converters -> converters.add(new OctetStreamHttpMessageConverter()))
-            .build();
-    api.setApiClient(new ApiClient(restClient));
+        // TODO: test validations
+    }
+    
+    /**
+     * Test single binary in multipart mime
+     *
+     * Test single binary in multipart mime
+     */
+    @Test
+    public void testBodyMultipartFormdataSingleBinaryTest()  {
+        File myFile = null;
+        String response = api.testBodyMultipartFormdataSingleBinary(myFile);
 
-    var tempFile = Files.createTempFile("test", ".txt");
-    Files.writeString(tempFile, "test123");
+        // TODO: test validations
+    }
+    
+    /**
+     * Test body parameter(s)
+     *
+     * Test body parameter(s)
+     */
+    @Test
+    public void testEchoBodyAllOfPetTest()  {
+        Pet pet = null;
+        Pet response = api.testEchoBodyAllOfPet(pet);
 
-    File body = tempFile.toFile();
+        // TODO: test validations
+    }
+    
+    /**
+     * Test free form object
+     *
+     * Test free form object
+     */
+    @Test
+    public void testEchoBodyFreeFormObjectResponseStringTest()  {
+        Object body = null;
+        String response = api.testEchoBodyFreeFormObjectResponseString(body);
 
-    // when
-    String response = api.testBodyApplicationOctetstreamBinary(body);
+        // TODO: test validations
+    }
+    
+    /**
+     * Test body parameter(s)
+     *
+     * Test body parameter(s)
+     */
+    @Test
+    public void testEchoBodyPetTest()  {
+        Pet pet = null;
+        Pet response = api.testEchoBodyPet(pet);
 
-    // then
-    assertThat(response, containsString("Content-Type: application/octet-stream"));
-    assertThat(response, containsString("test123"));
-  }
+        // TODO: test validations
+    }
+    
+    /**
+     * Test empty response body
+     *
+     * Test empty response body
+     */
+    @Test
+    public void testEchoBodyPetResponseStringTest()  {
+        Pet pet = null;
+        String response = api.testEchoBodyPetResponseString(pet);
 
-  /**
-   * Test array of binary in multipart mime
-   *
-   * <p>Test array of binary in multipart mime
-   */
-  @Test
-  public void testBodyMultipartFormdataArrayOfBinaryTest() throws IOException {
-    // given
-    var firstFile = Files.createTempFile("test", ".txt");
-    String firstFileContent = "Thanks for using OpenAPI generator :)";
-    Files.writeString(firstFile, firstFileContent);
+        // TODO: test validations
+    }
+    
+    /**
+     * Test string enum response body
+     *
+     * Test string enum response body
+     */
+    @Test
+    public void testEchoBodyStringEnumTest()  {
+        String body = null;
+        StringEnumRef response = api.testEchoBodyStringEnum(body);
 
-    var secondFile = Files.createTempFile("test2", ".txt");
-    String secondFileContent = "Your ad could be here";
-    Files.writeString(secondFile, secondFileContent);
+        // TODO: test validations
+    }
+    
+    /**
+     * Test empty json (request body)
+     *
+     * Test empty json (request body)
+     */
+    @Test
+    public void testEchoBodyTagResponseStringTest()  {
+        Tag tag = null;
+        String response = api.testEchoBodyTagResponseString(tag);
 
-    List<File> files = List.of(firstFile.toFile(), secondFile.toFile());
-
-    // when
-    String response = api.testBodyMultipartFormdataArrayOfBinary(files);
-
-    // then
-    assertThat(response, containsString("Content-Type: multipart/form-data"));
-    assertThat(response, containsString(firstFileContent));
-    assertThat(response, containsString(secondFileContent));
-  }
-
-  /**
-   * Test single binary in multipart mime
-   *
-   * <p>Test single binary in multipart mime
-   */
-  @Test
-  public void testBodyMultipartFormdataSingleBinaryTest() throws IOException {
-    // given
-    var testFile = Files.createTempFile("test", ".txt");
-    String testFileContent = "Lorem ipsum dolor sit amet";
-    Files.writeString(testFile, testFileContent);
-
-    // when
-    String response = api.testBodyMultipartFormdataSingleBinary(testFile.toFile());
-
-    // then
-    assertThat(response, containsString("Content-Type: multipart/form-data"));
-    assertThat(response, containsString(testFileContent));
-  }
-
-  /**
-   * Test body parameter(s)
-   *
-   * <p>Test body parameter(s)
-   */
-  @Test
-  public void testEchoBodyAllOfPetTest() {
-    // given
-    // The content length must be set to disable the Transfer-Encoding: chunked which would lead to
-    // unparsable response because the echo server is replying them as body.
-    api.getApiClient().addDefaultHeader("Content-Length", "192");
-
-    Pet pet =
-        new Pet()
-            .id(42L)
-            .name("Corgi")
-            .category(new Category().id(1L).name("Dogs"))
-            .status(StatusEnum.SOLD)
-            .addPhotoUrlsItem(
-                "https://cdn.pixabay.com/photo/2021/10/13/09/01/corgi-6705821_1280.jpg")
-            .addTagsItem(new Tag().id(1L).name("cute"));
-
-    // when
-    Pet response = api.testEchoBodyAllOfPet(pet);
-
-    // then
-    assertThat(response, is(pet));
-  }
-
-  /**
-   * Test free form object
-   *
-   * <p>Test free form object
-   */
-  @Test
-  public void testEchoBodyFreeFormObjectResponseStringTest() {
-    // given
-    // The content length must be set to disable the Transfer-Encoding: chunked which would lead to
-    // unparsable response because the echo server is replying them as body.
-    api.getApiClient().addDefaultHeader("Content-Length", "51");
-
-    Object mapAsObject =
-        new HashMap<>(
-            Map.of(
-                "firstKey", "firstValue",
-                "secondKey", "secondValue"));
-
-    // when
-    String response = api.testEchoBodyFreeFormObjectResponseString(mapAsObject);
-
-    // then
-    assertThat(response, is("{\"firstKey\":\"firstValue\",\"secondKey\":\"secondValue\"}"));
-  }
-
-  /**
-   * Test body parameter(s)
-   *
-   * <p>Test body parameter(s)
-   */
-  @Test
-  public void testEchoBodyPetTest() {
-    // given
-    // The content length must be set to disable the Transfer-Encoding: chunked which would lead to
-    // unparsable response because the echo server is replying them as body.
-    api.getApiClient().addDefaultHeader("Content-Length", "192");
-
-    Pet pet =
-        new Pet()
-            .id(42L)
-            .name("Corgi")
-            .category(new Category().id(1L).name("Dogs"))
-            .status(StatusEnum.SOLD)
-            .addPhotoUrlsItem(
-                "https://cdn.pixabay.com/photo/2021/10/13/09/01/corgi-6705821_1280.jpg")
-            .addTagsItem(new Tag().id(1L).name("cute"));
-
-    // when
-    Pet response = api.testEchoBodyPet(pet);
-
-    // then
-    assertThat(response, is(pet));
-  }
-
-  /**
-   * Test empty response body
-   *
-   * <p>Test empty response body
-   */
-  @Test
-  public void testEchoBodyPetResponseStringTest() {
-    // given
-    // The content length must be set to disable the Transfer-Encoding: chunked which would lead to
-    // unparsable response because the echo server is replying them as body.
-    api.getApiClient().addDefaultHeader("Content-Length", "192");
-
-    Pet pet =
-        new Pet()
-            .id(42L)
-            .name("Corgi")
-            .category(new Category().id(1L).name("Dogs"))
-            .status(StatusEnum.SOLD)
-            .addPhotoUrlsItem(
-                "https://cdn.pixabay.com/photo/2021/10/13/09/01/corgi-6705821_1280.jpg")
-            .addTagsItem(new Tag().id(1L).name("cute"));
-
-    // when
-    String response = api.testEchoBodyPetResponseString(pet);
-
-    // then
-    assertThat(
-        response,
-        is(
-            "{\"id\":42,\"name\":\"Corgi\",\"category\":{\"id\":1,\"name\":\"Dogs\"},\"photoUrls\":[\"https://cdn.pixabay.com/photo/2021/10/13/09/01/corgi-6705821_1280.jpg\"],\"tags\":[{\"id\":1,\"name\":\"cute\"}],\"status\":\"sold\"}"));
-  }
-
-  /**
-   * Test string enum response body
-   *
-   * <p>Test string enum response body
-   */
-  @Test
-  public void testEchoBodyStringEnumTest() {
-    // given
-    String body = "\"failure\"";
-
-    // when
-    StringEnumRef response = api.testEchoBodyStringEnum(body);
-
-    // then
-    assertThat(response, is(StringEnumRef.FAILURE));
-  }
-
-  /**
-   * Test empty json (request body)
-   *
-   * <p>Test empty json (request body)
-   */
-  @Test
-  public void testEchoBodyTagResponseStringTest() {
-    // given
-    Tag tag = null;
-
-    // when
-    String response = api.testEchoBodyTagResponseString(tag);
-
-    // then
-    assertThat(response, nullValue());
-  }
+        // TODO: test validations
+    }
+    
 }

--- a/samples/client/echo_api/java/restclient/src/test/java/org/openapitools/client/api/FormApiTest.java
+++ b/samples/client/echo_api/java/restclient/src/test/java/org/openapitools/client/api/FormApiTest.java
@@ -10,154 +10,72 @@
  * Do not edit the class manually.
  */
 
+
 package org.openapitools.client.api;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import org.junit.Test;
 import org.openapitools.client.model.TestFormObjectMultipartRequestMarker;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-/** API tests for FormApi */
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * API tests for FormApi
+ */
+@Disabled
 public class FormApiTest {
 
-  private final FormApi api = new FormApi();
+    private final FormApi api = new FormApi();
 
-  /**
-   * Test form parameter(s)
-   *
-   * <p>Test form parameter(s)
-   */
-  @Test
-  public void testFormIntegerBooleanStringTest() {
-    // Given
-    // The content length must be set to disable the Transfer-Encoding: chunked which would lead to
-    // unparsable response because the echo server is replying them as body.
-    api.getApiClient().addDefaultHeader("Content-Length", "53");
+    
+    /**
+     * Test form parameter(s)
+     *
+     * Test form parameter(s)
+     */
+    @Test
+    public void testFormIntegerBooleanStringTest()  {
+        Integer integerForm = null;
+        Boolean booleanForm = null;
+        String stringForm = null;
+        String response = api.testFormIntegerBooleanString(integerForm, booleanForm, stringForm);
 
-    Integer integerForm = 42;
-    Boolean booleanForm = true;
-    String stringForm = "Test123";
+        // TODO: test validations
+    }
+    
+    /**
+     * Test form parameter(s) for multipart schema
+     *
+     * Test form parameter(s) for multipart schema
+     */
+    @Test
+    public void testFormObjectMultipartTest()  {
+        TestFormObjectMultipartRequestMarker marker = null;
+        String response = api.testFormObjectMultipart(marker);
 
-    // When
-    String response = api.testFormIntegerBooleanString(integerForm, booleanForm, stringForm);
+        // TODO: test validations
+    }
+    
+    /**
+     * Test form parameter(s) for oneOf schema
+     *
+     * Test form parameter(s) for oneOf schema
+     */
+    @Test
+    public void testFormOneofTest()  {
+        String form1 = null;
+        Integer form2 = null;
+        String form3 = null;
+        Boolean form4 = null;
+        Long id = null;
+        String name = null;
+        String response = api.testFormOneof(form1, form2, form3, form4, id, name);
 
-    // Then
-    assertThat(response, containsString("integer_form=42&boolean_form=true&string_form=Test123"));
-  }
-
-  /**
-   * Test form parameter(s) for multipart schema
-   *
-   * <p>Test form parameter(s) for multipart schema
-   */
-  @Test
-  public void testFormObjectMultipartTest() {
-    // Given
-    TestFormObjectMultipartRequestMarker marker =
-        new TestFormObjectMultipartRequestMarker().name("Test Marker");
-
-    // When
-    String response = api.testFormObjectMultipart(marker);
-
-    // Then
-    assertThat(response, containsString("{\"name\":\"Test Marker\"}"));
-  }
-
-  /**
-   * Test form parameter(s) for oneOf schema with only the first parameters filled
-   *
-   * <p>Test form parameter(s) for oneOf schema
-   */
-  @Test
-  public void testFormOneofTest_first() {
-    // Given
-    String form1 = "test12";
-    Integer form2 = 12;
-
-    String form3 = null;
-    Boolean form4 = null;
-
-    Long id = null;
-    String name = null;
-
-    // When
-    String response = api.testFormOneof(form1, form2, form3, form4, id, name);
-
-    // Then
-    assertThat(response, containsString("form1=test12&form2=12"));
-  }
-
-  /**
-   * Test form parameter(s) for oneOf schema with only the second parameters filled
-   *
-   * <p>Test form parameter(s) for oneOf schema
-   */
-  @Test
-  public void testFormOneofTest_second() {
-    // Given
-    String form1 = null;
-    Integer form2 = null;
-
-    String form3 = "34test";
-    Boolean form4 = false;
-
-    Long id = null;
-    String name = null;
-
-    // When
-    String response = api.testFormOneof(form1, form2, form3, form4, id, name);
-
-    // Then
-    assertThat(response, containsString("form3=34test&form4=false"));
-  }
-
-  /**
-   * Test form parameter(s) for oneOf schema with only the third parameters filled
-   *
-   * <p>Test form parameter(s) for oneOf schema
-   */
-  @Test
-  public void testFormOneofTest_third() {
-    // Given
-    String form1 = null;
-    Integer form2 = null;
-
-    String form3 = null;
-    Boolean form4 = null;
-
-    Long id = 21L;
-    String name = "Hans";
-
-    // When
-    String response = api.testFormOneof(form1, form2, form3, form4, id, name);
-
-    // Then
-    assertThat(response, containsString("id=21&name=Hans"));
-  }
-
-  /**
-   * Test form parameter(s) for oneOf schema with all parameters filled
-   *
-   * <p>Test form parameter(s) for oneOf schema
-   */
-  @Test
-  public void testFormOneofTest_all() {
-    // Given
-    String form1 = "test12";
-    Integer form2 = 12;
-
-    String form3 = "34test";
-    Boolean form4 = false;
-
-    Long id = 21L;
-    String name = "Hans";
-
-    // When
-    String response = api.testFormOneof(form1, form2, form3, form4, id, name);
-
-    // Then
-    assertThat(
-        response, containsString("form1=test12&form2=12&form3=34test&form4=false&id=21&name=Hans"));
-  }
+        // TODO: test validations
+    }
+    
 }

--- a/samples/client/echo_api/java/restclient/src/test/java/org/openapitools/client/api/HeaderApiTest.java
+++ b/samples/client/echo_api/java/restclient/src/test/java/org/openapitools/client/api/HeaderApiTest.java
@@ -10,51 +10,43 @@
  * Do not edit the class manually.
  */
 
+
 package org.openapitools.client.api;
 
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import org.junit.Test;
 import org.openapitools.client.model.StringEnumRef;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-/** API tests for HeaderApi */
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * API tests for HeaderApi
+ */
+@Disabled
 public class HeaderApiTest {
 
-  private final HeaderApi api = new HeaderApi();
+    private final HeaderApi api = new HeaderApi();
 
-  /**
-   * Test header parameter(s)
-   *
-   * <p>Test header parameter(s)
-   */
-  @Test
-  public void testHeaderIntegerBooleanStringEnumsTest() {
-    // Given
-    Integer integerHeader = 11;
-    Boolean booleanHeader = true;
-    String stringHeader = "simple String Header";
-    String enumNonrefStringHeader = "false";
-    StringEnumRef enumRefStringHeader = StringEnumRef.UNCLASSIFIED;
+    
+    /**
+     * Test header parameter(s)
+     *
+     * Test header parameter(s)
+     */
+    @Test
+    public void testHeaderIntegerBooleanStringEnumsTest()  {
+        Integer integerHeader = null;
+        Boolean booleanHeader = null;
+        String stringHeader = null;
+        String enumNonrefStringHeader = null;
+        StringEnumRef enumRefStringHeader = null;
+        String response = api.testHeaderIntegerBooleanStringEnums(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
 
-    // When
-    String response =
-        api.testHeaderIntegerBooleanStringEnums(
-            integerHeader,
-            booleanHeader,
-            stringHeader,
-            enumNonrefStringHeader,
-            enumRefStringHeader);
-
-    // Then
-    assertThat(
-        response,
-        allOf(
-            containsString("integer_header: 11"),
-            containsString("boolean_header: true"),
-            containsString("string_header: simple String Header"),
-            containsString("enum_nonref_string_header: false"),
-            containsString("enum_ref_string_header: unclassified")));
-  }
+        // TODO: test validations
+    }
+    
 }

--- a/samples/client/echo_api/java/restclient/src/test/java/org/openapitools/client/api/PathApiTest.java
+++ b/samples/client/echo_api/java/restclient/src/test/java/org/openapitools/client/api/PathApiTest.java
@@ -10,40 +10,42 @@
  * Do not edit the class manually.
  */
 
+
 package org.openapitools.client.api;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import org.junit.Test;
 import org.openapitools.client.model.StringEnumRef;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-/** API tests for PathApi */
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * API tests for PathApi
+ */
+@Disabled
 public class PathApiTest {
 
-  private final PathApi api = new PathApi();
+    private final PathApi api = new PathApi();
 
-  /**
-   * Test path parameter(s)
-   *
-   * <p>Test path parameter(s)
-   */
-  @Test
-  public void
-      testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathTest() {
-    // Given
-    String pathString = "simple String Path";
-    Integer pathInteger = 50;
-    String enumNonrefStringPath = "true";
-    StringEnumRef enumRefStringPath = StringEnumRef.SUCCESS;
+    
+    /**
+     * Test path parameter(s)
+     *
+     * Test path parameter(s)
+     */
+    @Test
+    public void testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathTest()  {
+        String pathString = null;
+        Integer pathInteger = null;
+        String enumNonrefStringPath = null;
+        StringEnumRef enumRefStringPath = null;
+        String response = api.testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
 
-    // When
-    String response =
-        api.testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(
-            pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
-
-    // Then
-    assertThat(
-        response, containsString("/path/string/simple%20String%20Path/integer/50/true/success"));
-  }
+        // TODO: test validations
+    }
+    
 }

--- a/samples/client/echo_api/java/restclient/src/test/java/org/openapitools/client/api/QueryApiTest.java
+++ b/samples/client/echo_api/java/restclient/src/test/java/org/openapitools/client/api/QueryApiTest.java
@@ -10,206 +10,167 @@
  * Do not edit the class manually.
  */
 
+
 package org.openapitools.client.api;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import java.time.Instant;
-import java.time.LocalDate;
-import java.util.List;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.openapitools.client.model.DataQuery;
+import java.time.LocalDate;
+import java.time.Instant;
 import org.openapitools.client.model.Pet;
 import org.openapitools.client.model.StringEnumRef;
 import org.openapitools.client.model.TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter;
 import org.openapitools.client.model.TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-/** API tests for QueryApi */
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * API tests for QueryApi
+ */
+@Disabled
 public class QueryApiTest {
 
-  private final QueryApi api = new QueryApi();
+    private final QueryApi api = new QueryApi();
 
-  /**
-   * Test query parameter(s)
-   *
-   * <p>Test query parameter(s)
-   */
-  @Test
-  public void testEnumRefStringTest() {
-    // Given
-    String enumNonrefStringQuery = "false";
-    StringEnumRef enumRefStringQuery = StringEnumRef.SUCCESS;
+    
+    /**
+     * Test query parameter(s)
+     *
+     * Test query parameter(s)
+     */
+    @Test
+    public void testEnumRefStringTest()  {
+        String enumNonrefStringQuery = null;
+        StringEnumRef enumRefStringQuery = null;
+        String response = api.testEnumRefString(enumNonrefStringQuery, enumRefStringQuery);
 
-    // When
-    String response = api.testEnumRefString(enumNonrefStringQuery, enumRefStringQuery);
+        // TODO: test validations
+    }
+    
+    /**
+     * Test query parameter(s)
+     *
+     * Test query parameter(s)
+     */
+    @Test
+    public void testQueryDatetimeDateStringTest()  {
+        Instant datetimeQuery = null;
+        LocalDate dateQuery = null;
+        String stringQuery = null;
+        String response = api.testQueryDatetimeDateString(datetimeQuery, dateQuery, stringQuery);
 
-    // Then
-    assertThat(
-        response, containsString("?enum_nonref_string_query=false&enum_ref_string_query=success"));
-  }
+        // TODO: test validations
+    }
+    
+    /**
+     * Test query parameter(s)
+     *
+     * Test query parameter(s)
+     */
+    @Test
+    public void testQueryIntegerBooleanStringTest()  {
+        Integer integerQuery = null;
+        Boolean booleanQuery = null;
+        String stringQuery = null;
+        String response = api.testQueryIntegerBooleanString(integerQuery, booleanQuery, stringQuery);
 
-  /**
-   * Test query parameter(s)
-   *
-   * <p>Test query parameter(s)
-   */
-  @Test
-  public void testQueryDatetimeDateStringTest() {
-    // Given
-    Instant datetimeQuery = Instant.ofEpochMilli(1720361075);
-    LocalDate dateQuery = LocalDate.of(2024, 7, 7);
-    String stringQuery = "2024-07-07T16:05:59Z";
+        // TODO: test validations
+    }
+    
+    /**
+     * Test query parameter(s)
+     *
+     * Test query parameter(s)
+     */
+    @Test
+    public void testQueryStyleDeepObjectExplodeTrueObjectTest()  {
+        Pet queryObject = null;
+        String response = api.testQueryStyleDeepObjectExplodeTrueObject(queryObject);
 
-    // When
-    String response = api.testQueryDatetimeDateString(datetimeQuery, dateQuery, stringQuery);
+        // TODO: test validations
+    }
+    
+    /**
+     * Test query parameter(s)
+     *
+     * Test query parameter(s)
+     */
+    @Test
+    public void testQueryStyleDeepObjectExplodeTrueObjectAllOfTest()  {
+        TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter queryObject = null;
+        String response = api.testQueryStyleDeepObjectExplodeTrueObjectAllOf(queryObject);
 
-    // Then
-    assertThat(
-        response,
-        containsString(
-            "?datetime_query=1970-01-20T21%3A52%3A41.075Z&date_query=2024-07-07&string_query=2024-07-07T16%3A05%3A59Z"));
-  }
+        // TODO: test validations
+    }
+    
+    /**
+     * Test query parameter(s)
+     *
+     * Test query parameter(s)
+     */
+    @Test
+    public void testQueryStyleFormExplodeFalseArrayIntegerTest()  {
+        List<Integer> queryObject = null;
+        String response = api.testQueryStyleFormExplodeFalseArrayInteger(queryObject);
 
-  /**
-   * Test query parameter(s)
-   *
-   * <p>Test query parameter(s)
-   */
-  @Test
-  public void testQueryIntegerBooleanStringTest() {
-    // Given
-    Integer integerQuery = 42;
-    Boolean booleanQuery = false;
-    String stringQuery = "Hello World!";
+        // TODO: test validations
+    }
+    
+    /**
+     * Test query parameter(s)
+     *
+     * Test query parameter(s)
+     */
+    @Test
+    public void testQueryStyleFormExplodeFalseArrayStringTest()  {
+        List<String> queryObject = null;
+        String response = api.testQueryStyleFormExplodeFalseArrayString(queryObject);
 
-    // When
-    String response = api.testQueryIntegerBooleanString(integerQuery, booleanQuery, stringQuery);
+        // TODO: test validations
+    }
+    
+    /**
+     * Test query parameter(s)
+     *
+     * Test query parameter(s)
+     */
+    @Test
+    public void testQueryStyleFormExplodeTrueArrayStringTest()  {
+        TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter queryObject = null;
+        String response = api.testQueryStyleFormExplodeTrueArrayString(queryObject);
 
-    // Then
-    assertThat(
-        response,
-        containsString("?integer_query=42&boolean_query=false&string_query=Hello%20World%21"));
-  }
+        // TODO: test validations
+    }
+    
+    /**
+     * Test query parameter(s)
+     *
+     * Test query parameter(s)
+     */
+    @Test
+    public void testQueryStyleFormExplodeTrueObjectTest()  {
+        Pet queryObject = null;
+        String response = api.testQueryStyleFormExplodeTrueObject(queryObject);
 
-  /**
-   * Test query parameter(s)
-   *
-   * <p>Test query parameter(s)
-   */
-  @Test
-  @Disabled("The deep object style and the whole dynamic operations are currently not supported")
-  public void testQueryStyleDeepObjectExplodeTrueObjectTest() {
-    Pet queryObject = null;
-    String response = api.testQueryStyleDeepObjectExplodeTrueObject(queryObject);
+        // TODO: test validations
+    }
+    
+    /**
+     * Test query parameter(s)
+     *
+     * Test query parameter(s)
+     */
+    @Test
+    public void testQueryStyleFormExplodeTrueObjectAllOfTest()  {
+        DataQuery queryObject = null;
+        String response = api.testQueryStyleFormExplodeTrueObjectAllOf(queryObject);
 
-    // Like Spring WebClient and RestTemplate, the deep object style is currently not
-  }
-
-  /**
-   * Test query parameter(s)
-   *
-   * <p>Test query parameter(s)
-   */
-  @Test
-  @Disabled("The deep object style and the whole dynamic operations are currently not supported")
-  public void testQueryStyleDeepObjectExplodeTrueObjectAllOfTest() {
-    TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter queryObject = null;
-    String response = api.testQueryStyleDeepObjectExplodeTrueObjectAllOf(queryObject);
-
-    // Like Spring WebClient and RestTemplate, the deep object style and the whole dynamic
-    // operations are currently not supported
-  }
-
-  /**
-   * Test query parameter(s)
-   *
-   * <p>Test query parameter(s)
-   */
-  @Test
-  public void testQueryStyleFormExplodeFalseArrayIntegerTest() {
-    // Given
-    List<Integer> queryObject = List.of(1, 6, 2, 5, 3, 4);
-
-    // When
-    String response = api.testQueryStyleFormExplodeFalseArrayInteger(queryObject);
-
-    // Then
-    assertThat(response, containsString("?query_object=1%2C6%2C2%2C5%2C3%2C4"));
-  }
-
-  /**
-   * Test query parameter(s)
-   *
-   * <p>Test query parameter(s)
-   */
-  @Test
-  public void testQueryStyleFormExplodeFalseArrayStringTest() {
-    // Given
-    List<String> queryObject = List.of("Hello", "World");
-
-    // When
-    String response = api.testQueryStyleFormExplodeFalseArrayString(queryObject);
-
-    // Then
-    assertThat(response, containsString("?query_object=Hello%2CWorld"));
-  }
-
-  /**
-   * Test query parameter(s)
-   *
-   * <p>Test query parameter(s)
-   */
-  @Test
-  @Disabled("The deep object style and the whole dynamic operations are currently not supported")
-  public void testQueryStyleFormExplodeTrueArrayStringTest() {
-    // Given
-    TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter queryObject =
-        new TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter()
-            .addValuesItem("Hello")
-            .addValuesItem("Hallo")
-            .addValuesItem("Bonjour");
-
-    // When
-    String response = api.testQueryStyleFormExplodeTrueArrayString(queryObject);
-
-    // Then
-    // Like Spring WebClient and RestTemplate, the deep object style and the whole dynamic
-    // operations are currently not supported
-    assertThat(
-        response, containsString("?query_object=Hello&query_object=Hallo&query_object=Bonjour"));
-  }
-
-  /**
-   * Test query parameter(s)
-   *
-   * <p>Test query parameter(s)
-   */
-  @Test
-  @Disabled("The deep object style and the whole dynamic operations are currently not supported")
-  public void testQueryStyleFormExplodeTrueObjectTest() {
-    Pet queryObject = null;
-    String response = api.testQueryStyleFormExplodeTrueObject(queryObject);
-
-    // TODO: test validations
-    // Like Spring WebClient and RestTemplate, the deep object style and the whole dynamic
-    // operations are currently not supported
-  }
-
-  /**
-   * Test query parameter(s)
-   *
-   * <p>Test query parameter(s)
-   */
-  @Test
-  @Disabled("The deep object style and the whole dynamic operations are currently not supported")
-  public void testQueryStyleFormExplodeTrueObjectAllOfTest() {
-    DataQuery queryObject = null;
-    String response = api.testQueryStyleFormExplodeTrueObjectAllOf(queryObject);
-
-    // TODO: test validations
-    // Like Spring WebClient and RestTemplate, the deep object style and the whole dynamic
-    // operations are currently not supported
-  }
+        // TODO: test validations
+    }
+    
 }

--- a/samples/client/echo_api/java/resttemplate/build.gradle
+++ b/samples/client/echo_api/java/resttemplate/build.gradle
@@ -102,6 +102,7 @@ ext {
     jackson_databind_nullable_version = "0.2.6"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
+    beanvalidation_version = "2.0.2"
     jodatime_version = "2.9.9"
     junit_version = "5.10.2"
 }

--- a/samples/client/echo_api/java/resttemplate/pom.xml
+++ b/samples/client/echo_api/java/resttemplate/pom.xml
@@ -280,11 +280,12 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-web-version>5.3.33</spring-web-version>
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
+        <spring-web-version>5.3.33</spring-web-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
     </properties>

--- a/samples/client/others/java/jersey2-oneOf-Mixed/pom.xml
+++ b/samples/client/others/java/jersey2-oneOf-Mixed/pom.xml
@@ -333,6 +333,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>
         <spotless.version>2.21.0</spotless.version>
     </properties>

--- a/samples/client/others/java/jersey2-oneOf-duplicates/pom.xml
+++ b/samples/client/others/java/jersey2-oneOf-duplicates/pom.xml
@@ -333,6 +333,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>
         <spotless.version>2.21.0</spotless.version>
     </properties>

--- a/samples/client/others/java/okhttp-gson-oneOf/pom.xml
+++ b/samples/client/others/java/okhttp-gson-oneOf/pom.xml
@@ -329,6 +329,7 @@
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
         <jakarta.ws.rs-api-version>2.1.6</jakarta.ws.rs-api-version>

--- a/samples/client/others/java/okhttp-gson-streaming/pom.xml
+++ b/samples/client/others/java/okhttp-gson-streaming/pom.xml
@@ -329,6 +329,7 @@
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
         <jakarta.ws.rs-api-version>2.1.6</jakarta.ws.rs-api-version>

--- a/samples/client/others/java/restclient-useAbstractionForFiles/pom.xml
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/pom.xml
@@ -285,6 +285,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
     </properties>

--- a/samples/client/others/java/restclient-useAbstractionForFiles/src/test/java/org/openapitools/client/api/ResourceApiTest.java
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/src/test/java/org/openapitools/client/api/ResourceApiTest.java
@@ -14,8 +14,8 @@
 package org.openapitools.client.api;
 
 import java.io.File;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for ResourceApi
  */
-@Ignore
+@Disabled
 public class ResourceApiTest {
 
     private final ResourceApi api = new ResourceApi();

--- a/samples/client/others/java/resttemplate-list-schema-validation/build.gradle
+++ b/samples/client/others/java/resttemplate-list-schema-validation/build.gradle
@@ -102,6 +102,7 @@ ext {
     jackson_databind_nullable_version = "0.2.6"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
+    beanvalidation_version = "2.0.2"
     jodatime_version = "2.9.9"
     junit_version = "5.10.2"
 }

--- a/samples/client/others/java/resttemplate-list-schema-validation/pom.xml
+++ b/samples/client/others/java/resttemplate-list-schema-validation/pom.xml
@@ -287,12 +287,12 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-web-version>5.3.33</spring-web-version>
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
+        <spring-web-version>5.3.33</spring-web-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
-        <beanvalidation-version>3.0.2</beanvalidation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
     </properties>

--- a/samples/client/others/java/resttemplate-list-schema-validation/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/others/java/resttemplate-list-schema-validation/src/main/java/org/openapitools/client/api/UserApi.java
@@ -11,8 +11,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;

--- a/samples/client/others/java/resttemplate-list-schema-validation/src/test/java/org/openapitools/client/api/UserApiTest.java
+++ b/samples/client/others/java/resttemplate-list-schema-validation/src/test/java/org/openapitools/client/api/UserApiTest.java
@@ -24,8 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 /**
  * API tests for UserApi

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/build.gradle
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/build.gradle
@@ -102,6 +102,7 @@ ext {
     jackson_databind_nullable_version = "0.2.6"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
+    beanvalidation_version = "2.0.2"
     jodatime_version = "2.9.9"
     junit_version = "5.10.2"
 }

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/pom.xml
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/pom.xml
@@ -280,11 +280,12 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-web-version>5.3.33</spring-web-version>
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
+        <spring-web-version>5.3.33</spring-web-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
     </properties>

--- a/samples/client/others/java/webclient-useAbstractionForFiles/build.gradle
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/build.gradle
@@ -114,6 +114,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     spring_boot_version = "2.7.17"
     jakarta_annotation_version = "1.3.5"
+    beanvalidation_version = "2.0.2"
     reactor_version = "3.4.34"
     reactor_netty_version = "1.0.39"
     jackson_version = "2.17.1"

--- a/samples/client/petstore/java/apache-httpclient/pom.xml
+++ b/samples/client/petstore/java/apache-httpclient/pom.xml
@@ -274,6 +274,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/feign-no-nullable/pom.xml
+++ b/samples/client/petstore/java/feign-no-nullable/pom.xml
@@ -316,6 +316,7 @@
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <scribejava-version>8.3.3</scribejava-version>

--- a/samples/client/petstore/java/feign/pom.xml
+++ b/samples/client/petstore/java/feign/pom.xml
@@ -322,6 +322,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <scribejava-version>8.3.3</scribejava-version>

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/pom.xml
@@ -338,6 +338,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>
         <scribejava-apis-version>8.3.3</scribejava-apis-version>
         <spotless.version>2.21.0</spotless.version>

--- a/samples/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8/pom.xml
@@ -338,6 +338,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>
         <scribejava-apis-version>8.3.3</scribejava-apis-version>
         <spotless.version>2.21.0</spotless.version>

--- a/samples/client/petstore/java/native-async/pom.xml
+++ b/samples/client/petstore/java/native-async/pom.xml
@@ -256,6 +256,7 @@
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <httpmime-version>4.5.14</httpmime-version>
         <junit-version>5.10.2</junit-version>
         <spotless.version>2.27.2</spotless.version>

--- a/samples/client/petstore/java/native-jakarta/pom.xml
+++ b/samples/client/petstore/java/native-jakarta/pom.xml
@@ -256,6 +256,7 @@
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         <httpmime-version>4.5.14</httpmime-version>
         <junit-version>5.10.2</junit-version>
         <spotless.version>2.27.2</spotless.version>

--- a/samples/client/petstore/java/native/pom.xml
+++ b/samples/client/petstore/java/native/pom.xml
@@ -256,6 +256,7 @@
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <httpmime-version>4.5.14</httpmime-version>
         <junit-version>5.10.2</junit-version>
         <spotless.version>2.27.2</spotless.version>

--- a/samples/client/petstore/java/okhttp-gson-3.1/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-3.1/pom.xml
@@ -334,6 +334,7 @@
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
         <jakarta.ws.rs-api-version>2.1.6</jakarta.ws.rs-api-version>

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/pom.xml
@@ -339,6 +339,7 @@
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
         <jakarta.ws.rs-api-version>2.1.6</jakarta.ws.rs-api-version>

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/pom.xml
@@ -339,6 +339,7 @@
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
         <jakarta.ws.rs-api-version>2.1.6</jakarta.ws.rs-api-version>

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/pom.xml
@@ -334,6 +334,7 @@
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
         <jakarta.ws.rs-api-version>2.1.6</jakarta.ws.rs-api-version>

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/pom.xml
@@ -334,6 +334,7 @@
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
         <jakarta.ws.rs-api-version>2.1.6</jakarta.ws.rs-api-version>

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
@@ -341,6 +341,7 @@
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
         <jakarta.ws.rs-api-version>2.1.6</jakarta.ws.rs-api-version>

--- a/samples/client/petstore/java/okhttp-gson-swagger1/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/pom.xml
@@ -340,6 +340,7 @@
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
         <jakarta.ws.rs-api-version>2.1.6</jakarta.ws.rs-api-version>

--- a/samples/client/petstore/java/okhttp-gson-swagger2/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/pom.xml
@@ -340,6 +340,7 @@
         <commons-lang3-version>3.14.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
         <jakarta.ws.rs-api-version>2.1.6</jakarta.ws.rs-api-version>

--- a/samples/client/petstore/java/rest-assured-jackson/pom.xml
+++ b/samples/client/petstore/java/rest-assured-jackson/pom.xml
@@ -284,7 +284,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
-        <beanvalidation-version>3.0.2</beanvalidation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <okio-version>3.6.0</okio-version>
         <junit-version>5.10.3</junit-version>
     </properties>

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/BeanValidationException.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/BeanValidationException.java
@@ -15,8 +15,8 @@ package org.openapitools.client;
 
 import java.util.Set;
 
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.ValidationException;
+import javax.validation.ConstraintViolation;
+import javax.validation.ValidationException;
 
 public class BeanValidationException extends ValidationException {
     /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -28,8 +28,8 @@ import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.Method;
 import io.restassured.response.Response;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -35,8 +35,8 @@ import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.Method;
 import io.restassured.response.Response;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -27,8 +27,8 @@ import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.Method;
 import io.restassured.response.Response;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/PetApi.java
@@ -30,8 +30,8 @@ import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.Method;
 import io.restassured.response.Response;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -27,8 +27,8 @@ import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.Method;
 import io.restassured.response.Response;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/UserApi.java
@@ -28,8 +28,8 @@ import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.Method;
 import io.restassured.response.Response;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -24,8 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -24,8 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -26,8 +26,8 @@ import java.util.List;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -24,8 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -25,8 +25,8 @@ import java.util.HashMap;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -24,8 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -24,8 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Animal.java
@@ -25,8 +25,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -26,8 +26,8 @@ import java.util.Arrays;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -26,8 +26,8 @@ import java.util.Arrays;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -26,8 +26,8 @@ import java.util.List;
 import org.openapitools.client.model.ReadOnlyFirst;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/BigCat.java
@@ -26,8 +26,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import org.openapitools.client.model.Cat;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Cat.java
@@ -26,8 +26,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import org.openapitools.client.model.Animal;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Category.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Client.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Dog.java
@@ -26,8 +26,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import org.openapitools.client.model.Animal;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -25,8 +25,8 @@ import java.util.Arrays;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -17,8 +17,8 @@ import java.util.Objects;
 import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import org.openapitools.client.model.OuterEnum;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -26,8 +26,8 @@ import java.util.List;
 import org.openapitools.client.model.ModelFile;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -27,8 +27,8 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/MapTest.java
@@ -24,8 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -27,8 +27,8 @@ import java.util.UUID;
 import org.openapitools.client.model.Animal;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelFile.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelFile.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelList.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelList.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Name.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.math.BigDecimal;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Order.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.time.OffsetDateTime;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.math.BigDecimal;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -17,8 +17,8 @@ import java.util.Objects;
 import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Pet.java
@@ -30,8 +30,8 @@ import org.openapitools.client.model.Category;
 import org.openapitools.client.model.Tag;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Tag.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -26,8 +26,8 @@ import java.util.Arrays;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -26,8 +26,8 @@ import java.util.Arrays;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/User.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -26,8 +26,8 @@ import java.util.Arrays;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured-jackson/src/test/java/org/openapitools/client/api/AnotherFakeApiTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/test/java/org/openapitools/client/api/AnotherFakeApiTest.java
@@ -30,8 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import static io.restassured.config.ObjectMapperConfig.objectMapperConfig;
 import static io.restassured.config.RestAssuredConfig.config;

--- a/samples/client/petstore/java/rest-assured-jackson/src/test/java/org/openapitools/client/api/FakeApiTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/test/java/org/openapitools/client/api/FakeApiTest.java
@@ -37,8 +37,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import static io.restassured.config.ObjectMapperConfig.objectMapperConfig;
 import static io.restassured.config.RestAssuredConfig.config;

--- a/samples/client/petstore/java/rest-assured-jackson/src/test/java/org/openapitools/client/api/FakeClassnameTags123ApiTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/test/java/org/openapitools/client/api/FakeClassnameTags123ApiTest.java
@@ -29,8 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import static io.restassured.config.ObjectMapperConfig.objectMapperConfig;
 import static io.restassured.config.RestAssuredConfig.config;

--- a/samples/client/petstore/java/rest-assured-jackson/src/test/java/org/openapitools/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/test/java/org/openapitools/client/api/PetApiTest.java
@@ -32,8 +32,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import static io.restassured.config.ObjectMapperConfig.objectMapperConfig;
 import static io.restassured.config.RestAssuredConfig.config;

--- a/samples/client/petstore/java/rest-assured-jackson/src/test/java/org/openapitools/client/api/StoreApiTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/test/java/org/openapitools/client/api/StoreApiTest.java
@@ -29,8 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import static io.restassured.config.ObjectMapperConfig.objectMapperConfig;
 import static io.restassured.config.RestAssuredConfig.config;

--- a/samples/client/petstore/java/rest-assured-jackson/src/test/java/org/openapitools/client/api/UserApiTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/test/java/org/openapitools/client/api/UserApiTest.java
@@ -30,8 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import static io.restassured.config.ObjectMapperConfig.objectMapperConfig;
 import static io.restassured.config.RestAssuredConfig.config;

--- a/samples/client/petstore/java/rest-assured/pom.xml
+++ b/samples/client/petstore/java/rest-assured/pom.xml
@@ -258,7 +258,7 @@
         <gson-version>2.10.1</gson-version>
         <gson-fire-version>1.9.0</gson-fire-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
-        <beanvalidation-version>3.0.2</beanvalidation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <okio-version>3.6.0</okio-version>
         <junit-version>5.10.3</junit-version>
     </properties>

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/BeanValidationException.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/BeanValidationException.java
@@ -15,8 +15,8 @@ package org.openapitools.client;
 
 import java.util.Set;
 
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.ValidationException;
+import javax.validation.ConstraintViolation;
+import javax.validation.ValidationException;
 
 public class BeanValidationException extends ValidationException {
     /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -28,8 +28,8 @@ import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.Method;
 import io.restassured.response.Response;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -35,8 +35,8 @@ import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.Method;
 import io.restassured.response.Response;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -27,8 +27,8 @@ import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.Method;
 import io.restassured.response.Response;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/PetApi.java
@@ -30,8 +30,8 @@ import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.Method;
 import io.restassured.response.Response;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -27,8 +27,8 @@ import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.Method;
 import io.restassured.response.Response;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
@@ -28,8 +28,8 @@ import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.Method;
 import io.restassured.response.Response;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -23,8 +23,8 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -23,8 +23,8 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -25,8 +25,8 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -23,8 +23,8 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -23,8 +23,8 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -23,8 +23,8 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Animal.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -25,8 +25,8 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -25,8 +25,8 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -25,8 +25,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.openapitools.client.model.ReadOnlyFirst;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/BigCat.java
@@ -22,8 +22,8 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import org.openapitools.client.model.Cat;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Cat.java
@@ -22,8 +22,8 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import org.openapitools.client.model.Animal;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Category.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Client.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Dog.java
@@ -22,8 +22,8 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import org.openapitools.client.model.Animal;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -16,8 +16,8 @@ package org.openapitools.client.model;
 import java.util.Objects;
 import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 import java.io.IOException;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -22,8 +22,8 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import org.openapitools.client.model.OuterEnum;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -25,8 +25,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.openapitools.client.model.ModelFile;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -26,8 +26,8 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.UUID;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
@@ -23,8 +23,8 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -26,8 +26,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.openapitools.client.model.Animal;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelFile.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelFile.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelList.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelList.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Name.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -22,8 +22,8 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.math.BigDecimal;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
@@ -22,8 +22,8 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.time.OffsetDateTime;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -22,8 +22,8 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.math.BigDecimal;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -16,8 +16,8 @@ package org.openapitools.client.model;
 import java.util.Objects;
 import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 import java.io.IOException;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
@@ -28,8 +28,8 @@ import java.util.List;
 import java.util.Set;
 import org.openapitools.client.model.Category;
 import org.openapitools.client.model.Tag;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Tag.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -25,8 +25,8 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -25,8 +25,8 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/User.java
@@ -21,8 +21,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -25,8 +25,8 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.*;
 
 /**

--- a/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/AnotherFakeApiTest.java
+++ b/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/AnotherFakeApiTest.java
@@ -30,8 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import static io.restassured.config.ObjectMapperConfig.objectMapperConfig;
 import static io.restassured.config.RestAssuredConfig.config;

--- a/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/FakeApiTest.java
+++ b/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/FakeApiTest.java
@@ -37,8 +37,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import static io.restassured.config.ObjectMapperConfig.objectMapperConfig;
 import static io.restassured.config.RestAssuredConfig.config;

--- a/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/FakeClassnameTags123ApiTest.java
+++ b/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/FakeClassnameTags123ApiTest.java
@@ -29,8 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import static io.restassured.config.ObjectMapperConfig.objectMapperConfig;
 import static io.restassured.config.RestAssuredConfig.config;

--- a/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/PetApiTest.java
@@ -32,8 +32,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import static io.restassured.config.ObjectMapperConfig.objectMapperConfig;
 import static io.restassured.config.RestAssuredConfig.config;

--- a/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/StoreApiTest.java
+++ b/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/StoreApiTest.java
@@ -29,8 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import static io.restassured.config.ObjectMapperConfig.objectMapperConfig;
 import static io.restassured.config.RestAssuredConfig.config;

--- a/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/UserApiTest.java
+++ b/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/UserApiTest.java
@@ -30,8 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.validation.constraints.*;
-import jakarta.validation.Valid;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 import static io.restassured.config.ObjectMapperConfig.objectMapperConfig;
 import static io.restassured.config.RestAssuredConfig.config;

--- a/samples/client/petstore/java/restclient-nullable-arrays/pom.xml
+++ b/samples/client/petstore/java/restclient-nullable-arrays/pom.xml
@@ -285,6 +285,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
     </properties>

--- a/samples/client/petstore/java/restclient-nullable-arrays/src/test/java/org/openapitools/client/api/DefaultApiTest.java
+++ b/samples/client/petstore/java/restclient-nullable-arrays/src/test/java/org/openapitools/client/api/DefaultApiTest.java
@@ -14,8 +14,8 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.model.ByteArrayObject;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for DefaultApi
  */
-@Ignore
+@Disabled
 public class DefaultApiTest {
 
     private final DefaultApi api = new DefaultApi();

--- a/samples/client/petstore/java/restclient-swagger2/pom.xml
+++ b/samples/client/petstore/java/restclient-swagger2/pom.xml
@@ -291,6 +291,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
     </properties>

--- a/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/AnotherFakeApiTest.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/AnotherFakeApiTest.java
@@ -14,8 +14,8 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.model.Client;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for AnotherFakeApi
  */
-@Ignore
+@Disabled
 public class AnotherFakeApiTest {
 
     private final AnotherFakeApi api = new AnotherFakeApi();

--- a/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/DefaultApiTest.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/DefaultApiTest.java
@@ -14,8 +14,8 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.model.FooGetDefaultResponse;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for DefaultApi
  */
-@Ignore
+@Disabled
 public class DefaultApiTest {
 
     private final DefaultApi api = new DefaultApi();

--- a/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/FakeApiTest.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/FakeApiTest.java
@@ -28,8 +28,8 @@ import org.openapitools.client.model.OuterObjectWithEnumProperty;
 import org.openapitools.client.model.Pet;
 import org.openapitools.client.model.TestInlineFreeformAdditionalPropertiesRequest;
 import org.openapitools.client.model.User;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for FakeApi
  */
-@Ignore
+@Disabled
 public class FakeApiTest {
 
     private final FakeApi api = new FakeApi();

--- a/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/FakeClassnameTags123ApiTest.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/FakeClassnameTags123ApiTest.java
@@ -14,8 +14,8 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.model.Client;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for FakeClassnameTags123Api
  */
-@Ignore
+@Disabled
 public class FakeClassnameTags123ApiTest {
 
     private final FakeClassnameTags123Api api = new FakeClassnameTags123Api();

--- a/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/PetApiTest.java
@@ -17,8 +17,8 @@ import java.io.File;
 import org.openapitools.client.model.ModelApiResponse;
 import org.openapitools.client.model.Pet;
 import java.util.Set;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for PetApi
  */
-@Ignore
+@Disabled
 public class PetApiTest {
 
     private final PetApi api = new PetApi();

--- a/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/StoreApiTest.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/StoreApiTest.java
@@ -14,8 +14,8 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.model.Order;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for StoreApi
  */
-@Ignore
+@Disabled
 public class StoreApiTest {
 
     private final StoreApi api = new StoreApi();

--- a/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/UserApiTest.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/test/java/org/openapitools/client/api/UserApiTest.java
@@ -15,8 +15,8 @@ package org.openapitools.client.api;
 
 import java.time.OffsetDateTime;
 import org.openapitools.client.model.User;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for UserApi
  */
-@Ignore
+@Disabled
 public class UserApiTest {
 
     private final UserApi api = new UserApi();

--- a/samples/client/petstore/java/restclient/pom.xml
+++ b/samples/client/petstore/java/restclient/pom.xml
@@ -285,6 +285,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
     </properties>

--- a/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/AnotherFakeApiTest.java
+++ b/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/AnotherFakeApiTest.java
@@ -14,8 +14,8 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.model.Client;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for AnotherFakeApi
  */
-@Ignore
+@Disabled
 public class AnotherFakeApiTest {
 
     private final AnotherFakeApi api = new AnotherFakeApi();

--- a/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/DefaultApiTest.java
+++ b/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/DefaultApiTest.java
@@ -14,8 +14,8 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.model.FooGetDefaultResponse;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for DefaultApi
  */
-@Ignore
+@Disabled
 public class DefaultApiTest {
 
     private final DefaultApi api = new DefaultApi();

--- a/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/FakeApiTest.java
+++ b/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/FakeApiTest.java
@@ -28,8 +28,8 @@ import org.openapitools.client.model.OuterObjectWithEnumProperty;
 import org.openapitools.client.model.Pet;
 import org.openapitools.client.model.TestInlineFreeformAdditionalPropertiesRequest;
 import org.openapitools.client.model.User;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for FakeApi
  */
-@Ignore
+@Disabled
 public class FakeApiTest {
 
     private final FakeApi api = new FakeApi();

--- a/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/FakeClassnameTags123ApiTest.java
+++ b/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/FakeClassnameTags123ApiTest.java
@@ -14,8 +14,8 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.model.Client;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for FakeClassnameTags123Api
  */
-@Ignore
+@Disabled
 public class FakeClassnameTags123ApiTest {
 
     private final FakeClassnameTags123Api api = new FakeClassnameTags123Api();

--- a/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/PetApiTest.java
@@ -17,8 +17,8 @@ import java.io.File;
 import org.openapitools.client.model.ModelApiResponse;
 import org.openapitools.client.model.Pet;
 import java.util.Set;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for PetApi
  */
-@Ignore
+@Disabled
 public class PetApiTest {
 
     private final PetApi api = new PetApi();

--- a/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/StoreApiTest.java
+++ b/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/StoreApiTest.java
@@ -14,8 +14,8 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.model.Order;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for StoreApi
  */
-@Ignore
+@Disabled
 public class StoreApiTest {
 
     private final StoreApi api = new StoreApi();

--- a/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/UserApiTest.java
+++ b/samples/client/petstore/java/restclient/src/test/java/org/openapitools/client/api/UserApiTest.java
@@ -15,8 +15,8 @@ package org.openapitools.client.api;
 
 import java.time.OffsetDateTime;
 import org.openapitools.client.model.User;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 /**
  * API tests for UserApi
  */
-@Ignore
+@Disabled
 public class UserApiTest {
 
     private final UserApi api = new UserApi();

--- a/samples/client/petstore/java/resttemplate-jakarta/build.gradle
+++ b/samples/client/petstore/java/resttemplate-jakarta/build.gradle
@@ -102,6 +102,7 @@ ext {
     jackson_databind_nullable_version = "0.2.6"
     spring_web_version = "6.1.5"
     jakarta_annotation_version = "2.1.1"
+    beanvalidation_version = "3.0.2"
     jodatime_version = "2.9.9"
     junit_version = "5.10.2"
 }

--- a/samples/client/petstore/java/resttemplate-jakarta/pom.xml
+++ b/samples/client/petstore/java/resttemplate-jakarta/pom.xml
@@ -280,11 +280,12 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-web-version>6.1.5</spring-web-version>
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
+        <spring-web-version>6.1.5</spring-web-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        <beanvalidation-version>3.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
     </properties>

--- a/samples/client/petstore/java/resttemplate-swagger1/build.gradle
+++ b/samples/client/petstore/java/resttemplate-swagger1/build.gradle
@@ -103,6 +103,7 @@ ext {
     jackson_databind_nullable_version = "0.2.6"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
+    beanvalidation_version = "2.0.2"
     jodatime_version = "2.9.9"
     junit_version = "5.10.2"
 }

--- a/samples/client/petstore/java/resttemplate-swagger1/pom.xml
+++ b/samples/client/petstore/java/resttemplate-swagger1/pom.xml
@@ -286,11 +286,12 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.9</swagger-annotations-version>
-        <spring-web-version>5.3.33</spring-web-version>
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
+        <spring-web-version>5.3.33</spring-web-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
     </properties>

--- a/samples/client/petstore/java/resttemplate-swagger2/build.gradle
+++ b/samples/client/petstore/java/resttemplate-swagger2/build.gradle
@@ -103,6 +103,7 @@ ext {
     jackson_databind_nullable_version = "0.2.6"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
+    beanvalidation_version = "2.0.2"
     jodatime_version = "2.9.9"
     junit_version = "5.10.2"
 }

--- a/samples/client/petstore/java/resttemplate-swagger2/pom.xml
+++ b/samples/client/petstore/java/resttemplate-swagger2/pom.xml
@@ -286,11 +286,12 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>2.2.15</swagger-annotations-version>
-        <spring-web-version>5.3.33</spring-web-version>
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
+        <spring-web-version>5.3.33</spring-web-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
     </properties>

--- a/samples/client/petstore/java/resttemplate-withXml/build.gradle
+++ b/samples/client/petstore/java/resttemplate-withXml/build.gradle
@@ -102,6 +102,7 @@ ext {
     jackson_databind_nullable_version = "0.2.6"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
+    beanvalidation_version = "2.0.2"
     jodatime_version = "2.9.9"
     junit_version = "5.10.2"
 }

--- a/samples/client/petstore/java/resttemplate-withXml/pom.xml
+++ b/samples/client/petstore/java/resttemplate-withXml/pom.xml
@@ -292,11 +292,12 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-web-version>5.3.33</spring-web-version>
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
+        <spring-web-version>5.3.33</spring-web-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
     </properties>

--- a/samples/client/petstore/java/resttemplate/build.gradle
+++ b/samples/client/petstore/java/resttemplate/build.gradle
@@ -102,6 +102,7 @@ ext {
     jackson_databind_nullable_version = "0.2.6"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
+    beanvalidation_version = "2.0.2"
     jodatime_version = "2.9.9"
     junit_version = "5.10.2"
 }

--- a/samples/client/petstore/java/resttemplate/pom.xml
+++ b/samples/client/petstore/java/resttemplate/pom.xml
@@ -280,11 +280,12 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-web-version>5.3.33</spring-web-version>
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
+        <spring-web-version>5.3.33</spring-web-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
         <junit-platform-runner.version>1.10.0</junit-platform-runner.version>
     </properties>

--- a/samples/client/petstore/java/retrofit2/pom.xml
+++ b/samples/client/petstore/java/retrofit2/pom.xml
@@ -264,6 +264,7 @@
         <swagger-annotations-version>1.6.3</swagger-annotations-version>
         <retrofit-version>2.11.0</retrofit-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <oltu-version>1.0.1</oltu-version>
         <junit-version>5.10.3</junit-version>
     </properties>

--- a/samples/client/petstore/java/retrofit2rx2/pom.xml
+++ b/samples/client/petstore/java/retrofit2rx2/pom.xml
@@ -275,6 +275,7 @@
         <retrofit-version>2.11.0</retrofit-version>
         <rxjava-version>2.1.1</rxjava-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <oltu-version>1.0.1</oltu-version>
         <junit-version>5.10.3</junit-version>
     </properties>

--- a/samples/client/petstore/java/retrofit2rx3/pom.xml
+++ b/samples/client/petstore/java/retrofit2rx3/pom.xml
@@ -275,6 +275,7 @@
         <retrofit-version>2.11.0</retrofit-version>
         <rxjava-version>3.0.4</rxjava-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <oltu-version>1.0.1</oltu-version>
         <junit-version>5.10.3</junit-version>
     </properties>

--- a/samples/client/petstore/java/webclient-jakarta/build.gradle
+++ b/samples/client/petstore/java/webclient-jakarta/build.gradle
@@ -114,6 +114,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     spring_boot_version = "3.0.12"
     jakarta_annotation_version = "2.1.1"
+    beanvalidation_version = "3.0.2"
     reactor_version = "3.5.12"
     reactor_netty_version = "1.1.13"
     jackson_version = "2.17.1"

--- a/samples/client/petstore/java/webclient-nullable-arrays/build.gradle
+++ b/samples/client/petstore/java/webclient-nullable-arrays/build.gradle
@@ -114,6 +114,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     spring_boot_version = "2.7.17"
     jakarta_annotation_version = "1.3.5"
+    beanvalidation_version = "2.0.2"
     reactor_version = "3.4.34"
     reactor_netty_version = "1.0.39"
     jackson_version = "2.17.1"

--- a/samples/client/petstore/java/webclient-swagger2/build.gradle
+++ b/samples/client/petstore/java/webclient-swagger2/build.gradle
@@ -115,6 +115,7 @@ ext {
     swagger_annotations_version = "2.2.9"
     spring_boot_version = "2.7.17"
     jakarta_annotation_version = "1.3.5"
+    beanvalidation_version = "2.0.2"
     reactor_version = "3.4.34"
     reactor_netty_version = "1.0.39"
     jackson_version = "2.17.1"

--- a/samples/client/petstore/java/webclient/build.gradle
+++ b/samples/client/petstore/java/webclient/build.gradle
@@ -114,6 +114,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     spring_boot_version = "2.7.17"
     jakarta_annotation_version = "1.3.5"
+    beanvalidation_version = "2.0.2"
     reactor_version = "3.4.34"
     reactor_netty_version = "1.0.39"
     jackson_version = "2.17.1"

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/pom.xml
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/pom.xml
@@ -333,6 +333,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>
         <spotless.version>2.21.0</spotless.version>
     </properties>

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/pom.xml
@@ -333,6 +333,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>
         <spotless.version>2.21.0</spotless.version>
     </properties>

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/pom.xml
@@ -344,6 +344,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>
         <scribejava-apis-version>8.3.3</scribejava-apis-version>
         <spotless.version>2.21.0</spotless.version>

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/pom.xml
@@ -344,6 +344,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>
         <scribejava-apis-version>8.3.3</scribejava-apis-version>
         <spotless.version>2.21.0</spotless.version>

--- a/samples/openapi3/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/pom.xml
@@ -343,6 +343,7 @@
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>
         <http-signature-version>1.8</http-signature-version>
         <scribejava-apis-version>8.3.3</scribejava-apis-version>


### PR DESCRIPTION
Fixes #19398 and #19437

For context, `useJakartaEe` previously only determined the javax/jakarta imports for validation-api, not the maven Jakarta dependency version (that only worked for annotation-api).

#18332 and #19171 aligned the validation-api to use `jakarta.*` package as a previous commit had already upgraded the validation-api version to 3.x. Unfortunately this caused a regression as end users can manually specify 2.x, in which case they would still need the `javax.*` package. This partially reverts those changes and once again makes the javax/jakarta package configurable.

This PR allows the use of `useJakartaEe` flag in the same way Jakarta annotation-api switches between `javax.*` and `jakarta.*` packages. This also switches between `jakarta.validation-api` 2 and 3 so the correct dependencies are included.

Note that it only applies to generators in `Java/libraries`

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)



