### PR TITLE
[dart-dio] Fix dictionary/map deserialization, fixes #19495

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/deserialize.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/deserialize.mustache
@@ -52,13 +52,13 @@ final _regMap = RegExp(r'^Map<String,(.*)>$');
               .toSet() as ReturnType;
           }
           if (value is Map && (match = _regMap.firstMatch(targetType)) != null) {
-            targetType = match![1]!; // ignore: parameter_assignments
-            return Map<dynamic, BaseType>.fromIterables(
-              value.keys,
+            targetType = match![1]!.trim(); // ignore: parameter_assignments
+            return Map<String, BaseType>.fromIterables(
+              value.keys as Iterable<String>,
               value.values.map((dynamic v) => deserialize<BaseType, BaseType>(v, targetType, growable: growable)),
             ) as ReturnType;
           }
           break;
-    } 
+    }
     throw Exception('Cannot deserialize');
   }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/deserialize.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/deserialize.dart
@@ -183,13 +183,13 @@ final _regMap = RegExp(r'^Map<String,(.*)>$');
               .toSet() as ReturnType;
           }
           if (value is Map && (match = _regMap.firstMatch(targetType)) != null) {
-            targetType = match![1]!; // ignore: parameter_assignments
-            return Map<dynamic, BaseType>.fromIterables(
-              value.keys,
+            targetType = match![1]!.trim(); // ignore: parameter_assignments
+            return Map<String, BaseType>.fromIterables(
+              value.keys as Iterable<String>,
               value.values.map((dynamic v) => deserialize<BaseType, BaseType>(v, targetType, growable: growable)),
             ) as ReturnType;
           }
           break;
-    } 
+    }
     throw Exception('Cannot deserialize');
   }


### PR DESCRIPTION
To fix #19495, to allow deserialization of dictionary/map response types.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
