### PR TITLE
[typescript-fetch] Fixed issue where unique arrays (sets) of primitive values aren't initialized properly 

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -56,10 +56,10 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{#isPrimitiveType}}
         {{#isArray}}
         {{#uniqueItems}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}new Set(json['{{baseName}}']),{{/required}}
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set(json['{{baseName}}']),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}json['{{baseName}}'],{{/required}}
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}json['{{baseName}}'],
         {{/uniqueItems}}
         {{/isArray}}
         {{^isArray}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -59,7 +59,7 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}new Set(json['{{baseName}}']),{{/required}}
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}(json['{{baseName}}'] as Array<any>),{{/required}}
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}json['{{baseName}}'],{{/required}}
         {{/uniqueItems}}
         {{/isArray}}
         {{^isArray}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -54,6 +54,15 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{/additionalPropertiesType}}
         {{#vars}}
         {{#isPrimitiveType}}
+        {{#isArray}}
+        {{#uniqueItems}}
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}new Set(json['{{baseName}}']),{{/required}}
+        {{/uniqueItems}}
+        {{^uniqueItems}}
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}(json['{{baseName}}'] as Array<any>),{{/required}}
+        {{/uniqueItems}}
+        {{/isArray}}
+        {{^isArray}}
         {{#isDateType}}
         '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
         {{/isDateType}}
@@ -65,6 +74,7 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}json['{{baseName}}'],
         {{/isDateTimeType}}
         {{/isDateType}}
+        {{/isArray}}
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isArray}}

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
@@ -104,7 +104,7 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'id': json['id'] == null ? undefined : json['id'],
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
-        'photoUrls': json['photoUrls'],
+        'photoUrls': new Set(json['photoUrls']),
         'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'] == null ? undefined : json['status'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
@@ -104,7 +104,7 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'id': json['id'] == null ? undefined : json['id'],
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
-        'photoUrls': json['photoUrls'],
+        'photoUrls': new Set(json['photoUrls']),
         'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'] == null ? undefined : json['status'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
@@ -105,7 +105,7 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'id': json['id'] == null ? undefined : json['id'],
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
-        'photoUrls': json['photoUrls'],
+        'photoUrls': new Set(json['photoUrls']),
         'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'] == null ? undefined : json['status'],
     };


### PR DESCRIPTION
Resolves https://github.com/OpenAPITools/openapi-generator/issues/19520 

This PR aims to fix the above bug, by ensuring that set properties from API responses are correctly initialized as sets instead of being passed directly as arrays. 

### Explanation of the `modelGeneric.mustache` change

`isPrimitiveType` appears to be true for arrays which contain primitives, not just for primitives themselves. Because of the template conditions, this means that arrays of primitives were being passed verbatim from the API response. 

This logic is fine for regular arrays, but for sets this causes a problem, as the values aren't being converted to a `Set` after being retrieved from the API. This leads to issues where the client thinks the property is a `Set`, but it's actually an array. The outcome of this is that accessing `Set` members such as `size` won't work at runtime, but trying to access `length` will cause a TypeScript compilation error. 

This PR aims to fix this problem by adjusting the logic in `modelGeneric.mustache` to correctly handle arrays of primitives which contain unique items. 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
