### PR TITLE
[POWERSHELL] fix: keep array context when converting to json

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/api.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/api.mustache
@@ -188,7 +188,7 @@ function {{{vendorExtensions.x-powershell-method-name}}} {
         {{/isNullable}}
         {{/required}}
         {{#isArray}}
-        $LocalVarBodyParameter = ,${{{paramName}}} | ConvertTo-Json -Depth 100
+        $LocalVarBodyParameter = ConvertTo-Json @(${{{paramName}}}) -Depth 100
         {{/isArray}}
         {{^isArray}}
         $LocalVarBodyParameter = ${{{paramName}}} | ConvertTo-Json -Depth 100

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSUserApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSUserApi.ps1
@@ -133,7 +133,7 @@ function New-PSUsersWithArrayInput {
             throw "Error! The required parameter `User` missing when calling createUsersWithArrayInput."
         }
 
-        $LocalVarBodyParameter = ,$User | ConvertTo-Json -Depth 100
+        $LocalVarBodyParameter = ConvertTo-Json @($User) -Depth 100
 
         $LocalVarResult = Invoke-PSApiClient -Method 'POST' `
                                 -Uri $LocalVarUri `
@@ -208,7 +208,7 @@ function New-PSUsersWithListInput {
             throw "Error! The required parameter `User` missing when calling createUsersWithListInput."
         }
 
-        $LocalVarBodyParameter = ,$User | ConvertTo-Json -Depth 100
+        $LocalVarBodyParameter = ConvertTo-Json @($User) -Depth 100
 
         $LocalVarResult = Invoke-PSApiClient -Method 'POST' `
                                 -Uri $LocalVarUri `


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR aims to correct [Issue #18427 ](https://github.com/OpenAPITools/openapi-generator/issues/18427). The fix submitted by @condorcorde in [PR #19262 ](https://github.com/OpenAPITools/openapi-generator/pull/19262) seems to give a different behavior than the one expected.

When using `$LocalVarBodyParameter = ,$User | ConvertTo-Json  -Depth 100`, `$User` being a 1-element array, the output will look something like this :
`{ "Value" : _content of $User_, "Length" : 1 }`

Which is different from the expected behavior, that is to only get the array itself. This PR fixes this by forcing the cast of $User to an array using the `@()` syntax before converting it to Json.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @wing328 