### PR TITLE
[PHP/Dart/Python] Correctly escape strings in single quotes (Fixes #17582)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1117,6 +1117,20 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     /**
+     * This method escapes text to be used in a single quoted string
+     * @param input the input string
+     * @return the escaped string
+     */
+    public String escapeTextInSingleQuotes(String input) {
+        if (input == null) {
+            return null;
+        }
+
+        return escapeText(input).replace("'", "\\'");
+    }
+
+
+    /**
      * Escape characters while allowing new lines
      *
      * @param input String to be escaped

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -752,8 +752,16 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
                 "int".equalsIgnoreCase(datatype)) {
             return value;
         } else {
-            return "'" + escapeText(value) + "'";
+            return "'" + escapeTextInSingleQuotes(value) + "'";
         }
+    }
+
+    public String escapeTextInSingleQuotes(String input) {
+        if (input == null) {
+            return null;
+        }
+
+        return escapeText(input).replace("'", "\\'");
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -756,14 +756,6 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
         }
     }
 
-    public String escapeTextInSingleQuotes(String input) {
-        if (input == null) {
-            return null;
-        }
-
-        return escapeText(input).replace("'", "\\'");
-    }
-
     @Override
     public String toOperationId(String operationId) {
         operationId = super.toOperationId(operationId);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -801,14 +801,14 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         return super.escapeText(input).trim();
     }
 
+    @Override
     public String escapeTextInSingleQuotes(String input) {
         if (input == null) {
             return input;
         }
 
         // Unescape double quotes because PHP keeps the backslashes if a character does not need to be escaped
-        return escapeText(input).replace("'", "\\'")
-                .replace("\\\"", "\"");
+        return super.escapeTextInSingleQuotes(input).replace("\\\"", "\"");
     }
 
     public void escapeMediaType(List<CodegenOperation> operationList) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -634,9 +634,10 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
         if ("String".equalsIgnoreCase(type) || p.isString) {
             if (example == null) {
-                example = "'" + p.paramName + "_example'";
+                example = "'" +  escapeTextInSingleQuotes(p.paramName) + "_example'";
+            } else {
+                example = escapeText(example);
             }
-            example = escapeText(example);
         } else if ("Integer".equals(type) || "int".equals(type)) {
             if (example == null) {
                 example = "56";
@@ -653,17 +654,17 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             if (example == null) {
                 example = "/path/to/file.txt";
             }
-            example = "\"" + escapeText(example) + "\"";
+            example = "'" + escapeTextInSingleQuotes(example) + "'";
         } else if ("\\Date".equalsIgnoreCase(type)) {
             if (example == null) {
                 example = "2013-10-20";
             }
-            example = "new \\DateTime(\"" + escapeText(example) + "\")";
+            example = "new \\DateTime('" + escapeTextInSingleQuotes(example) + "')";
         } else if ("\\DateTime".equalsIgnoreCase(type)) {
             if (example == null) {
                 example = "2013-10-20T19:20:30+01:00";
             }
-            example = "new \\DateTime(\"" + escapeText(example) + "\")";
+            example = "new \\DateTime('" + escapeTextInSingleQuotes(example) + "')";
         } else if ("object".equals(type)) {
             example = "new \\stdClass";
         } else if (!languageSpecificPrimitives.contains(type)) {
@@ -689,7 +690,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         if ("int".equals(datatype) || "float".equals(datatype)) {
             return value;
         } else {
-            return "\'" + escapeText(value) + "\'";
+            return "'" + escapeTextInSingleQuotes(value) + "'";
         }
     }
 
@@ -798,6 +799,16 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
         // Trim the string to avoid leading and trailing spaces.
         return super.escapeText(input).trim();
+    }
+
+    public String escapeTextInSingleQuotes(String input) {
+        if (input == null) {
+            return input;
+        }
+
+        // Unescape double quotes because PHP keeps the backslashes if a character does not need to be escaped
+        return escapeText(input).replace("'", "\\'")
+                .replace("\\\"", "\"");
     }
 
     public void escapeMediaType(List<CodegenOperation> operationList) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -1416,14 +1416,6 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         }
     }
 
-    public String escapeTextInSingleQuotes(String input) {
-        if (input == null) {
-            return null;
-        }
-
-        return escapeText(input).replace("'", "\\'");
-    }
-
     @Override
     public String toEnumDefaultValue(CodegenProperty property, String value) {
         if (property.isEnumRef) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -422,7 +422,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             // Enum case:
             example = schema.getEnum().get(0).toString();
             if (ModelUtils.isStringSchema(schema)) {
-                example = "'" + escapeText(example) + "'";
+                example = "'" + escapeTextInSingleQuotes(example) + "'";
             }
             if (null == example)
                 LOGGER.warn("Empty enum. Cannot built an example!");
@@ -521,7 +521,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 if (additional.getEnum() != null && !additional.getEnum().isEmpty()) {
                     theKey = additional.getEnum().get(0).toString();
                     if (ModelUtils.isStringSchema(additional)) {
-                        theKey = "'" + escapeText(theKey) + "'";
+                        theKey = "'" + escapeTextInSingleQuotes(theKey) + "'";
                     }
                 }
                 example = "{\n" + indentationString + theKey + " : " + toExampleValueRecursive(additional, includedSchemas, indentation + 1) + "\n" + indentationString + "}";
@@ -587,7 +587,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         }
 
         if (ModelUtils.isStringSchema(schema)) {
-            example = "'" + escapeText(example) + "'";
+            example = "'" + escapeTextInSingleQuotes(example) + "'";
         }
 
         return example;
@@ -613,7 +613,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             if (example == null) {
                 example = p.paramName + "_example";
             }
-            example = "'" + escapeText(example) + "'";
+            example = "'" + escapeTextInSingleQuotes(example) + "'";
         } else if ("Integer".equals(type) || "int".equals(type)) {
             if (example == null) {
                 example = "56";
@@ -630,17 +630,17 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             if (example == null) {
                 example = "/path/to/file";
             }
-            example = "'" + escapeText(example) + "'";
+            example = "'" + escapeTextInSingleQuotes(example) + "'";
         } else if ("Date".equalsIgnoreCase(type)) {
             if (example == null) {
                 example = "2013-10-20";
             }
-            example = "'" + escapeText(example) + "'";
+            example = "'" + escapeTextInSingleQuotes(example) + "'";
         } else if ("DateTime".equalsIgnoreCase(type)) {
             if (example == null) {
                 example = "2013-10-20T19:20:30+01:00";
             }
-            example = "'" + escapeText(example) + "'";
+            example = "'" + escapeTextInSingleQuotes(example) + "'";
         } else if (!languageSpecificPrimitives.contains(type)) {
             // type is a model class, e.g. User
             example = this.packageName + "." + type + "()";
@@ -1412,8 +1412,16 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         if ("int".equals(datatype) || "float".equals(datatype)) {
             return value;
         } else {
-            return "\'" + escapeText(value) + "\'";
+            return "'" + escapeTextInSingleQuotes(value) + "'";
         }
+    }
+
+    public String escapeTextInSingleQuotes(String input) {
+        if (input == null) {
+            return null;
+        }
+
+        return escapeText(input).replace("'", "\\'");
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -232,15 +232,6 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
     }
 
     @Override
-    public String escapeText(String input) {
-        if (input != null) {
-            // Trim the string to avoid leading and trailing spaces.
-            return super.escapeText(input).trim();
-        }
-        return input;
-    }
-
-    @Override
     public CodegenType getTag() {
         return CodegenType.SERVER;
     }
@@ -574,15 +565,6 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
             return name;
         } else {
             return modelPackage() + "\\" + name;
-        }
-    }
-
-    @Override
-    public String toEnumValue(String value, String datatype) {
-        if ("int".equals(datatype) || "float".equals(datatype)) {
-            return value;
-        } else {
-            return "\"" + escapeText(value) + "\"";
         }
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientCodegenTest.java
@@ -85,4 +85,15 @@ public class DartClientCodegenTest {
         }
     }
 
+
+    @Test(description = "Enum value with quotes (#17582)")
+    public void testEnumPropertyWithQuotes() {
+        final DartClientCodegen codegen = new DartClientCodegen();
+
+        Assert.assertEquals(codegen.toEnumValue("enum-value", "string"), "'enum-value'");
+        Assert.assertEquals(codegen.toEnumValue("won't fix", "string"), "'won\\'t fix'");
+        Assert.assertEquals(codegen.toEnumValue("\"", "string"), "'\\\"'");
+        Assert.assertEquals(codegen.toEnumValue("1.0", "number"), "1.0");
+        Assert.assertEquals(codegen.toEnumValue("1", "int"), "1");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
@@ -176,4 +176,13 @@ public class AbstractPhpCodegenTest {
         CodegenProperty cp1 = cm1.vars.get(0);
         Assert.assertEquals(cp1.getDefaultValue(), "'VALUE'");
     }
+
+    @Test(description = "Enum value with quotes (#17582)")
+    public void testEnumPropertyWithQuotes() {
+        Assert.assertEquals(codegen.toEnumValue("enum-value", "string"), "'enum-value'");
+        Assert.assertEquals(codegen.toEnumValue("won't fix", "string"), "'won\\'t fix'");
+        Assert.assertEquals(codegen.toEnumValue("\"", "string"), "'\"'");
+        Assert.assertEquals(codegen.toEnumValue("1.0", "float"), "1.0");
+        Assert.assertEquals(codegen.toEnumValue("1", "int"), "1");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -530,4 +530,15 @@ public class PythonClientCodegenTest {
         assertFileContains(apiFile.toPath(), "_header_params['X-CUSTOM_CONSTANT_HEADER'] = 'CONSTANT_VALUE'");
         assertFileContains(apiFile.toPath(), "_query_params.append(('CONSTANT_QUERY_STRING_KEY', 'CONSTANT_QUERY_STRING_VALUE'))");
     }
+
+    @Test(description = "Enum value with quotes (#17582)")
+    public void testEnumPropertyWithQuotes() {
+        final PythonClientCodegen codegen = new PythonClientCodegen();
+
+        Assert.assertEquals(codegen.toEnumValue("enum-value", "string"), "'enum-value'");
+        Assert.assertEquals(codegen.toEnumValue("won't fix", "string"), "'won\\'t fix'");
+        Assert.assertEquals(codegen.toEnumValue("\"", "string"), "'\\\"'");
+        Assert.assertEquals(codegen.toEnumValue("1.0", "float"), "1.0");
+        Assert.assertEquals(codegen.toEnumValue("1", "int"), "1");
+    }
 }

--- a/samples/client/echo_api/php-nextgen-streaming/docs/Api/BodyApi.md
+++ b/samples/client/echo_api/php-nextgen-streaming/docs/Api/BodyApi.md
@@ -92,7 +92,7 @@ $apiInstance = new OpenAPI\Client\Api\BodyApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$body = "/path/to/file.txt"; // \Psr\Http\Message\StreamInterface
+$body = '/path/to/file.txt'; // \Psr\Http\Message\StreamInterface
 
 try {
     $result = $apiInstance->testBodyApplicationOctetstreamBinary($body);
@@ -148,7 +148,7 @@ $apiInstance = new OpenAPI\Client\Api\BodyApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$files = array("/path/to/file.txt"); // \Psr\Http\Message\StreamInterface[]
+$files = array('/path/to/file.txt'); // \Psr\Http\Message\StreamInterface[]
 
 try {
     $result = $apiInstance->testBodyMultipartFormdataArrayOfBinary($files);
@@ -204,7 +204,7 @@ $apiInstance = new OpenAPI\Client\Api\BodyApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$my_file = "/path/to/file.txt"; // \Psr\Http\Message\StreamInterface
+$my_file = '/path/to/file.txt'; // \Psr\Http\Message\StreamInterface
 
 try {
     $result = $apiInstance->testBodyMultipartFormdataSingleBinary($my_file);

--- a/samples/client/echo_api/php-nextgen-streaming/docs/Api/QueryApi.md
+++ b/samples/client/echo_api/php-nextgen-streaming/docs/Api/QueryApi.md
@@ -97,8 +97,8 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$datetime_query = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime
-$date_query = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime
+$datetime_query = new \DateTime('2013-10-20T19:20:30+01:00'); // \DateTime
+$date_query = new \DateTime('2013-10-20T19:20:30+01:00'); // \DateTime
 $string_query = 'string_query_example'; // string
 
 try {

--- a/samples/client/echo_api/php-nextgen/docs/Api/BodyApi.md
+++ b/samples/client/echo_api/php-nextgen/docs/Api/BodyApi.md
@@ -92,7 +92,7 @@ $apiInstance = new OpenAPI\Client\Api\BodyApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$body = "/path/to/file.txt"; // \SplFileObject
+$body = '/path/to/file.txt'; // \SplFileObject
 
 try {
     $result = $apiInstance->testBodyApplicationOctetstreamBinary($body);
@@ -148,7 +148,7 @@ $apiInstance = new OpenAPI\Client\Api\BodyApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$files = array("/path/to/file.txt"); // \SplFileObject[]
+$files = array('/path/to/file.txt'); // \SplFileObject[]
 
 try {
     $result = $apiInstance->testBodyMultipartFormdataArrayOfBinary($files);
@@ -204,7 +204,7 @@ $apiInstance = new OpenAPI\Client\Api\BodyApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$my_file = "/path/to/file.txt"; // \SplFileObject
+$my_file = '/path/to/file.txt'; // \SplFileObject
 
 try {
     $result = $apiInstance->testBodyMultipartFormdataSingleBinary($my_file);

--- a/samples/client/echo_api/php-nextgen/docs/Api/QueryApi.md
+++ b/samples/client/echo_api/php-nextgen/docs/Api/QueryApi.md
@@ -97,8 +97,8 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$datetime_query = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime
-$date_query = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime
+$datetime_query = new \DateTime('2013-10-20T19:20:30+01:00'); // \DateTime
+$date_query = new \DateTime('2013-10-20T19:20:30+01:00'); // \DateTime
 $string_query = 'string_query_example'; // string
 
 try {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -549,7 +549,7 @@ $apiInstance = new OpenAPI\Client\Api\FakeApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$body = "/path/to/file.txt"; // \SplFileObject | image to upload
+$body = '/path/to/file.txt'; // \SplFileObject | image to upload
 
 try {
     $apiInstance->testBodyWithBinary($body);
@@ -785,9 +785,9 @@ $int32 = 56; // int | None
 $int64 = 56; // int | None
 $float = 3.4; // float | None
 $string = 'string_example'; // string | None
-$binary = "/path/to/file.txt"; // \SplFileObject | None
-$date = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime | None
-$date_time = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime | None
+$binary = '/path/to/file.txt'; // \SplFileObject | None
+$date = new \DateTime('2013-10-20T19:20:30+01:00'); // \DateTime | None
+$date_time = new \DateTime('2013-10-20T19:20:30+01:00'); // \DateTime | None
 $password = 'password_example'; // string | None
 $callback = 'callback_example'; // string | None
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Api/PetApi.md
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Api/PetApi.md
@@ -514,7 +514,7 @@ $apiInstance = new OpenAPI\Client\Api\PetApi(
 );
 $pet_id = 56; // int | ID of pet to update
 $additional_metadata = 'additional_metadata_example'; // string | Additional data to pass to server
-$file = "/path/to/file.txt"; // \SplFileObject | file to upload
+$file = '/path/to/file.txt'; // \SplFileObject | file to upload
 
 try {
     $result = $apiInstance->uploadFile($pet_id, $additional_metadata, $file);
@@ -577,7 +577,7 @@ $apiInstance = new OpenAPI\Client\Api\PetApi(
     $config
 );
 $pet_id = 56; // int | ID of pet to update
-$required_file = "/path/to/file.txt"; // \SplFileObject | file to upload
+$required_file = '/path/to/file.txt'; // \SplFileObject | file to upload
 $additional_metadata = 'additional_metadata_example'; // string | Additional data to pass to server
 
 try {

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -610,7 +610,7 @@ $apiInstance = new OpenAPI\Client\Api\FakeApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$body = "/path/to/file.txt"; // \SplFileObject | image to upload
+$body = '/path/to/file.txt'; // \SplFileObject | image to upload
 
 try {
     $apiInstance->testBodyWithBinary($body);
@@ -846,9 +846,9 @@ $int32 = 56; // int | None
 $int64 = 56; // int | None
 $float = 3.4; // float | None
 $string = 'string_example'; // string | None
-$binary = "/path/to/file.txt"; // \SplFileObject | None
-$date = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime | None
-$date_time = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime | None
+$binary = '/path/to/file.txt'; // \SplFileObject | None
+$date = new \DateTime('2013-10-20T19:20:30+01:00'); // \DateTime | None
+$date_time = new \DateTime('2013-10-20T19:20:30+01:00'); // \DateTime | None
 $password = 'password_example'; // string | None
 $callback = 'callback_example'; // string | None
 

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Api/PetApi.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Api/PetApi.md
@@ -514,7 +514,7 @@ $apiInstance = new OpenAPI\Client\Api\PetApi(
 );
 $pet_id = 56; // int | ID of pet to update
 $additional_metadata = 'additional_metadata_example'; // string | Additional data to pass to server
-$file = "/path/to/file.txt"; // \SplFileObject | file to upload
+$file = '/path/to/file.txt'; // \SplFileObject | file to upload
 
 try {
     $result = $apiInstance->uploadFile($pet_id, $additional_metadata, $file);
@@ -577,7 +577,7 @@ $apiInstance = new OpenAPI\Client\Api\PetApi(
     $config
 );
 $pet_id = 56; // int | ID of pet to update
-$required_file = "/path/to/file.txt"; // \SplFileObject | file to upload
+$required_file = '/path/to/file.txt'; // \SplFileObject | file to upload
 $additional_metadata = 'additional_metadata_example'; // string | Additional data to pass to server
 
 try {

--- a/samples/client/petstore/php/psr-18/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/psr-18/docs/Api/FakeApi.md
@@ -610,7 +610,7 @@ $apiInstance = new OpenAPI\Client\Api\FakeApi(
     // This is optional, `Psr18ClientDiscovery` will be used to find http client. For instance `GuzzleHttp\Client` implements that interface
     new GuzzleHttp\Client()
 );
-$body = "/path/to/file.txt"; // \SplFileObject | image to upload
+$body = '/path/to/file.txt'; // \SplFileObject | image to upload
 
 try {
     $apiInstance->testBodyWithBinary($body);
@@ -846,9 +846,9 @@ $int32 = 56; // int | None
 $int64 = 56; // int | None
 $float = 3.4; // float | None
 $string = 'string_example'; // string | None
-$binary = "/path/to/file.txt"; // \SplFileObject | None
-$date = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime | None
-$date_time = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime | None
+$binary = '/path/to/file.txt'; // \SplFileObject | None
+$date = new \DateTime('2013-10-20T19:20:30+01:00'); // \DateTime | None
+$date_time = new \DateTime('2013-10-20T19:20:30+01:00'); // \DateTime | None
 $password = 'password_example'; // string | None
 $callback = 'callback_example'; // string | None
 

--- a/samples/client/petstore/php/psr-18/docs/Api/PetApi.md
+++ b/samples/client/petstore/php/psr-18/docs/Api/PetApi.md
@@ -468,7 +468,7 @@ $apiInstance = new OpenAPI\Client\Api\PetApi(
 );
 $pet_id = 56; // int | ID of pet to update
 $additional_metadata = 'additional_metadata_example'; // string | Additional data to pass to server
-$file = "/path/to/file.txt"; // \SplFileObject | file to upload
+$file = '/path/to/file.txt'; // \SplFileObject | file to upload
 
 try {
     $result = $apiInstance->uploadFile($pet_id, $additional_metadata, $file);
@@ -531,7 +531,7 @@ $apiInstance = new OpenAPI\Client\Api\PetApi(
     $config
 );
 $pet_id = 56; // int | ID of pet to update
-$required_file = "/path/to/file.txt"; // \SplFileObject | file to upload
+$required_file = '/path/to/file.txt'; // \SplFileObject | file to upload
 $additional_metadata = 'additional_metadata_example'; // string | Additional data to pass to server
 
 try {

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
@@ -255,7 +255,7 @@ class PetController extends Controller
         $asserts = [];
         $asserts[] = new Assert\NotNull();
         $asserts[] = new Assert\All([
-            new Assert\Choice([ "available", "pending", "sold" ])
+            new Assert\Choice([ 'available', 'pending', 'sold' ])
         ]);
         $asserts[] = new Assert\All([
             new Assert\Type("string"),

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/EnumStringModel.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/EnumStringModel.php
@@ -44,9 +44,9 @@ use JMS\Serializer\Annotation\SerializedName;
  */
 enum EnumStringModel: string
 {
-        case AVAILABLE = "available";
-        case PENDING = "pending";
-        case SOLD = "sold";
+        case AVAILABLE = 'available';
+        case PENDING = 'pending';
+        case SOLD = 'sold';
 }
 
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
@@ -84,7 +84,7 @@ class Order
      * @SerializedName("status")
      * @Type("string")
     */
-    #[Assert\Choice(["placed", "approved", "delivered"])]
+    #[Assert\Choice(['placed', 'approved', 'delivered'])]
     #[Assert\Type("string")]
     protected ?string $status = null;
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
@@ -98,7 +98,7 @@ class Pet
      * @SerializedName("status")
      * @Type("string")
     */
-    #[Assert\Choice(["available", "pending", "sold"])]
+    #[Assert\Choice(['available', 'pending', 'sold'])]
     #[Assert\Type("string")]
     protected ?string $status = null;
 


### PR DESCRIPTION
This PR fixes #17582 by correctly escaping strings inside the single quotes for the PHP, Dart and Python generators.
For the PHP generator, double quotes escaped by the default generator are unescaped because PHP treats `'\"'` as a string containing a backslash and a double quote.
I have verified that python and dart treat `'\"'` as a string containing just a double quote character.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Dart: @jaumard @josh-burton @amondnet @sbu-WBT @kuhnroyal @agilob @ahmednfwela
PHP: @jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon
Python: @cbornet @tomplus @krjakbrjak @fa0311 @multani
