### PR TITLE
Fix for #15736 [TYPESCRIPT-FETCH] Subclassing components using discri…

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -286,7 +286,7 @@ export class {{classname}} extends runtime.BaseAPI {
             {{#bodyParam}}
             {{#isContainer}}
             {{^withoutRuntimeChecks}}
-            body: requestParameters['{{paramName}}']{{#isArray}}{{#items}}{{^isPrimitiveType}}!.map({{datatype}}ToJSON){{/isPrimitiveType}}{{/items}}{{/isArray}},
+            body: requestParameters['{{paramName}}']{{#isArray}}{{#items}}{{^isPrimitiveType}}!.map(x => {{datatype}}ToJSON(x)){{/isPrimitiveType}}{{/items}}{{/isArray}},
             {{/withoutRuntimeChecks}}
             {{#withoutRuntimeChecks}}
             body: requestParameters['{{paramName}}'],

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -286,7 +286,7 @@ export class {{classname}} extends runtime.BaseAPI {
             {{#bodyParam}}
             {{#isContainer}}
             {{^withoutRuntimeChecks}}
-            body: requestParameters['{{paramName}}']{{#isArray}}{{#items}}{{^isPrimitiveType}}!.map(x => {{datatype}}ToJSON(x)){{/isPrimitiveType}}{{/items}}{{/isArray}},
+            body: requestParameters['{{paramName}}']{{#isArray}}{{#items}}{{^isPrimitiveType}}!.map({{datatype}}ToJSON){{/isPrimitiveType}}{{/items}}{{/isArray}},
             {{/withoutRuntimeChecks}}
             {{#withoutRuntimeChecks}}
             body: requestParameters['{{paramName}}'],

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -22,3 +22,7 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
 export function {{classname}}ToJSON(value?: {{classname}} | null): any {
     return value as any;
 }
+
+export function {{classname}}ToJSONTyped(value: any, ignoreDiscriminator: boolean): {{classname}} {
+    return value as {{classname}};
+}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -12,7 +12,7 @@ import {
 {{/hasImports}}
 {{#discriminator}}
 {{#discriminator.mappedModels}}
-import { {{modelName}}FromJSONTyped } from './{{modelName}}{{importFileExtension}}';
+import { {{modelName}}, {{modelName}}FromJSONTyped, {{modelName}}ToJSON } from './{{modelName}}{{importFileExtension}}';
 {{/discriminator.mappedModels}}
 {{/discriminator}}
 {{>modelGenericInterfaces}}
@@ -42,13 +42,13 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     if (!ignoreDiscriminator) {
 {{#discriminator.mappedModels}}
         if (json['{{discriminator.propertyBaseName}}'] === '{{mappingName}}') {
-            return {{modelName}}FromJSONTyped(json, true);
+            return {{modelName}}FromJSONTyped(json, ignoreDiscriminator);
         }
 {{/discriminator.mappedModels}}
     }
 {{/discriminator}}
     return {
-        {{#parent}}...{{{.}}}FromJSONTyped(json, ignoreDiscriminator),{{/parent}}
+        {{#parent}}...{{{.}}}FromJSONTyped(json, true),{{/parent}}
         {{#additionalPropertiesType}}
             ...json,
         {{/additionalPropertiesType}}
@@ -69,10 +69,10 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{^isPrimitiveType}}
         {{#isArray}}
         {{#uniqueItems}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set((json['{{baseName}}'] as Array<any>).map(s => {{#items}}{{datatype}}{{/items}}FromJSON(s)))),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}(json['{{baseName}}'] as Array<any>).map(s => {{#items}}{{datatype}}{{/items}}FromJSON(s))),
         {{/uniqueItems}}
         {{/isArray}}
         {{#isMap}}
@@ -97,13 +97,27 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     {{/hasVars}}
 }
 
-export function {{classname}}ToJSON(value?: {{#hasReadOnly}}Omit<{{classname}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{classname}}{{/hasReadOnly}} | null): any {
+export function {{classname}}ToJSON(value?: {{#hasReadOnly}}Omit<{{classname}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{classname}}{{/hasReadOnly}} | null, ignoreDiscriminator: boolean = false): any {
     {{#hasVars}}
     if (value == null) {
         return value;
     }
+    {{#discriminator}}
+
+    if (!ignoreDiscriminator) {
+        switch (value['{{discriminator.propertyName}}']) {
+        {{#discriminator.mappedModels}}
+            case '{{mappingName}}':
+                return {{modelName}}ToJSON(value as {{modelName}}, ignoreDiscriminator);
+        {{/discriminator.mappedModels}}
+            default:
+                throw new Error(`No variant of {{classname}} exists with '{{discriminator.propertyName}}=${value['{{discriminator.propertyName}}']}'`);
+        }
+    }
+    {{/discriminator}}
+
     return {
-        {{#parent}}...{{{.}}}ToJSON(value),{{/parent}}
+        {{#parent}}...{{{.}}}ToJSON(value, true),{{/parent}}
         {{#additionalPropertiesType}}
             ...value,
         {{/additionalPropertiesType}}
@@ -130,10 +144,10 @@ export function {{classname}}ToJSON(value?: {{#hasReadOnly}}Omit<{{classname}}, 
         {{^isPrimitiveType}}
         {{#isArray}}
         {{#uniqueItems}}
-        '{{baseName}}': {{^required}}value['{{name}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}Array.from(value['{{name}}'] as Set<any>).map({{#items}}{{datatype}}{{/items}}ToJSON)),
+        '{{baseName}}': {{^required}}value['{{name}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}Array.from(value['{{name}}'] as Set<any>).map(s => {{#items}}{{datatype}}{{/items}}ToJSON(s))),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{baseName}}': {{^required}}value['{{name}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}(value['{{name}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}ToJSON)),
+        '{{baseName}}': {{^required}}value['{{name}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}(value['{{name}}'] as Array<any>).map(a => {{#items}}{{datatype}}{{/items}}ToJSON(a))),
         {{/uniqueItems}}
         {{/isArray}}
         {{#isMap}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -6,13 +6,14 @@ import {
     {{classname}}FromJSON,
     {{classname}}FromJSONTyped,
     {{classname}}ToJSON,
+    {{classname}}ToJSONTyped,
 } from './{{filename}}{{importFileExtension}}';
 {{/tsImports}}
 
 {{/hasImports}}
 {{#discriminator}}
 {{#discriminator.mappedModels}}
-import { {{modelName}}, {{modelName}}FromJSONTyped, {{modelName}}ToJSON } from './{{modelName}}{{importFileExtension}}';
+import { {{modelName}}, {{modelName}}FromJSONTyped, {{modelName}}ToJSON, {{modelName}}ToJSONTyped } from './{{modelName}}{{importFileExtension}}';
 {{/discriminator.mappedModels}}
 {{/discriminator}}
 {{>modelGenericInterfaces}}
@@ -69,10 +70,10 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{^isPrimitiveType}}
         {{#isArray}}
         {{#uniqueItems}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set((json['{{baseName}}'] as Array<any>).map(s => {{#items}}{{datatype}}{{/items}}FromJSON(s)))),
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}(json['{{baseName}}'] as Array<any>).map(s => {{#items}}{{datatype}}{{/items}}FromJSON(s))),
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/uniqueItems}}
         {{/isArray}}
         {{#isMap}}
@@ -97,7 +98,11 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     {{/hasVars}}
 }
 
-export function {{classname}}ToJSON(value?: {{#hasReadOnly}}Omit<{{classname}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{classname}}{{/hasReadOnly}} | null, ignoreDiscriminator: boolean = false): any {
+  export function {{classname}}ToJSON(json: any): {{classname}} {
+      return {{classname}}ToJSONTyped(json, false);
+  }
+
+  export function {{classname}}ToJSONTyped(value?: {{#hasReadOnly}}Omit<{{classname}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{classname}}{{/hasReadOnly}} | null, ignoreDiscriminator: boolean = false): any {
     {{#hasVars}}
     if (value == null) {
         return value;
@@ -108,7 +113,7 @@ export function {{classname}}ToJSON(value?: {{#hasReadOnly}}Omit<{{classname}}, 
         switch (value['{{discriminator.propertyName}}']) {
         {{#discriminator.mappedModels}}
             case '{{mappingName}}':
-                return {{modelName}}ToJSON(value as {{modelName}}, ignoreDiscriminator);
+                return {{modelName}}ToJSONTyped(value as {{modelName}}, ignoreDiscriminator);
         {{/discriminator.mappedModels}}
             default:
                 throw new Error(`No variant of {{classname}} exists with '{{discriminator.propertyName}}=${value['{{discriminator.propertyName}}']}'`);
@@ -117,7 +122,7 @@ export function {{classname}}ToJSON(value?: {{#hasReadOnly}}Omit<{{classname}}, 
     {{/discriminator}}
 
     return {
-        {{#parent}}...{{{.}}}ToJSON(value, true),{{/parent}}
+        {{#parent}}...{{{.}}}ToJSONTyped(value, true),{{/parent}}
         {{#additionalPropertiesType}}
             ...value,
         {{/additionalPropertiesType}}
@@ -144,10 +149,10 @@ export function {{classname}}ToJSON(value?: {{#hasReadOnly}}Omit<{{classname}}, 
         {{^isPrimitiveType}}
         {{#isArray}}
         {{#uniqueItems}}
-        '{{baseName}}': {{^required}}value['{{name}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}Array.from(value['{{name}}'] as Set<any>).map(s => {{#items}}{{datatype}}{{/items}}ToJSON(s))),
+        '{{baseName}}': {{^required}}value['{{name}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}Array.from(value['{{name}}'] as Set<any>).map({{#items}}{{datatype}}{{/items}}ToJSON)),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{baseName}}': {{^required}}value['{{name}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}(value['{{name}}'] as Array<any>).map(a => {{#items}}{{datatype}}{{/items}}ToJSON(a))),
+        '{{baseName}}': {{^required}}value['{{name}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}(value['{{name}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}ToJSON)),
         {{/uniqueItems}}
         {{/isArray}}
         {{#isMap}}

--- a/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
@@ -18,10 +18,11 @@ import {
     BranchDtoFromJSON,
     BranchDtoFromJSONTyped,
     BranchDtoToJSON,
+    BranchDtoToJSONTyped,
 } from './BranchDto';
 
-import { InternalAuthenticatedUserDto, InternalAuthenticatedUserDtoFromJSONTyped, InternalAuthenticatedUserDtoToJSON } from './InternalAuthenticatedUserDto';
-import { RemoteAuthenticatedUserDto, RemoteAuthenticatedUserDtoFromJSONTyped, RemoteAuthenticatedUserDtoToJSON } from './RemoteAuthenticatedUserDto';
+import { InternalAuthenticatedUserDto, InternalAuthenticatedUserDtoFromJSONTyped, InternalAuthenticatedUserDtoToJSON, InternalAuthenticatedUserDtoToJSONTyped } from './InternalAuthenticatedUserDto';
+import { RemoteAuthenticatedUserDto, RemoteAuthenticatedUserDtoFromJSONTyped, RemoteAuthenticatedUserDtoToJSON, RemoteAuthenticatedUserDtoToJSONTyped } from './RemoteAuthenticatedUserDto';
 /**
  * 
  * @export
@@ -79,7 +80,11 @@ export function AbstractUserDtoFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function AbstractUserDtoToJSON(value?: AbstractUserDto | null, ignoreDiscriminator: boolean = false): any {
+  export function AbstractUserDtoToJSON(json: any): AbstractUserDto {
+      return AbstractUserDtoToJSONTyped(json, false);
+  }
+
+  export function AbstractUserDtoToJSONTyped(value?: AbstractUserDto | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -87,9 +92,9 @@ export function AbstractUserDtoToJSON(value?: AbstractUserDto | null, ignoreDisc
     if (!ignoreDiscriminator) {
         switch (value['type']) {
             case 'internal-authenticated':
-                return InternalAuthenticatedUserDtoToJSON(value as InternalAuthenticatedUserDto, ignoreDiscriminator);
+                return InternalAuthenticatedUserDtoToJSONTyped(value as InternalAuthenticatedUserDto, ignoreDiscriminator);
             case 'remote-authenticated':
-                return RemoteAuthenticatedUserDtoToJSON(value as RemoteAuthenticatedUserDto, ignoreDiscriminator);
+                return RemoteAuthenticatedUserDtoToJSONTyped(value as RemoteAuthenticatedUserDto, ignoreDiscriminator);
             default:
                 throw new Error(`No variant of AbstractUserDto exists with 'type=${value['type']}'`);
         }

--- a/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
@@ -20,8 +20,8 @@ import {
     BranchDtoToJSON,
 } from './BranchDto';
 
-import { InternalAuthenticatedUserDtoFromJSONTyped } from './InternalAuthenticatedUserDto';
-import { RemoteAuthenticatedUserDtoFromJSONTyped } from './RemoteAuthenticatedUserDto';
+import { InternalAuthenticatedUserDto, InternalAuthenticatedUserDtoFromJSONTyped, InternalAuthenticatedUserDtoToJSON } from './InternalAuthenticatedUserDto';
+import { RemoteAuthenticatedUserDto, RemoteAuthenticatedUserDtoFromJSONTyped, RemoteAuthenticatedUserDtoToJSON } from './RemoteAuthenticatedUserDto';
 /**
  * 
  * @export
@@ -65,10 +65,10 @@ export function AbstractUserDtoFromJSONTyped(json: any, ignoreDiscriminator: boo
     }
     if (!ignoreDiscriminator) {
         if (json['type'] === 'internal-authenticated') {
-            return InternalAuthenticatedUserDtoFromJSONTyped(json, true);
+            return InternalAuthenticatedUserDtoFromJSONTyped(json, ignoreDiscriminator);
         }
         if (json['type'] === 'remote-authenticated') {
-            return RemoteAuthenticatedUserDtoFromJSONTyped(json, true);
+            return RemoteAuthenticatedUserDtoFromJSONTyped(json, ignoreDiscriminator);
         }
     }
     return {
@@ -79,10 +79,22 @@ export function AbstractUserDtoFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function AbstractUserDtoToJSON(value?: AbstractUserDto | null): any {
+export function AbstractUserDtoToJSON(value?: AbstractUserDto | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
+    if (!ignoreDiscriminator) {
+        switch (value['type']) {
+            case 'internal-authenticated':
+                return InternalAuthenticatedUserDtoToJSON(value as InternalAuthenticatedUserDto, ignoreDiscriminator);
+            case 'remote-authenticated':
+                return RemoteAuthenticatedUserDtoToJSON(value as RemoteAuthenticatedUserDto, ignoreDiscriminator);
+            default:
+                throw new Error(`No variant of AbstractUserDto exists with 'type=${value['type']}'`);
+        }
+    }
+
     return {
         
         'username': value['username'],

--- a/samples/client/others/typescript-fetch/self-import-issue/models/BranchDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/BranchDto.ts
@@ -48,7 +48,11 @@ export function BranchDtoFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function BranchDtoToJSON(value?: BranchDto | null, ignoreDiscriminator: boolean = false): any {
+  export function BranchDtoToJSON(json: any): BranchDto {
+      return BranchDtoToJSONTyped(json, false);
+  }
+
+  export function BranchDtoToJSONTyped(value?: BranchDto | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/others/typescript-fetch/self-import-issue/models/BranchDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/BranchDto.ts
@@ -48,10 +48,11 @@ export function BranchDtoFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function BranchDtoToJSON(value?: BranchDto | null): any {
+export function BranchDtoToJSON(value?: BranchDto | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'name': value['name'],

--- a/samples/client/others/typescript-fetch/self-import-issue/models/InternalAuthenticatedUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/InternalAuthenticatedUserDto.ts
@@ -18,12 +18,14 @@ import {
     BranchDtoFromJSON,
     BranchDtoFromJSONTyped,
     BranchDtoToJSON,
+    BranchDtoToJSONTyped,
 } from './BranchDto';
 import type { AbstractUserDto } from './AbstractUserDto';
 import {
     AbstractUserDtoFromJSON,
     AbstractUserDtoFromJSONTyped,
     AbstractUserDtoToJSON,
+    AbstractUserDtoToJSONTyped,
 } from './AbstractUserDto';
 
 /**
@@ -49,7 +51,11 @@ export function InternalAuthenticatedUserDtoFromJSONTyped(json: any, ignoreDiscr
     return json;
 }
 
-export function InternalAuthenticatedUserDtoToJSON(value?: InternalAuthenticatedUserDto | null, ignoreDiscriminator: boolean = false): any {
+  export function InternalAuthenticatedUserDtoToJSON(json: any): InternalAuthenticatedUserDto {
+      return InternalAuthenticatedUserDtoToJSONTyped(json, false);
+  }
+
+  export function InternalAuthenticatedUserDtoToJSONTyped(value?: InternalAuthenticatedUserDto | null, ignoreDiscriminator: boolean = false): any {
     return value;
 }
 

--- a/samples/client/others/typescript-fetch/self-import-issue/models/InternalAuthenticatedUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/InternalAuthenticatedUserDto.ts
@@ -49,7 +49,7 @@ export function InternalAuthenticatedUserDtoFromJSONTyped(json: any, ignoreDiscr
     return json;
 }
 
-export function InternalAuthenticatedUserDtoToJSON(value?: InternalAuthenticatedUserDto | null): any {
+export function InternalAuthenticatedUserDtoToJSON(value?: InternalAuthenticatedUserDto | null, ignoreDiscriminator: boolean = false): any {
     return value;
 }
 

--- a/samples/client/others/typescript-fetch/self-import-issue/models/RemoteAuthenticatedUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/RemoteAuthenticatedUserDto.ts
@@ -18,12 +18,14 @@ import {
     BranchDtoFromJSON,
     BranchDtoFromJSONTyped,
     BranchDtoToJSON,
+    BranchDtoToJSONTyped,
 } from './BranchDto';
 import type { AbstractUserDto } from './AbstractUserDto';
 import {
     AbstractUserDtoFromJSON,
     AbstractUserDtoFromJSONTyped,
     AbstractUserDtoToJSON,
+    AbstractUserDtoToJSONTyped,
 } from './AbstractUserDto';
 
 /**
@@ -49,7 +51,11 @@ export function RemoteAuthenticatedUserDtoFromJSONTyped(json: any, ignoreDiscrim
     return json;
 }
 
-export function RemoteAuthenticatedUserDtoToJSON(value?: RemoteAuthenticatedUserDto | null, ignoreDiscriminator: boolean = false): any {
+  export function RemoteAuthenticatedUserDtoToJSON(json: any): RemoteAuthenticatedUserDto {
+      return RemoteAuthenticatedUserDtoToJSONTyped(json, false);
+  }
+
+  export function RemoteAuthenticatedUserDtoToJSONTyped(value?: RemoteAuthenticatedUserDto | null, ignoreDiscriminator: boolean = false): any {
     return value;
 }
 

--- a/samples/client/others/typescript-fetch/self-import-issue/models/RemoteAuthenticatedUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/RemoteAuthenticatedUserDto.ts
@@ -49,7 +49,7 @@ export function RemoteAuthenticatedUserDtoFromJSONTyped(json: any, ignoreDiscrim
     return json;
 }
 
-export function RemoteAuthenticatedUserDtoToJSON(value?: RemoteAuthenticatedUserDto | null): any {
+export function RemoteAuthenticatedUserDtoToJSON(value?: RemoteAuthenticatedUserDto | null, ignoreDiscriminator: boolean = false): any {
     return value;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
@@ -55,10 +55,11 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
     };
 }
 
-export function ClubToJSON(value?: Club | null): any {
+export function ClubToJSON(value?: Club | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'owner': OwnerToJSON(value['owner']),

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
@@ -18,6 +18,7 @@ import {
     OwnerFromJSON,
     OwnerFromJSONTyped,
     OwnerToJSON,
+    OwnerToJSONTyped,
 } from './Owner';
 
 /**
@@ -55,7 +56,11 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
     };
 }
 
-export function ClubToJSON(value?: Club | null, ignoreDiscriminator: boolean = false): any {
+  export function ClubToJSON(json: any): Club {
+      return ClubToJSONTyped(json, false);
+  }
+
+  export function ClubToJSONTyped(value?: Club | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
@@ -48,10 +48,11 @@ export function OwnerFromJSONTyped(json: any, ignoreDiscriminator: boolean): Own
     };
 }
 
-export function OwnerToJSON(value?: Owner | null): any {
+export function OwnerToJSON(value?: Owner | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'name': value['name'],

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
@@ -48,7 +48,11 @@ export function OwnerFromJSONTyped(json: any, ignoreDiscriminator: boolean): Own
     };
 }
 
-export function OwnerToJSON(value?: Owner | null, ignoreDiscriminator: boolean = false): any {
+  export function OwnerToJSON(json: any): Owner {
+      return OwnerToJSONTyped(json, false);
+  }
+
+  export function OwnerToJSONTyped(value?: Owner | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
@@ -18,6 +18,7 @@ import {
     OwnerFromJSON,
     OwnerFromJSONTyped,
     OwnerToJSON,
+    OwnerToJSONTyped,
 } from './Owner';
 
 /**
@@ -55,7 +56,11 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
     };
 }
 
-export function ClubToJSON(value?: Omit<Club, 'owner'> | null, ignoreDiscriminator: boolean = false): any {
+  export function ClubToJSON(json: any): Club {
+      return ClubToJSONTyped(json, false);
+  }
+
+  export function ClubToJSONTyped(value?: Omit<Club, 'owner'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
@@ -55,10 +55,11 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
     };
 }
 
-export function ClubToJSON(value?: Omit<Club, 'owner'> | null): any {
+export function ClubToJSON(value?: Omit<Club, 'owner'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
     };

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
@@ -48,10 +48,11 @@ export function OwnerFromJSONTyped(json: any, ignoreDiscriminator: boolean): Own
     };
 }
 
-export function OwnerToJSON(value?: Owner | null): any {
+export function OwnerToJSON(value?: Owner | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'name': value['name'],

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
@@ -48,7 +48,11 @@ export function OwnerFromJSONTyped(json: any, ignoreDiscriminator: boolean): Own
     };
 }
 
-export function OwnerToJSON(value?: Owner | null, ignoreDiscriminator: boolean = false): any {
+  export function OwnerToJSON(json: any): Owner {
+      return OwnerToJSONTyped(json, false);
+  }
+
+  export function OwnerToJSONTyped(value?: Owner | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
@@ -117,7 +117,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['user']!.map(x => UserToJSON(x)),
+            body: requestParameters['user']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -154,7 +154,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['user']!.map(x => UserToJSON(x)),
+            body: requestParameters['user']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
@@ -117,7 +117,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['user']!.map(UserToJSON),
+            body: requestParameters['user']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -154,7 +154,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['user']!.map(UserToJSON),
+            body: requestParameters['user']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
@@ -55,7 +55,11 @@ export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscrimi
     };
 }
 
-export function AdditionalPropertiesClassToJSON(value?: AdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
+  export function AdditionalPropertiesClassToJSON(json: any): AdditionalPropertiesClass {
+      return AdditionalPropertiesClassToJSONTyped(json, false);
+  }
+
+  export function AdditionalPropertiesClassToJSONTyped(value?: AdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
@@ -55,10 +55,11 @@ export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscrimi
     };
 }
 
-export function AdditionalPropertiesClassToJSON(value?: AdditionalPropertiesClass | null): any {
+export function AdditionalPropertiesClassToJSON(value?: AdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'map_property': value['mapProperty'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
@@ -18,6 +18,7 @@ import {
     SingleRefTypeFromJSON,
     SingleRefTypeFromJSONTyped,
     SingleRefTypeToJSON,
+    SingleRefTypeToJSONTyped,
 } from './SingleRefType';
 
 /**
@@ -64,7 +65,11 @@ export function AllOfWithSingleRefFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function AllOfWithSingleRefToJSON(value?: AllOfWithSingleRef | null, ignoreDiscriminator: boolean = false): any {
+  export function AllOfWithSingleRefToJSON(json: any): AllOfWithSingleRef {
+      return AllOfWithSingleRefToJSONTyped(json, false);
+  }
+
+  export function AllOfWithSingleRefToJSONTyped(value?: AllOfWithSingleRef | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
@@ -64,10 +64,11 @@ export function AllOfWithSingleRefFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function AllOfWithSingleRefToJSON(value?: AllOfWithSingleRef | null): any {
+export function AllOfWithSingleRefToJSON(value?: AllOfWithSingleRef | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'username': value['username'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
@@ -13,8 +13,8 @@
  */
 
 import { mapValues } from '../runtime';
-import { Cat, CatFromJSONTyped, CatToJSON } from './Cat';
-import { Dog, DogFromJSONTyped, DogToJSON } from './Dog';
+import { Cat, CatFromJSONTyped, CatToJSON, CatToJSONTyped } from './Cat';
+import { Dog, DogFromJSONTyped, DogToJSON, DogToJSONTyped } from './Dog';
 /**
  * 
  * @export
@@ -66,7 +66,11 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
     };
 }
 
-export function AnimalToJSON(value?: Animal | null, ignoreDiscriminator: boolean = false): any {
+  export function AnimalToJSON(json: any): Animal {
+      return AnimalToJSONTyped(json, false);
+  }
+
+  export function AnimalToJSONTyped(value?: Animal | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -74,9 +78,9 @@ export function AnimalToJSON(value?: Animal | null, ignoreDiscriminator: boolean
     if (!ignoreDiscriminator) {
         switch (value['className']) {
             case 'CAT':
-                return CatToJSON(value as Cat, ignoreDiscriminator);
+                return CatToJSONTyped(value as Cat, ignoreDiscriminator);
             case 'DOG':
-                return DogToJSON(value as Dog, ignoreDiscriminator);
+                return DogToJSONTyped(value as Dog, ignoreDiscriminator);
             default:
                 throw new Error(`No variant of Animal exists with 'className=${value['className']}'`);
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
@@ -13,8 +13,8 @@
  */
 
 import { mapValues } from '../runtime';
-import { CatFromJSONTyped } from './Cat';
-import { DogFromJSONTyped } from './Dog';
+import { Cat, CatFromJSONTyped, CatToJSON } from './Cat';
+import { Dog, DogFromJSONTyped, DogToJSON } from './Dog';
 /**
  * 
  * @export
@@ -53,10 +53,10 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
     }
     if (!ignoreDiscriminator) {
         if (json['className'] === 'CAT') {
-            return CatFromJSONTyped(json, true);
+            return CatFromJSONTyped(json, ignoreDiscriminator);
         }
         if (json['className'] === 'DOG') {
-            return DogFromJSONTyped(json, true);
+            return DogFromJSONTyped(json, ignoreDiscriminator);
         }
     }
     return {
@@ -66,10 +66,22 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
     };
 }
 
-export function AnimalToJSON(value?: Animal | null): any {
+export function AnimalToJSON(value?: Animal | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
+    if (!ignoreDiscriminator) {
+        switch (value['className']) {
+            case 'CAT':
+                return CatToJSON(value as Cat, ignoreDiscriminator);
+            case 'DOG':
+                return DogToJSON(value as Dog, ignoreDiscriminator);
+            default:
+                throw new Error(`No variant of Animal exists with 'className=${value['className']}'`);
+        }
+    }
+
     return {
         
         'className': value['className'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
@@ -48,10 +48,11 @@ export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-export function ArrayOfArrayOfNumberOnlyToJSON(value?: ArrayOfArrayOfNumberOnly | null): any {
+export function ArrayOfArrayOfNumberOnlyToJSON(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'ArrayArrayNumber': value['arrayArrayNumber'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
@@ -48,7 +48,11 @@ export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-export function ArrayOfArrayOfNumberOnlyToJSON(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
+  export function ArrayOfArrayOfNumberOnlyToJSON(json: any): ArrayOfArrayOfNumberOnly {
+      return ArrayOfArrayOfNumberOnlyToJSONTyped(json, false);
+  }
+
+  export function ArrayOfArrayOfNumberOnlyToJSONTyped(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
@@ -48,10 +48,11 @@ export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function ArrayOfNumberOnlyToJSON(value?: ArrayOfNumberOnly | null): any {
+export function ArrayOfNumberOnlyToJSON(value?: ArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'ArrayNumber': value['arrayNumber'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
@@ -48,7 +48,11 @@ export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function ArrayOfNumberOnlyToJSON(value?: ArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
+  export function ArrayOfNumberOnlyToJSON(json: any): ArrayOfNumberOnly {
+      return ArrayOfNumberOnlyToJSONTyped(json, false);
+  }
+
+  export function ArrayOfNumberOnlyToJSONTyped(value?: ArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
@@ -69,10 +69,11 @@ export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ArrayTestToJSON(value?: ArrayTest | null): any {
+export function ArrayTestToJSON(value?: ArrayTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'array_of_string': value['arrayOfString'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
@@ -18,6 +18,7 @@ import {
     ReadOnlyFirstFromJSON,
     ReadOnlyFirstFromJSONTyped,
     ReadOnlyFirstToJSON,
+    ReadOnlyFirstToJSONTyped,
 } from './ReadOnlyFirst';
 
 /**
@@ -69,7 +70,11 @@ export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ArrayTestToJSON(value?: ArrayTest | null, ignoreDiscriminator: boolean = false): any {
+  export function ArrayTestToJSON(json: any): ArrayTest {
+      return ArrayTestToJSONTyped(json, false);
+  }
+
+  export function ArrayTestToJSONTyped(value?: ArrayTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
@@ -84,10 +84,11 @@ export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function CapitalizationToJSON(value?: Capitalization | null): any {
+export function CapitalizationToJSON(value?: Capitalization | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'smallCamel': value['smallCamel'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
@@ -84,7 +84,11 @@ export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function CapitalizationToJSON(value?: Capitalization | null, ignoreDiscriminator: boolean = false): any {
+  export function CapitalizationToJSON(json: any): Capitalization {
+      return CapitalizationToJSONTyped(json, false);
+  }
+
+  export function CapitalizationToJSONTyped(value?: Capitalization | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
@@ -18,6 +18,7 @@ import {
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
+    AnimalToJSONTyped,
 } from './Animal';
 
 /**
@@ -55,13 +56,17 @@ export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
     };
 }
 
-export function CatToJSON(value?: Cat | null, ignoreDiscriminator: boolean = false): any {
+  export function CatToJSON(json: any): Cat {
+      return CatToJSONTyped(json, false);
+  }
+
+  export function CatToJSONTyped(value?: Cat | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
 
     return {
-        ...AnimalToJSON(value, true),
+        ...AnimalToJSONTyped(value, true),
         'declawed': value['declawed'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
@@ -50,17 +50,18 @@ export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
         return json;
     }
     return {
-        ...AnimalFromJSONTyped(json, ignoreDiscriminator),
+        ...AnimalFromJSONTyped(json, true),
         'declawed': json['declawed'] == null ? undefined : json['declawed'],
     };
 }
 
-export function CatToJSON(value?: Cat | null): any {
+export function CatToJSON(value?: Cat | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
-        ...AnimalToJSON(value),
+        ...AnimalToJSON(value, true),
         'declawed': value['declawed'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
@@ -56,10 +56,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null): any {
+export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
@@ -56,7 +56,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+  export function CategoryToJSON(json: any): Category {
+      return CategoryToJSONTyped(json, false);
+  }
+
+  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
@@ -18,6 +18,7 @@ import {
     ParentWithNullableFromJSON,
     ParentWithNullableFromJSONTyped,
     ParentWithNullableToJSON,
+    ParentWithNullableToJSONTyped,
 } from './ParentWithNullable';
 
 /**
@@ -57,13 +58,17 @@ export function ChildWithNullableFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function ChildWithNullableToJSON(value?: ChildWithNullable | null, ignoreDiscriminator: boolean = false): any {
+  export function ChildWithNullableToJSON(json: any): ChildWithNullable {
+      return ChildWithNullableToJSONTyped(json, false);
+  }
+
+  export function ChildWithNullableToJSONTyped(value?: ChildWithNullable | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
 
     return {
-        ...ParentWithNullableToJSON(value, true),
+        ...ParentWithNullableToJSONTyped(value, true),
         'otherProperty': value['otherProperty'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
@@ -52,17 +52,18 @@ export function ChildWithNullableFromJSONTyped(json: any, ignoreDiscriminator: b
         return json;
     }
     return {
-        ...ParentWithNullableFromJSONTyped(json, ignoreDiscriminator),
+        ...ParentWithNullableFromJSONTyped(json, true),
         'otherProperty': json['otherProperty'] == null ? undefined : json['otherProperty'],
     };
 }
 
-export function ChildWithNullableToJSON(value?: ChildWithNullable | null): any {
+export function ChildWithNullableToJSON(value?: ChildWithNullable | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
-        ...ParentWithNullableToJSON(value),
+        ...ParentWithNullableToJSON(value, true),
         'otherProperty': value['otherProperty'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
@@ -48,7 +48,11 @@ export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function ClassModelToJSON(value?: ClassModel | null, ignoreDiscriminator: boolean = false): any {
+  export function ClassModelToJSON(json: any): ClassModel {
+      return ClassModelToJSONTyped(json, false);
+  }
+
+  export function ClassModelToJSONTyped(value?: ClassModel | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
@@ -48,10 +48,11 @@ export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function ClassModelToJSON(value?: ClassModel | null): any {
+export function ClassModelToJSON(value?: ClassModel | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         '_class': value['_class'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
@@ -48,7 +48,11 @@ export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cl
     };
 }
 
-export function ClientToJSON(value?: Client | null, ignoreDiscriminator: boolean = false): any {
+  export function ClientToJSON(json: any): Client {
+      return ClientToJSONTyped(json, false);
+  }
+
+  export function ClientToJSONTyped(value?: Client | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
@@ -48,10 +48,11 @@ export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cl
     };
 }
 
-export function ClientToJSON(value?: Client | null): any {
+export function ClientToJSON(value?: Client | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'client': value['client'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
@@ -48,7 +48,11 @@ export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function DeprecatedObjectToJSON(value?: DeprecatedObject | null, ignoreDiscriminator: boolean = false): any {
+  export function DeprecatedObjectToJSON(json: any): DeprecatedObject {
+      return DeprecatedObjectToJSONTyped(json, false);
+  }
+
+  export function DeprecatedObjectToJSONTyped(value?: DeprecatedObject | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
@@ -48,10 +48,11 @@ export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function DeprecatedObjectToJSON(value?: DeprecatedObject | null): any {
+export function DeprecatedObjectToJSON(value?: DeprecatedObject | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'name': value['name'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
@@ -50,17 +50,18 @@ export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
         return json;
     }
     return {
-        ...AnimalFromJSONTyped(json, ignoreDiscriminator),
+        ...AnimalFromJSONTyped(json, true),
         'breed': json['breed'] == null ? undefined : json['breed'],
     };
 }
 
-export function DogToJSON(value?: Dog | null): any {
+export function DogToJSON(value?: Dog | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
-        ...AnimalToJSON(value),
+        ...AnimalToJSON(value, true),
         'breed': value['breed'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
@@ -18,6 +18,7 @@ import {
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
+    AnimalToJSONTyped,
 } from './Animal';
 
 /**
@@ -55,13 +56,17 @@ export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
     };
 }
 
-export function DogToJSON(value?: Dog | null, ignoreDiscriminator: boolean = false): any {
+  export function DogToJSON(json: any): Dog {
+      return DogToJSONTyped(json, false);
+  }
+
+  export function DogToJSONTyped(value?: Dog | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
 
     return {
-        ...AnimalToJSON(value, true),
+        ...AnimalToJSONTyped(value, true),
         'breed': value['breed'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
@@ -75,7 +75,11 @@ export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function EnumArraysToJSON(value?: EnumArrays | null, ignoreDiscriminator: boolean = false): any {
+  export function EnumArraysToJSON(json: any): EnumArrays {
+      return EnumArraysToJSONTyped(json, false);
+  }
+
+  export function EnumArraysToJSONTyped(value?: EnumArrays | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
@@ -75,10 +75,11 @@ export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function EnumArraysToJSON(value?: EnumArrays | null): any {
+export function EnumArraysToJSON(value?: EnumArrays | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'just_symbol': value['justSymbol'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
@@ -48,3 +48,7 @@ export function EnumClassToJSON(value?: EnumClass | null): any {
     return value as any;
 }
 
+export function EnumClassToJSONTyped(value: any, ignoreDiscriminator: boolean): EnumClass {
+    return value as EnumClass;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -163,10 +163,11 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function EnumTestToJSON(value?: EnumTest | null): any {
+export function EnumTestToJSON(value?: EnumTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'enum_string': value['enumString'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -18,24 +18,28 @@ import {
     OuterEnumFromJSON,
     OuterEnumFromJSONTyped,
     OuterEnumToJSON,
+    OuterEnumToJSONTyped,
 } from './OuterEnum';
 import type { OuterEnumIntegerDefaultValue } from './OuterEnumIntegerDefaultValue';
 import {
     OuterEnumIntegerDefaultValueFromJSON,
     OuterEnumIntegerDefaultValueFromJSONTyped,
     OuterEnumIntegerDefaultValueToJSON,
+    OuterEnumIntegerDefaultValueToJSONTyped,
 } from './OuterEnumIntegerDefaultValue';
 import type { OuterEnumInteger } from './OuterEnumInteger';
 import {
     OuterEnumIntegerFromJSON,
     OuterEnumIntegerFromJSONTyped,
     OuterEnumIntegerToJSON,
+    OuterEnumIntegerToJSONTyped,
 } from './OuterEnumInteger';
 import type { OuterEnumDefaultValue } from './OuterEnumDefaultValue';
 import {
     OuterEnumDefaultValueFromJSON,
     OuterEnumDefaultValueFromJSONTyped,
     OuterEnumDefaultValueToJSON,
+    OuterEnumDefaultValueToJSONTyped,
 } from './OuterEnumDefaultValue';
 
 /**
@@ -163,7 +167,11 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function EnumTestToJSON(value?: EnumTest | null, ignoreDiscriminator: boolean = false): any {
+  export function EnumTestToJSON(json: any): EnumTest {
+      return EnumTestToJSONTyped(json, false);
+  }
+
+  export function EnumTestToJSONTyped(value?: EnumTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
@@ -55,7 +55,11 @@ export function FakeBigDecimalMap200ResponseFromJSONTyped(json: any, ignoreDiscr
     };
 }
 
-export function FakeBigDecimalMap200ResponseToJSON(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator: boolean = false): any {
+  export function FakeBigDecimalMap200ResponseToJSON(json: any): FakeBigDecimalMap200Response {
+      return FakeBigDecimalMap200ResponseToJSONTyped(json, false);
+  }
+
+  export function FakeBigDecimalMap200ResponseToJSONTyped(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
@@ -55,10 +55,11 @@ export function FakeBigDecimalMap200ResponseFromJSONTyped(json: any, ignoreDiscr
     };
 }
 
-export function FakeBigDecimalMap200ResponseToJSON(value?: FakeBigDecimalMap200Response | null): any {
+export function FakeBigDecimalMap200ResponseToJSON(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'someId': value['someId'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
@@ -55,7 +55,11 @@ export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator:
     };
 }
 
-export function FileSchemaTestClassToJSON(value?: FileSchemaTestClass | null, ignoreDiscriminator: boolean = false): any {
+  export function FileSchemaTestClassToJSON(json: any): FileSchemaTestClass {
+      return FileSchemaTestClassToJSONTyped(json, false);
+  }
+
+  export function FileSchemaTestClassToJSONTyped(value?: FileSchemaTestClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
@@ -55,10 +55,11 @@ export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator:
     };
 }
 
-export function FileSchemaTestClassToJSON(value?: FileSchemaTestClass | null): any {
+export function FileSchemaTestClassToJSON(value?: FileSchemaTestClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'file': value['file'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
@@ -48,7 +48,11 @@ export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
     };
 }
 
-export function FooToJSON(value?: Foo | null, ignoreDiscriminator: boolean = false): any {
+  export function FooToJSON(json: any): Foo {
+      return FooToJSONTyped(json, false);
+  }
+
+  export function FooToJSONTyped(value?: Foo | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
@@ -48,10 +48,11 @@ export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
     };
 }
 
-export function FooToJSON(value?: Foo | null): any {
+export function FooToJSON(value?: Foo | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'bar': value['bar'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
@@ -55,10 +55,11 @@ export function FooGetDefaultResponseFromJSONTyped(json: any, ignoreDiscriminato
     };
 }
 
-export function FooGetDefaultResponseToJSON(value?: FooGetDefaultResponse | null): any {
+export function FooGetDefaultResponseToJSON(value?: FooGetDefaultResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'string': FooToJSON(value['string']),

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
@@ -18,6 +18,7 @@ import {
     FooFromJSON,
     FooFromJSONTyped,
     FooToJSON,
+    FooToJSONTyped,
 } from './Foo';
 
 /**
@@ -55,7 +56,11 @@ export function FooGetDefaultResponseFromJSONTyped(json: any, ignoreDiscriminato
     };
 }
 
-export function FooGetDefaultResponseToJSON(value?: FooGetDefaultResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function FooGetDefaultResponseToJSON(json: any): FooGetDefaultResponse {
+      return FooGetDefaultResponseToJSONTyped(json, false);
+  }
+
+  export function FooGetDefaultResponseToJSONTyped(value?: FooGetDefaultResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
@@ -164,10 +164,11 @@ export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function FormatTestToJSON(value?: FormatTest | null): any {
+export function FormatTestToJSON(value?: FormatTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'integer': value['integer'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
@@ -18,6 +18,7 @@ import {
     DecimalFromJSON,
     DecimalFromJSONTyped,
     DecimalToJSON,
+    DecimalToJSONTyped,
 } from './Decimal';
 
 /**
@@ -164,7 +165,11 @@ export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function FormatTestToJSON(value?: FormatTest | null, ignoreDiscriminator: boolean = false): any {
+  export function FormatTestToJSON(json: any): FormatTest {
+      return FormatTestToJSONTyped(json, false);
+  }
+
+  export function FormatTestToJSONTyped(value?: FormatTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
@@ -55,7 +55,11 @@ export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function HasOnlyReadOnlyToJSON(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null, ignoreDiscriminator: boolean = false): any {
+  export function HasOnlyReadOnlyToJSON(json: any): HasOnlyReadOnly {
+      return HasOnlyReadOnlyToJSONTyped(json, false);
+  }
+
+  export function HasOnlyReadOnlyToJSONTyped(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
@@ -55,10 +55,11 @@ export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function HasOnlyReadOnlyToJSON(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null): any {
+export function HasOnlyReadOnlyToJSON(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
     };

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
@@ -48,10 +48,11 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function HealthCheckResultToJSON(value?: HealthCheckResult | null): any {
+export function HealthCheckResultToJSON(value?: HealthCheckResult | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'NullableMessage': value['nullableMessage'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
@@ -48,7 +48,11 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function HealthCheckResultToJSON(value?: HealthCheckResult | null, ignoreDiscriminator: boolean = false): any {
+  export function HealthCheckResultToJSON(json: any): HealthCheckResult {
+      return HealthCheckResultToJSONTyped(json, false);
+  }
+
+  export function HealthCheckResultToJSONTyped(value?: HealthCheckResult | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
@@ -48,10 +48,11 @@ export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List
     };
 }
 
-export function ListToJSON(value?: List | null): any {
+export function ListToJSON(value?: List | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         '123-list': value['_123list'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
@@ -48,7 +48,11 @@ export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List
     };
 }
 
-export function ListToJSON(value?: List | null, ignoreDiscriminator: boolean = false): any {
+  export function ListToJSON(json: any): List {
+      return ListToJSONTyped(json, false);
+  }
+
+  export function ListToJSONTyped(value?: List | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
@@ -80,10 +80,11 @@ export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): M
     };
 }
 
-export function MapTestToJSON(value?: MapTest | null): any {
+export function MapTestToJSON(value?: MapTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'map_map_of_string': value['mapMapOfString'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
@@ -80,7 +80,11 @@ export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): M
     };
 }
 
-export function MapTestToJSON(value?: MapTest | null, ignoreDiscriminator: boolean = false): any {
+  export function MapTestToJSON(json: any): MapTest {
+      return MapTestToJSONTyped(json, false);
+  }
+
+  export function MapTestToJSONTyped(value?: MapTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -69,10 +69,11 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: a
     };
 }
 
-export function MixedPropertiesAndAdditionalPropertiesClassToJSON(value?: MixedPropertiesAndAdditionalPropertiesClass | null): any {
+export function MixedPropertiesAndAdditionalPropertiesClassToJSON(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'uuid': value['uuid'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -18,6 +18,7 @@ import {
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
+    AnimalToJSONTyped,
 } from './Animal';
 
 /**
@@ -69,7 +70,11 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: a
     };
 }
 
-export function MixedPropertiesAndAdditionalPropertiesClassToJSON(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
+  export function MixedPropertiesAndAdditionalPropertiesClassToJSON(json: any): MixedPropertiesAndAdditionalPropertiesClass {
+      return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(json, false);
+  }
+
+  export function MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
@@ -55,10 +55,11 @@ export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function Model200ResponseToJSON(value?: Model200Response | null): any {
+export function Model200ResponseToJSON(value?: Model200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'name': value['name'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
@@ -55,7 +55,11 @@ export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function Model200ResponseToJSON(value?: Model200Response | null, ignoreDiscriminator: boolean = false): any {
+  export function Model200ResponseToJSON(json: any): Model200Response {
+      return Model200ResponseToJSONTyped(json, false);
+  }
+
+  export function Model200ResponseToJSONTyped(value?: Model200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
@@ -62,7 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+      return ModelApiResponseToJSONTyped(json, false);
+  }
+
+  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
@@ -62,10 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'code': value['code'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
@@ -48,7 +48,11 @@ export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ModelFileToJSON(value?: ModelFile | null, ignoreDiscriminator: boolean = false): any {
+  export function ModelFileToJSON(json: any): ModelFile {
+      return ModelFileToJSONTyped(json, false);
+  }
+
+  export function ModelFileToJSONTyped(value?: ModelFile | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
@@ -48,10 +48,11 @@ export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ModelFileToJSON(value?: ModelFile | null): any {
+export function ModelFileToJSON(value?: ModelFile | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'sourceURI': value['sourceURI'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
@@ -70,10 +70,11 @@ export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name
     };
 }
 
-export function NameToJSON(value?: Omit<Name, 'snake_case'|'123Number'> | null): any {
+export function NameToJSON(value?: Omit<Name, 'snake_case'|'123Number'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'name': value['name'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
@@ -70,7 +70,11 @@ export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name
     };
 }
 
-export function NameToJSON(value?: Omit<Name, 'snake_case'|'123Number'> | null, ignoreDiscriminator: boolean = false): any {
+  export function NameToJSON(json: any): Name {
+      return NameToJSONTyped(json, false);
+  }
+
+  export function NameToJSONTyped(value?: Omit<Name, 'snake_case'|'123Number'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -127,7 +127,11 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function NullableClassToJSON(value?: NullableClass | null, ignoreDiscriminator: boolean = false): any {
+  export function NullableClassToJSON(json: any): NullableClass {
+      return NullableClassToJSONTyped(json, false);
+  }
+
+  export function NullableClassToJSONTyped(value?: NullableClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -127,10 +127,11 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function NullableClassToJSON(value?: NullableClass | null): any {
+export function NullableClassToJSON(value?: NullableClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
             ...value,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
@@ -48,7 +48,11 @@ export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function NumberOnlyToJSON(value?: NumberOnly | null, ignoreDiscriminator: boolean = false): any {
+  export function NumberOnlyToJSON(json: any): NumberOnly {
+      return NumberOnlyToJSONTyped(json, false);
+  }
+
+  export function NumberOnlyToJSONTyped(value?: NumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
@@ -48,10 +48,11 @@ export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function NumberOnlyToJSON(value?: NumberOnly | null): any {
+export function NumberOnlyToJSON(value?: NumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'JustNumber': value['justNumber'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
@@ -79,10 +79,11 @@ export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscrim
     };
 }
 
-export function ObjectWithDeprecatedFieldsToJSON(value?: ObjectWithDeprecatedFields | null): any {
+export function ObjectWithDeprecatedFieldsToJSON(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'uuid': value['uuid'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
@@ -18,6 +18,7 @@ import {
     DeprecatedObjectFromJSON,
     DeprecatedObjectFromJSONTyped,
     DeprecatedObjectToJSON,
+    DeprecatedObjectToJSONTyped,
 } from './DeprecatedObject';
 
 /**
@@ -79,7 +80,11 @@ export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscrim
     };
 }
 
-export function ObjectWithDeprecatedFieldsToJSON(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator: boolean = false): any {
+  export function ObjectWithDeprecatedFieldsToJSON(json: any): ObjectWithDeprecatedFields {
+      return ObjectWithDeprecatedFieldsToJSONTyped(json, false);
+  }
+
+  export function ObjectWithDeprecatedFieldsToJSONTyped(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
@@ -95,7 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+  export function OrderToJSON(json: any): Order {
+      return OrderToJSONTyped(json, false);
+  }
+
+  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
@@ -95,10 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null): any {
+export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
@@ -62,10 +62,11 @@ export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function OuterCompositeToJSON(value?: OuterComposite | null): any {
+export function OuterCompositeToJSON(value?: OuterComposite | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'my_number': value['myNumber'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
@@ -62,7 +62,11 @@ export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function OuterCompositeToJSON(value?: OuterComposite | null, ignoreDiscriminator: boolean = false): any {
+  export function OuterCompositeToJSON(json: any): OuterComposite {
+      return OuterCompositeToJSONTyped(json, false);
+  }
+
+  export function OuterCompositeToJSONTyped(value?: OuterComposite | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
@@ -48,3 +48,7 @@ export function OuterEnumToJSON(value?: OuterEnum | null): any {
     return value as any;
 }
 
+export function OuterEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnum {
+    return value as OuterEnum;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
@@ -48,3 +48,7 @@ export function OuterEnumDefaultValueToJSON(value?: OuterEnumDefaultValue | null
     return value as any;
 }
 
+export function OuterEnumDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumDefaultValue {
+    return value as OuterEnumDefaultValue;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
@@ -48,3 +48,7 @@ export function OuterEnumIntegerToJSON(value?: OuterEnumInteger | null): any {
     return value as any;
 }
 
+export function OuterEnumIntegerToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumInteger {
+    return value as OuterEnumInteger;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
@@ -48,3 +48,7 @@ export function OuterEnumIntegerDefaultValueToJSON(value?: OuterEnumIntegerDefau
     return value as any;
 }
 
+export function OuterEnumIntegerDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumIntegerDefaultValue {
+    return value as OuterEnumIntegerDefaultValue;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
@@ -18,6 +18,7 @@ import {
     OuterEnumIntegerFromJSON,
     OuterEnumIntegerFromJSONTyped,
     OuterEnumIntegerToJSON,
+    OuterEnumIntegerToJSONTyped,
 } from './OuterEnumInteger';
 
 /**
@@ -58,7 +59,11 @@ export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscri
     };
 }
 
-export function OuterObjectWithEnumPropertyToJSON(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator: boolean = false): any {
+  export function OuterObjectWithEnumPropertyToJSON(json: any): OuterObjectWithEnumProperty {
+      return OuterObjectWithEnumPropertyToJSONTyped(json, false);
+  }
+
+  export function OuterObjectWithEnumPropertyToJSONTyped(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
@@ -58,10 +58,11 @@ export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscri
     };
 }
 
-export function OuterObjectWithEnumPropertyToJSON(value?: OuterObjectWithEnumProperty | null): any {
+export function OuterObjectWithEnumPropertyToJSON(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'value': OuterEnumIntegerToJSON(value['value']),

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -13,7 +13,7 @@
  */
 
 import { mapValues } from '../runtime';
-import { ChildWithNullableFromJSONTyped } from './ChildWithNullable';
+import { ChildWithNullable, ChildWithNullableFromJSONTyped, ChildWithNullableToJSON } from './ChildWithNullable';
 /**
  * 
  * @export
@@ -61,7 +61,7 @@ export function ParentWithNullableFromJSONTyped(json: any, ignoreDiscriminator: 
     }
     if (!ignoreDiscriminator) {
         if (json['type'] === 'ChildWithNullable') {
-            return ChildWithNullableFromJSONTyped(json, true);
+            return ChildWithNullableFromJSONTyped(json, ignoreDiscriminator);
         }
     }
     return {
@@ -71,10 +71,20 @@ export function ParentWithNullableFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function ParentWithNullableToJSON(value?: ParentWithNullable | null): any {
+export function ParentWithNullableToJSON(value?: ParentWithNullable | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
+    if (!ignoreDiscriminator) {
+        switch (value['type']) {
+            case 'ChildWithNullable':
+                return ChildWithNullableToJSON(value as ChildWithNullable, ignoreDiscriminator);
+            default:
+                throw new Error(`No variant of ParentWithNullable exists with 'type=${value['type']}'`);
+        }
+    }
+
     return {
         
         'type': value['type'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -13,7 +13,7 @@
  */
 
 import { mapValues } from '../runtime';
-import { ChildWithNullable, ChildWithNullableFromJSONTyped, ChildWithNullableToJSON } from './ChildWithNullable';
+import { ChildWithNullable, ChildWithNullableFromJSONTyped, ChildWithNullableToJSON, ChildWithNullableToJSONTyped } from './ChildWithNullable';
 /**
  * 
  * @export
@@ -71,7 +71,11 @@ export function ParentWithNullableFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function ParentWithNullableToJSON(value?: ParentWithNullable | null, ignoreDiscriminator: boolean = false): any {
+  export function ParentWithNullableToJSON(json: any): ParentWithNullable {
+      return ParentWithNullableToJSONTyped(json, false);
+  }
+
+  export function ParentWithNullableToJSONTyped(value?: ParentWithNullable | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -79,7 +83,7 @@ export function ParentWithNullableToJSON(value?: ParentWithNullable | null, igno
     if (!ignoreDiscriminator) {
         switch (value['type']) {
             case 'ChildWithNullable':
-                return ChildWithNullableToJSON(value as ChildWithNullable, ignoreDiscriminator);
+                return ChildWithNullableToJSONTyped(value as ChildWithNullable, ignoreDiscriminator);
             default:
                 throw new Error(`No variant of ParentWithNullable exists with 'type=${value['type']}'`);
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -105,12 +107,16 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+  export function PetToJSON(json: any): Pet {
+      return PetToJSONTyped(json, false);
+  }
+
+  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -121,7 +127,7 @@ export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = fal
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': Array.from(value['photoUrls'] as Set<any>),
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
@@ -105,22 +105,23 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null): any {
+export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': Array.from(value['photoUrls'] as Set<any>),
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
@@ -55,7 +55,11 @@ export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function ReadOnlyFirstToJSON(value?: Omit<ReadOnlyFirst, 'bar'> | null, ignoreDiscriminator: boolean = false): any {
+  export function ReadOnlyFirstToJSON(json: any): ReadOnlyFirst {
+      return ReadOnlyFirstToJSONTyped(json, false);
+  }
+
+  export function ReadOnlyFirstToJSONTyped(value?: Omit<ReadOnlyFirst, 'bar'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
@@ -55,10 +55,11 @@ export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function ReadOnlyFirstToJSON(value?: Omit<ReadOnlyFirst, 'bar'> | null): any {
+export function ReadOnlyFirstToJSON(value?: Omit<ReadOnlyFirst, 'bar'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'baz': value['baz'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
@@ -48,10 +48,11 @@ export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Re
     };
 }
 
-export function ReturnToJSON(value?: Return | null): any {
+export function ReturnToJSON(value?: Return | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'return': value['_return'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
@@ -48,7 +48,11 @@ export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Re
     };
 }
 
-export function ReturnToJSON(value?: Return | null, ignoreDiscriminator: boolean = false): any {
+  export function ReturnToJSON(json: any): Return {
+      return ReturnToJSONTyped(json, false);
+  }
+
+  export function ReturnToJSONTyped(value?: Return | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
@@ -47,3 +47,7 @@ export function SingleRefTypeToJSON(value?: SingleRefType | null): any {
     return value as any;
 }
 
+export function SingleRefTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): SingleRefType {
+    return value as SingleRefType;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
@@ -48,7 +48,11 @@ export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function SpecialModelNameToJSON(value?: SpecialModelName | null, ignoreDiscriminator: boolean = false): any {
+  export function SpecialModelNameToJSON(json: any): SpecialModelName {
+      return SpecialModelNameToJSONTyped(json, false);
+  }
+
+  export function SpecialModelNameToJSONTyped(value?: SpecialModelName | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
@@ -48,10 +48,11 @@ export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function SpecialModelNameToJSON(value?: SpecialModelName | null): any {
+export function SpecialModelNameToJSON(value?: SpecialModelName | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         '$special[property.name]': value['$specialPropertyName'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
@@ -55,10 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null): any {
+export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
@@ -55,7 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+  export function TagToJSON(json: any): Tag {
+      return TagToJSONTyped(json, false);
+  }
+
+  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
@@ -50,10 +50,11 @@ export function TestInlineFreeformAdditionalPropertiesRequestFromJSONTyped(json:
     };
 }
 
-export function TestInlineFreeformAdditionalPropertiesRequestToJSON(value?: TestInlineFreeformAdditionalPropertiesRequest | null): any {
+export function TestInlineFreeformAdditionalPropertiesRequestToJSON(value?: TestInlineFreeformAdditionalPropertiesRequest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
             ...value,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
@@ -50,7 +50,11 @@ export function TestInlineFreeformAdditionalPropertiesRequestFromJSONTyped(json:
     };
 }
 
-export function TestInlineFreeformAdditionalPropertiesRequestToJSON(value?: TestInlineFreeformAdditionalPropertiesRequest | null, ignoreDiscriminator: boolean = false): any {
+  export function TestInlineFreeformAdditionalPropertiesRequestToJSON(json: any): TestInlineFreeformAdditionalPropertiesRequest {
+      return TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(json, false);
+  }
+
+  export function TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(value?: TestInlineFreeformAdditionalPropertiesRequest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
@@ -97,10 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null): any {
+export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
@@ -97,7 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
+  export function UserToJSON(json: any): User {
+      return UserToJSONTyped(json, false);
+  }
+
+  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
@@ -116,7 +116,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -151,7 +151,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
@@ -116,7 +116,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -151,7 +151,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
@@ -55,7 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+  export function CategoryToJSON(json: any): Category {
+      return CategoryToJSONTyped(json, false);
+  }
+
+  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
@@ -55,10 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null): any {
+export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
@@ -62,7 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+      return ModelApiResponseToJSONTyped(json, false);
+  }
+
+  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
@@ -62,10 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'code': value['code'],

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
@@ -95,7 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+  export function OrderToJSON(json: any): Order {
+      return OrderToJSONTyped(json, false);
+  }
+
+  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
@@ -95,10 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null): any {
+export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
@@ -105,22 +105,23 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null): any {
+export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -105,12 +107,16 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+  export function PetToJSON(json: any): Pet {
+      return PetToJSONTyped(json, false);
+  }
+
+  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -121,7 +127,7 @@ export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = fal
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
@@ -55,10 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null): any {
+export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
@@ -55,7 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+  export function TagToJSON(json: any): Tag {
+      return TagToJSONTyped(json, false);
+  }
+
+  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
@@ -97,10 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null): any {
+export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
@@ -97,7 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
+  export function UserToJSON(json: any): User {
+      return UserToJSONTyped(json, false);
+  }
+
+  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -84,10 +84,11 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function EnumPatternObjectToJSON(value?: EnumPatternObject | null): any {
+export function EnumPatternObjectToJSON(value?: EnumPatternObject | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'string-enum': StringEnumToJSON(value['stringEnum']),

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -18,12 +18,14 @@ import {
     NumberEnumFromJSON,
     NumberEnumFromJSONTyped,
     NumberEnumToJSON,
+    NumberEnumToJSONTyped,
 } from './NumberEnum';
 import type { StringEnum } from './StringEnum';
 import {
     StringEnumFromJSON,
     StringEnumFromJSONTyped,
     StringEnumToJSON,
+    StringEnumToJSONTyped,
 } from './StringEnum';
 
 /**
@@ -84,7 +86,11 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function EnumPatternObjectToJSON(value?: EnumPatternObject | null, ignoreDiscriminator: boolean = false): any {
+  export function EnumPatternObjectToJSON(json: any): EnumPatternObject {
+      return EnumPatternObjectToJSONTyped(json, false);
+  }
+
+  export function EnumPatternObjectToJSONTyped(value?: EnumPatternObject | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
@@ -111,7 +111,11 @@ export function FakeEnumRequestGetInline200ResponseFromJSONTyped(json: any, igno
     };
 }
 
-export function FakeEnumRequestGetInline200ResponseToJSON(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator: boolean = false): any {
+  export function FakeEnumRequestGetInline200ResponseToJSON(json: any): FakeEnumRequestGetInline200Response {
+      return FakeEnumRequestGetInline200ResponseToJSONTyped(json, false);
+  }
+
+  export function FakeEnumRequestGetInline200ResponseToJSONTyped(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
@@ -111,10 +111,11 @@ export function FakeEnumRequestGetInline200ResponseFromJSONTyped(json: any, igno
     };
 }
 
-export function FakeEnumRequestGetInline200ResponseToJSON(value?: FakeEnumRequestGetInline200Response | null): any {
+export function FakeEnumRequestGetInline200ResponseToJSON(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'string-enum': value['stringEnum'],

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
@@ -48,3 +48,7 @@ export function NumberEnumToJSON(value?: NumberEnum | null): any {
     return value as any;
 }
 
+export function NumberEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): NumberEnum {
+    return value as NumberEnum;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
@@ -48,3 +48,7 @@ export function StringEnumToJSON(value?: StringEnum | null): any {
     return value as any;
 }
 
+export function StringEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): StringEnum {
+    return value as StringEnum;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
@@ -116,7 +116,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -151,7 +151,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
@@ -116,7 +116,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -151,7 +151,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
@@ -55,7 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+  export function CategoryToJSON(json: any): Category {
+      return CategoryToJSONTyped(json, false);
+  }
+
+  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
@@ -55,10 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null): any {
+export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
@@ -62,7 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+      return ModelApiResponseToJSONTyped(json, false);
+  }
+
+  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
@@ -62,10 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'code': value['code'],

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
@@ -95,7 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+  export function OrderToJSON(json: any): Order {
+      return OrderToJSONTyped(json, false);
+  }
+
+  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
@@ -95,10 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null): any {
+export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
@@ -105,22 +105,23 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null): any {
+export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -105,12 +107,16 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+  export function PetToJSON(json: any): Pet {
+      return PetToJSONTyped(json, false);
+  }
+
+  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -121,7 +127,7 @@ export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = fal
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
@@ -55,10 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null): any {
+export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
@@ -55,7 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+  export function TagToJSON(json: any): Tag {
+      return TagToJSONTyped(json, false);
+  }
+
+  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
@@ -97,10 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null): any {
+export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
@@ -97,7 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
+  export function UserToJSON(json: any): User {
+      return UserToJSONTyped(json, false);
+  }
+
+  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
@@ -116,7 +116,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -151,7 +151,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
@@ -116,7 +116,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -151,7 +151,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
@@ -55,7 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+  export function CategoryToJSON(json: any): Category {
+      return CategoryToJSONTyped(json, false);
+  }
+
+  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
@@ -55,10 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null): any {
+export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
@@ -62,7 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+      return ModelApiResponseToJSONTyped(json, false);
+  }
+
+  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
@@ -62,10 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'code': value['code'],

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
@@ -95,7 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+  export function OrderToJSON(json: any): Order {
+      return OrderToJSONTyped(json, false);
+  }
+
+  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
@@ -95,10 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null): any {
+export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
@@ -105,22 +105,23 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null): any {
+export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -105,12 +107,16 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+  export function PetToJSON(json: any): Pet {
+      return PetToJSONTyped(json, false);
+  }
+
+  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -121,7 +127,7 @@ export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = fal
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
@@ -55,10 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null): any {
+export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
@@ -55,7 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+  export function TagToJSON(json: any): Tag {
+      return TagToJSONTyped(json, false);
+  }
+
+  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
@@ -97,10 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null): any {
+export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
@@ -97,7 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
+  export function UserToJSON(json: any): User {
+      return UserToJSONTyped(json, false);
+  }
+
+  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestA.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestA.ts
@@ -49,7 +49,11 @@ export function TestAFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tes
     };
 }
 
-export function TestAToJSON(value?: TestA | null, ignoreDiscriminator: boolean = false): any {
+  export function TestAToJSON(json: any): TestA {
+      return TestAToJSONTyped(json, false);
+  }
+
+  export function TestAToJSONTyped(value?: TestA | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestA.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestA.ts
@@ -49,10 +49,11 @@ export function TestAFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tes
     };
 }
 
-export function TestAToJSON(value?: TestA | null): any {
+export function TestAToJSON(value?: TestA | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'foo': value['foo'],

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestB.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestB.ts
@@ -49,10 +49,11 @@ export function TestBFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tes
     };
 }
 
-export function TestBToJSON(value?: TestB | null): any {
+export function TestBToJSON(value?: TestB | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'bar': value['bar'],

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestB.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestB.ts
@@ -49,7 +49,11 @@ export function TestBFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tes
     };
 }
 
-export function TestBToJSON(value?: TestB | null, ignoreDiscriminator: boolean = false): any {
+  export function TestBToJSON(json: any): TestB {
+      return TestBToJSONTyped(json, false);
+  }
+
+  export function TestBToJSONTyped(value?: TestB | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/pom.xml
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/pom.xml
@@ -53,19 +53,6 @@
                             </arguments>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>npm-test</id>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>npm</executable>
-                            <arguments>
-                                <argument>test</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
@@ -116,7 +116,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -151,7 +151,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
@@ -116,7 +116,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -151,7 +151,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
@@ -55,7 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+  export function CategoryToJSON(json: any): Category {
+      return CategoryToJSONTyped(json, false);
+  }
+
+  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
@@ -55,10 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null): any {
+export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
@@ -62,7 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+      return ModelApiResponseToJSONTyped(json, false);
+  }
+
+  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
@@ -62,10 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'code': value['code'],

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
@@ -95,7 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+  export function OrderToJSON(json: any): Order {
+      return OrderToJSONTyped(json, false);
+  }
+
+  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
@@ -95,10 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null): any {
+export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
@@ -105,22 +105,23 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null): any {
+export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -105,12 +107,16 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+  export function PetToJSON(json: any): Pet {
+      return PetToJSONTyped(json, false);
+  }
+
+  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -121,7 +127,7 @@ export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = fal
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
@@ -55,10 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null): any {
+export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
@@ -55,7 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+  export function TagToJSON(json: any): Tag {
+      return TagToJSONTyped(json, false);
+  }
+
+  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
@@ -97,10 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null): any {
+export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
@@ -97,7 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
+  export function UserToJSON(json: any): User {
+      return UserToJSONTyped(json, false);
+  }
+
+  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
@@ -119,7 +119,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -154,7 +154,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
@@ -119,7 +119,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -154,7 +154,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
@@ -48,3 +48,7 @@ export function BehaviorTypeToJSON(value?: BehaviorType | null): any {
     return value as any;
 }
 
+export function BehaviorTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): BehaviorType {
+    return value as BehaviorType;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
@@ -55,7 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+  export function CategoryToJSON(json: any): Category {
+      return CategoryToJSONTyped(json, false);
+  }
+
+  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
@@ -55,10 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null): any {
+export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
@@ -56,10 +56,11 @@ export function DefaultMetaOnlyResponseFromJSONTyped(json: any, ignoreDiscrimina
     };
 }
 
-export function DefaultMetaOnlyResponseToJSON(value?: DefaultMetaOnlyResponse | null): any {
+export function DefaultMetaOnlyResponseToJSON(value?: DefaultMetaOnlyResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'meta': ResponseMetaToJSON(value['meta']),

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
@@ -18,6 +18,7 @@ import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 
 /**
@@ -56,7 +57,11 @@ export function DefaultMetaOnlyResponseFromJSONTyped(json: any, ignoreDiscrimina
     };
 }
 
-export function DefaultMetaOnlyResponseToJSON(value?: DefaultMetaOnlyResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function DefaultMetaOnlyResponseToJSON(json: any): DefaultMetaOnlyResponse {
+      return DefaultMetaOnlyResponseToJSONTyped(json, false);
+  }
+
+  export function DefaultMetaOnlyResponseToJSONTyped(value?: DefaultMetaOnlyResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
@@ -57,3 +57,7 @@ export function DeploymentRequestStatusToJSON(value?: DeploymentRequestStatus | 
     return value as any;
 }
 
+export function DeploymentRequestStatusToJSONTyped(value: any, ignoreDiscriminator: boolean): DeploymentRequestStatus {
+    return value as DeploymentRequestStatus;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
@@ -63,3 +63,7 @@ export function ErrorCodeToJSON(value?: ErrorCode | null): any {
     return value as any;
 }
 
+export function ErrorCodeToJSONTyped(value: any, ignoreDiscriminator: boolean): ErrorCode {
+    return value as ErrorCode;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
@@ -18,12 +18,14 @@ import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 import type { Pet } from './Pet';
 import {
     PetFromJSON,
     PetFromJSONTyped,
     PetToJSON,
+    PetToJSONTyped,
 } from './Pet';
 
 /**
@@ -65,11 +67,15 @@ export function FindPetsByStatusResponseFromJSONTyped(json: any, ignoreDiscrimin
     return {
         
         'meta': ResponseMetaFromJSON(json['meta']),
-        'data': json['data'] == null ? undefined : ((json['data'] as Array<any>).map(s => PetFromJSON(s))),
+        'data': json['data'] == null ? undefined : ((json['data'] as Array<any>).map(PetFromJSON)),
     };
 }
 
-export function FindPetsByStatusResponseToJSON(value?: FindPetsByStatusResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function FindPetsByStatusResponseToJSON(json: any): FindPetsByStatusResponse {
+      return FindPetsByStatusResponseToJSONTyped(json, false);
+  }
+
+  export function FindPetsByStatusResponseToJSONTyped(value?: FindPetsByStatusResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -77,7 +83,7 @@ export function FindPetsByStatusResponseToJSON(value?: FindPetsByStatusResponse 
     return {
         
         'meta': ResponseMetaToJSON(value['meta']),
-        'data': value['data'] == null ? undefined : ((value['data'] as Array<any>).map(a => PetToJSON(a))),
+        'data': value['data'] == null ? undefined : ((value['data'] as Array<any>).map(PetToJSON)),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
@@ -65,18 +65,19 @@ export function FindPetsByStatusResponseFromJSONTyped(json: any, ignoreDiscrimin
     return {
         
         'meta': ResponseMetaFromJSON(json['meta']),
-        'data': json['data'] == null ? undefined : ((json['data'] as Array<any>).map(PetFromJSON)),
+        'data': json['data'] == null ? undefined : ((json['data'] as Array<any>).map(s => PetFromJSON(s))),
     };
 }
 
-export function FindPetsByStatusResponseToJSON(value?: FindPetsByStatusResponse | null): any {
+export function FindPetsByStatusResponseToJSON(value?: FindPetsByStatusResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'meta': ResponseMetaToJSON(value['meta']),
-        'data': value['data'] == null ? undefined : ((value['data'] as Array<any>).map(PetToJSON)),
+        'data': value['data'] == null ? undefined : ((value['data'] as Array<any>).map(a => PetToJSON(a))),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
@@ -65,18 +65,19 @@ export function FindPetsByUserResponseFromJSONTyped(json: any, ignoreDiscriminat
     return {
         
         'meta': ResponseMetaFromJSON(json['meta']),
-        'data': json['data'] == null ? undefined : ((json['data'] as Array<any>).map(UserFromJSON)),
+        'data': json['data'] == null ? undefined : ((json['data'] as Array<any>).map(s => UserFromJSON(s))),
     };
 }
 
-export function FindPetsByUserResponseToJSON(value?: FindPetsByUserResponse | null): any {
+export function FindPetsByUserResponseToJSON(value?: FindPetsByUserResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'meta': ResponseMetaToJSON(value['meta']),
-        'data': value['data'] == null ? undefined : ((value['data'] as Array<any>).map(UserToJSON)),
+        'data': value['data'] == null ? undefined : ((value['data'] as Array<any>).map(a => UserToJSON(a))),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
@@ -18,12 +18,14 @@ import {
     UserFromJSON,
     UserFromJSONTyped,
     UserToJSON,
+    UserToJSONTyped,
 } from './User';
 import type { ResponseMeta } from './ResponseMeta';
 import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 
 /**
@@ -65,11 +67,15 @@ export function FindPetsByUserResponseFromJSONTyped(json: any, ignoreDiscriminat
     return {
         
         'meta': ResponseMetaFromJSON(json['meta']),
-        'data': json['data'] == null ? undefined : ((json['data'] as Array<any>).map(s => UserFromJSON(s))),
+        'data': json['data'] == null ? undefined : ((json['data'] as Array<any>).map(UserFromJSON)),
     };
 }
 
-export function FindPetsByUserResponseToJSON(value?: FindPetsByUserResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function FindPetsByUserResponseToJSON(json: any): FindPetsByUserResponse {
+      return FindPetsByUserResponseToJSONTyped(json, false);
+  }
+
+  export function FindPetsByUserResponseToJSONTyped(value?: FindPetsByUserResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -77,7 +83,7 @@ export function FindPetsByUserResponseToJSON(value?: FindPetsByUserResponse | nu
     return {
         
         'meta': ResponseMetaToJSON(value['meta']),
-        'data': value['data'] == null ? undefined : ((value['data'] as Array<any>).map(a => UserToJSON(a))),
+        'data': value['data'] == null ? undefined : ((value['data'] as Array<any>).map(UserToJSON)),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
@@ -63,10 +63,11 @@ export function GetBehaviorPermissionsResponseFromJSONTyped(json: any, ignoreDis
     };
 }
 
-export function GetBehaviorPermissionsResponseToJSON(value?: GetBehaviorPermissionsResponse | null): any {
+export function GetBehaviorPermissionsResponseToJSON(value?: GetBehaviorPermissionsResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'meta': ResponseMetaToJSON(value['meta']),

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
@@ -18,6 +18,7 @@ import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 
 /**
@@ -63,7 +64,11 @@ export function GetBehaviorPermissionsResponseFromJSONTyped(json: any, ignoreDis
     };
 }
 
-export function GetBehaviorPermissionsResponseToJSON(value?: GetBehaviorPermissionsResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function GetBehaviorPermissionsResponseToJSON(json: any): GetBehaviorPermissionsResponse {
+      return GetBehaviorPermissionsResponseToJSONTyped(json, false);
+  }
+
+  export function GetBehaviorPermissionsResponseToJSONTyped(value?: GetBehaviorPermissionsResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
@@ -18,12 +18,14 @@ import {
     BehaviorTypeFromJSON,
     BehaviorTypeFromJSONTyped,
     BehaviorTypeToJSON,
+    BehaviorTypeToJSONTyped,
 } from './BehaviorType';
 import type { ResponseMeta } from './ResponseMeta';
 import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 
 /**
@@ -71,7 +73,11 @@ export function GetBehaviorTypeResponseFromJSONTyped(json: any, ignoreDiscrimina
     };
 }
 
-export function GetBehaviorTypeResponseToJSON(value?: GetBehaviorTypeResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function GetBehaviorTypeResponseToJSON(json: any): GetBehaviorTypeResponse {
+      return GetBehaviorTypeResponseToJSONTyped(json, false);
+  }
+
+  export function GetBehaviorTypeResponseToJSONTyped(value?: GetBehaviorTypeResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
@@ -71,10 +71,11 @@ export function GetBehaviorTypeResponseFromJSONTyped(json: any, ignoreDiscrimina
     };
 }
 
-export function GetBehaviorTypeResponseToJSON(value?: GetBehaviorTypeResponse | null): any {
+export function GetBehaviorTypeResponseToJSON(value?: GetBehaviorTypeResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'meta': ResponseMetaToJSON(value['meta']),

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
@@ -69,10 +69,11 @@ export function GetMatchingPartsResponseFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-export function GetMatchingPartsResponseToJSON(value?: GetMatchingPartsResponse | null): any {
+export function GetMatchingPartsResponseToJSON(value?: GetMatchingPartsResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'meta': ResponseMetaToJSON(value['meta']),

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
@@ -18,12 +18,14 @@ import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 import type { MatchingParts } from './MatchingParts';
 import {
     MatchingPartsFromJSON,
     MatchingPartsFromJSONTyped,
     MatchingPartsToJSON,
+    MatchingPartsToJSONTyped,
 } from './MatchingParts';
 
 /**
@@ -69,7 +71,11 @@ export function GetMatchingPartsResponseFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-export function GetMatchingPartsResponseToJSON(value?: GetMatchingPartsResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function GetMatchingPartsResponseToJSON(json: any): GetMatchingPartsResponse {
+      return GetMatchingPartsResponseToJSONTyped(json, false);
+  }
+
+  export function GetMatchingPartsResponseToJSONTyped(value?: GetMatchingPartsResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
@@ -18,12 +18,14 @@ import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 import type { PetPartType } from './PetPartType';
 import {
     PetPartTypeFromJSON,
     PetPartTypeFromJSONTyped,
     PetPartTypeToJSON,
+    PetPartTypeToJSONTyped,
 } from './PetPartType';
 
 /**
@@ -71,7 +73,11 @@ export function GetPetPartTypeResponseFromJSONTyped(json: any, ignoreDiscriminat
     };
 }
 
-export function GetPetPartTypeResponseToJSON(value?: GetPetPartTypeResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function GetPetPartTypeResponseToJSON(json: any): GetPetPartTypeResponse {
+      return GetPetPartTypeResponseToJSONTyped(json, false);
+  }
+
+  export function GetPetPartTypeResponseToJSONTyped(value?: GetPetPartTypeResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
@@ -71,10 +71,11 @@ export function GetPetPartTypeResponseFromJSONTyped(json: any, ignoreDiscriminat
     };
 }
 
-export function GetPetPartTypeResponseToJSON(value?: GetPetPartTypeResponse | null): any {
+export function GetPetPartTypeResponseToJSON(value?: GetPetPartTypeResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'meta': ResponseMetaToJSON(value['meta']),

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
@@ -57,10 +57,11 @@ export function ItemIdFromJSONTyped(json: any, ignoreDiscriminator: boolean): It
     };
 }
 
-export function ItemIdToJSON(value?: ItemId | null): any {
+export function ItemIdToJSON(value?: ItemId | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
@@ -57,7 +57,11 @@ export function ItemIdFromJSONTyped(json: any, ignoreDiscriminator: boolean): It
     };
 }
 
-export function ItemIdToJSON(value?: ItemId | null, ignoreDiscriminator: boolean = false): any {
+  export function ItemIdToJSON(json: any): ItemId {
+      return ItemIdToJSONTyped(json, false);
+  }
+
+  export function ItemIdToJSONTyped(value?: ItemId | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
@@ -18,6 +18,7 @@ import {
     PartFromJSON,
     PartFromJSONTyped,
     PartToJSON,
+    PartToJSONTyped,
 } from './Part';
 
 /**
@@ -59,20 +60,24 @@ export function MatchingPartsFromJSONTyped(json: any, ignoreDiscriminator: boole
     }
     return {
         
-        'connected': ((json['connected'] as Array<any>).map(s => PartFromJSON(s))),
-        'related': ((json['related'] as Array<any>).map(s => PartFromJSON(s))),
+        'connected': ((json['connected'] as Array<any>).map(PartFromJSON)),
+        'related': ((json['related'] as Array<any>).map(PartFromJSON)),
     };
 }
 
-export function MatchingPartsToJSON(value?: MatchingParts | null, ignoreDiscriminator: boolean = false): any {
+  export function MatchingPartsToJSON(json: any): MatchingParts {
+      return MatchingPartsToJSONTyped(json, false);
+  }
+
+  export function MatchingPartsToJSONTyped(value?: MatchingParts | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
 
     return {
         
-        'connected': ((value['connected'] as Array<any>).map(a => PartToJSON(a))),
-        'related': ((value['related'] as Array<any>).map(a => PartToJSON(a))),
+        'connected': ((value['connected'] as Array<any>).map(PartToJSON)),
+        'related': ((value['related'] as Array<any>).map(PartToJSON)),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
@@ -59,19 +59,20 @@ export function MatchingPartsFromJSONTyped(json: any, ignoreDiscriminator: boole
     }
     return {
         
-        'connected': ((json['connected'] as Array<any>).map(PartFromJSON)),
-        'related': ((json['related'] as Array<any>).map(PartFromJSON)),
+        'connected': ((json['connected'] as Array<any>).map(s => PartFromJSON(s))),
+        'related': ((json['related'] as Array<any>).map(s => PartFromJSON(s))),
     };
 }
 
-export function MatchingPartsToJSON(value?: MatchingParts | null): any {
+export function MatchingPartsToJSON(value?: MatchingParts | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
-        'connected': ((value['connected'] as Array<any>).map(PartToJSON)),
-        'related': ((value['related'] as Array<any>).map(PartToJSON)),
+        'connected': ((value['connected'] as Array<any>).map(a => PartToJSON(a))),
+        'related': ((value['related'] as Array<any>).map(a => PartToJSON(a))),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
@@ -62,7 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+      return ModelApiResponseToJSONTyped(json, false);
+  }
+
+  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
@@ -62,10 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'code': value['code'],

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
@@ -18,6 +18,7 @@ import {
     ItemIdFromJSON,
     ItemIdFromJSONTyped,
     ItemIdToJSON,
+    ItemIdToJSONTyped,
 } from './ItemId';
 
 /**
@@ -77,7 +78,11 @@ export function ModelErrorFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function ModelErrorToJSON(value?: ModelError | null, ignoreDiscriminator: boolean = false): any {
+  export function ModelErrorToJSON(json: any): ModelError {
+      return ModelErrorToJSONTyped(json, false);
+  }
+
+  export function ModelErrorToJSONTyped(value?: ModelError | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
@@ -77,10 +77,11 @@ export function ModelErrorFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function ModelErrorToJSON(value?: ModelError | null): any {
+export function ModelErrorToJSON(value?: ModelError | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'type': value['type'],

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
@@ -95,7 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+  export function OrderToJSON(json: any): Order {
+      return OrderToJSONTyped(json, false);
+  }
+
+  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
@@ -95,10 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null): any {
+export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
@@ -57,7 +57,11 @@ export function PartFromJSONTyped(json: any, ignoreDiscriminator: boolean): Part
     };
 }
 
-export function PartToJSON(value?: Part | null, ignoreDiscriminator: boolean = false): any {
+  export function PartToJSON(json: any): Part {
+      return PartToJSONTyped(json, false);
+  }
+
+  export function PartToJSONTyped(value?: Part | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
@@ -57,10 +57,11 @@ export function PartFromJSONTyped(json: any, ignoreDiscriminator: boolean): Part
     };
 }
 
-export function PartToJSON(value?: Part | null): any {
+export function PartToJSON(value?: Part | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
@@ -18,24 +18,28 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { DeploymentRequestStatus } from './DeploymentRequestStatus';
 import {
     DeploymentRequestStatusFromJSON,
     DeploymentRequestStatusFromJSONTyped,
     DeploymentRequestStatusToJSON,
+    DeploymentRequestStatusToJSONTyped,
 } from './DeploymentRequestStatus';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 import type { WarningCode } from './WarningCode';
 import {
     WarningCodeFromJSON,
     WarningCodeFromJSONTyped,
     WarningCodeToJSON,
+    WarningCodeToJSONTyped,
 } from './WarningCode';
 
 /**
@@ -225,21 +229,25 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': CategoryFromJSON(json['category']),
         'optionalCategory': json['optionalCategory'] == null ? undefined : CategoryFromJSON(json['optionalCategory']),
         'name': json['name'],
-        '_entries': json['entries'] == null ? undefined : ((json['entries'] as Array<any>).map(s => CategoryFromJSON(s))),
+        '_entries': json['entries'] == null ? undefined : ((json['entries'] as Array<any>).map(CategoryFromJSON)),
         'surname': json['surname'] == null ? undefined : json['surname'],
         'photoUrls': json['photoUrls'],
         'warningStatus': WarningCodeFromJSON(json['warningStatus']),
         'depStatus': json['depStatus'] == null ? undefined : DeploymentRequestStatusFromJSON(json['depStatus']),
         'alternateStatus': DeploymentRequestStatusFromJSON(json['alternateStatus']),
-        'otherDepStatuses': ((json['otherDepStatuses'] as Array<any>).map(s => DeploymentRequestStatusFromJSON(s))),
-        'tags': ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
-        'optionalTags': json['optionalTags'] == null ? undefined : ((json['optionalTags'] as Array<any>).map(s => TagFromJSON(s))),
+        'otherDepStatuses': ((json['otherDepStatuses'] as Array<any>).map(DeploymentRequestStatusFromJSON)),
+        'tags': ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'optionalTags': json['optionalTags'] == null ? undefined : ((json['optionalTags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'],
         'regions': json['regions'] == null ? undefined : json['regions'],
     };
 }
 
-export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+  export function PetToJSON(json: any): Pet {
+      return PetToJSONTyped(json, false);
+  }
+
+  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -256,15 +264,15 @@ export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = fal
         'category': CategoryToJSON(value['category']),
         'optionalCategory': CategoryToJSON(value['optionalCategory']),
         'name': value['name'],
-        'entries': value['_entries'] == null ? undefined : ((value['_entries'] as Array<any>).map(a => CategoryToJSON(a))),
+        'entries': value['_entries'] == null ? undefined : ((value['_entries'] as Array<any>).map(CategoryToJSON)),
         'surname': value['surname'],
         'photoUrls': value['photoUrls'],
         'warningStatus': WarningCodeToJSON(value['warningStatus']),
         'depStatus': DeploymentRequestStatusToJSON(value['depStatus']),
         'alternateStatus': DeploymentRequestStatusToJSON(value['alternateStatus']),
-        'otherDepStatuses': ((value['otherDepStatuses'] as Array<any>).map(a => DeploymentRequestStatusToJSON(a))),
-        'tags': ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
-        'optionalTags': value['optionalTags'] == null ? undefined : ((value['optionalTags'] as Array<any>).map(a => TagToJSON(a))),
+        'otherDepStatuses': ((value['otherDepStatuses'] as Array<any>).map(DeploymentRequestStatusToJSON)),
+        'tags': ((value['tags'] as Array<any>).map(TagToJSON)),
+        'optionalTags': value['optionalTags'] == null ? undefined : ((value['optionalTags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
         'regions': value['regions'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
@@ -225,24 +225,25 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': CategoryFromJSON(json['category']),
         'optionalCategory': json['optionalCategory'] == null ? undefined : CategoryFromJSON(json['optionalCategory']),
         'name': json['name'],
-        '_entries': json['entries'] == null ? undefined : ((json['entries'] as Array<any>).map(CategoryFromJSON)),
+        '_entries': json['entries'] == null ? undefined : ((json['entries'] as Array<any>).map(s => CategoryFromJSON(s))),
         'surname': json['surname'] == null ? undefined : json['surname'],
         'photoUrls': json['photoUrls'],
         'warningStatus': WarningCodeFromJSON(json['warningStatus']),
         'depStatus': json['depStatus'] == null ? undefined : DeploymentRequestStatusFromJSON(json['depStatus']),
         'alternateStatus': DeploymentRequestStatusFromJSON(json['alternateStatus']),
-        'otherDepStatuses': ((json['otherDepStatuses'] as Array<any>).map(DeploymentRequestStatusFromJSON)),
-        'tags': ((json['tags'] as Array<any>).map(TagFromJSON)),
-        'optionalTags': json['optionalTags'] == null ? undefined : ((json['optionalTags'] as Array<any>).map(TagFromJSON)),
+        'otherDepStatuses': ((json['otherDepStatuses'] as Array<any>).map(s => DeploymentRequestStatusFromJSON(s))),
+        'tags': ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
+        'optionalTags': json['optionalTags'] == null ? undefined : ((json['optionalTags'] as Array<any>).map(s => TagFromJSON(s))),
         'status': json['status'],
         'regions': json['regions'] == null ? undefined : json['regions'],
     };
 }
 
-export function PetToJSON(value?: Pet | null): any {
+export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],
@@ -255,15 +256,15 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value['category']),
         'optionalCategory': CategoryToJSON(value['optionalCategory']),
         'name': value['name'],
-        'entries': value['_entries'] == null ? undefined : ((value['_entries'] as Array<any>).map(CategoryToJSON)),
+        'entries': value['_entries'] == null ? undefined : ((value['_entries'] as Array<any>).map(a => CategoryToJSON(a))),
         'surname': value['surname'],
         'photoUrls': value['photoUrls'],
         'warningStatus': WarningCodeToJSON(value['warningStatus']),
         'depStatus': DeploymentRequestStatusToJSON(value['depStatus']),
         'alternateStatus': DeploymentRequestStatusToJSON(value['alternateStatus']),
-        'otherDepStatuses': ((value['otherDepStatuses'] as Array<any>).map(DeploymentRequestStatusToJSON)),
-        'tags': ((value['tags'] as Array<any>).map(TagToJSON)),
-        'optionalTags': value['optionalTags'] == null ? undefined : ((value['optionalTags'] as Array<any>).map(TagToJSON)),
+        'otherDepStatuses': ((value['otherDepStatuses'] as Array<any>).map(a => DeploymentRequestStatusToJSON(a))),
+        'tags': ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
+        'optionalTags': value['optionalTags'] == null ? undefined : ((value['optionalTags'] as Array<any>).map(a => TagToJSON(a))),
         'status': value['status'],
         'regions': value['regions'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
@@ -48,3 +48,7 @@ export function PetPartTypeToJSON(value?: PetPartType | null): any {
     return value as any;
 }
 
+export function PetPartTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): PetPartType {
+    return value as PetPartType;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
@@ -18,6 +18,7 @@ import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 
 /**
@@ -63,7 +64,11 @@ export function PetRegionsResponseFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function PetRegionsResponseToJSON(value?: PetRegionsResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function PetRegionsResponseToJSON(json: any): PetRegionsResponse {
+      return PetRegionsResponseToJSONTyped(json, false);
+  }
+
+  export function PetRegionsResponseToJSONTyped(value?: PetRegionsResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
@@ -63,10 +63,11 @@ export function PetRegionsResponseFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function PetRegionsResponseToJSON(value?: PetRegionsResponse | null): any {
+export function PetRegionsResponseToJSON(value?: PetRegionsResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'meta': ResponseMetaToJSON(value['meta']),

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
@@ -123,10 +123,11 @@ export function ResponseMetaFromJSONTyped(json: any, ignoreDiscriminator: boolea
     };
 }
 
-export function ResponseMetaToJSON(value?: ResponseMeta | null): any {
+export function ResponseMetaToJSON(value?: ResponseMeta | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'code': value['code'],

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
@@ -18,6 +18,7 @@ import {
     ErrorCodeFromJSON,
     ErrorCodeFromJSONTyped,
     ErrorCodeToJSON,
+    ErrorCodeToJSONTyped,
 } from './ErrorCode';
 
 /**
@@ -123,7 +124,11 @@ export function ResponseMetaFromJSONTyped(json: any, ignoreDiscriminator: boolea
     };
 }
 
-export function ResponseMetaToJSON(value?: ResponseMeta | null, ignoreDiscriminator: boolean = false): any {
+  export function ResponseMetaToJSON(json: any): ResponseMeta {
+      return ResponseMetaToJSONTyped(json, false);
+  }
+
+  export function ResponseMetaToJSONTyped(value?: ResponseMeta | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
@@ -55,10 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null): any {
+export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
@@ -55,7 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+  export function TagToJSON(json: any): Tag {
+      return TagToJSONTyped(json, false);
+  }
+
+  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
@@ -113,10 +113,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null): any {
+export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
@@ -113,7 +113,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
+  export function UserToJSON(json: any): User {
+      return UserToJSONTyped(json, false);
+  }
+
+  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
@@ -48,3 +48,7 @@ export function WarningCodeToJSON(value?: WarningCode | null): any {
     return value as any;
 }
 
+export function WarningCodeToJSONTyped(value: any, ignoreDiscriminator: boolean): WarningCode {
+    return value as WarningCode;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/UserApi.ts
@@ -117,7 +117,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['user']!.map(x => UserToJSON(x)),
+            body: requestParameters['user']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -154,7 +154,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['user']!.map(x => UserToJSON(x)),
+            body: requestParameters['user']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/UserApi.ts
@@ -117,7 +117,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['user']!.map(UserToJSON),
+            body: requestParameters['user']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -154,7 +154,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['user']!.map(UserToJSON),
+            body: requestParameters['user']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
@@ -55,7 +55,11 @@ export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscrimi
     };
 }
 
-export function AdditionalPropertiesClassToJSON(value?: AdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
+  export function AdditionalPropertiesClassToJSON(json: any): AdditionalPropertiesClass {
+      return AdditionalPropertiesClassToJSONTyped(json, false);
+  }
+
+  export function AdditionalPropertiesClassToJSONTyped(value?: AdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
@@ -55,10 +55,11 @@ export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscrimi
     };
 }
 
-export function AdditionalPropertiesClassToJSON(value?: AdditionalPropertiesClass | null): any {
+export function AdditionalPropertiesClassToJSON(value?: AdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'map_property': value['mapProperty'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
@@ -18,6 +18,7 @@ import {
     SingleRefTypeFromJSON,
     SingleRefTypeFromJSONTyped,
     SingleRefTypeToJSON,
+    SingleRefTypeToJSONTyped,
 } from './SingleRefType';
 
 /**
@@ -64,7 +65,11 @@ export function AllOfWithSingleRefFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function AllOfWithSingleRefToJSON(value?: AllOfWithSingleRef | null, ignoreDiscriminator: boolean = false): any {
+  export function AllOfWithSingleRefToJSON(json: any): AllOfWithSingleRef {
+      return AllOfWithSingleRefToJSONTyped(json, false);
+  }
+
+  export function AllOfWithSingleRefToJSONTyped(value?: AllOfWithSingleRef | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
@@ -64,10 +64,11 @@ export function AllOfWithSingleRefFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function AllOfWithSingleRefToJSON(value?: AllOfWithSingleRef | null): any {
+export function AllOfWithSingleRefToJSON(value?: AllOfWithSingleRef | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'username': value['username'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
@@ -13,8 +13,8 @@
  */
 
 import { mapValues } from '../runtime';
-import { CatFromJSONTyped } from './Cat';
-import { DogFromJSONTyped } from './Dog';
+import { Cat, CatFromJSONTyped, CatToJSON } from './Cat';
+import { Dog, DogFromJSONTyped, DogToJSON } from './Dog';
 /**
  * 
  * @export
@@ -53,10 +53,10 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
     }
     if (!ignoreDiscriminator) {
         if (json['class_name'] === 'CAT') {
-            return CatFromJSONTyped(json, true);
+            return CatFromJSONTyped(json, ignoreDiscriminator);
         }
         if (json['class_name'] === 'DOG') {
-            return DogFromJSONTyped(json, true);
+            return DogFromJSONTyped(json, ignoreDiscriminator);
         }
     }
     return {
@@ -66,10 +66,22 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
     };
 }
 
-export function AnimalToJSON(value?: Animal | null): any {
+export function AnimalToJSON(value?: Animal | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
+    if (!ignoreDiscriminator) {
+        switch (value['className']) {
+            case 'CAT':
+                return CatToJSON(value as Cat, ignoreDiscriminator);
+            case 'DOG':
+                return DogToJSON(value as Dog, ignoreDiscriminator);
+            default:
+                throw new Error(`No variant of Animal exists with 'className=${value['className']}'`);
+        }
+    }
+
     return {
         
         'class_name': value['className'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
@@ -13,8 +13,8 @@
  */
 
 import { mapValues } from '../runtime';
-import { Cat, CatFromJSONTyped, CatToJSON } from './Cat';
-import { Dog, DogFromJSONTyped, DogToJSON } from './Dog';
+import { Cat, CatFromJSONTyped, CatToJSON, CatToJSONTyped } from './Cat';
+import { Dog, DogFromJSONTyped, DogToJSON, DogToJSONTyped } from './Dog';
 /**
  * 
  * @export
@@ -66,7 +66,11 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
     };
 }
 
-export function AnimalToJSON(value?: Animal | null, ignoreDiscriminator: boolean = false): any {
+  export function AnimalToJSON(json: any): Animal {
+      return AnimalToJSONTyped(json, false);
+  }
+
+  export function AnimalToJSONTyped(value?: Animal | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -74,9 +78,9 @@ export function AnimalToJSON(value?: Animal | null, ignoreDiscriminator: boolean
     if (!ignoreDiscriminator) {
         switch (value['className']) {
             case 'CAT':
-                return CatToJSON(value as Cat, ignoreDiscriminator);
+                return CatToJSONTyped(value as Cat, ignoreDiscriminator);
             case 'DOG':
-                return DogToJSON(value as Dog, ignoreDiscriminator);
+                return DogToJSONTyped(value as Dog, ignoreDiscriminator);
             default:
                 throw new Error(`No variant of Animal exists with 'className=${value['className']}'`);
         }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
@@ -48,10 +48,11 @@ export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-export function ArrayOfArrayOfNumberOnlyToJSON(value?: ArrayOfArrayOfNumberOnly | null): any {
+export function ArrayOfArrayOfNumberOnlyToJSON(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'ArrayArrayNumber': value['arrayArrayNumber'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
@@ -48,7 +48,11 @@ export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-export function ArrayOfArrayOfNumberOnlyToJSON(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
+  export function ArrayOfArrayOfNumberOnlyToJSON(json: any): ArrayOfArrayOfNumberOnly {
+      return ArrayOfArrayOfNumberOnlyToJSONTyped(json, false);
+  }
+
+  export function ArrayOfArrayOfNumberOnlyToJSONTyped(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
@@ -48,10 +48,11 @@ export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function ArrayOfNumberOnlyToJSON(value?: ArrayOfNumberOnly | null): any {
+export function ArrayOfNumberOnlyToJSON(value?: ArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'ArrayNumber': value['arrayNumber'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
@@ -48,7 +48,11 @@ export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function ArrayOfNumberOnlyToJSON(value?: ArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
+  export function ArrayOfNumberOnlyToJSON(json: any): ArrayOfNumberOnly {
+      return ArrayOfNumberOnlyToJSONTyped(json, false);
+  }
+
+  export function ArrayOfNumberOnlyToJSONTyped(value?: ArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
@@ -69,10 +69,11 @@ export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ArrayTestToJSON(value?: ArrayTest | null): any {
+export function ArrayTestToJSON(value?: ArrayTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'array_of_string': value['arrayOfString'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
@@ -18,6 +18,7 @@ import {
     ReadOnlyFirstFromJSON,
     ReadOnlyFirstFromJSONTyped,
     ReadOnlyFirstToJSON,
+    ReadOnlyFirstToJSONTyped,
 } from './ReadOnlyFirst';
 
 /**
@@ -69,7 +70,11 @@ export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ArrayTestToJSON(value?: ArrayTest | null, ignoreDiscriminator: boolean = false): any {
+  export function ArrayTestToJSON(json: any): ArrayTest {
+      return ArrayTestToJSONTyped(json, false);
+  }
+
+  export function ArrayTestToJSONTyped(value?: ArrayTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
@@ -84,10 +84,11 @@ export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function CapitalizationToJSON(value?: Capitalization | null): any {
+export function CapitalizationToJSON(value?: Capitalization | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'smallCamel': value['smallCamel'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
@@ -84,7 +84,11 @@ export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function CapitalizationToJSON(value?: Capitalization | null, ignoreDiscriminator: boolean = false): any {
+  export function CapitalizationToJSON(json: any): Capitalization {
+      return CapitalizationToJSONTyped(json, false);
+  }
+
+  export function CapitalizationToJSONTyped(value?: Capitalization | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
@@ -18,6 +18,7 @@ import {
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
+    AnimalToJSONTyped,
 } from './Animal';
 
 /**
@@ -55,13 +56,17 @@ export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
     };
 }
 
-export function CatToJSON(value?: Cat | null, ignoreDiscriminator: boolean = false): any {
+  export function CatToJSON(json: any): Cat {
+      return CatToJSONTyped(json, false);
+  }
+
+  export function CatToJSONTyped(value?: Cat | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
 
     return {
-        ...AnimalToJSON(value, true),
+        ...AnimalToJSONTyped(value, true),
         'declawed': value['declawed'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
@@ -50,17 +50,18 @@ export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
         return json;
     }
     return {
-        ...AnimalFromJSONTyped(json, ignoreDiscriminator),
+        ...AnimalFromJSONTyped(json, true),
         'declawed': json['declawed'] == null ? undefined : json['declawed'],
     };
 }
 
-export function CatToJSON(value?: Cat | null): any {
+export function CatToJSON(value?: Cat | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
-        ...AnimalToJSON(value),
+        ...AnimalToJSON(value, true),
         'declawed': value['declawed'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
@@ -56,10 +56,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null): any {
+export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
@@ -56,7 +56,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+  export function CategoryToJSON(json: any): Category {
+      return CategoryToJSONTyped(json, false);
+  }
+
+  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
@@ -48,7 +48,11 @@ export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function ClassModelToJSON(value?: ClassModel | null, ignoreDiscriminator: boolean = false): any {
+  export function ClassModelToJSON(json: any): ClassModel {
+      return ClassModelToJSONTyped(json, false);
+  }
+
+  export function ClassModelToJSONTyped(value?: ClassModel | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
@@ -48,10 +48,11 @@ export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function ClassModelToJSON(value?: ClassModel | null): any {
+export function ClassModelToJSON(value?: ClassModel | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         '_class': value['_class'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
@@ -48,7 +48,11 @@ export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cl
     };
 }
 
-export function ClientToJSON(value?: Client | null, ignoreDiscriminator: boolean = false): any {
+  export function ClientToJSON(json: any): Client {
+      return ClientToJSONTyped(json, false);
+  }
+
+  export function ClientToJSONTyped(value?: Client | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
@@ -48,10 +48,11 @@ export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cl
     };
 }
 
-export function ClientToJSON(value?: Client | null): any {
+export function ClientToJSON(value?: Client | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'client': value['client'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
@@ -48,7 +48,11 @@ export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function DeprecatedObjectToJSON(value?: DeprecatedObject | null, ignoreDiscriminator: boolean = false): any {
+  export function DeprecatedObjectToJSON(json: any): DeprecatedObject {
+      return DeprecatedObjectToJSONTyped(json, false);
+  }
+
+  export function DeprecatedObjectToJSONTyped(value?: DeprecatedObject | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
@@ -48,10 +48,11 @@ export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function DeprecatedObjectToJSON(value?: DeprecatedObject | null): any {
+export function DeprecatedObjectToJSON(value?: DeprecatedObject | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'name': value['name'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
@@ -50,17 +50,18 @@ export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
         return json;
     }
     return {
-        ...AnimalFromJSONTyped(json, ignoreDiscriminator),
+        ...AnimalFromJSONTyped(json, true),
         'breed': json['breed'] == null ? undefined : json['breed'],
     };
 }
 
-export function DogToJSON(value?: Dog | null): any {
+export function DogToJSON(value?: Dog | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
-        ...AnimalToJSON(value),
+        ...AnimalToJSON(value, true),
         'breed': value['breed'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
@@ -18,6 +18,7 @@ import {
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
+    AnimalToJSONTyped,
 } from './Animal';
 
 /**
@@ -55,13 +56,17 @@ export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
     };
 }
 
-export function DogToJSON(value?: Dog | null, ignoreDiscriminator: boolean = false): any {
+  export function DogToJSON(json: any): Dog {
+      return DogToJSONTyped(json, false);
+  }
+
+  export function DogToJSONTyped(value?: Dog | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
 
     return {
-        ...AnimalToJSON(value, true),
+        ...AnimalToJSONTyped(value, true),
         'breed': value['breed'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
@@ -75,7 +75,11 @@ export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function EnumArraysToJSON(value?: EnumArrays | null, ignoreDiscriminator: boolean = false): any {
+  export function EnumArraysToJSON(json: any): EnumArrays {
+      return EnumArraysToJSONTyped(json, false);
+  }
+
+  export function EnumArraysToJSONTyped(value?: EnumArrays | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
@@ -75,10 +75,11 @@ export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function EnumArraysToJSON(value?: EnumArrays | null): any {
+export function EnumArraysToJSON(value?: EnumArrays | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'just_symbol': value['justSymbol'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
@@ -48,3 +48,7 @@ export function EnumClassToJSON(value?: EnumClass | null): any {
     return value as any;
 }
 
+export function EnumClassToJSONTyped(value: any, ignoreDiscriminator: boolean): EnumClass {
+    return value as EnumClass;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
@@ -163,10 +163,11 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function EnumTestToJSON(value?: EnumTest | null): any {
+export function EnumTestToJSON(value?: EnumTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'enum_string': value['enumString'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
@@ -18,24 +18,28 @@ import {
     OuterEnumFromJSON,
     OuterEnumFromJSONTyped,
     OuterEnumToJSON,
+    OuterEnumToJSONTyped,
 } from './OuterEnum';
 import type { OuterEnumIntegerDefaultValue } from './OuterEnumIntegerDefaultValue';
 import {
     OuterEnumIntegerDefaultValueFromJSON,
     OuterEnumIntegerDefaultValueFromJSONTyped,
     OuterEnumIntegerDefaultValueToJSON,
+    OuterEnumIntegerDefaultValueToJSONTyped,
 } from './OuterEnumIntegerDefaultValue';
 import type { OuterEnumInteger } from './OuterEnumInteger';
 import {
     OuterEnumIntegerFromJSON,
     OuterEnumIntegerFromJSONTyped,
     OuterEnumIntegerToJSON,
+    OuterEnumIntegerToJSONTyped,
 } from './OuterEnumInteger';
 import type { OuterEnumDefaultValue } from './OuterEnumDefaultValue';
 import {
     OuterEnumDefaultValueFromJSON,
     OuterEnumDefaultValueFromJSONTyped,
     OuterEnumDefaultValueToJSON,
+    OuterEnumDefaultValueToJSONTyped,
 } from './OuterEnumDefaultValue';
 
 /**
@@ -163,7 +167,11 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function EnumTestToJSON(value?: EnumTest | null, ignoreDiscriminator: boolean = false): any {
+  export function EnumTestToJSON(json: any): EnumTest {
+      return EnumTestToJSONTyped(json, false);
+  }
+
+  export function EnumTestToJSONTyped(value?: EnumTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
@@ -55,7 +55,11 @@ export function FakeBigDecimalMap200ResponseFromJSONTyped(json: any, ignoreDiscr
     };
 }
 
-export function FakeBigDecimalMap200ResponseToJSON(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator: boolean = false): any {
+  export function FakeBigDecimalMap200ResponseToJSON(json: any): FakeBigDecimalMap200Response {
+      return FakeBigDecimalMap200ResponseToJSONTyped(json, false);
+  }
+
+  export function FakeBigDecimalMap200ResponseToJSONTyped(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
@@ -55,10 +55,11 @@ export function FakeBigDecimalMap200ResponseFromJSONTyped(json: any, ignoreDiscr
     };
 }
 
-export function FakeBigDecimalMap200ResponseToJSON(value?: FakeBigDecimalMap200Response | null): any {
+export function FakeBigDecimalMap200ResponseToJSON(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'someId': value['someId'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
@@ -55,7 +55,11 @@ export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator:
     };
 }
 
-export function FileSchemaTestClassToJSON(value?: FileSchemaTestClass | null, ignoreDiscriminator: boolean = false): any {
+  export function FileSchemaTestClassToJSON(json: any): FileSchemaTestClass {
+      return FileSchemaTestClassToJSONTyped(json, false);
+  }
+
+  export function FileSchemaTestClassToJSONTyped(value?: FileSchemaTestClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
@@ -55,10 +55,11 @@ export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator:
     };
 }
 
-export function FileSchemaTestClassToJSON(value?: FileSchemaTestClass | null): any {
+export function FileSchemaTestClassToJSON(value?: FileSchemaTestClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'file': value['file'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
@@ -48,7 +48,11 @@ export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
     };
 }
 
-export function FooToJSON(value?: Foo | null, ignoreDiscriminator: boolean = false): any {
+  export function FooToJSON(json: any): Foo {
+      return FooToJSONTyped(json, false);
+  }
+
+  export function FooToJSONTyped(value?: Foo | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
@@ -48,10 +48,11 @@ export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
     };
 }
 
-export function FooToJSON(value?: Foo | null): any {
+export function FooToJSON(value?: Foo | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'bar': value['bar'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
@@ -55,10 +55,11 @@ export function FooGetDefaultResponseFromJSONTyped(json: any, ignoreDiscriminato
     };
 }
 
-export function FooGetDefaultResponseToJSON(value?: FooGetDefaultResponse | null): any {
+export function FooGetDefaultResponseToJSON(value?: FooGetDefaultResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'string': FooToJSON(value['string']),

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
@@ -18,6 +18,7 @@ import {
     FooFromJSON,
     FooFromJSONTyped,
     FooToJSON,
+    FooToJSONTyped,
 } from './Foo';
 
 /**
@@ -55,7 +56,11 @@ export function FooGetDefaultResponseFromJSONTyped(json: any, ignoreDiscriminato
     };
 }
 
-export function FooGetDefaultResponseToJSON(value?: FooGetDefaultResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function FooGetDefaultResponseToJSON(json: any): FooGetDefaultResponse {
+      return FooGetDefaultResponseToJSONTyped(json, false);
+  }
+
+  export function FooGetDefaultResponseToJSONTyped(value?: FooGetDefaultResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
@@ -164,10 +164,11 @@ export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function FormatTestToJSON(value?: FormatTest | null): any {
+export function FormatTestToJSON(value?: FormatTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'integer': value['integer'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
@@ -18,6 +18,7 @@ import {
     DecimalFromJSON,
     DecimalFromJSONTyped,
     DecimalToJSON,
+    DecimalToJSONTyped,
 } from './Decimal';
 
 /**
@@ -164,7 +165,11 @@ export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function FormatTestToJSON(value?: FormatTest | null, ignoreDiscriminator: boolean = false): any {
+  export function FormatTestToJSON(json: any): FormatTest {
+      return FormatTestToJSONTyped(json, false);
+  }
+
+  export function FormatTestToJSONTyped(value?: FormatTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
@@ -55,7 +55,11 @@ export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function HasOnlyReadOnlyToJSON(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null, ignoreDiscriminator: boolean = false): any {
+  export function HasOnlyReadOnlyToJSON(json: any): HasOnlyReadOnly {
+      return HasOnlyReadOnlyToJSONTyped(json, false);
+  }
+
+  export function HasOnlyReadOnlyToJSONTyped(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
@@ -55,10 +55,11 @@ export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function HasOnlyReadOnlyToJSON(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null): any {
+export function HasOnlyReadOnlyToJSON(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
     };

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
@@ -48,10 +48,11 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function HealthCheckResultToJSON(value?: HealthCheckResult | null): any {
+export function HealthCheckResultToJSON(value?: HealthCheckResult | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'NullableMessage': value['nullableMessage'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
@@ -48,7 +48,11 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function HealthCheckResultToJSON(value?: HealthCheckResult | null, ignoreDiscriminator: boolean = false): any {
+  export function HealthCheckResultToJSON(json: any): HealthCheckResult {
+      return HealthCheckResultToJSONTyped(json, false);
+  }
+
+  export function HealthCheckResultToJSONTyped(value?: HealthCheckResult | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
@@ -48,10 +48,11 @@ export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List
     };
 }
 
-export function ListToJSON(value?: List | null): any {
+export function ListToJSON(value?: List | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         '123-list': value['_123list'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
@@ -48,7 +48,11 @@ export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List
     };
 }
 
-export function ListToJSON(value?: List | null, ignoreDiscriminator: boolean = false): any {
+  export function ListToJSON(json: any): List {
+      return ListToJSONTyped(json, false);
+  }
+
+  export function ListToJSONTyped(value?: List | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
@@ -80,10 +80,11 @@ export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): M
     };
 }
 
-export function MapTestToJSON(value?: MapTest | null): any {
+export function MapTestToJSON(value?: MapTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'map_map_of_string': value['mapMapOfString'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
@@ -80,7 +80,11 @@ export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): M
     };
 }
 
-export function MapTestToJSON(value?: MapTest | null, ignoreDiscriminator: boolean = false): any {
+  export function MapTestToJSON(json: any): MapTest {
+      return MapTestToJSONTyped(json, false);
+  }
+
+  export function MapTestToJSONTyped(value?: MapTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -69,10 +69,11 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: a
     };
 }
 
-export function MixedPropertiesAndAdditionalPropertiesClassToJSON(value?: MixedPropertiesAndAdditionalPropertiesClass | null): any {
+export function MixedPropertiesAndAdditionalPropertiesClassToJSON(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'uuid': value['uuid'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -18,6 +18,7 @@ import {
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
+    AnimalToJSONTyped,
 } from './Animal';
 
 /**
@@ -69,7 +70,11 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: a
     };
 }
 
-export function MixedPropertiesAndAdditionalPropertiesClassToJSON(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
+  export function MixedPropertiesAndAdditionalPropertiesClassToJSON(json: any): MixedPropertiesAndAdditionalPropertiesClass {
+      return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(json, false);
+  }
+
+  export function MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
@@ -55,10 +55,11 @@ export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function Model200ResponseToJSON(value?: Model200Response | null): any {
+export function Model200ResponseToJSON(value?: Model200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'name': value['name'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
@@ -55,7 +55,11 @@ export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function Model200ResponseToJSON(value?: Model200Response | null, ignoreDiscriminator: boolean = false): any {
+  export function Model200ResponseToJSON(json: any): Model200Response {
+      return Model200ResponseToJSONTyped(json, false);
+  }
+
+  export function Model200ResponseToJSONTyped(value?: Model200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
@@ -62,7 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+      return ModelApiResponseToJSONTyped(json, false);
+  }
+
+  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
@@ -62,10 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'code': value['code'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
@@ -48,7 +48,11 @@ export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ModelFileToJSON(value?: ModelFile | null, ignoreDiscriminator: boolean = false): any {
+  export function ModelFileToJSON(json: any): ModelFile {
+      return ModelFileToJSONTyped(json, false);
+  }
+
+  export function ModelFileToJSONTyped(value?: ModelFile | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
@@ -48,10 +48,11 @@ export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ModelFileToJSON(value?: ModelFile | null): any {
+export function ModelFileToJSON(value?: ModelFile | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'sourceURI': value['sourceURI'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
@@ -70,10 +70,11 @@ export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name
     };
 }
 
-export function NameToJSON(value?: Omit<Name, 'snake_case'|'123Number'> | null): any {
+export function NameToJSON(value?: Omit<Name, 'snake_case'|'123Number'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'name': value['name'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
@@ -70,7 +70,11 @@ export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name
     };
 }
 
-export function NameToJSON(value?: Omit<Name, 'snake_case'|'123Number'> | null, ignoreDiscriminator: boolean = false): any {
+  export function NameToJSON(json: any): Name {
+      return NameToJSONTyped(json, false);
+  }
+
+  export function NameToJSONTyped(value?: Omit<Name, 'snake_case'|'123Number'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
@@ -127,7 +127,11 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function NullableClassToJSON(value?: NullableClass | null, ignoreDiscriminator: boolean = false): any {
+  export function NullableClassToJSON(json: any): NullableClass {
+      return NullableClassToJSONTyped(json, false);
+  }
+
+  export function NullableClassToJSONTyped(value?: NullableClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
@@ -127,10 +127,11 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function NullableClassToJSON(value?: NullableClass | null): any {
+export function NullableClassToJSON(value?: NullableClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
             ...value,

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
@@ -48,7 +48,11 @@ export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function NumberOnlyToJSON(value?: NumberOnly | null, ignoreDiscriminator: boolean = false): any {
+  export function NumberOnlyToJSON(json: any): NumberOnly {
+      return NumberOnlyToJSONTyped(json, false);
+  }
+
+  export function NumberOnlyToJSONTyped(value?: NumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
@@ -48,10 +48,11 @@ export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function NumberOnlyToJSON(value?: NumberOnly | null): any {
+export function NumberOnlyToJSON(value?: NumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'JustNumber': value['justNumber'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
@@ -79,10 +79,11 @@ export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscrim
     };
 }
 
-export function ObjectWithDeprecatedFieldsToJSON(value?: ObjectWithDeprecatedFields | null): any {
+export function ObjectWithDeprecatedFieldsToJSON(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'uuid': value['uuid'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
@@ -18,6 +18,7 @@ import {
     DeprecatedObjectFromJSON,
     DeprecatedObjectFromJSONTyped,
     DeprecatedObjectToJSON,
+    DeprecatedObjectToJSONTyped,
 } from './DeprecatedObject';
 
 /**
@@ -79,7 +80,11 @@ export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscrim
     };
 }
 
-export function ObjectWithDeprecatedFieldsToJSON(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator: boolean = false): any {
+  export function ObjectWithDeprecatedFieldsToJSON(json: any): ObjectWithDeprecatedFields {
+      return ObjectWithDeprecatedFieldsToJSONTyped(json, false);
+  }
+
+  export function ObjectWithDeprecatedFieldsToJSONTyped(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
@@ -95,7 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+  export function OrderToJSON(json: any): Order {
+      return OrderToJSONTyped(json, false);
+  }
+
+  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
@@ -95,10 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null): any {
+export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
@@ -62,10 +62,11 @@ export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function OuterCompositeToJSON(value?: OuterComposite | null): any {
+export function OuterCompositeToJSON(value?: OuterComposite | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'my_number': value['myNumber'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
@@ -62,7 +62,11 @@ export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function OuterCompositeToJSON(value?: OuterComposite | null, ignoreDiscriminator: boolean = false): any {
+  export function OuterCompositeToJSON(json: any): OuterComposite {
+      return OuterCompositeToJSONTyped(json, false);
+  }
+
+  export function OuterCompositeToJSONTyped(value?: OuterComposite | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
@@ -48,3 +48,7 @@ export function OuterEnumToJSON(value?: OuterEnum | null): any {
     return value as any;
 }
 
+export function OuterEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnum {
+    return value as OuterEnum;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
@@ -48,3 +48,7 @@ export function OuterEnumDefaultValueToJSON(value?: OuterEnumDefaultValue | null
     return value as any;
 }
 
+export function OuterEnumDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumDefaultValue {
+    return value as OuterEnumDefaultValue;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
@@ -48,3 +48,7 @@ export function OuterEnumIntegerToJSON(value?: OuterEnumInteger | null): any {
     return value as any;
 }
 
+export function OuterEnumIntegerToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumInteger {
+    return value as OuterEnumInteger;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
@@ -48,3 +48,7 @@ export function OuterEnumIntegerDefaultValueToJSON(value?: OuterEnumIntegerDefau
     return value as any;
 }
 
+export function OuterEnumIntegerDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumIntegerDefaultValue {
+    return value as OuterEnumIntegerDefaultValue;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
@@ -18,6 +18,7 @@ import {
     OuterEnumIntegerFromJSON,
     OuterEnumIntegerFromJSONTyped,
     OuterEnumIntegerToJSON,
+    OuterEnumIntegerToJSONTyped,
 } from './OuterEnumInteger';
 
 /**
@@ -58,7 +59,11 @@ export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscri
     };
 }
 
-export function OuterObjectWithEnumPropertyToJSON(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator: boolean = false): any {
+  export function OuterObjectWithEnumPropertyToJSON(json: any): OuterObjectWithEnumProperty {
+      return OuterObjectWithEnumPropertyToJSONTyped(json, false);
+  }
+
+  export function OuterObjectWithEnumPropertyToJSONTyped(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
@@ -58,10 +58,11 @@ export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscri
     };
 }
 
-export function OuterObjectWithEnumPropertyToJSON(value?: OuterObjectWithEnumProperty | null): any {
+export function OuterObjectWithEnumPropertyToJSON(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'value': OuterEnumIntegerToJSON(value['value']),

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -105,12 +107,16 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+  export function PetToJSON(json: any): Pet {
+      return PetToJSONTyped(json, false);
+  }
+
+  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -121,7 +127,7 @@ export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = fal
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': Array.from(value['photoUrls'] as Set<any>),
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
@@ -105,22 +105,23 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null): any {
+export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': Array.from(value['photoUrls'] as Set<any>),
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
@@ -55,7 +55,11 @@ export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function ReadOnlyFirstToJSON(value?: Omit<ReadOnlyFirst, 'bar'> | null, ignoreDiscriminator: boolean = false): any {
+  export function ReadOnlyFirstToJSON(json: any): ReadOnlyFirst {
+      return ReadOnlyFirstToJSONTyped(json, false);
+  }
+
+  export function ReadOnlyFirstToJSONTyped(value?: Omit<ReadOnlyFirst, 'bar'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
@@ -55,10 +55,11 @@ export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function ReadOnlyFirstToJSON(value?: Omit<ReadOnlyFirst, 'bar'> | null): any {
+export function ReadOnlyFirstToJSON(value?: Omit<ReadOnlyFirst, 'bar'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'baz': value['baz'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
@@ -48,10 +48,11 @@ export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Re
     };
 }
 
-export function ReturnToJSON(value?: Return | null): any {
+export function ReturnToJSON(value?: Return | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'return': value['_return'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
@@ -48,7 +48,11 @@ export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Re
     };
 }
 
-export function ReturnToJSON(value?: Return | null, ignoreDiscriminator: boolean = false): any {
+  export function ReturnToJSON(json: any): Return {
+      return ReturnToJSONTyped(json, false);
+  }
+
+  export function ReturnToJSONTyped(value?: Return | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
@@ -47,3 +47,7 @@ export function SingleRefTypeToJSON(value?: SingleRefType | null): any {
     return value as any;
 }
 
+export function SingleRefTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): SingleRefType {
+    return value as SingleRefType;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
@@ -48,7 +48,11 @@ export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function SpecialModelNameToJSON(value?: SpecialModelName | null, ignoreDiscriminator: boolean = false): any {
+  export function SpecialModelNameToJSON(json: any): SpecialModelName {
+      return SpecialModelNameToJSONTyped(json, false);
+  }
+
+  export function SpecialModelNameToJSONTyped(value?: SpecialModelName | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
@@ -48,10 +48,11 @@ export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function SpecialModelNameToJSON(value?: SpecialModelName | null): any {
+export function SpecialModelNameToJSON(value?: SpecialModelName | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         '$special[property.name]': value['$specialPropertyName'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
@@ -55,10 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null): any {
+export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
@@ -55,7 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+  export function TagToJSON(json: any): Tag {
+      return TagToJSONTyped(json, false);
+  }
+
+  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
@@ -97,10 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null): any {
+export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
@@ -97,7 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
+  export function UserToJSON(json: any): User {
+      return UserToJSONTyped(json, false);
+  }
+
+  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/UserApi.ts
@@ -125,7 +125,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['user']!.map(UserToJSON),
+            body: requestParameters['user']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -166,7 +166,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['user']!.map(UserToJSON),
+            body: requestParameters['user']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/UserApi.ts
@@ -125,7 +125,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['user']!.map(x => UserToJSON(x)),
+            body: requestParameters['user']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -166,7 +166,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['user']!.map(x => UserToJSON(x)),
+            body: requestParameters['user']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
@@ -55,7 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+  export function CategoryToJSON(json: any): Category {
+      return CategoryToJSONTyped(json, false);
+  }
+
+  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
@@ -55,10 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null): any {
+export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
@@ -62,7 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+      return ModelApiResponseToJSONTyped(json, false);
+  }
+
+  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
@@ -62,10 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'code': value['code'],

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
@@ -97,7 +97,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+  export function OrderToJSON(json: any): Order {
+      return OrderToJSONTyped(json, false);
+  }
+
+  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
@@ -97,10 +97,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null): any {
+export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
             ...value,

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -106,12 +108,16 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+  export function PetToJSON(json: any): Pet {
+      return PetToJSONTyped(json, false);
+  }
+
+  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -122,7 +128,7 @@ export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = fal
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': Array.from(value['photoUrls'] as Set<any>),
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
@@ -106,22 +106,23 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null): any {
+export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': Array.from(value['photoUrls'] as Set<any>),
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
@@ -55,10 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null): any {
+export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
@@ -55,7 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+  export function TagToJSON(json: any): Tag {
+      return TagToJSONTyped(json, false);
+  }
+
+  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
@@ -97,10 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null): any {
+export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
@@ -97,7 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
+  export function UserToJSON(json: any): User {
+      return UserToJSONTyped(json, false);
+  }
+
+  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
@@ -249,7 +249,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -284,7 +284,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
@@ -249,7 +249,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -284,7 +284,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
@@ -55,7 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+  export function CategoryToJSON(json: any): Category {
+      return CategoryToJSONTyped(json, false);
+  }
+
+  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
@@ -55,10 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null): any {
+export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
@@ -62,7 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+      return ModelApiResponseToJSONTyped(json, false);
+  }
+
+  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
@@ -62,10 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'code': value['code'],

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
@@ -95,7 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+  export function OrderToJSON(json: any): Order {
+      return OrderToJSONTyped(json, false);
+  }
+
+  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
@@ -95,10 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null): any {
+export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
@@ -105,22 +105,23 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null): any {
+export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -105,12 +107,16 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+  export function PetToJSON(json: any): Pet {
+      return PetToJSONTyped(json, false);
+  }
+
+  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -121,7 +127,7 @@ export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = fal
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
@@ -55,10 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null): any {
+export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
@@ -55,7 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+  export function TagToJSON(json: any): Tag {
+      return TagToJSONTyped(json, false);
+  }
+
+  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
@@ -97,10 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null): any {
+export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
@@ -97,7 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
+  export function UserToJSON(json: any): User {
+      return UserToJSONTyped(json, false);
+  }
+
+  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
@@ -116,7 +116,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -151,7 +151,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(x => UserToJSON(x)),
+            body: requestParameters['body']!.map(UserToJSON),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
@@ -116,7 +116,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -151,7 +151,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: requestParameters['body']!.map(UserToJSON),
+            body: requestParameters['body']!.map(x => UserToJSON(x)),
         }, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
@@ -55,7 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+  export function CategoryToJSON(json: any): Category {
+      return CategoryToJSONTyped(json, false);
+  }
+
+  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
@@ -55,10 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(value?: Category | null): any {
+export function CategoryToJSON(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
@@ -62,7 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+      return ModelApiResponseToJSONTyped(json, false);
+  }
+
+  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
@@ -62,10 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'code': value['code'],

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
@@ -95,7 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+  export function OrderToJSON(json: any): Order {
+      return OrderToJSONTyped(json, false);
+  }
+
+  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
@@ -95,10 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(value?: Order | null): any {
+export function OrderToJSON(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
@@ -105,22 +105,23 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null): any {
+export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -105,12 +107,16 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(s => TagFromJSON(s))),
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+  export function PetToJSON(json: any): Pet {
+      return PetToJSONTyped(json, false);
+  }
+
+  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
@@ -121,7 +127,7 @@ export function PetToJSON(value?: Pet | null, ignoreDiscriminator: boolean = fal
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(a => TagToJSON(a))),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
@@ -55,10 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null): any {
+export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
@@ -55,7 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+  export function TagToJSON(json: any): Tag {
+      return TagToJSONTyped(json, false);
+  }
+
+  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
@@ -97,10 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null): any {
+export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'id': value['id'],

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
@@ -97,7 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(value?: User | null, ignoreDiscriminator: boolean = false): any {
+  export function UserToJSON(json: any): User {
+      return UserToJSONTyped(json, false);
+  }
+
+  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
@@ -84,10 +84,11 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function EnumPatternObjectToJSON(value?: EnumPatternObject | null): any {
+export function EnumPatternObjectToJSON(value?: EnumPatternObject | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'string-enum': StringEnumToJSON(value['stringEnum']),

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
@@ -18,12 +18,14 @@ import {
     NumberEnumFromJSON,
     NumberEnumFromJSONTyped,
     NumberEnumToJSON,
+    NumberEnumToJSONTyped,
 } from './NumberEnum';
 import type { StringEnum } from './StringEnum';
 import {
     StringEnumFromJSON,
     StringEnumFromJSONTyped,
     StringEnumToJSON,
+    StringEnumToJSONTyped,
 } from './StringEnum';
 
 /**
@@ -84,7 +86,11 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function EnumPatternObjectToJSON(value?: EnumPatternObject | null, ignoreDiscriminator: boolean = false): any {
+  export function EnumPatternObjectToJSON(json: any): EnumPatternObject {
+      return EnumPatternObjectToJSONTyped(json, false);
+  }
+
+  export function EnumPatternObjectToJSONTyped(value?: EnumPatternObject | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
@@ -107,10 +107,11 @@ export function FakeEnumRequestGetInline200ResponseFromJSONTyped(json: any, igno
     };
 }
 
-export function FakeEnumRequestGetInline200ResponseToJSON(value?: FakeEnumRequestGetInline200Response | null): any {
+export function FakeEnumRequestGetInline200ResponseToJSON(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }
+
     return {
         
         'string-enum': value['stringEnum'],

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
@@ -107,7 +107,11 @@ export function FakeEnumRequestGetInline200ResponseFromJSONTyped(json: any, igno
     };
 }
 
-export function FakeEnumRequestGetInline200ResponseToJSON(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator: boolean = false): any {
+  export function FakeEnumRequestGetInline200ResponseToJSON(json: any): FakeEnumRequestGetInline200Response {
+      return FakeEnumRequestGetInline200ResponseToJSONTyped(json, false);
+  }
+
+  export function FakeEnumRequestGetInline200ResponseToJSONTyped(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
@@ -47,3 +47,7 @@ export function NumberEnumToJSON(value?: NumberEnum | null): any {
     return value as any;
 }
 
+export function NumberEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): NumberEnum {
+    return value as NumberEnum;
+}
+

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
@@ -47,3 +47,7 @@ export function StringEnumToJSON(value?: StringEnum | null): any {
     return value as any;
 }
 
+export function StringEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): StringEnum {
+    return value as StringEnum;
+}
+

--- a/samples/client/petstore/typescript-fetch/tests/default/tsconfig.json
+++ b/samples/client/petstore/typescript-fetch/tests/default/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "forceConsistentCasingInFileNames": false,
         "module": "commonjs",
         "target": "es5",
         "noImplicitAny": true,


### PR DESCRIPTION
…minators fails to convert subclasses to JSON.

@macjohnny, for your kind attention:

- Added similar discriminator handling to ToJSON as was already in place for FromJSON. 
- The actual files changed are typescript-fetch/modelGeneric.mustache and typescript-fetch/modelEnum.mustache.
- Also, adjusted FromJSON a bit in an attempt to support multiple hierarchical levels of discriminators. 
- ~~And fixed an issue with calling FromJSON from the map() function, which caused the index parameter getting inadvertently passed as the ignoreDiscriminator parameter. ~~
- Additionally, fixed failing "mvn integration-test -f samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/pom.xml" 
- Moreover, added forceConsistentCasingInFileNames:false into tsconfig.json to make tests compile on OsX.

### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ z] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package - did not run, as only changed templates
  ./bin/generate-samples.sh ./bin/configs/*.yaml - ran for typescript-fetch only, as my changes concerned only that
  ./bin/utils/export_docs_generators.sh - did not commit changes resulting from this, as they were not related to my changes, and committing them would probably result in conflicts.
  ``` 
- [x ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


fixes #15736
closes https://github.com/OpenAPITools/openapi-generator/pull/13260