### PR TITLE
Fix rust axum doc tests (#19538)

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-axum/types.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/types.mustache
@@ -175,7 +175,7 @@ impl<T> Nullable<T> {
     /// assert_eq!(x.expect("the world is ending"), "value");
     /// ```
     ///
-    /// ```{.should_panic}
+    /// ```should_panic
     /// # use {{{externCrateName}}}::types::Nullable;
     ///
     /// let x: Nullable<&str> = Nullable::Null;
@@ -210,7 +210,7 @@ impl<T> Nullable<T> {
     /// assert_eq!(x.unwrap(), "air");
     /// ```
     ///
-    /// ```{.should_panic}
+    /// ```should_panic
     /// # use {{{externCrateName}}}::types::Nullable;
     ///
     /// let x: Nullable<&str> = Nullable::Null;


### PR DESCRIPTION
Fixes the Rust doc tests generated by rust-axum. The doc tests used an invalid `should_panic` attribute, probably a typo.

For reference, this is how a doc test that is expected to panic should look like: https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#attributes

Sorry for not providing a minimal OpenAPI spec to reproduce the issue but I think the problem is obvious and the fix is trivial enough.

@frol @farcaller @richardwhiuk @paladinzh @jacob-pro

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
