### PR TITLE
[PHP-Client] Allow Content-Type merge-match+json for encoding

### DIFF
--- a/.ddev/web-build/Dockerfile.maven
+++ b/.ddev/web-build/Dockerfile.maven
@@ -1,0 +1,1 @@
+RUN apt update && apt install -y maven

--- a/modules/openapi-generator/src/main/resources/php/HeaderSelector.mustache
+++ b/modules/openapi-generator/src/main/resources/php/HeaderSelector.mustache
@@ -76,7 +76,7 @@ class HeaderSelector
         }
 
         # If none of the available Accept headers is of type "json", then just use all them
-        $headersWithJson = preg_grep('~(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$~', $accept);
+        $headersWithJson = $this->selectJsonMimeList($accept);
         if (count($headersWithJson) === 0) {
             return implode(',', $accept);
         }
@@ -85,6 +85,34 @@ class HeaderSelector
         # to give the highest priority to json-like headers - recalculating the existing ones, if needed
         return $this->getAcceptHeaderWithAdjustedWeight($accept, $headersWithJson);
     }
+
+    /**
+    * Detects whether a string contains a valid JSON mime type
+    *
+    * @param string $searchString
+    * @return bool
+    */
+    public function isJsonMime(string $searchString): bool
+    {
+        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $searchString) === 1;
+    }
+    
+    /**
+    * Select all items from a list containing a JSON mime type
+    *
+    * @param array $mimeList
+    * @return array
+    */
+    private function selectJsonMimeList(array $mimeList): array {
+        $jsonMimeList = [];
+        foreach ($mimeList as $mime) {
+            if($this->isJsonMime($mime)) {
+                $jsonMimeList[] = $mime;
+            }
+        }
+        return $jsonMimeList;
+    }
+
 
     /**
     * Create an Accept header string from the given "Accept" headers array, recalculating all weights

--- a/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
@@ -780,12 +780,7 @@ use function sprintf;
 
     private function bodyShouldBeEncoded(string $contentType): bool 
     {        
-        foreach(self::JSON_FORMATS as $format) {
-            if(stripos($contentType, $format) !== false) {
-               return true;
-            }
-        }
-        return false;
+        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
@@ -613,7 +613,7 @@ use function sprintf;
         // for model (json/xml)
         {{#bodyParams}}
         if (isset(${{paramName}})) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization(${{paramName}}));
             } else {
                 $httpBody = ${{paramName}};
@@ -637,7 +637,7 @@ use function sprintf;
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -770,7 +770,13 @@ use function sprintf;
         return $uri;
     }
 
-    private function bodyShouldBeEncoded(string $contentType): bool 
+    /**
+     * Detects whether the string contains a valid JSON mime type
+     * 
+     * @param string $contentType
+     * @return bool
+     */
+    private function isJsonMime(string $contentType): bool 
     {        
         return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }

--- a/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
@@ -94,14 +94,6 @@ use function sprintf;
      */
     protected $streamFactory;
     
-    /**
-     * @var string[]
-     */
-    public const JSON_FORMATS = [
-        'application/merge-patch+json', 
-        'application/json',
-    ]; 
-
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,

--- a/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
@@ -93,7 +93,7 @@ use function sprintf;
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
-    
+
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,

--- a/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
@@ -93,6 +93,14 @@ use function sprintf;
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
+    
+    /**
+     * @var string[]
+     */
+    public const JSON_FORMATS = [
+        'application/merge-patch+json', 
+        'application/json',
+    ]; 
 
     public function __construct(
         ClientInterface $httpClient = null,
@@ -613,7 +621,7 @@ use function sprintf;
         // for model (json/xml)
         {{#bodyParams}}
         if (isset(${{paramName}})) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization(${{paramName}}));
             } else {
                 $httpBody = ${{paramName}};
@@ -637,7 +645,7 @@ use function sprintf;
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -768,6 +776,16 @@ use function sprintf;
         }
 
         return $uri;
+    }
+
+    private function bodyShouldBeEncoded(string $contentType): bool 
+    {        
+        foreach(self::JSON_FORMATS as $format) {
+            if(stripos($contentType, $format) !== false) {
+               return true;
+            }
+        }
+        return false;
     }
 }
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
@@ -613,7 +613,7 @@ use function sprintf;
         // for model (json/xml)
         {{#bodyParams}}
         if (isset(${{paramName}})) {
-            if ($this->isJsonMime($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization(${{paramName}}));
             } else {
                 $httpBody = ${{paramName}};
@@ -637,7 +637,7 @@ use function sprintf;
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->isJsonMime($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -768,17 +768,6 @@ use function sprintf;
         }
 
         return $uri;
-    }
-
-    /**
-     * Detects whether the string contains a valid JSON mime type
-     * 
-     * @param string $contentType
-     * @return bool
-     */
-    private function isJsonMime(string $contentType): bool 
-    {        
-        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }
 {{/operations}}

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/HeaderSelector.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/HeaderSelector.php
@@ -85,7 +85,7 @@ class HeaderSelector
         }
 
         # If none of the available Accept headers is of type "json", then just use all them
-        $headersWithJson = preg_grep('~(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$~', $accept);
+        $headersWithJson = $this->selectJsonMimeList($accept);
         if (count($headersWithJson) === 0) {
             return implode(',', $accept);
         }
@@ -94,6 +94,34 @@ class HeaderSelector
         # to give the highest priority to json-like headers - recalculating the existing ones, if needed
         return $this->getAcceptHeaderWithAdjustedWeight($accept, $headersWithJson);
     }
+
+    /**
+    * Detects whether a string contains a valid JSON mime type
+    *
+    * @param string $searchString
+    * @return bool
+    */
+    public function isJsonMime(string $searchString): bool
+    {
+        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $searchString) === 1;
+    }
+    
+    /**
+    * Select all items from a list containing a JSON mime type
+    *
+    * @param array $mimeList
+    * @return array
+    */
+    private function selectJsonMimeList(array $mimeList): array {
+        $jsonMimeList = [];
+        foreach ($mimeList as $mime) {
+            if($this->isJsonMime($mime)) {
+                $jsonMimeList[] = $mime;
+            }
+        }
+        return $jsonMimeList;
+    }
+
 
     /**
     * Create an Accept header string from the given "Accept" headers array, recalculating all weights

--- a/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
@@ -102,7 +102,7 @@ class AnotherFakeApi
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
-    
+
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,
@@ -376,7 +376,7 @@ class AnotherFakeApi
 
         // for model (json/xml)
         if (isset($client)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($client));
             } else {
                 $httpBody = $client;
@@ -396,7 +396,7 @@ class AnotherFakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -488,10 +488,5 @@ class AnotherFakeApi
         }
 
         return $uri;
-    }
-
-    private function bodyShouldBeEncoded(string $contentType): bool 
-    {        
-        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
@@ -500,11 +500,6 @@ class AnotherFakeApi
 
     private function bodyShouldBeEncoded(string $contentType): bool 
     {        
-        foreach(self::JSON_FORMATS as $format) {
-            if(stripos($contentType, $format) !== false) {
-               return true;
-            }
-        }
-        return false;
+        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
@@ -103,14 +103,6 @@ class AnotherFakeApi
      */
     protected $streamFactory;
     
-    /**
-     * @var string[]
-     */
-    public const JSON_FORMATS = [
-        'application/merge-patch+json', 
-        'application/json',
-    ]; 
-
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,

--- a/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
@@ -102,6 +102,14 @@ class AnotherFakeApi
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
+    
+    /**
+     * @var string[]
+     */
+    public const JSON_FORMATS = [
+        'application/merge-patch+json', 
+        'application/json',
+    ]; 
 
     public function __construct(
         ClientInterface $httpClient = null,
@@ -376,7 +384,7 @@ class AnotherFakeApi
 
         // for model (json/xml)
         if (isset($client)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($client));
             } else {
                 $httpBody = $client;
@@ -396,7 +404,7 @@ class AnotherFakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -488,5 +496,15 @@ class AnotherFakeApi
         }
 
         return $uri;
+    }
+
+    private function bodyShouldBeEncoded(string $contentType): bool 
+    {        
+        foreach(self::JSON_FORMATS as $format) {
+            if(stripos($contentType, $format) !== false) {
+               return true;
+            }
+        }
+        return false;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
@@ -103,14 +103,6 @@ class DefaultApi
      */
     protected $streamFactory;
     
-    /**
-     * @var string[]
-     */
-    public const JSON_FORMATS = [
-        'application/merge-patch+json', 
-        'application/json',
-    ]; 
-
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,

--- a/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
@@ -102,6 +102,14 @@ class DefaultApi
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
+    
+    /**
+     * @var string[]
+     */
+    public const JSON_FORMATS = [
+        'application/merge-patch+json', 
+        'application/json',
+    ]; 
 
     public function __construct(
         ClientInterface $httpClient = null,
@@ -371,7 +379,7 @@ class DefaultApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -463,5 +471,15 @@ class DefaultApi
         }
 
         return $uri;
+    }
+
+    private function bodyShouldBeEncoded(string $contentType): bool 
+    {        
+        foreach(self::JSON_FORMATS as $format) {
+            if(stripos($contentType, $format) !== false) {
+               return true;
+            }
+        }
+        return false;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
@@ -475,11 +475,6 @@ class DefaultApi
 
     private function bodyShouldBeEncoded(string $contentType): bool 
     {        
-        foreach(self::JSON_FORMATS as $format) {
-            if(stripos($contentType, $format) !== false) {
-               return true;
-            }
-        }
-        return false;
+        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
@@ -102,7 +102,7 @@ class DefaultApi
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
-    
+
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,
@@ -371,7 +371,7 @@ class DefaultApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -463,10 +463,5 @@ class DefaultApi
         }
 
         return $uri;
-    }
-
-    private function bodyShouldBeEncoded(string $contentType): bool 
-    {        
-        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
@@ -102,7 +102,7 @@ class FakeApi
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
-    
+
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,
@@ -371,7 +371,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -606,7 +606,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -818,7 +818,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($pet)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($pet));
             } else {
                 $httpBody = $pet;
@@ -838,7 +838,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1056,7 +1056,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($body)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($body));
             } else {
                 $httpBody = $body;
@@ -1076,7 +1076,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1294,7 +1294,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($outer_composite)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($outer_composite));
             } else {
                 $httpBody = $outer_composite;
@@ -1314,7 +1314,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1532,7 +1532,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($body)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($body));
             } else {
                 $httpBody = $body;
@@ -1552,7 +1552,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1770,7 +1770,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($body)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($body));
             } else {
                 $httpBody = $body;
@@ -1790,7 +1790,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2014,7 +2014,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($outer_object_with_enum_property)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($outer_object_with_enum_property));
             } else {
                 $httpBody = $outer_object_with_enum_property;
@@ -2034,7 +2034,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2313,7 +2313,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2500,7 +2500,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($request_body)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($request_body));
             } else {
                 $httpBody = $request_body;
@@ -2520,7 +2520,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2699,7 +2699,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($body)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($body));
             } else {
                 $httpBody = $body;
@@ -2719,7 +2719,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2898,7 +2898,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($file_schema_test_class)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($file_schema_test_class));
             } else {
                 $httpBody = $file_schema_test_class;
@@ -2918,7 +2918,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -3119,7 +3119,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -3139,7 +3139,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -3371,7 +3371,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($client)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($client));
             } else {
                 $httpBody = $client;
@@ -3391,7 +3391,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -3786,7 +3786,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -4099,7 +4099,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -4407,7 +4407,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -4598,7 +4598,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($request_body)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($request_body));
             } else {
                 $httpBody = $request_body;
@@ -4618,7 +4618,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -4805,7 +4805,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($test_inline_freeform_additional_properties_request)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($test_inline_freeform_additional_properties_request));
             } else {
                 $httpBody = $test_inline_freeform_additional_properties_request;
@@ -4825,7 +4825,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -5045,7 +5045,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -5359,7 +5359,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -5546,7 +5546,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($request_body)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($request_body));
             } else {
                 $httpBody = $request_body;
@@ -5566,7 +5566,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -5658,10 +5658,5 @@ class FakeApi
         }
 
         return $uri;
-    }
-
-    private function bodyShouldBeEncoded(string $contentType): bool 
-    {        
-        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
@@ -103,14 +103,6 @@ class FakeApi
      */
     protected $streamFactory;
     
-    /**
-     * @var string[]
-     */
-    public const JSON_FORMATS = [
-        'application/merge-patch+json', 
-        'application/json',
-    ]; 
-
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
@@ -102,6 +102,14 @@ class FakeApi
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
+    
+    /**
+     * @var string[]
+     */
+    public const JSON_FORMATS = [
+        'application/merge-patch+json', 
+        'application/json',
+    ]; 
 
     public function __construct(
         ClientInterface $httpClient = null,
@@ -371,7 +379,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -606,7 +614,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -818,7 +826,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($pet)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($pet));
             } else {
                 $httpBody = $pet;
@@ -838,7 +846,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1056,7 +1064,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($body)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($body));
             } else {
                 $httpBody = $body;
@@ -1076,7 +1084,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1294,7 +1302,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($outer_composite)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($outer_composite));
             } else {
                 $httpBody = $outer_composite;
@@ -1314,7 +1322,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1532,7 +1540,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($body)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($body));
             } else {
                 $httpBody = $body;
@@ -1552,7 +1560,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1770,7 +1778,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($body)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($body));
             } else {
                 $httpBody = $body;
@@ -1790,7 +1798,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2014,7 +2022,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($outer_object_with_enum_property)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($outer_object_with_enum_property));
             } else {
                 $httpBody = $outer_object_with_enum_property;
@@ -2034,7 +2042,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2313,7 +2321,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2500,7 +2508,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($request_body)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($request_body));
             } else {
                 $httpBody = $request_body;
@@ -2520,7 +2528,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2699,7 +2707,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($body)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($body));
             } else {
                 $httpBody = $body;
@@ -2719,7 +2727,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2898,7 +2906,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($file_schema_test_class)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($file_schema_test_class));
             } else {
                 $httpBody = $file_schema_test_class;
@@ -2918,7 +2926,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -3119,7 +3127,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -3139,7 +3147,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -3371,7 +3379,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($client)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($client));
             } else {
                 $httpBody = $client;
@@ -3391,7 +3399,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -3786,7 +3794,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -4099,7 +4107,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -4407,7 +4415,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -4598,7 +4606,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($request_body)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($request_body));
             } else {
                 $httpBody = $request_body;
@@ -4618,7 +4626,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -4805,7 +4813,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($test_inline_freeform_additional_properties_request)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($test_inline_freeform_additional_properties_request));
             } else {
                 $httpBody = $test_inline_freeform_additional_properties_request;
@@ -4825,7 +4833,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -5045,7 +5053,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -5359,7 +5367,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -5546,7 +5554,7 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($request_body)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($request_body));
             } else {
                 $httpBody = $request_body;
@@ -5566,7 +5574,7 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -5658,5 +5666,15 @@ class FakeApi
         }
 
         return $uri;
+    }
+
+    private function bodyShouldBeEncoded(string $contentType): bool 
+    {        
+        foreach(self::JSON_FORMATS as $format) {
+            if(stripos($contentType, $format) !== false) {
+               return true;
+            }
+        }
+        return false;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
@@ -5670,11 +5670,6 @@ class FakeApi
 
     private function bodyShouldBeEncoded(string $contentType): bool 
     {        
-        foreach(self::JSON_FORMATS as $format) {
-            if(stripos($contentType, $format) !== false) {
-               return true;
-            }
-        }
-        return false;
+        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
@@ -102,7 +102,7 @@ class FakeClassnameTags123Api
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
-    
+
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,
@@ -376,7 +376,7 @@ class FakeClassnameTags123Api
 
         // for model (json/xml)
         if (isset($client)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($client));
             } else {
                 $httpBody = $client;
@@ -396,7 +396,7 @@ class FakeClassnameTags123Api
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -493,10 +493,5 @@ class FakeClassnameTags123Api
         }
 
         return $uri;
-    }
-
-    private function bodyShouldBeEncoded(string $contentType): bool 
-    {        
-        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
@@ -102,6 +102,14 @@ class FakeClassnameTags123Api
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
+    
+    /**
+     * @var string[]
+     */
+    public const JSON_FORMATS = [
+        'application/merge-patch+json', 
+        'application/json',
+    ]; 
 
     public function __construct(
         ClientInterface $httpClient = null,
@@ -376,7 +384,7 @@ class FakeClassnameTags123Api
 
         // for model (json/xml)
         if (isset($client)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($client));
             } else {
                 $httpBody = $client;
@@ -396,7 +404,7 @@ class FakeClassnameTags123Api
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -493,5 +501,15 @@ class FakeClassnameTags123Api
         }
 
         return $uri;
+    }
+
+    private function bodyShouldBeEncoded(string $contentType): bool 
+    {        
+        foreach(self::JSON_FORMATS as $format) {
+            if(stripos($contentType, $format) !== false) {
+               return true;
+            }
+        }
+        return false;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
@@ -505,11 +505,6 @@ class FakeClassnameTags123Api
 
     private function bodyShouldBeEncoded(string $contentType): bool 
     {        
-        foreach(self::JSON_FORMATS as $format) {
-            if(stripos($contentType, $format) !== false) {
-               return true;
-            }
-        }
-        return false;
+        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
@@ -103,14 +103,6 @@ class FakeClassnameTags123Api
      */
     protected $streamFactory;
     
-    /**
-     * @var string[]
-     */
-    public const JSON_FORMATS = [
-        'application/merge-patch+json', 
-        'application/json',
-    ]; 
-
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,

--- a/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
@@ -102,6 +102,14 @@ class PetApi
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
+    
+    /**
+     * @var string[]
+     */
+    public const JSON_FORMATS = [
+        'application/merge-patch+json', 
+        'application/json',
+    ]; 
 
     public function __construct(
         ClientInterface $httpClient = null,
@@ -356,7 +364,7 @@ class PetApi
 
         // for model (json/xml)
         if (isset($pet)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($pet));
             } else {
                 $httpBody = $pet;
@@ -376,7 +384,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -602,7 +610,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -859,7 +867,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1117,7 +1125,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1375,7 +1383,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1592,7 +1600,7 @@ class PetApi
 
         // for model (json/xml)
         if (isset($pet)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($pet));
             } else {
                 $httpBody = $pet;
@@ -1612,7 +1620,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1847,7 +1855,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2131,7 +2139,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2421,7 +2429,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2517,5 +2525,15 @@ class PetApi
         }
 
         return $uri;
+    }
+
+    private function bodyShouldBeEncoded(string $contentType): bool 
+    {        
+        foreach(self::JSON_FORMATS as $format) {
+            if(stripos($contentType, $format) !== false) {
+               return true;
+            }
+        }
+        return false;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
@@ -2529,11 +2529,6 @@ class PetApi
 
     private function bodyShouldBeEncoded(string $contentType): bool 
     {        
-        foreach(self::JSON_FORMATS as $format) {
-            if(stripos($contentType, $format) !== false) {
-               return true;
-            }
-        }
-        return false;
+        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
@@ -103,14 +103,6 @@ class PetApi
      */
     protected $streamFactory;
     
-    /**
-     * @var string[]
-     */
-    public const JSON_FORMATS = [
-        'application/merge-patch+json', 
-        'application/json',
-    ]; 
-
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,

--- a/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
@@ -102,7 +102,7 @@ class PetApi
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
-    
+
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,
@@ -356,7 +356,7 @@ class PetApi
 
         // for model (json/xml)
         if (isset($pet)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($pet));
             } else {
                 $httpBody = $pet;
@@ -376,7 +376,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -602,7 +602,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -859,7 +859,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1117,7 +1117,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1375,7 +1375,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1592,7 +1592,7 @@ class PetApi
 
         // for model (json/xml)
         if (isset($pet)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($pet));
             } else {
                 $httpBody = $pet;
@@ -1612,7 +1612,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1847,7 +1847,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2131,7 +2131,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2421,7 +2421,7 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2517,10 +2517,5 @@ class PetApi
         }
 
         return $uri;
-    }
-
-    private function bodyShouldBeEncoded(string $contentType): bool 
-    {        
-        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
@@ -102,6 +102,14 @@ class StoreApi
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
+    
+    /**
+     * @var string[]
+     */
+    public const JSON_FORMATS = [
+        'application/merge-patch+json', 
+        'application/json',
+    ]; 
 
     public function __construct(
         ClientInterface $httpClient = null,
@@ -353,7 +361,7 @@ class StoreApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -588,7 +596,7 @@ class StoreApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -854,7 +862,7 @@ class StoreApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1086,7 +1094,7 @@ class StoreApi
 
         // for model (json/xml)
         if (isset($order)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($order));
             } else {
                 $httpBody = $order;
@@ -1106,7 +1114,7 @@ class StoreApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1198,5 +1206,15 @@ class StoreApi
         }
 
         return $uri;
+    }
+
+    private function bodyShouldBeEncoded(string $contentType): bool 
+    {        
+        foreach(self::JSON_FORMATS as $format) {
+            if(stripos($contentType, $format) !== false) {
+               return true;
+            }
+        }
+        return false;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
@@ -1210,11 +1210,6 @@ class StoreApi
 
     private function bodyShouldBeEncoded(string $contentType): bool 
     {        
-        foreach(self::JSON_FORMATS as $format) {
-            if(stripos($contentType, $format) !== false) {
-               return true;
-            }
-        }
-        return false;
+        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
@@ -102,7 +102,7 @@ class StoreApi
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
-    
+
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,
@@ -353,7 +353,7 @@ class StoreApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -588,7 +588,7 @@ class StoreApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -854,7 +854,7 @@ class StoreApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1086,7 +1086,7 @@ class StoreApi
 
         // for model (json/xml)
         if (isset($order)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($order));
             } else {
                 $httpBody = $order;
@@ -1106,7 +1106,7 @@ class StoreApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1198,10 +1198,5 @@ class StoreApi
         }
 
         return $uri;
-    }
-
-    private function bodyShouldBeEncoded(string $contentType): bool 
-    {        
-        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
@@ -103,14 +103,6 @@ class StoreApi
      */
     protected $streamFactory;
     
-    /**
-     * @var string[]
-     */
-    public const JSON_FORMATS = [
-        'application/merge-patch+json', 
-        'application/json',
-    ]; 
-
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,

--- a/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
@@ -2027,11 +2027,6 @@ class UserApi
 
     private function bodyShouldBeEncoded(string $contentType): bool 
     {        
-        foreach(self::JSON_FORMATS as $format) {
-            if(stripos($contentType, $format) !== false) {
-               return true;
-            }
-        }
-        return false;
+        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
@@ -102,6 +102,14 @@ class UserApi
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
+    
+    /**
+     * @var string[]
+     */
+    public const JSON_FORMATS = [
+        'application/merge-patch+json', 
+        'application/json',
+    ]; 
 
     public function __construct(
         ClientInterface $httpClient = null,
@@ -331,7 +339,7 @@ class UserApi
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -351,7 +359,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -538,7 +546,7 @@ class UserApi
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -558,7 +566,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -745,7 +753,7 @@ class UserApi
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -765,7 +773,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -974,7 +982,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1228,7 +1236,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1507,7 +1515,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1697,7 +1705,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1903,7 +1911,7 @@ class UserApi
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -1923,7 +1931,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2015,5 +2023,15 @@ class UserApi
         }
 
         return $uri;
+    }
+
+    private function bodyShouldBeEncoded(string $contentType): bool 
+    {        
+        foreach(self::JSON_FORMATS as $format) {
+            if(stripos($contentType, $format) !== false) {
+               return true;
+            }
+        }
+        return false;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
@@ -103,14 +103,6 @@ class UserApi
      */
     protected $streamFactory;
     
-    /**
-     * @var string[]
-     */
-    public const JSON_FORMATS = [
-        'application/merge-patch+json', 
-        'application/json',
-    ]; 
-
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,

--- a/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
@@ -102,7 +102,7 @@ class UserApi
      * @var StreamFactoryInterface
      */
     protected $streamFactory;
-    
+
     public function __construct(
         ClientInterface $httpClient = null,
         Configuration $config = null,
@@ -331,7 +331,7 @@ class UserApi
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -351,7 +351,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -538,7 +538,7 @@ class UserApi
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -558,7 +558,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -745,7 +745,7 @@ class UserApi
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -765,7 +765,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -974,7 +974,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1228,7 +1228,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1507,7 +1507,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1697,7 +1697,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -1903,7 +1903,7 @@ class UserApi
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            if ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -1923,7 +1923,7 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($this->bodyShouldBeEncoded($headers['Content-Type'])) {
+            } elseif ($this->headerSelector->isJsonMime($headers['Content-Type'])) {
                 $httpBody = json_encode($formParams);
 
             } else {
@@ -2015,10 +2015,5 @@ class UserApi
         }
 
         return $uri;
-    }
-
-    private function bodyShouldBeEncoded(string $contentType): bool 
-    {        
-        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $contentType) === 1;
     }
 }

--- a/samples/client/petstore/php/psr-18/lib/HeaderSelector.php
+++ b/samples/client/petstore/php/psr-18/lib/HeaderSelector.php
@@ -85,7 +85,7 @@ class HeaderSelector
         }
 
         # If none of the available Accept headers is of type "json", then just use all them
-        $headersWithJson = preg_grep('~(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$~', $accept);
+        $headersWithJson = $this->selectJsonMimeList($accept);
         if (count($headersWithJson) === 0) {
             return implode(',', $accept);
         }
@@ -94,6 +94,34 @@ class HeaderSelector
         # to give the highest priority to json-like headers - recalculating the existing ones, if needed
         return $this->getAcceptHeaderWithAdjustedWeight($accept, $headersWithJson);
     }
+
+    /**
+    * Detects whether a string contains a valid JSON mime type
+    *
+    * @param string $searchString
+    * @return bool
+    */
+    public function isJsonMime(string $searchString): bool
+    {
+        return preg_match('~^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)~', $searchString) === 1;
+    }
+    
+    /**
+    * Select all items from a list containing a JSON mime type
+    *
+    * @param array $mimeList
+    * @return array
+    */
+    private function selectJsonMimeList(array $mimeList): array {
+        $jsonMimeList = [];
+        foreach ($mimeList as $mime) {
+            if($this->isJsonMime($mime)) {
+                $jsonMimeList[] = $mime;
+            }
+        }
+        return $jsonMimeList;
+    }
+
 
     /**
     * Create an Accept header string from the given "Accept" headers array, recalculating all weights


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Some APIs offer a PATCH-Request method for Entities and use "application/merge-patch+json" as Content-Type. This was not detected as json_encode and ObjectSerializer target and thus resultet in an Exception,

```
Nyholm\Psr7\Request::withBody(): Argument #1 ($body) must be of type Psr\Http\Message\StreamInterface, _XXX__ given, called in XXX
```

This PR fixes this.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier , @dkarlovi , @mandrean , @jfastnacht , @ybelenko , @renepardon 