### PR TITLE
bugfix: use the correct key when generating auth example in readme

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/README.mustache
+++ b/modules/openapi-generator/src/main/resources/go/README.mustache
@@ -109,7 +109,7 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: {{{keyParamName}}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 
-Note, each API key must be added to a map of `map[string]APIKey` where the key is: {{keyParamName}} and passed in as the auth context for each request.
+Note, each API key must be added to a map of `map[string]APIKey` where the key is: {{name}} and passed in as the auth context for each request.
 
 Example
 
@@ -118,7 +118,7 @@ auth := context.WithValue(
 		context.Background(),
 		{{packageName}}.ContextAPIKeys,
 		map[string]{{packageName}}.APIKey{
-			"{{keyParamName}}": {Key: "API_KEY_STRING"},
+			"{{name}}": {Key: "API_KEY_STRING"},
 		},
 	)
 r, err := client.Service.Operation(auth, args)

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/README.md
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/README.md
@@ -98,7 +98,7 @@ Authentication schemes defined for the API:
 - **API key parameter name**: X-Api-Key
 - **Location**: HTTP header
 
-Note, each API key must be added to a map of `map[string]APIKey` where the key is: X-Api-Key and passed in as the auth context for each request.
+Note, each API key must be added to a map of `map[string]APIKey` where the key is: api_key and passed in as the auth context for each request.
 
 Example
 
@@ -107,7 +107,7 @@ auth := context.WithValue(
 		context.Background(),
 		x_auth_id_alias.ContextAPIKeys,
 		map[string]x_auth_id_alias.APIKey{
-			"X-Api-Key": {Key: "API_KEY_STRING"},
+			"api_key": {Key: "API_KEY_STRING"},
 		},
 	)
 r, err := client.Service.Operation(auth, args)
@@ -119,7 +119,7 @@ r, err := client.Service.Operation(auth, args)
 - **API key parameter name**: api_key
 - **Location**: URL query string
 
-Note, each API key must be added to a map of `map[string]APIKey` where the key is: api_key and passed in as the auth context for each request.
+Note, each API key must be added to a map of `map[string]APIKey` where the key is: api_key_query and passed in as the auth context for each request.
 
 Example
 
@@ -128,7 +128,7 @@ auth := context.WithValue(
 		context.Background(),
 		x_auth_id_alias.ContextAPIKeys,
 		map[string]x_auth_id_alias.APIKey{
-			"api_key": {Key: "API_KEY_STRING"},
+			"api_key_query": {Key: "API_KEY_STRING"},
 		},
 	)
 r, err := client.Service.Operation(auth, args)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Generates a working example of api key auth in README.md.

cc @antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5

closes #19490

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
