### PR TITLE
[GO] Go Server: preserve order of the routes as defined in the OpenAPI file

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -256,6 +256,10 @@ public interface CodegenConfig {
 
     void setSkipOperationExample(boolean skipOperationExample);
 
+    boolean isSkipSortingOperations();
+
+    void setSkipSortingOperations(boolean skipSortingOperations);
+
     public boolean isHideGenerationTimestamp();
 
     public void setHideGenerationTimestamp(boolean hideGenerationTimestamp);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -224,6 +224,8 @@ public class DefaultCodegen implements CodegenConfig {
     @Getter @Setter
     protected int removeOperationIdPrefixCount = 1;
     protected boolean skipOperationExample;
+    // sort operations by default
+    protected boolean skipSortingOperations = false;
 
     protected final static Pattern XML_MIME_PATTERN = Pattern.compile("(?i)application\\/(.*)[+]?xml(;.*)?");
     protected final static Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)application\\/json(;.*)?");
@@ -6152,6 +6154,16 @@ public class DefaultCodegen implements CodegenConfig {
     @Override
     public void setSkipOperationExample(boolean skipOperationExample) {
         this.skipOperationExample = skipOperationExample;
+    }
+
+    @Override
+    public boolean isSkipSortingOperations() {
+        return this.skipSortingOperations;
+    }
+
+    @Override
+    public void setSkipSortingOperations(boolean skipSortingOperations) {
+        this.skipSortingOperations = skipSortingOperations;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -121,6 +121,7 @@ public class DefaultGenerator implements Generator {
         this.opts = opts;
         this.openAPI = opts.getOpenAPI();
         this.config = opts.getConfig();
+
         List<TemplateDefinition> userFiles = opts.getUserDefinedTemplates();
         if (userFiles != null) {
             this.userDefinedTemplates = Collections.unmodifiableList(userFiles);
@@ -680,7 +681,10 @@ public class DefaultGenerator implements Generator {
         for (String tag : paths.keySet()) {
             try {
                 List<CodegenOperation> ops = paths.get(tag);
-                ops.sort((one, another) -> ObjectUtils.compare(one.operationId, another.operationId));
+                if(!this.config.isSkipSortingOperations()) {
+                    // sort operations by operationId
+                    ops.sort((one, another) -> ObjectUtils.compare(one.operationId, another.operationId));
+                }
                 OperationsMap operation = processOperations(config, tag, ops, allModels);
                 URL url = URLPathUtils.getServerURL(openAPI, config.serverVariableOverrides());
                 operation.put("basePath", basePath);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
@@ -66,6 +66,9 @@ public class GoServerCodegen extends AbstractGoCodegen {
     public GoServerCodegen() {
         super();
 
+        // skip sorting of operations to preserve the order found in the OpenAPI spec file
+        super.setSkipSortingOperations(true);
+
         modifyFeatureSet(features -> features
                 .includeDocumentationFeatures(DocumentationFeature.Readme)
                 .wireFormatFeatures(EnumSet.of(WireFormatFeature.JSON, WireFormatFeature.XML))

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/goserver/GoServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/goserver/GoServerCodegenTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ * Copyright 2018 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.goserver;
+
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class GoServerCodegenTest {
+
+    @Test
+    public void verifyGoMod() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = createDefaultCodegenConfigurator(output)
+                .setInputSpec("src/test/resources/3_0/go-server/route-order.yaml");
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileExists(Paths.get(output + "/go.mod"));
+        TestUtils.assertFileContains(Paths.get(output + "/go.mod"),
+                "module github.com/my-user/my-repo");
+        TestUtils.assertFileContains(Paths.get(output + "/go.mod"),
+                "require github.com/gorilla/mux v1.8.0");
+    }
+
+    @Test
+    public void verifyOrder() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = createDefaultCodegenConfigurator(output)
+                .setInputSpec("src/test/resources/3_0/go-server/route-order.yaml");
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileExists(Paths.get(output + "/go/routers.go"));
+        TestUtils.assertFileContains(Paths.get(output + "/go/routers.go"),
+                "type Routes map[string]Route");
+
+        TestUtils.assertFileExists(Paths.get(output + "/go/api_dev.go"));
+        // verify /getPath/latest is first route
+        Assert.assertEquals(Files.readAllLines(Paths.get(output + "/go/api_dev.go")).get(52), "\t\t\"GetLatest\": Route{");
+        // verify /getPath/{id} is second route
+        Assert.assertEquals(Files.readAllLines(Paths.get(output + "/go/api_dev.go")).get(57), "\t\t\"GetById\": Route{");
+
+    }
+
+    private static CodegenConfigurator createDefaultCodegenConfigurator(File output) {
+        return new CodegenConfigurator()
+                .setGeneratorName("go-server")
+                .setGitUserId("my-user")
+                .setGitRepoId("my-repo")
+                .setPackageName("mypackage")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+    }
+
+}

--- a/modules/openapi-generator/src/test/resources/3_0/go-server/route-order.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/go-server/route-order.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+
+info:
+  version: 1.0.0
+  title: Simple no path and body param spec
+
+paths:
+  /getPath/latest:
+    get:
+      tags:
+        - dev
+      summary: summary
+      description: description
+      operationId: getLatest
+      responses:
+        '204':
+          description: successful operation
+  /getPath/{id}:
+    get:
+      tags:
+        - dev
+      summary: summary
+      description: description
+      operationId: GetById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: successful operation

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api.go
@@ -22,24 +22,24 @@ import (
 // The PetAPIRouter implementation should parse necessary information from the http request,
 // pass the data to a PetAPIServicer to perform the required actions, then write the service results to the http response.
 type PetAPIRouter interface { 
+	UpdatePet(http.ResponseWriter, *http.Request)
 	AddPet(http.ResponseWriter, *http.Request)
-	DeletePet(http.ResponseWriter, *http.Request)
 	FindPetsByStatus(http.ResponseWriter, *http.Request)
 	// Deprecated
 	FindPetsByTags(http.ResponseWriter, *http.Request)
 	GetPetById(http.ResponseWriter, *http.Request)
-	UpdatePet(http.ResponseWriter, *http.Request)
 	UpdatePetWithForm(http.ResponseWriter, *http.Request)
+	DeletePet(http.ResponseWriter, *http.Request)
 	UploadFile(http.ResponseWriter, *http.Request)
 }
 // StoreAPIRouter defines the required methods for binding the api requests to a responses for the StoreAPI
 // The StoreAPIRouter implementation should parse necessary information from the http request,
 // pass the data to a StoreAPIServicer to perform the required actions, then write the service results to the http response.
 type StoreAPIRouter interface { 
-	DeleteOrder(http.ResponseWriter, *http.Request)
 	GetInventory(http.ResponseWriter, *http.Request)
-	GetOrderById(http.ResponseWriter, *http.Request)
 	PlaceOrder(http.ResponseWriter, *http.Request)
+	GetOrderById(http.ResponseWriter, *http.Request)
+	DeleteOrder(http.ResponseWriter, *http.Request)
 }
 // UserAPIRouter defines the required methods for binding the api requests to a responses for the UserAPI
 // The UserAPIRouter implementation should parse necessary information from the http request,
@@ -48,11 +48,11 @@ type UserAPIRouter interface {
 	CreateUser(http.ResponseWriter, *http.Request)
 	CreateUsersWithArrayInput(http.ResponseWriter, *http.Request)
 	CreateUsersWithListInput(http.ResponseWriter, *http.Request)
-	DeleteUser(http.ResponseWriter, *http.Request)
-	GetUserByName(http.ResponseWriter, *http.Request)
 	LoginUser(http.ResponseWriter, *http.Request)
 	LogoutUser(http.ResponseWriter, *http.Request)
+	GetUserByName(http.ResponseWriter, *http.Request)
 	UpdateUser(http.ResponseWriter, *http.Request)
+	DeleteUser(http.ResponseWriter, *http.Request)
 }
 
 
@@ -61,14 +61,14 @@ type UserAPIRouter interface {
 // while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type PetAPIServicer interface { 
+	UpdatePet(context.Context, Pet) (ImplResponse, error)
 	AddPet(context.Context, Pet) (ImplResponse, error)
-	DeletePet(context.Context, int64, string) (ImplResponse, error)
 	FindPetsByStatus(context.Context, []string) (ImplResponse, error)
 	// Deprecated
 	FindPetsByTags(context.Context, []string) (ImplResponse, error)
 	GetPetById(context.Context, int64) (ImplResponse, error)
-	UpdatePet(context.Context, Pet) (ImplResponse, error)
 	UpdatePetWithForm(context.Context, int64, string, string) (ImplResponse, error)
+	DeletePet(context.Context, int64, string) (ImplResponse, error)
 	UploadFile(context.Context, int64, string, *os.File) (ImplResponse, error)
 }
 
@@ -78,10 +78,10 @@ type PetAPIServicer interface {
 // while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type StoreAPIServicer interface { 
-	DeleteOrder(context.Context, string) (ImplResponse, error)
 	GetInventory(context.Context) (ImplResponse, error)
-	GetOrderById(context.Context, int64) (ImplResponse, error)
 	PlaceOrder(context.Context, Order) (ImplResponse, error)
+	GetOrderById(context.Context, int64) (ImplResponse, error)
+	DeleteOrder(context.Context, string) (ImplResponse, error)
 }
 
 
@@ -93,9 +93,9 @@ type UserAPIServicer interface {
 	CreateUser(context.Context, User) (ImplResponse, error)
 	CreateUsersWithArrayInput(context.Context, []User) (ImplResponse, error)
 	CreateUsersWithListInput(context.Context, []User) (ImplResponse, error)
-	DeleteUser(context.Context, string, bool) (ImplResponse, error)
-	GetUserByName(context.Context, string) (ImplResponse, error)
 	LoginUser(context.Context, string, string, int32, int64, float32, float64, bool) (ImplResponse, error)
 	LogoutUser(context.Context) (ImplResponse, error)
+	GetUserByName(context.Context, string) (ImplResponse, error)
 	UpdateUser(context.Context, string, User) (ImplResponse, error)
+	DeleteUser(context.Context, string, bool) (ImplResponse, error)
 }

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_pet.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_pet.go
@@ -52,15 +52,15 @@ func NewPetAPIController(s PetAPIServicer, opts ...PetAPIOption) *PetAPIControll
 // Routes returns all the api routes for the PetAPIController
 func (c *PetAPIController) Routes() Routes {
 	return Routes{
+		"UpdatePet": Route{
+			strings.ToUpper("Put"),
+			"/v2/pet",
+			c.UpdatePet,
+		},
 		"AddPet": Route{
 			strings.ToUpper("Post"),
 			"/v2/pet",
 			c.AddPet,
-		},
-		"DeletePet": Route{
-			strings.ToUpper("Delete"),
-			"/v2/pet/{petId}",
-			c.DeletePet,
 		},
 		"FindPetsByStatus": Route{
 			strings.ToUpper("Get"),
@@ -77,15 +77,15 @@ func (c *PetAPIController) Routes() Routes {
 			"/v2/pet/{petId}",
 			c.GetPetById,
 		},
-		"UpdatePet": Route{
-			strings.ToUpper("Put"),
-			"/v2/pet",
-			c.UpdatePet,
-		},
 		"UpdatePetWithForm": Route{
 			strings.ToUpper("Post"),
 			"/v2/pet/{petId}",
 			c.UpdatePetWithForm,
+		},
+		"DeletePet": Route{
+			strings.ToUpper("Delete"),
+			"/v2/pet/{petId}",
+			c.DeletePet,
 		},
 		"UploadFile": Route{
 			strings.ToUpper("Post"),
@@ -93,6 +93,33 @@ func (c *PetAPIController) Routes() Routes {
 			c.UploadFile,
 		},
 	}
+}
+
+// UpdatePet - Update an existing pet
+func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
+	petParam := Pet{}
+	d := json.NewDecoder(r.Body)
+	d.DisallowUnknownFields()
+	if err := d.Decode(&petParam); err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	if err := AssertPetRequired(petParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	if err := AssertPetConstraints(petParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	result, err := c.service.UpdatePet(r.Context(), petParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
 // AddPet - Add a new pet to the store
@@ -113,27 +140,6 @@ func (c *PetAPIController) AddPet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	result, err := c.service.AddPet(r.Context(), petParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// DeletePet - Deletes a pet
-func (c *PetAPIController) DeletePet(w http.ResponseWriter, r *http.Request) {
-	petIdParam, err := parseNumericParameter[int64](
-		chi.URLParam(r, "petId"),
-		WithRequire[int64](parseInt64),
-	)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
-		return
-	}
-	apiKeyParam := r.Header.Get("api_key")
-	result, err := c.service.DeletePet(r.Context(), petIdParam, apiKeyParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -206,33 +212,6 @@ func (c *PetAPIController) GetPetById(w http.ResponseWriter, r *http.Request) {
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
-// UpdatePet - Update an existing pet
-func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
-	d := json.NewDecoder(r.Body)
-	d.DisallowUnknownFields()
-	if err := d.Decode(&petParam); err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
-		return
-	}
-	if err := AssertPetRequired(petParam); err != nil {
-		c.errorHandler(w, r, err, nil)
-		return
-	}
-	if err := AssertPetConstraints(petParam); err != nil {
-		c.errorHandler(w, r, err, nil)
-		return
-	}
-	result, err := c.service.UpdatePet(r.Context(), petParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
 // UpdatePetWithForm - Updates a pet in the store with form data
 func (c *PetAPIController) UpdatePetWithForm(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
@@ -254,6 +233,27 @@ func (c *PetAPIController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 	
 	statusParam := r.FormValue("status")
 	result, err := c.service.UpdatePetWithForm(r.Context(), petIdParam, nameParam, statusParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// DeletePet - Deletes a pet
+func (c *PetAPIController) DeletePet(w http.ResponseWriter, r *http.Request) {
+	petIdParam, err := parseNumericParameter[int64](
+		chi.URLParam(r, "petId"),
+		WithRequire[int64](parseInt64),
+	)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
+		return
+	}
+	apiKeyParam := r.Header.Get("api_key")
+	result, err := c.service.DeletePet(r.Context(), petIdParam, apiKeyParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_pet_service.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_pet_service.go
@@ -28,6 +28,26 @@ func NewPetAPIService() *PetAPIService {
 	return &PetAPIService{}
 }
 
+// UpdatePet - Update an existing pet
+func (s *PetAPIService) UpdatePet(ctx context.Context, pet Pet) (ImplResponse, error) {
+	// TODO - update UpdatePet with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, Pet{}) or use other options such as http.Ok ...
+	// return Response(200, Pet{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	// TODO: Uncomment the next line to return response Response(405, {}) or use other options such as http.Ok ...
+	// return Response(405, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("UpdatePet method not implemented")
+}
+
 // AddPet - Add a new pet to the store
 func (s *PetAPIService) AddPet(ctx context.Context, pet Pet) (ImplResponse, error) {
 	// TODO - update AddPet with the required logic for this service method.
@@ -40,17 +60,6 @@ func (s *PetAPIService) AddPet(ctx context.Context, pet Pet) (ImplResponse, erro
 	// return Response(405, nil),nil
 
 	return Response(http.StatusNotImplemented, nil), errors.New("AddPet method not implemented")
-}
-
-// DeletePet - Deletes a pet
-func (s *PetAPIService) DeletePet(ctx context.Context, petId int64, apiKey string) (ImplResponse, error) {
-	// TODO - update DeletePet with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("DeletePet method not implemented")
 }
 
 // FindPetsByStatus - Finds Pets by status
@@ -99,26 +108,6 @@ func (s *PetAPIService) GetPetById(ctx context.Context, petId int64) (ImplRespon
 	return Response(http.StatusNotImplemented, nil), errors.New("GetPetById method not implemented")
 }
 
-// UpdatePet - Update an existing pet
-func (s *PetAPIService) UpdatePet(ctx context.Context, pet Pet) (ImplResponse, error) {
-	// TODO - update UpdatePet with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, Pet{}) or use other options such as http.Ok ...
-	// return Response(200, Pet{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(405, {}) or use other options such as http.Ok ...
-	// return Response(405, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("UpdatePet method not implemented")
-}
-
 // UpdatePetWithForm - Updates a pet in the store with form data
 func (s *PetAPIService) UpdatePetWithForm(ctx context.Context, petId int64, name string, status string) (ImplResponse, error) {
 	// TODO - update UpdatePetWithForm with the required logic for this service method.
@@ -128,6 +117,17 @@ func (s *PetAPIService) UpdatePetWithForm(ctx context.Context, petId int64, name
 	// return Response(405, nil),nil
 
 	return Response(http.StatusNotImplemented, nil), errors.New("UpdatePetWithForm method not implemented")
+}
+
+// DeletePet - Deletes a pet
+func (s *PetAPIService) DeletePet(ctx context.Context, petId int64, apiKey string) (ImplResponse, error) {
+	// TODO - update DeletePet with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("DeletePet method not implemented")
 }
 
 // UploadFile - uploads an image

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_store.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_store.go
@@ -51,37 +51,32 @@ func NewStoreAPIController(s StoreAPIServicer, opts ...StoreAPIOption) *StoreAPI
 // Routes returns all the api routes for the StoreAPIController
 func (c *StoreAPIController) Routes() Routes {
 	return Routes{
-		"DeleteOrder": Route{
-			strings.ToUpper("Delete"),
-			"/v2/store/order/{orderId}",
-			c.DeleteOrder,
-		},
 		"GetInventory": Route{
 			strings.ToUpper("Get"),
 			"/v2/store/inventory",
 			c.GetInventory,
-		},
-		"GetOrderById": Route{
-			strings.ToUpper("Get"),
-			"/v2/store/order/{orderId}",
-			c.GetOrderById,
 		},
 		"PlaceOrder": Route{
 			strings.ToUpper("Post"),
 			"/v2/store/order",
 			c.PlaceOrder,
 		},
+		"GetOrderById": Route{
+			strings.ToUpper("Get"),
+			"/v2/store/order/{orderId}",
+			c.GetOrderById,
+		},
+		"DeleteOrder": Route{
+			strings.ToUpper("Delete"),
+			"/v2/store/order/{orderId}",
+			c.DeleteOrder,
+		},
 	}
 }
 
-// DeleteOrder - Delete purchase order by ID
-func (c *StoreAPIController) DeleteOrder(w http.ResponseWriter, r *http.Request) {
-	orderIdParam := chi.URLParam(r, "orderId")
-	if orderIdParam == "" {
-		c.errorHandler(w, r, &RequiredError{"orderId"}, nil)
-		return
-	}
-	result, err := c.service.DeleteOrder(r.Context(), orderIdParam)
+// GetInventory - Returns pet inventories by status
+func (c *StoreAPIController) GetInventory(w http.ResponseWriter, r *http.Request) {
+	result, err := c.service.GetInventory(r.Context())
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -91,9 +86,24 @@ func (c *StoreAPIController) DeleteOrder(w http.ResponseWriter, r *http.Request)
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
-// GetInventory - Returns pet inventories by status
-func (c *StoreAPIController) GetInventory(w http.ResponseWriter, r *http.Request) {
-	result, err := c.service.GetInventory(r.Context())
+// PlaceOrder - Place an order for a pet
+func (c *StoreAPIController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
+	orderParam := Order{}
+	d := json.NewDecoder(r.Body)
+	d.DisallowUnknownFields()
+	if err := d.Decode(&orderParam); err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	if err := AssertOrderRequired(orderParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	if err := AssertOrderConstraints(orderParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	result, err := c.service.PlaceOrder(r.Context(), orderParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -125,24 +135,14 @@ func (c *StoreAPIController) GetOrderById(w http.ResponseWriter, r *http.Request
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
-// PlaceOrder - Place an order for a pet
-func (c *StoreAPIController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
-	orderParam := Order{}
-	d := json.NewDecoder(r.Body)
-	d.DisallowUnknownFields()
-	if err := d.Decode(&orderParam); err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+// DeleteOrder - Delete purchase order by ID
+func (c *StoreAPIController) DeleteOrder(w http.ResponseWriter, r *http.Request) {
+	orderIdParam := chi.URLParam(r, "orderId")
+	if orderIdParam == "" {
+		c.errorHandler(w, r, &RequiredError{"orderId"}, nil)
 		return
 	}
-	if err := AssertOrderRequired(orderParam); err != nil {
-		c.errorHandler(w, r, err, nil)
-		return
-	}
-	if err := AssertOrderConstraints(orderParam); err != nil {
-		c.errorHandler(w, r, err, nil)
-		return
-	}
-	result, err := c.service.PlaceOrder(r.Context(), orderParam)
+	result, err := c.service.DeleteOrder(r.Context(), orderIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_store_service.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_store_service.go
@@ -27,20 +27,6 @@ func NewStoreAPIService() *StoreAPIService {
 	return &StoreAPIService{}
 }
 
-// DeleteOrder - Delete purchase order by ID
-func (s *StoreAPIService) DeleteOrder(ctx context.Context, orderId string) (ImplResponse, error) {
-	// TODO - update DeleteOrder with the required logic for this service method.
-	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("DeleteOrder method not implemented")
-}
-
 // GetInventory - Returns pet inventories by status
 func (s *StoreAPIService) GetInventory(ctx context.Context) (ImplResponse, error) {
 	// TODO - update GetInventory with the required logic for this service method.
@@ -50,6 +36,20 @@ func (s *StoreAPIService) GetInventory(ctx context.Context) (ImplResponse, error
 	// return Response(200, map[string]int32{}), nil
 
 	return Response(http.StatusNotImplemented, nil), errors.New("GetInventory method not implemented")
+}
+
+// PlaceOrder - Place an order for a pet
+func (s *StoreAPIService) PlaceOrder(ctx context.Context, order Order) (ImplResponse, error) {
+	// TODO - update PlaceOrder with the required logic for this service method.
+	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, Order{}) or use other options such as http.Ok ...
+	// return Response(200, Order{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("PlaceOrder method not implemented")
 }
 
 // GetOrderById - Find purchase order by ID
@@ -69,16 +69,16 @@ func (s *StoreAPIService) GetOrderById(ctx context.Context, orderId int64) (Impl
 	return Response(http.StatusNotImplemented, nil), errors.New("GetOrderById method not implemented")
 }
 
-// PlaceOrder - Place an order for a pet
-func (s *StoreAPIService) PlaceOrder(ctx context.Context, order Order) (ImplResponse, error) {
-	// TODO - update PlaceOrder with the required logic for this service method.
+// DeleteOrder - Delete purchase order by ID
+func (s *StoreAPIService) DeleteOrder(ctx context.Context, orderId string) (ImplResponse, error) {
+	// TODO - update DeleteOrder with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, Order{}) or use other options such as http.Ok ...
-	// return Response(200, Order{}), nil
 
 	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
 	// return Response(400, nil),nil
 
-	return Response(http.StatusNotImplemented, nil), errors.New("PlaceOrder method not implemented")
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("DeleteOrder method not implemented")
 }

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_user.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_user.go
@@ -66,16 +66,6 @@ func (c *UserAPIController) Routes() Routes {
 			"/v2/user/createWithList",
 			c.CreateUsersWithListInput,
 		},
-		"DeleteUser": Route{
-			strings.ToUpper("Delete"),
-			"/v2/user/{username}",
-			c.DeleteUser,
-		},
-		"GetUserByName": Route{
-			strings.ToUpper("Get"),
-			"/v2/user/{username}",
-			c.GetUserByName,
-		},
 		"LoginUser": Route{
 			strings.ToUpper("Get"),
 			"/v2/user/login",
@@ -86,10 +76,20 @@ func (c *UserAPIController) Routes() Routes {
 			"/v2/user/logout",
 			c.LogoutUser,
 		},
+		"GetUserByName": Route{
+			strings.ToUpper("Get"),
+			"/v2/user/{username}",
+			c.GetUserByName,
+		},
 		"UpdateUser": Route{
 			strings.ToUpper("Put"),
 			"/v2/user/{username}",
 			c.UpdateUser,
+		},
+		"DeleteUser": Route{
+			strings.ToUpper("Delete"),
+			"/v2/user/{username}",
+			c.DeleteUser,
 		},
 	}
 }
@@ -162,59 +162,6 @@ func (c *UserAPIController) CreateUsersWithListInput(w http.ResponseWriter, r *h
 		}
 	}
 	result, err := c.service.CreateUsersWithListInput(r.Context(), userParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// DeleteUser - Delete user
-func (c *UserAPIController) DeleteUser(w http.ResponseWriter, r *http.Request) {
-	query, err := parseQuery(r.URL.RawQuery)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
-		return
-	}
-	usernameParam := chi.URLParam(r, "username")
-	if usernameParam == "" {
-		c.errorHandler(w, r, &RequiredError{"username"}, nil)
-		return
-	}
-	var booleanTestParam bool
-	if query.Has("boolean_test") {
-		param, err := parseBoolParameter(
-			query.Get("boolean_test"),
-			WithParse[bool](parseBool),
-		)
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "boolean_test", Err: err}, nil)
-			return
-		}
-
-		booleanTestParam = param
-	} else {
-	}
-	result, err := c.service.DeleteUser(r.Context(), usernameParam, booleanTestParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// GetUserByName - Get user by user name
-func (c *UserAPIController) GetUserByName(w http.ResponseWriter, r *http.Request) {
-	usernameParam := chi.URLParam(r, "username")
-	if usernameParam == "" {
-		c.errorHandler(w, r, &RequiredError{"username"}, nil)
-		return
-	}
-	result, err := c.service.GetUserByName(r.Context(), usernameParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -341,6 +288,23 @@ func (c *UserAPIController) LogoutUser(w http.ResponseWriter, r *http.Request) {
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
+// GetUserByName - Get user by user name
+func (c *UserAPIController) GetUserByName(w http.ResponseWriter, r *http.Request) {
+	usernameParam := chi.URLParam(r, "username")
+	if usernameParam == "" {
+		c.errorHandler(w, r, &RequiredError{"username"}, nil)
+		return
+	}
+	result, err := c.service.GetUserByName(r.Context(), usernameParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
 // UpdateUser - Updated user
 func (c *UserAPIController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	usernameParam := chi.URLParam(r, "username")
@@ -364,6 +328,42 @@ func (c *UserAPIController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	result, err := c.service.UpdateUser(r.Context(), usernameParam, userParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// DeleteUser - Delete user
+func (c *UserAPIController) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	query, err := parseQuery(r.URL.RawQuery)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	usernameParam := chi.URLParam(r, "username")
+	if usernameParam == "" {
+		c.errorHandler(w, r, &RequiredError{"username"}, nil)
+		return
+	}
+	var booleanTestParam bool
+	if query.Has("boolean_test") {
+		param, err := parseBoolParameter(
+			query.Get("boolean_test"),
+			WithParse[bool](parseBool),
+		)
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "boolean_test", Err: err}, nil)
+			return
+		}
+
+		booleanTestParam = param
+	} else {
+	}
+	result, err := c.service.DeleteUser(r.Context(), usernameParam, booleanTestParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_user_service.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_user_service.go
@@ -60,37 +60,6 @@ func (s *UserAPIService) CreateUsersWithListInput(ctx context.Context, user []Us
 	return Response(http.StatusNotImplemented, nil), errors.New("CreateUsersWithListInput method not implemented")
 }
 
-// DeleteUser - Delete user
-func (s *UserAPIService) DeleteUser(ctx context.Context, username string, booleanTest bool) (ImplResponse, error) {
-	// TODO - update DeleteUser with the required logic for this service method.
-	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("DeleteUser method not implemented")
-}
-
-// GetUserByName - Get user by user name
-func (s *UserAPIService) GetUserByName(ctx context.Context, username string) (ImplResponse, error) {
-	// TODO - update GetUserByName with the required logic for this service method.
-	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, User{}) or use other options such as http.Ok ...
-	// return Response(200, User{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("GetUserByName method not implemented")
-}
-
 // LoginUser - Logs user into the system
 func (s *UserAPIService) LoginUser(ctx context.Context, username string, password string, int32Test int32, int64Test int64, float32Test float32, float64Test float64, booleanTest bool) (ImplResponse, error) {
 	// TODO - update LoginUser with the required logic for this service method.
@@ -116,6 +85,23 @@ func (s *UserAPIService) LogoutUser(ctx context.Context) (ImplResponse, error) {
 	return Response(http.StatusNotImplemented, nil), errors.New("LogoutUser method not implemented")
 }
 
+// GetUserByName - Get user by user name
+func (s *UserAPIService) GetUserByName(ctx context.Context, username string) (ImplResponse, error) {
+	// TODO - update GetUserByName with the required logic for this service method.
+	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, User{}) or use other options such as http.Ok ...
+	// return Response(200, User{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("GetUserByName method not implemented")
+}
+
 // UpdateUser - Updated user
 func (s *UserAPIService) UpdateUser(ctx context.Context, username string, user User) (ImplResponse, error) {
 	// TODO - update UpdateUser with the required logic for this service method.
@@ -128,4 +114,18 @@ func (s *UserAPIService) UpdateUser(ctx context.Context, username string, user U
 	// return Response(404, nil),nil
 
 	return Response(http.StatusNotImplemented, nil), errors.New("UpdateUser method not implemented")
+}
+
+// DeleteUser - Delete user
+func (s *UserAPIService) DeleteUser(ctx context.Context, username string, booleanTest bool) (ImplResponse, error) {
+	// TODO - update DeleteUser with the required logic for this service method.
+	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("DeleteUser method not implemented")
 }

--- a/samples/server/petstore/go-api-server/go/api.go
+++ b/samples/server/petstore/go-api-server/go/api.go
@@ -23,30 +23,30 @@ import (
 // The PetAPIRouter implementation should parse necessary information from the http request,
 // pass the data to a PetAPIServicer to perform the required actions, then write the service results to the http response.
 type PetAPIRouter interface { 
+	UpdatePet(http.ResponseWriter, *http.Request)
 	AddPet(http.ResponseWriter, *http.Request)
-	DeletePet(http.ResponseWriter, *http.Request)
-	FilterPetsByCategory(http.ResponseWriter, *http.Request)
 	FindPetsByStatus(http.ResponseWriter, *http.Request)
+	SearchPet(http.ResponseWriter, *http.Request)
 	// Deprecated
 	FindPetsByTags(http.ResponseWriter, *http.Request)
+	FilterPetsByCategory(http.ResponseWriter, *http.Request)
 	GetPetById(http.ResponseWriter, *http.Request)
-	GetPetImageById(http.ResponseWriter, *http.Request)
-	GetPetsByTime(http.ResponseWriter, *http.Request)
-	GetPetsUsingBooleanQueryParameters(http.ResponseWriter, *http.Request)
-	SearchPet(http.ResponseWriter, *http.Request)
-	UpdatePet(http.ResponseWriter, *http.Request)
 	UpdatePetWithForm(http.ResponseWriter, *http.Request)
+	DeletePet(http.ResponseWriter, *http.Request)
+	GetPetImageById(http.ResponseWriter, *http.Request)
 	UploadFile(http.ResponseWriter, *http.Request)
 	UploadFileArrayOfFiles(http.ResponseWriter, *http.Request)
+	GetPetsUsingBooleanQueryParameters(http.ResponseWriter, *http.Request)
+	GetPetsByTime(http.ResponseWriter, *http.Request)
 }
 // StoreAPIRouter defines the required methods for binding the api requests to a responses for the StoreAPI
 // The StoreAPIRouter implementation should parse necessary information from the http request,
 // pass the data to a StoreAPIServicer to perform the required actions, then write the service results to the http response.
 type StoreAPIRouter interface { 
-	DeleteOrder(http.ResponseWriter, *http.Request)
 	GetInventory(http.ResponseWriter, *http.Request)
-	GetOrderById(http.ResponseWriter, *http.Request)
 	PlaceOrder(http.ResponseWriter, *http.Request)
+	GetOrderById(http.ResponseWriter, *http.Request)
+	DeleteOrder(http.ResponseWriter, *http.Request)
 }
 // UserAPIRouter defines the required methods for binding the api requests to a responses for the UserAPI
 // The UserAPIRouter implementation should parse necessary information from the http request,
@@ -55,11 +55,11 @@ type UserAPIRouter interface {
 	CreateUser(http.ResponseWriter, *http.Request)
 	CreateUsersWithArrayInput(http.ResponseWriter, *http.Request)
 	CreateUsersWithListInput(http.ResponseWriter, *http.Request)
-	DeleteUser(http.ResponseWriter, *http.Request)
-	GetUserByName(http.ResponseWriter, *http.Request)
 	LoginUser(http.ResponseWriter, *http.Request)
 	LogoutUser(http.ResponseWriter, *http.Request)
+	GetUserByName(http.ResponseWriter, *http.Request)
 	UpdateUser(http.ResponseWriter, *http.Request)
+	DeleteUser(http.ResponseWriter, *http.Request)
 }
 
 
@@ -68,21 +68,21 @@ type UserAPIRouter interface {
 // while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type PetAPIServicer interface { 
+	UpdatePet(context.Context, Pet) (ImplResponse, error)
 	AddPet(context.Context, Pet) (ImplResponse, error)
-	DeletePet(context.Context, int64, string) (ImplResponse, error)
-	FilterPetsByCategory(context.Context, Gender, Species, []Species) (ImplResponse, error)
 	FindPetsByStatus(context.Context, []string, string, string, int32, float32, string) (ImplResponse, error)
+	SearchPet(context.Context, *int64, *float32, *time.Time, *bool) (ImplResponse, error)
 	// Deprecated
 	FindPetsByTags(context.Context, []string, time.Time, time.Time, Colour) (ImplResponse, error)
+	FilterPetsByCategory(context.Context, Gender, Species, []Species) (ImplResponse, error)
 	GetPetById(context.Context, int64) (ImplResponse, error)
-	GetPetImageById(context.Context, int64) (ImplResponse, error)
-	GetPetsByTime(context.Context, time.Time) (ImplResponse, error)
-	GetPetsUsingBooleanQueryParameters(context.Context, bool, bool, bool) (ImplResponse, error)
-	SearchPet(context.Context, *int64, *float32, *time.Time, *bool) (ImplResponse, error)
-	UpdatePet(context.Context, Pet) (ImplResponse, error)
 	UpdatePetWithForm(context.Context, int64, string, string) (ImplResponse, error)
+	DeletePet(context.Context, int64, string) (ImplResponse, error)
+	GetPetImageById(context.Context, int64) (ImplResponse, error)
 	UploadFile(context.Context, int64, string, []string, *os.File) (ImplResponse, error)
 	UploadFileArrayOfFiles(context.Context, int64, string, []*os.File) (ImplResponse, error)
+	GetPetsUsingBooleanQueryParameters(context.Context, bool, bool, bool) (ImplResponse, error)
+	GetPetsByTime(context.Context, time.Time) (ImplResponse, error)
 }
 
 
@@ -91,10 +91,10 @@ type PetAPIServicer interface {
 // while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type StoreAPIServicer interface { 
-	DeleteOrder(context.Context, string) (ImplResponse, error)
 	GetInventory(context.Context) (ImplResponse, error)
-	GetOrderById(context.Context, int64) (ImplResponse, error)
 	PlaceOrder(context.Context, Order) (ImplResponse, error)
+	GetOrderById(context.Context, int64) (ImplResponse, error)
+	DeleteOrder(context.Context, string) (ImplResponse, error)
 }
 
 
@@ -106,9 +106,9 @@ type UserAPIServicer interface {
 	CreateUser(context.Context, User) (ImplResponse, error)
 	CreateUsersWithArrayInput(context.Context, []User) (ImplResponse, error)
 	CreateUsersWithListInput(context.Context, []User) (ImplResponse, error)
-	DeleteUser(context.Context, string, bool) (ImplResponse, error)
-	GetUserByName(context.Context, string) (ImplResponse, error)
 	LoginUser(context.Context, string, string, bool) (ImplResponse, error)
 	LogoutUser(context.Context) (ImplResponse, error)
+	GetUserByName(context.Context, string) (ImplResponse, error)
 	UpdateUser(context.Context, string, User) (ImplResponse, error)
+	DeleteUser(context.Context, string, bool) (ImplResponse, error)
 }

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -53,65 +53,55 @@ func NewPetAPIController(s PetAPIServicer, opts ...PetAPIOption) *PetAPIControll
 // Routes returns all the api routes for the PetAPIController
 func (c *PetAPIController) Routes() Routes {
 	return Routes{
+		"UpdatePet": Route{
+			strings.ToUpper("Put"),
+			"/v2/pet",
+			c.UpdatePet,
+		},
 		"AddPet": Route{
 			strings.ToUpper("Post"),
 			"/v2/pet",
 			c.AddPet,
-		},
-		"DeletePet": Route{
-			strings.ToUpper("Delete"),
-			"/v2/pet/{petId}",
-			c.DeletePet,
-		},
-		"FilterPetsByCategory": Route{
-			strings.ToUpper("Get"),
-			"/v2/pet/filterPets/{gender}",
-			c.FilterPetsByCategory,
 		},
 		"FindPetsByStatus": Route{
 			strings.ToUpper("Get"),
 			"/v2/pet/findByStatus",
 			c.FindPetsByStatus,
 		},
+		"SearchPet": Route{
+			strings.ToUpper("Get"),
+			"/v2/pet/searchPetWithManyFilters",
+			c.SearchPet,
+		},
 		"FindPetsByTags": Route{
 			strings.ToUpper("Get"),
 			"/v2/pet/findByTags",
 			c.FindPetsByTags,
+		},
+		"FilterPetsByCategory": Route{
+			strings.ToUpper("Get"),
+			"/v2/pet/filterPets/{gender}",
+			c.FilterPetsByCategory,
 		},
 		"GetPetById": Route{
 			strings.ToUpper("Get"),
 			"/v2/pet/{petId}",
 			c.GetPetById,
 		},
-		"GetPetImageById": Route{
-			strings.ToUpper("Get"),
-			"/v2/pet/{petId}/uploadImage",
-			c.GetPetImageById,
-		},
-		"GetPetsByTime": Route{
-			strings.ToUpper("Get"),
-			"/v2/pets/byTime/{createdTime}",
-			c.GetPetsByTime,
-		},
-		"GetPetsUsingBooleanQueryParameters": Route{
-			strings.ToUpper("Get"),
-			"/v2/pets/boolean/parsing",
-			c.GetPetsUsingBooleanQueryParameters,
-		},
-		"SearchPet": Route{
-			strings.ToUpper("Get"),
-			"/v2/pet/searchPetWithManyFilters",
-			c.SearchPet,
-		},
-		"UpdatePet": Route{
-			strings.ToUpper("Put"),
-			"/v2/pet",
-			c.UpdatePet,
-		},
 		"UpdatePetWithForm": Route{
 			strings.ToUpper("Post"),
 			"/v2/pet/{petId}",
 			c.UpdatePetWithForm,
+		},
+		"DeletePet": Route{
+			strings.ToUpper("Delete"),
+			"/v2/pet/{petId}",
+			c.DeletePet,
+		},
+		"GetPetImageById": Route{
+			strings.ToUpper("Get"),
+			"/v2/pet/{petId}/uploadImage",
+			c.GetPetImageById,
 		},
 		"UploadFile": Route{
 			strings.ToUpper("Post"),
@@ -123,7 +113,44 @@ func (c *PetAPIController) Routes() Routes {
 			"/v2/fake/uploadImage/array of_file",
 			c.UploadFileArrayOfFiles,
 		},
+		"GetPetsUsingBooleanQueryParameters": Route{
+			strings.ToUpper("Get"),
+			"/v2/pets/boolean/parsing",
+			c.GetPetsUsingBooleanQueryParameters,
+		},
+		"GetPetsByTime": Route{
+			strings.ToUpper("Get"),
+			"/v2/pets/byTime/{createdTime}",
+			c.GetPetsByTime,
+		},
 	}
+}
+
+// UpdatePet - Update an existing pet
+func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
+	petParam := Pet{}
+	d := json.NewDecoder(r.Body)
+	d.DisallowUnknownFields()
+	if err := d.Decode(&petParam); err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	if err := AssertPetRequired(petParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	if err := AssertPetConstraints(petParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	result, err := c.service.UpdatePet(r.Context(), petParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
 // AddPet - Add a new pet to the store
@@ -144,73 +171,6 @@ func (c *PetAPIController) AddPet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	result, err := c.service.AddPet(r.Context(), petParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// DeletePet - Deletes a pet
-func (c *PetAPIController) DeletePet(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	petIdParam, err := parseNumericParameter[int64](
-		params["petId"],
-		WithRequire[int64](parseInt64),
-	)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
-		return
-	}
-	apiKeyParam := r.Header.Get("api_key")
-	result, err := c.service.DeletePet(r.Context(), petIdParam, apiKeyParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// FilterPetsByCategory - Finds Pets
-func (c *PetAPIController) FilterPetsByCategory(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	query, err := parseQuery(r.URL.RawQuery)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
-		return
-	}
-	genderParam, err := NewGenderFromValue(params["gender"])
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Param: "gender", Err: err}, nil)
-		return
-	}
-	var speciesParam Species
-	if query.Has("species") {
-		param := Species(query.Get("species"))
-
-		speciesParam = param
-	} else {
-		c.errorHandler(w, r, &RequiredError{Field: "species"}, nil)
-		return
-	}
-	var notSpeciesParam []Species
-	if query.Has("notSpecies") {
-		paramSplits := strings.Split(query.Get("notSpecies"), ",")
-		notSpeciesParam = make([]Species, 0, len(paramSplits))
-		for _, param := range paramSplits {
-			paramEnum, err := NewSpeciesFromValue(param)
-			if err != nil {
-				c.errorHandler(w, r, &ParsingError{Param: "notSpecies", Err: err}, nil)
-				return
-			}
-			notSpeciesParam = append(notSpeciesParam, paramEnum)
-		}
-	}
-	result, err := c.service.FilterPetsByCategory(r.Context(), genderParam, speciesParam, notSpeciesParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -295,182 +255,6 @@ func (c *PetAPIController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
-// FindPetsByTags - Finds Pets by tags
-// Deprecated
-func (c *PetAPIController) FindPetsByTags(w http.ResponseWriter, r *http.Request) {
-	query, err := parseQuery(r.URL.RawQuery)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
-		return
-	}
-	var tagsParam []string
-	if query.Has("tags") {
-		tagsParam = strings.Split(query.Get("tags"), ",")
-	}
-	var bornAfterParam time.Time
-	if query.Has("bornAfter"){
-		param, err := parseTime(query.Get("bornAfter"))
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "bornAfter", Err: err}, nil)
-			return
-		}
-
-		bornAfterParam = param
-	} else {
-		c.errorHandler(w, r, &RequiredError{"bornAfter"}, nil)
-		return
-	}
-	var bornBeforeParam time.Time
-	if query.Has("bornBefore"){
-		param, err := parseTime(query.Get("bornBefore"))
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "bornBefore", Err: err}, nil)
-			return
-		}
-
-		bornBeforeParam = param
-	} else {
-	}
-	var colourParam Colour
-	if query.Has("colour") {
-		param := Colour(query.Get("colour"))
-
-		colourParam = param
-	} else {
-	}
-	result, err := c.service.FindPetsByTags(r.Context(), tagsParam, bornAfterParam, bornBeforeParam, colourParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// GetPetById - Find pet by ID
-func (c *PetAPIController) GetPetById(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	petIdParam, err := parseNumericParameter[int64](
-		params["petId"],
-		WithRequire[int64](parseInt64),
-	)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
-		return
-	}
-	result, err := c.service.GetPetById(r.Context(), petIdParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// GetPetImageById - Returns the image for the Pet that has been previously uploaded
-func (c *PetAPIController) GetPetImageById(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	petIdParam, err := parseNumericParameter[int64](
-		params["petId"],
-		WithRequire[int64](parseInt64),
-	)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
-		return
-	}
-	result, err := c.service.GetPetImageById(r.Context(), petIdParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// GetPetsByTime - Get the pets by time
-func (c *PetAPIController) GetPetsByTime(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	createdTimeParam, err := parseTime(params["createdTime"])
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Param: "createdTime", Err: err}, nil)
-		return
-	}
-	result, err := c.service.GetPetsByTime(r.Context(), createdTimeParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// GetPetsUsingBooleanQueryParameters - Get the pets by only using boolean query parameters
-func (c *PetAPIController) GetPetsUsingBooleanQueryParameters(w http.ResponseWriter, r *http.Request) {
-	query, err := parseQuery(r.URL.RawQuery)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
-		return
-	}
-	var exprParam bool
-	if query.Has("expr") {
-		param, err := parseBoolParameter(
-			query.Get("expr"),
-			WithParse[bool](parseBool),
-		)
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "expr", Err: err}, nil)
-			return
-		}
-
-		exprParam = param
-	} else {
-		c.errorHandler(w, r, &RequiredError{Field: "expr"}, nil)
-		return
-	}
-	var groupingParam bool
-	if query.Has("grouping") {
-		param, err := parseBoolParameter(
-			query.Get("grouping"),
-			WithParse[bool](parseBool),
-		)
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "grouping", Err: err}, nil)
-			return
-		}
-
-		groupingParam = param
-	} else {
-	}
-	var inactiveParam bool
-	if query.Has("inactive") {
-		param, err := parseBoolParameter(
-			query.Get("inactive"),
-			WithParse[bool](parseBool),
-		)
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "inactive", Err: err}, nil)
-			return
-		}
-
-		inactiveParam = param
-	} else {
-		var param bool = false
-		inactiveParam = param
-	}
-	result, err := c.service.GetPetsUsingBooleanQueryParameters(r.Context(), exprParam, groupingParam, inactiveParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
 // SearchPet - Search Pets by filters
 func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 	query, err := parseQuery(r.URL.RawQuery)
@@ -541,24 +325,116 @@ func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
-// UpdatePet - Update an existing pet
-func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
-	d := json.NewDecoder(r.Body)
-	d.DisallowUnknownFields()
-	if err := d.Decode(&petParam); err != nil {
+// FindPetsByTags - Finds Pets by tags
+// Deprecated
+func (c *PetAPIController) FindPetsByTags(w http.ResponseWriter, r *http.Request) {
+	query, err := parseQuery(r.URL.RawQuery)
+	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertPetRequired(petParam); err != nil {
-		c.errorHandler(w, r, err, nil)
+	var tagsParam []string
+	if query.Has("tags") {
+		tagsParam = strings.Split(query.Get("tags"), ",")
+	}
+	var bornAfterParam time.Time
+	if query.Has("bornAfter"){
+		param, err := parseTime(query.Get("bornAfter"))
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "bornAfter", Err: err}, nil)
+			return
+		}
+
+		bornAfterParam = param
+	} else {
+		c.errorHandler(w, r, &RequiredError{"bornAfter"}, nil)
 		return
 	}
-	if err := AssertPetConstraints(petParam); err != nil {
-		c.errorHandler(w, r, err, nil)
+	var bornBeforeParam time.Time
+	if query.Has("bornBefore"){
+		param, err := parseTime(query.Get("bornBefore"))
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "bornBefore", Err: err}, nil)
+			return
+		}
+
+		bornBeforeParam = param
+	} else {
+	}
+	var colourParam Colour
+	if query.Has("colour") {
+		param := Colour(query.Get("colour"))
+
+		colourParam = param
+	} else {
+	}
+	result, err := c.service.FindPetsByTags(r.Context(), tagsParam, bornAfterParam, bornBeforeParam, colourParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
 		return
 	}
-	result, err := c.service.UpdatePet(r.Context(), petParam)
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// FilterPetsByCategory - Finds Pets
+func (c *PetAPIController) FilterPetsByCategory(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	query, err := parseQuery(r.URL.RawQuery)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	genderParam, err := NewGenderFromValue(params["gender"])
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "gender", Err: err}, nil)
+		return
+	}
+	var speciesParam Species
+	if query.Has("species") {
+		param := Species(query.Get("species"))
+
+		speciesParam = param
+	} else {
+		c.errorHandler(w, r, &RequiredError{Field: "species"}, nil)
+		return
+	}
+	var notSpeciesParam []Species
+	if query.Has("notSpecies") {
+		paramSplits := strings.Split(query.Get("notSpecies"), ",")
+		notSpeciesParam = make([]Species, 0, len(paramSplits))
+		for _, param := range paramSplits {
+			paramEnum, err := NewSpeciesFromValue(param)
+			if err != nil {
+				c.errorHandler(w, r, &ParsingError{Param: "notSpecies", Err: err}, nil)
+				return
+			}
+			notSpeciesParam = append(notSpeciesParam, paramEnum)
+		}
+	}
+	result, err := c.service.FilterPetsByCategory(r.Context(), genderParam, speciesParam, notSpeciesParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// GetPetById - Find pet by ID
+func (c *PetAPIController) GetPetById(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	petIdParam, err := parseNumericParameter[int64](
+		params["petId"],
+		WithRequire[int64](parseInt64),
+	)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
+		return
+	}
+	result, err := c.service.GetPetById(r.Context(), petIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -590,6 +466,49 @@ func (c *PetAPIController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 	
 	statusParam := r.FormValue("status")
 	result, err := c.service.UpdatePetWithForm(r.Context(), petIdParam, nameParam, statusParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// DeletePet - Deletes a pet
+func (c *PetAPIController) DeletePet(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	petIdParam, err := parseNumericParameter[int64](
+		params["petId"],
+		WithRequire[int64](parseInt64),
+	)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
+		return
+	}
+	apiKeyParam := r.Header.Get("api_key")
+	result, err := c.service.DeletePet(r.Context(), petIdParam, apiKeyParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// GetPetImageById - Returns the image for the Pet that has been previously uploaded
+func (c *PetAPIController) GetPetImageById(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	petIdParam, err := parseNumericParameter[int64](
+		params["petId"],
+		WithRequire[int64](parseInt64),
+	)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
+		return
+	}
+	result, err := c.service.GetPetImageById(r.Context(), petIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -673,6 +592,87 @@ func (c *PetAPIController) UploadFileArrayOfFiles(w http.ResponseWriter, r *http
 	
 	
 	result, err := c.service.UploadFileArrayOfFiles(r.Context(), petIdParam, additionalMetadataParam, filesParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// GetPetsUsingBooleanQueryParameters - Get the pets by only using boolean query parameters
+func (c *PetAPIController) GetPetsUsingBooleanQueryParameters(w http.ResponseWriter, r *http.Request) {
+	query, err := parseQuery(r.URL.RawQuery)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	var exprParam bool
+	if query.Has("expr") {
+		param, err := parseBoolParameter(
+			query.Get("expr"),
+			WithParse[bool](parseBool),
+		)
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "expr", Err: err}, nil)
+			return
+		}
+
+		exprParam = param
+	} else {
+		c.errorHandler(w, r, &RequiredError{Field: "expr"}, nil)
+		return
+	}
+	var groupingParam bool
+	if query.Has("grouping") {
+		param, err := parseBoolParameter(
+			query.Get("grouping"),
+			WithParse[bool](parseBool),
+		)
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "grouping", Err: err}, nil)
+			return
+		}
+
+		groupingParam = param
+	} else {
+	}
+	var inactiveParam bool
+	if query.Has("inactive") {
+		param, err := parseBoolParameter(
+			query.Get("inactive"),
+			WithParse[bool](parseBool),
+		)
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "inactive", Err: err}, nil)
+			return
+		}
+
+		inactiveParam = param
+	} else {
+		var param bool = false
+		inactiveParam = param
+	}
+	result, err := c.service.GetPetsUsingBooleanQueryParameters(r.Context(), exprParam, groupingParam, inactiveParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// GetPetsByTime - Get the pets by time
+func (c *PetAPIController) GetPetsByTime(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	createdTimeParam, err := parseTime(params["createdTime"])
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "createdTime", Err: err}, nil)
+		return
+	}
+	result, err := c.service.GetPetsByTime(r.Context(), createdTimeParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-api-server/go/api_pet_service.go
+++ b/samples/server/petstore/go-api-server/go/api_pet_service.go
@@ -29,141 +29,6 @@ func NewPetAPIService() *PetAPIService {
 	return &PetAPIService{}
 }
 
-// AddPet - Add a new pet to the store
-func (s *PetAPIService) AddPet(ctx context.Context, pet Pet) (ImplResponse, error) {
-	// TODO - update AddPet with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, Pet{}) or use other options such as http.Ok ...
-	// return Response(200, Pet{}), nil
-
-	// TODO: Uncomment the next line to return response Response(405, {}) or use other options such as http.Ok ...
-	// return Response(405, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("AddPet method not implemented")
-}
-
-// DeletePet - Deletes a pet
-func (s *PetAPIService) DeletePet(ctx context.Context, petId int64, apiKey string) (ImplResponse, error) {
-	// TODO - update DeletePet with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("DeletePet method not implemented")
-}
-
-// FilterPetsByCategory - Finds Pets
-func (s *PetAPIService) FilterPetsByCategory(ctx context.Context, gender Gender, species Species, notSpecies []Species) (ImplResponse, error) {
-	// TODO - update FilterPetsByCategory with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
-	// return Response(200, []Pet{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("FilterPetsByCategory method not implemented")
-}
-
-// FindPetsByStatus - Finds Pets by status
-func (s *PetAPIService) FindPetsByStatus(ctx context.Context, status []string, inlineEnumPath string, inlineEnum string, defaultInt int32, defaultNum float32, defaultStr string) (ImplResponse, error) {
-	// TODO - update FindPetsByStatus with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
-	// return Response(200, []Pet{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("FindPetsByStatus method not implemented")
-}
-
-// FindPetsByTags - Finds Pets by tags
-// Deprecated
-func (s *PetAPIService) FindPetsByTags(ctx context.Context, tags []string, bornAfter time.Time, bornBefore time.Time, colour Colour) (ImplResponse, error) {
-	// TODO - update FindPetsByTags with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
-	// return Response(200, []Pet{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("FindPetsByTags method not implemented")
-}
-
-// GetPetById - Find pet by ID
-func (s *PetAPIService) GetPetById(ctx context.Context, petId int64) (ImplResponse, error) {
-	// TODO - update GetPetById with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, Pet{}) or use other options such as http.Ok ...
-	// return Response(200, Pet{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("GetPetById method not implemented")
-}
-
-// GetPetImageById - Returns the image for the Pet that has been previously uploaded
-func (s *PetAPIService) GetPetImageById(ctx context.Context, petId int64) (ImplResponse, error) {
-	// TODO - update GetPetImageById with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, *os.File{}) or use other options such as http.Ok ...
-	// return Response(200, *os.File{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("GetPetImageById method not implemented")
-}
-
-// GetPetsByTime - Get the pets by time
-func (s *PetAPIService) GetPetsByTime(ctx context.Context, createdTime time.Time) (ImplResponse, error) {
-	// TODO - update GetPetsByTime with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, ApiResponse{}) or use other options such as http.Ok ...
-	// return Response(200, ApiResponse{}), nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("GetPetsByTime method not implemented")
-}
-
-// GetPetsUsingBooleanQueryParameters - Get the pets by only using boolean query parameters
-func (s *PetAPIService) GetPetsUsingBooleanQueryParameters(ctx context.Context, expr bool, grouping bool, inactive bool) (ImplResponse, error) {
-	// TODO - update GetPetsUsingBooleanQueryParameters with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, ApiResponse{}) or use other options such as http.Ok ...
-	// return Response(200, ApiResponse{}), nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("GetPetsUsingBooleanQueryParameters method not implemented")
-}
-
-// SearchPet - Search Pets by filters
-func (s *PetAPIService) SearchPet(ctx context.Context, age *int64, price *float32, bornAfter *time.Time, old *bool) (ImplResponse, error) {
-	// TODO - update SearchPet with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
-	// return Response(200, []Pet{}), nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("SearchPet method not implemented")
-}
-
 // UpdatePet - Update an existing pet
 func (s *PetAPIService) UpdatePet(ctx context.Context, pet Pet) (ImplResponse, error) {
 	// TODO - update UpdatePet with the required logic for this service method.
@@ -184,6 +49,91 @@ func (s *PetAPIService) UpdatePet(ctx context.Context, pet Pet) (ImplResponse, e
 	return Response(http.StatusNotImplemented, nil), errors.New("UpdatePet method not implemented")
 }
 
+// AddPet - Add a new pet to the store
+func (s *PetAPIService) AddPet(ctx context.Context, pet Pet) (ImplResponse, error) {
+	// TODO - update AddPet with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, Pet{}) or use other options such as http.Ok ...
+	// return Response(200, Pet{}), nil
+
+	// TODO: Uncomment the next line to return response Response(405, {}) or use other options such as http.Ok ...
+	// return Response(405, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("AddPet method not implemented")
+}
+
+// FindPetsByStatus - Finds Pets by status
+func (s *PetAPIService) FindPetsByStatus(ctx context.Context, status []string, inlineEnumPath string, inlineEnum string, defaultInt int32, defaultNum float32, defaultStr string) (ImplResponse, error) {
+	// TODO - update FindPetsByStatus with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
+	// return Response(200, []Pet{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("FindPetsByStatus method not implemented")
+}
+
+// SearchPet - Search Pets by filters
+func (s *PetAPIService) SearchPet(ctx context.Context, age *int64, price *float32, bornAfter *time.Time, old *bool) (ImplResponse, error) {
+	// TODO - update SearchPet with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
+	// return Response(200, []Pet{}), nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("SearchPet method not implemented")
+}
+
+// FindPetsByTags - Finds Pets by tags
+// Deprecated
+func (s *PetAPIService) FindPetsByTags(ctx context.Context, tags []string, bornAfter time.Time, bornBefore time.Time, colour Colour) (ImplResponse, error) {
+	// TODO - update FindPetsByTags with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
+	// return Response(200, []Pet{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("FindPetsByTags method not implemented")
+}
+
+// FilterPetsByCategory - Finds Pets
+func (s *PetAPIService) FilterPetsByCategory(ctx context.Context, gender Gender, species Species, notSpecies []Species) (ImplResponse, error) {
+	// TODO - update FilterPetsByCategory with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
+	// return Response(200, []Pet{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("FilterPetsByCategory method not implemented")
+}
+
+// GetPetById - Find pet by ID
+func (s *PetAPIService) GetPetById(ctx context.Context, petId int64) (ImplResponse, error) {
+	// TODO - update GetPetById with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, Pet{}) or use other options such as http.Ok ...
+	// return Response(200, Pet{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("GetPetById method not implemented")
+}
+
 // UpdatePetWithForm - Updates a pet in the store with form data
 func (s *PetAPIService) UpdatePetWithForm(ctx context.Context, petId int64, name string, status string) (ImplResponse, error) {
 	// TODO - update UpdatePetWithForm with the required logic for this service method.
@@ -193,6 +143,34 @@ func (s *PetAPIService) UpdatePetWithForm(ctx context.Context, petId int64, name
 	// return Response(405, nil),nil
 
 	return Response(http.StatusNotImplemented, nil), errors.New("UpdatePetWithForm method not implemented")
+}
+
+// DeletePet - Deletes a pet
+func (s *PetAPIService) DeletePet(ctx context.Context, petId int64, apiKey string) (ImplResponse, error) {
+	// TODO - update DeletePet with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("DeletePet method not implemented")
+}
+
+// GetPetImageById - Returns the image for the Pet that has been previously uploaded
+func (s *PetAPIService) GetPetImageById(ctx context.Context, petId int64) (ImplResponse, error) {
+	// TODO - update GetPetImageById with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, *os.File{}) or use other options such as http.Ok ...
+	// return Response(200, *os.File{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("GetPetImageById method not implemented")
 }
 
 // UploadFile - uploads an image
@@ -215,4 +193,26 @@ func (s *PetAPIService) UploadFileArrayOfFiles(ctx context.Context, petId int64,
 	// return Response(200, ApiResponse{}), nil
 
 	return Response(http.StatusNotImplemented, nil), errors.New("UploadFileArrayOfFiles method not implemented")
+}
+
+// GetPetsUsingBooleanQueryParameters - Get the pets by only using boolean query parameters
+func (s *PetAPIService) GetPetsUsingBooleanQueryParameters(ctx context.Context, expr bool, grouping bool, inactive bool) (ImplResponse, error) {
+	// TODO - update GetPetsUsingBooleanQueryParameters with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, ApiResponse{}) or use other options such as http.Ok ...
+	// return Response(200, ApiResponse{}), nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("GetPetsUsingBooleanQueryParameters method not implemented")
+}
+
+// GetPetsByTime - Get the pets by time
+func (s *PetAPIService) GetPetsByTime(ctx context.Context, createdTime time.Time) (ImplResponse, error) {
+	// TODO - update GetPetsByTime with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, ApiResponse{}) or use other options such as http.Ok ...
+	// return Response(200, ApiResponse{}), nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("GetPetsByTime method not implemented")
 }

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -51,38 +51,32 @@ func NewStoreAPIController(s StoreAPIServicer, opts ...StoreAPIOption) *StoreAPI
 // Routes returns all the api routes for the StoreAPIController
 func (c *StoreAPIController) Routes() Routes {
 	return Routes{
-		"DeleteOrder": Route{
-			strings.ToUpper("Delete"),
-			"/v2/store/order/{orderId}",
-			c.DeleteOrder,
-		},
 		"GetInventory": Route{
 			strings.ToUpper("Get"),
 			"/v2/store/inventory",
 			c.GetInventory,
-		},
-		"GetOrderById": Route{
-			strings.ToUpper("Get"),
-			"/v2/store/order/{orderId}",
-			c.GetOrderById,
 		},
 		"PlaceOrder": Route{
 			strings.ToUpper("Post"),
 			"/v2/store/order",
 			c.PlaceOrder,
 		},
+		"GetOrderById": Route{
+			strings.ToUpper("Get"),
+			"/v2/store/order/{orderId}",
+			c.GetOrderById,
+		},
+		"DeleteOrder": Route{
+			strings.ToUpper("Delete"),
+			"/v2/store/order/{orderId}",
+			c.DeleteOrder,
+		},
 	}
 }
 
-// DeleteOrder - Delete purchase order by ID
-func (c *StoreAPIController) DeleteOrder(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	orderIdParam := params["orderId"]
-	if orderIdParam == "" {
-		c.errorHandler(w, r, &RequiredError{"orderId"}, nil)
-		return
-	}
-	result, err := c.service.DeleteOrder(r.Context(), orderIdParam)
+// GetInventory - Returns pet inventories by status
+func (c *StoreAPIController) GetInventory(w http.ResponseWriter, r *http.Request) {
+	result, err := c.service.GetInventory(r.Context())
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -92,9 +86,24 @@ func (c *StoreAPIController) DeleteOrder(w http.ResponseWriter, r *http.Request)
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
-// GetInventory - Returns pet inventories by status
-func (c *StoreAPIController) GetInventory(w http.ResponseWriter, r *http.Request) {
-	result, err := c.service.GetInventory(r.Context())
+// PlaceOrder - Place an order for a pet
+func (c *StoreAPIController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
+	orderParam := Order{}
+	d := json.NewDecoder(r.Body)
+	d.DisallowUnknownFields()
+	if err := d.Decode(&orderParam); err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	if err := AssertOrderRequired(orderParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	if err := AssertOrderConstraints(orderParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	result, err := c.service.PlaceOrder(r.Context(), orderParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -127,24 +136,15 @@ func (c *StoreAPIController) GetOrderById(w http.ResponseWriter, r *http.Request
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
-// PlaceOrder - Place an order for a pet
-func (c *StoreAPIController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
-	orderParam := Order{}
-	d := json.NewDecoder(r.Body)
-	d.DisallowUnknownFields()
-	if err := d.Decode(&orderParam); err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+// DeleteOrder - Delete purchase order by ID
+func (c *StoreAPIController) DeleteOrder(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	orderIdParam := params["orderId"]
+	if orderIdParam == "" {
+		c.errorHandler(w, r, &RequiredError{"orderId"}, nil)
 		return
 	}
-	if err := AssertOrderRequired(orderParam); err != nil {
-		c.errorHandler(w, r, err, nil)
-		return
-	}
-	if err := AssertOrderConstraints(orderParam); err != nil {
-		c.errorHandler(w, r, err, nil)
-		return
-	}
-	result, err := c.service.PlaceOrder(r.Context(), orderParam)
+	result, err := c.service.DeleteOrder(r.Context(), orderIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-api-server/go/api_store_service.go
+++ b/samples/server/petstore/go-api-server/go/api_store_service.go
@@ -27,20 +27,6 @@ func NewStoreAPIService() *StoreAPIService {
 	return &StoreAPIService{}
 }
 
-// DeleteOrder - Delete purchase order by ID
-func (s *StoreAPIService) DeleteOrder(ctx context.Context, orderId string) (ImplResponse, error) {
-	// TODO - update DeleteOrder with the required logic for this service method.
-	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("DeleteOrder method not implemented")
-}
-
 // GetInventory - Returns pet inventories by status
 func (s *StoreAPIService) GetInventory(ctx context.Context) (ImplResponse, error) {
 	// TODO - update GetInventory with the required logic for this service method.
@@ -50,6 +36,20 @@ func (s *StoreAPIService) GetInventory(ctx context.Context) (ImplResponse, error
 	// return Response(200, map[string]int32{}), nil
 
 	return Response(http.StatusNotImplemented, nil), errors.New("GetInventory method not implemented")
+}
+
+// PlaceOrder - Place an order for a pet
+func (s *StoreAPIService) PlaceOrder(ctx context.Context, order Order) (ImplResponse, error) {
+	// TODO - update PlaceOrder with the required logic for this service method.
+	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, Order{}) or use other options such as http.Ok ...
+	// return Response(200, Order{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("PlaceOrder method not implemented")
 }
 
 // GetOrderById - Find purchase order by ID
@@ -69,16 +69,16 @@ func (s *StoreAPIService) GetOrderById(ctx context.Context, orderId int64) (Impl
 	return Response(http.StatusNotImplemented, nil), errors.New("GetOrderById method not implemented")
 }
 
-// PlaceOrder - Place an order for a pet
-func (s *StoreAPIService) PlaceOrder(ctx context.Context, order Order) (ImplResponse, error) {
-	// TODO - update PlaceOrder with the required logic for this service method.
+// DeleteOrder - Delete purchase order by ID
+func (s *StoreAPIService) DeleteOrder(ctx context.Context, orderId string) (ImplResponse, error) {
+	// TODO - update DeleteOrder with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, Order{}) or use other options such as http.Ok ...
-	// return Response(200, Order{}), nil
 
 	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
 	// return Response(400, nil),nil
 
-	return Response(http.StatusNotImplemented, nil), errors.New("PlaceOrder method not implemented")
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("DeleteOrder method not implemented")
 }

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -66,16 +66,6 @@ func (c *UserAPIController) Routes() Routes {
 			"/v2/user/createWithList",
 			c.CreateUsersWithListInput,
 		},
-		"DeleteUser": Route{
-			strings.ToUpper("Delete"),
-			"/v2/user/{username}",
-			c.DeleteUser,
-		},
-		"GetUserByName": Route{
-			strings.ToUpper("Get"),
-			"/v2/user/{username}",
-			c.GetUserByName,
-		},
 		"LoginUser": Route{
 			strings.ToUpper("Get"),
 			"/v2/user/login",
@@ -86,10 +76,20 @@ func (c *UserAPIController) Routes() Routes {
 			"/v2/user/logout",
 			c.LogoutUser,
 		},
+		"GetUserByName": Route{
+			strings.ToUpper("Get"),
+			"/v2/user/{username}",
+			c.GetUserByName,
+		},
 		"UpdateUser": Route{
 			strings.ToUpper("Put"),
 			"/v2/user/{username}",
 			c.UpdateUser,
+		},
+		"DeleteUser": Route{
+			strings.ToUpper("Delete"),
+			"/v2/user/{username}",
+			c.DeleteUser,
 		},
 	}
 }
@@ -171,61 +171,6 @@ func (c *UserAPIController) CreateUsersWithListInput(w http.ResponseWriter, r *h
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
-// DeleteUser - Delete user
-func (c *UserAPIController) DeleteUser(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	query, err := parseQuery(r.URL.RawQuery)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
-		return
-	}
-	usernameParam := params["username"]
-	if usernameParam == "" {
-		c.errorHandler(w, r, &RequiredError{"username"}, nil)
-		return
-	}
-	var confirmationParam bool
-	if query.Has("confirmation") {
-		param, err := parseBoolParameter(
-			query.Get("confirmation"),
-			WithParse[bool](parseBool),
-		)
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "confirmation", Err: err}, nil)
-			return
-		}
-
-		confirmationParam = param
-	} else {
-	}
-	result, err := c.service.DeleteUser(r.Context(), usernameParam, confirmationParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// GetUserByName - Get user by user name
-func (c *UserAPIController) GetUserByName(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	usernameParam := params["username"]
-	if usernameParam == "" {
-		c.errorHandler(w, r, &RequiredError{"username"}, nil)
-		return
-	}
-	result, err := c.service.GetUserByName(r.Context(), usernameParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
 // LoginUser - Logs user into the system
 func (c *UserAPIController) LoginUser(w http.ResponseWriter, r *http.Request) {
 	query, err := parseQuery(r.URL.RawQuery)
@@ -287,6 +232,24 @@ func (c *UserAPIController) LogoutUser(w http.ResponseWriter, r *http.Request) {
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
+// GetUserByName - Get user by user name
+func (c *UserAPIController) GetUserByName(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	usernameParam := params["username"]
+	if usernameParam == "" {
+		c.errorHandler(w, r, &RequiredError{"username"}, nil)
+		return
+	}
+	result, err := c.service.GetUserByName(r.Context(), usernameParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
 // UpdateUser - Updated user
 func (c *UserAPIController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
@@ -311,6 +274,43 @@ func (c *UserAPIController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	result, err := c.service.UpdateUser(r.Context(), usernameParam, userParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// DeleteUser - Delete user
+func (c *UserAPIController) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	query, err := parseQuery(r.URL.RawQuery)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	usernameParam := params["username"]
+	if usernameParam == "" {
+		c.errorHandler(w, r, &RequiredError{"username"}, nil)
+		return
+	}
+	var confirmationParam bool
+	if query.Has("confirmation") {
+		param, err := parseBoolParameter(
+			query.Get("confirmation"),
+			WithParse[bool](parseBool),
+		)
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "confirmation", Err: err}, nil)
+			return
+		}
+
+		confirmationParam = param
+	} else {
+	}
+	result, err := c.service.DeleteUser(r.Context(), usernameParam, confirmationParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-api-server/go/api_user_service.go
+++ b/samples/server/petstore/go-api-server/go/api_user_service.go
@@ -60,37 +60,6 @@ func (s *UserAPIService) CreateUsersWithListInput(ctx context.Context, user []Us
 	return Response(http.StatusNotImplemented, nil), errors.New("CreateUsersWithListInput method not implemented")
 }
 
-// DeleteUser - Delete user
-func (s *UserAPIService) DeleteUser(ctx context.Context, username string, confirmation bool) (ImplResponse, error) {
-	// TODO - update DeleteUser with the required logic for this service method.
-	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("DeleteUser method not implemented")
-}
-
-// GetUserByName - Get user by user name
-func (s *UserAPIService) GetUserByName(ctx context.Context, username string) (ImplResponse, error) {
-	// TODO - update GetUserByName with the required logic for this service method.
-	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, User{}) or use other options such as http.Ok ...
-	// return Response(200, User{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("GetUserByName method not implemented")
-}
-
 // LoginUser - Logs user into the system
 func (s *UserAPIService) LoginUser(ctx context.Context, username string, password string, rememberMe bool) (ImplResponse, error) {
 	// TODO - update LoginUser with the required logic for this service method.
@@ -116,6 +85,23 @@ func (s *UserAPIService) LogoutUser(ctx context.Context) (ImplResponse, error) {
 	return Response(http.StatusNotImplemented, nil), errors.New("LogoutUser method not implemented")
 }
 
+// GetUserByName - Get user by user name
+func (s *UserAPIService) GetUserByName(ctx context.Context, username string) (ImplResponse, error) {
+	// TODO - update GetUserByName with the required logic for this service method.
+	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, User{}) or use other options such as http.Ok ...
+	// return Response(200, User{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("GetUserByName method not implemented")
+}
+
 // UpdateUser - Updated user
 func (s *UserAPIService) UpdateUser(ctx context.Context, username string, user User) (ImplResponse, error) {
 	// TODO - update UpdateUser with the required logic for this service method.
@@ -128,4 +114,18 @@ func (s *UserAPIService) UpdateUser(ctx context.Context, username string, user U
 	// return Response(404, nil),nil
 
 	return Response(http.StatusNotImplemented, nil), errors.New("UpdateUser method not implemented")
+}
+
+// DeleteUser - Delete user
+func (s *UserAPIService) DeleteUser(ctx context.Context, username string, confirmation bool) (ImplResponse, error) {
+	// TODO - update DeleteUser with the required logic for this service method.
+	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("DeleteUser method not implemented")
 }

--- a/samples/server/petstore/go-chi-server/go/api.go
+++ b/samples/server/petstore/go-chi-server/go/api.go
@@ -23,30 +23,30 @@ import (
 // The PetAPIRouter implementation should parse necessary information from the http request,
 // pass the data to a PetAPIServicer to perform the required actions, then write the service results to the http response.
 type PetAPIRouter interface { 
+	UpdatePet(http.ResponseWriter, *http.Request)
 	AddPet(http.ResponseWriter, *http.Request)
-	DeletePet(http.ResponseWriter, *http.Request)
-	FilterPetsByCategory(http.ResponseWriter, *http.Request)
 	FindPetsByStatus(http.ResponseWriter, *http.Request)
+	SearchPet(http.ResponseWriter, *http.Request)
 	// Deprecated
 	FindPetsByTags(http.ResponseWriter, *http.Request)
+	FilterPetsByCategory(http.ResponseWriter, *http.Request)
 	GetPetById(http.ResponseWriter, *http.Request)
-	GetPetImageById(http.ResponseWriter, *http.Request)
-	GetPetsByTime(http.ResponseWriter, *http.Request)
-	GetPetsUsingBooleanQueryParameters(http.ResponseWriter, *http.Request)
-	SearchPet(http.ResponseWriter, *http.Request)
-	UpdatePet(http.ResponseWriter, *http.Request)
 	UpdatePetWithForm(http.ResponseWriter, *http.Request)
+	DeletePet(http.ResponseWriter, *http.Request)
+	GetPetImageById(http.ResponseWriter, *http.Request)
 	UploadFile(http.ResponseWriter, *http.Request)
 	UploadFileArrayOfFiles(http.ResponseWriter, *http.Request)
+	GetPetsUsingBooleanQueryParameters(http.ResponseWriter, *http.Request)
+	GetPetsByTime(http.ResponseWriter, *http.Request)
 }
 // StoreAPIRouter defines the required methods for binding the api requests to a responses for the StoreAPI
 // The StoreAPIRouter implementation should parse necessary information from the http request,
 // pass the data to a StoreAPIServicer to perform the required actions, then write the service results to the http response.
 type StoreAPIRouter interface { 
-	DeleteOrder(http.ResponseWriter, *http.Request)
 	GetInventory(http.ResponseWriter, *http.Request)
-	GetOrderById(http.ResponseWriter, *http.Request)
 	PlaceOrder(http.ResponseWriter, *http.Request)
+	GetOrderById(http.ResponseWriter, *http.Request)
+	DeleteOrder(http.ResponseWriter, *http.Request)
 }
 // UserAPIRouter defines the required methods for binding the api requests to a responses for the UserAPI
 // The UserAPIRouter implementation should parse necessary information from the http request,
@@ -55,11 +55,11 @@ type UserAPIRouter interface {
 	CreateUser(http.ResponseWriter, *http.Request)
 	CreateUsersWithArrayInput(http.ResponseWriter, *http.Request)
 	CreateUsersWithListInput(http.ResponseWriter, *http.Request)
-	DeleteUser(http.ResponseWriter, *http.Request)
-	GetUserByName(http.ResponseWriter, *http.Request)
 	LoginUser(http.ResponseWriter, *http.Request)
 	LogoutUser(http.ResponseWriter, *http.Request)
+	GetUserByName(http.ResponseWriter, *http.Request)
 	UpdateUser(http.ResponseWriter, *http.Request)
+	DeleteUser(http.ResponseWriter, *http.Request)
 }
 
 
@@ -68,21 +68,21 @@ type UserAPIRouter interface {
 // while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type PetAPIServicer interface { 
+	UpdatePet(context.Context, Pet) (ImplResponse, error)
 	AddPet(context.Context, Pet) (ImplResponse, error)
-	DeletePet(context.Context, int64, string) (ImplResponse, error)
-	FilterPetsByCategory(context.Context, Gender, Species, []Species) (ImplResponse, error)
 	FindPetsByStatus(context.Context, []string, string, string, int32, float32, string) (ImplResponse, error)
+	SearchPet(context.Context, *int64, *float32, *time.Time, *bool) (ImplResponse, error)
 	// Deprecated
 	FindPetsByTags(context.Context, []string, time.Time, time.Time, Colour) (ImplResponse, error)
+	FilterPetsByCategory(context.Context, Gender, Species, []Species) (ImplResponse, error)
 	GetPetById(context.Context, int64) (ImplResponse, error)
-	GetPetImageById(context.Context, int64) (ImplResponse, error)
-	GetPetsByTime(context.Context, time.Time) (ImplResponse, error)
-	GetPetsUsingBooleanQueryParameters(context.Context, bool, bool, bool) (ImplResponse, error)
-	SearchPet(context.Context, *int64, *float32, *time.Time, *bool) (ImplResponse, error)
-	UpdatePet(context.Context, Pet) (ImplResponse, error)
 	UpdatePetWithForm(context.Context, int64, string, string) (ImplResponse, error)
+	DeletePet(context.Context, int64, string) (ImplResponse, error)
+	GetPetImageById(context.Context, int64) (ImplResponse, error)
 	UploadFile(context.Context, int64, string, []string, *os.File) (ImplResponse, error)
 	UploadFileArrayOfFiles(context.Context, int64, string, []*os.File) (ImplResponse, error)
+	GetPetsUsingBooleanQueryParameters(context.Context, bool, bool, bool) (ImplResponse, error)
+	GetPetsByTime(context.Context, time.Time) (ImplResponse, error)
 }
 
 
@@ -91,10 +91,10 @@ type PetAPIServicer interface {
 // while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type StoreAPIServicer interface { 
-	DeleteOrder(context.Context, string) (ImplResponse, error)
 	GetInventory(context.Context) (ImplResponse, error)
-	GetOrderById(context.Context, int64) (ImplResponse, error)
 	PlaceOrder(context.Context, Order) (ImplResponse, error)
+	GetOrderById(context.Context, int64) (ImplResponse, error)
+	DeleteOrder(context.Context, string) (ImplResponse, error)
 }
 
 
@@ -106,9 +106,9 @@ type UserAPIServicer interface {
 	CreateUser(context.Context, User) (ImplResponse, error)
 	CreateUsersWithArrayInput(context.Context, []User) (ImplResponse, error)
 	CreateUsersWithListInput(context.Context, []User) (ImplResponse, error)
-	DeleteUser(context.Context, string, bool) (ImplResponse, error)
-	GetUserByName(context.Context, string) (ImplResponse, error)
 	LoginUser(context.Context, string, string, bool) (ImplResponse, error)
 	LogoutUser(context.Context) (ImplResponse, error)
+	GetUserByName(context.Context, string) (ImplResponse, error)
 	UpdateUser(context.Context, string, User) (ImplResponse, error)
+	DeleteUser(context.Context, string, bool) (ImplResponse, error)
 }

--- a/samples/server/petstore/go-chi-server/go/api_pet.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet.go
@@ -53,65 +53,55 @@ func NewPetAPIController(s PetAPIServicer, opts ...PetAPIOption) *PetAPIControll
 // Routes returns all the api routes for the PetAPIController
 func (c *PetAPIController) Routes() Routes {
 	return Routes{
+		"UpdatePet": Route{
+			strings.ToUpper("Put"),
+			"/v2/pet",
+			c.UpdatePet,
+		},
 		"AddPet": Route{
 			strings.ToUpper("Post"),
 			"/v2/pet",
 			c.AddPet,
-		},
-		"DeletePet": Route{
-			strings.ToUpper("Delete"),
-			"/v2/pet/{petId}",
-			c.DeletePet,
-		},
-		"FilterPetsByCategory": Route{
-			strings.ToUpper("Get"),
-			"/v2/pet/filterPets/{gender}",
-			c.FilterPetsByCategory,
 		},
 		"FindPetsByStatus": Route{
 			strings.ToUpper("Get"),
 			"/v2/pet/findByStatus",
 			c.FindPetsByStatus,
 		},
+		"SearchPet": Route{
+			strings.ToUpper("Get"),
+			"/v2/pet/searchPetWithManyFilters",
+			c.SearchPet,
+		},
 		"FindPetsByTags": Route{
 			strings.ToUpper("Get"),
 			"/v2/pet/findByTags",
 			c.FindPetsByTags,
+		},
+		"FilterPetsByCategory": Route{
+			strings.ToUpper("Get"),
+			"/v2/pet/filterPets/{gender}",
+			c.FilterPetsByCategory,
 		},
 		"GetPetById": Route{
 			strings.ToUpper("Get"),
 			"/v2/pet/{petId}",
 			c.GetPetById,
 		},
-		"GetPetImageById": Route{
-			strings.ToUpper("Get"),
-			"/v2/pet/{petId}/uploadImage",
-			c.GetPetImageById,
-		},
-		"GetPetsByTime": Route{
-			strings.ToUpper("Get"),
-			"/v2/pets/byTime/{createdTime}",
-			c.GetPetsByTime,
-		},
-		"GetPetsUsingBooleanQueryParameters": Route{
-			strings.ToUpper("Get"),
-			"/v2/pets/boolean/parsing",
-			c.GetPetsUsingBooleanQueryParameters,
-		},
-		"SearchPet": Route{
-			strings.ToUpper("Get"),
-			"/v2/pet/searchPetWithManyFilters",
-			c.SearchPet,
-		},
-		"UpdatePet": Route{
-			strings.ToUpper("Put"),
-			"/v2/pet",
-			c.UpdatePet,
-		},
 		"UpdatePetWithForm": Route{
 			strings.ToUpper("Post"),
 			"/v2/pet/{petId}",
 			c.UpdatePetWithForm,
+		},
+		"DeletePet": Route{
+			strings.ToUpper("Delete"),
+			"/v2/pet/{petId}",
+			c.DeletePet,
+		},
+		"GetPetImageById": Route{
+			strings.ToUpper("Get"),
+			"/v2/pet/{petId}/uploadImage",
+			c.GetPetImageById,
 		},
 		"UploadFile": Route{
 			strings.ToUpper("Post"),
@@ -123,7 +113,44 @@ func (c *PetAPIController) Routes() Routes {
 			"/v2/fake/uploadImage/array of_file",
 			c.UploadFileArrayOfFiles,
 		},
+		"GetPetsUsingBooleanQueryParameters": Route{
+			strings.ToUpper("Get"),
+			"/v2/pets/boolean/parsing",
+			c.GetPetsUsingBooleanQueryParameters,
+		},
+		"GetPetsByTime": Route{
+			strings.ToUpper("Get"),
+			"/v2/pets/byTime/{createdTime}",
+			c.GetPetsByTime,
+		},
 	}
+}
+
+// UpdatePet - Update an existing pet
+func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
+	petParam := Pet{}
+	d := json.NewDecoder(r.Body)
+	d.DisallowUnknownFields()
+	if err := d.Decode(&petParam); err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	if err := AssertPetRequired(petParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	if err := AssertPetConstraints(petParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	result, err := c.service.UpdatePet(r.Context(), petParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
 // AddPet - Add a new pet to the store
@@ -144,71 +171,6 @@ func (c *PetAPIController) AddPet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	result, err := c.service.AddPet(r.Context(), petParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// DeletePet - Deletes a pet
-func (c *PetAPIController) DeletePet(w http.ResponseWriter, r *http.Request) {
-	petIdParam, err := parseNumericParameter[int64](
-		chi.URLParam(r, "petId"),
-		WithRequire[int64](parseInt64),
-	)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
-		return
-	}
-	apiKeyParam := r.Header.Get("api_key")
-	result, err := c.service.DeletePet(r.Context(), petIdParam, apiKeyParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// FilterPetsByCategory - Finds Pets
-func (c *PetAPIController) FilterPetsByCategory(w http.ResponseWriter, r *http.Request) {
-	query, err := parseQuery(r.URL.RawQuery)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
-		return
-	}
-	genderParam, err := NewGenderFromValue(chi.URLParam(r, "gender"))
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Param: "gender", Err: err}, nil)
-		return
-	}
-	var speciesParam Species
-	if query.Has("species") {
-		param := Species(query.Get("species"))
-
-		speciesParam = param
-	} else {
-		c.errorHandler(w, r, &RequiredError{Field: "species"}, nil)
-		return
-	}
-	var notSpeciesParam []Species
-	if query.Has("notSpecies") {
-		paramSplits := strings.Split(query.Get("notSpecies"), ",")
-		notSpeciesParam = make([]Species, 0, len(paramSplits))
-		for _, param := range paramSplits {
-			paramEnum, err := NewSpeciesFromValue(param)
-			if err != nil {
-				c.errorHandler(w, r, &ParsingError{Param: "notSpecies", Err: err}, nil)
-				return
-			}
-			notSpeciesParam = append(notSpeciesParam, paramEnum)
-		}
-	}
-	result, err := c.service.FilterPetsByCategory(r.Context(), genderParam, speciesParam, notSpeciesParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -292,179 +254,6 @@ func (c *PetAPIController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
-// FindPetsByTags - Finds Pets by tags
-// Deprecated
-func (c *PetAPIController) FindPetsByTags(w http.ResponseWriter, r *http.Request) {
-	query, err := parseQuery(r.URL.RawQuery)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
-		return
-	}
-	var tagsParam []string
-	if query.Has("tags") {
-		tagsParam = strings.Split(query.Get("tags"), ",")
-	}
-	var bornAfterParam time.Time
-	if query.Has("bornAfter"){
-		param, err := parseTime(query.Get("bornAfter"))
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "bornAfter", Err: err}, nil)
-			return
-		}
-
-		bornAfterParam = param
-	} else {
-		c.errorHandler(w, r, &RequiredError{"bornAfter"}, nil)
-		return
-	}
-	var bornBeforeParam time.Time
-	if query.Has("bornBefore"){
-		param, err := parseTime(query.Get("bornBefore"))
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "bornBefore", Err: err}, nil)
-			return
-		}
-
-		bornBeforeParam = param
-	} else {
-	}
-	var colourParam Colour
-	if query.Has("colour") {
-		param := Colour(query.Get("colour"))
-
-		colourParam = param
-	} else {
-	}
-	result, err := c.service.FindPetsByTags(r.Context(), tagsParam, bornAfterParam, bornBeforeParam, colourParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// GetPetById - Find pet by ID
-func (c *PetAPIController) GetPetById(w http.ResponseWriter, r *http.Request) {
-	petIdParam, err := parseNumericParameter[int64](
-		chi.URLParam(r, "petId"),
-		WithRequire[int64](parseInt64),
-	)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
-		return
-	}
-	result, err := c.service.GetPetById(r.Context(), petIdParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// GetPetImageById - Returns the image for the Pet that has been previously uploaded
-func (c *PetAPIController) GetPetImageById(w http.ResponseWriter, r *http.Request) {
-	petIdParam, err := parseNumericParameter[int64](
-		chi.URLParam(r, "petId"),
-		WithRequire[int64](parseInt64),
-	)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
-		return
-	}
-	result, err := c.service.GetPetImageById(r.Context(), petIdParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// GetPetsByTime - Get the pets by time
-func (c *PetAPIController) GetPetsByTime(w http.ResponseWriter, r *http.Request) {
-	createdTimeParam, err := parseTime(chi.URLParam(r, "createdTime"))
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Param: "createdTime", Err: err}, nil)
-		return
-	}
-	result, err := c.service.GetPetsByTime(r.Context(), createdTimeParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// GetPetsUsingBooleanQueryParameters - Get the pets by only using boolean query parameters
-func (c *PetAPIController) GetPetsUsingBooleanQueryParameters(w http.ResponseWriter, r *http.Request) {
-	query, err := parseQuery(r.URL.RawQuery)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
-		return
-	}
-	var exprParam bool
-	if query.Has("expr") {
-		param, err := parseBoolParameter(
-			query.Get("expr"),
-			WithParse[bool](parseBool),
-		)
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "expr", Err: err}, nil)
-			return
-		}
-
-		exprParam = param
-	} else {
-		c.errorHandler(w, r, &RequiredError{Field: "expr"}, nil)
-		return
-	}
-	var groupingParam bool
-	if query.Has("grouping") {
-		param, err := parseBoolParameter(
-			query.Get("grouping"),
-			WithParse[bool](parseBool),
-		)
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "grouping", Err: err}, nil)
-			return
-		}
-
-		groupingParam = param
-	} else {
-	}
-	var inactiveParam bool
-	if query.Has("inactive") {
-		param, err := parseBoolParameter(
-			query.Get("inactive"),
-			WithParse[bool](parseBool),
-		)
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "inactive", Err: err}, nil)
-			return
-		}
-
-		inactiveParam = param
-	} else {
-		var param bool = false
-		inactiveParam = param
-	}
-	result, err := c.service.GetPetsUsingBooleanQueryParameters(r.Context(), exprParam, groupingParam, inactiveParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
 // SearchPet - Search Pets by filters
 func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 	query, err := parseQuery(r.URL.RawQuery)
@@ -535,24 +324,114 @@ func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
-// UpdatePet - Update an existing pet
-func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
-	d := json.NewDecoder(r.Body)
-	d.DisallowUnknownFields()
-	if err := d.Decode(&petParam); err != nil {
+// FindPetsByTags - Finds Pets by tags
+// Deprecated
+func (c *PetAPIController) FindPetsByTags(w http.ResponseWriter, r *http.Request) {
+	query, err := parseQuery(r.URL.RawQuery)
+	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertPetRequired(petParam); err != nil {
-		c.errorHandler(w, r, err, nil)
+	var tagsParam []string
+	if query.Has("tags") {
+		tagsParam = strings.Split(query.Get("tags"), ",")
+	}
+	var bornAfterParam time.Time
+	if query.Has("bornAfter"){
+		param, err := parseTime(query.Get("bornAfter"))
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "bornAfter", Err: err}, nil)
+			return
+		}
+
+		bornAfterParam = param
+	} else {
+		c.errorHandler(w, r, &RequiredError{"bornAfter"}, nil)
 		return
 	}
-	if err := AssertPetConstraints(petParam); err != nil {
-		c.errorHandler(w, r, err, nil)
+	var bornBeforeParam time.Time
+	if query.Has("bornBefore"){
+		param, err := parseTime(query.Get("bornBefore"))
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "bornBefore", Err: err}, nil)
+			return
+		}
+
+		bornBeforeParam = param
+	} else {
+	}
+	var colourParam Colour
+	if query.Has("colour") {
+		param := Colour(query.Get("colour"))
+
+		colourParam = param
+	} else {
+	}
+	result, err := c.service.FindPetsByTags(r.Context(), tagsParam, bornAfterParam, bornBeforeParam, colourParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
 		return
 	}
-	result, err := c.service.UpdatePet(r.Context(), petParam)
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// FilterPetsByCategory - Finds Pets
+func (c *PetAPIController) FilterPetsByCategory(w http.ResponseWriter, r *http.Request) {
+	query, err := parseQuery(r.URL.RawQuery)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	genderParam, err := NewGenderFromValue(chi.URLParam(r, "gender"))
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "gender", Err: err}, nil)
+		return
+	}
+	var speciesParam Species
+	if query.Has("species") {
+		param := Species(query.Get("species"))
+
+		speciesParam = param
+	} else {
+		c.errorHandler(w, r, &RequiredError{Field: "species"}, nil)
+		return
+	}
+	var notSpeciesParam []Species
+	if query.Has("notSpecies") {
+		paramSplits := strings.Split(query.Get("notSpecies"), ",")
+		notSpeciesParam = make([]Species, 0, len(paramSplits))
+		for _, param := range paramSplits {
+			paramEnum, err := NewSpeciesFromValue(param)
+			if err != nil {
+				c.errorHandler(w, r, &ParsingError{Param: "notSpecies", Err: err}, nil)
+				return
+			}
+			notSpeciesParam = append(notSpeciesParam, paramEnum)
+		}
+	}
+	result, err := c.service.FilterPetsByCategory(r.Context(), genderParam, speciesParam, notSpeciesParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// GetPetById - Find pet by ID
+func (c *PetAPIController) GetPetById(w http.ResponseWriter, r *http.Request) {
+	petIdParam, err := parseNumericParameter[int64](
+		chi.URLParam(r, "petId"),
+		WithRequire[int64](parseInt64),
+	)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
+		return
+	}
+	result, err := c.service.GetPetById(r.Context(), petIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -583,6 +462,47 @@ func (c *PetAPIController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 	
 	statusParam := r.FormValue("status")
 	result, err := c.service.UpdatePetWithForm(r.Context(), petIdParam, nameParam, statusParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// DeletePet - Deletes a pet
+func (c *PetAPIController) DeletePet(w http.ResponseWriter, r *http.Request) {
+	petIdParam, err := parseNumericParameter[int64](
+		chi.URLParam(r, "petId"),
+		WithRequire[int64](parseInt64),
+	)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
+		return
+	}
+	apiKeyParam := r.Header.Get("api_key")
+	result, err := c.service.DeletePet(r.Context(), petIdParam, apiKeyParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// GetPetImageById - Returns the image for the Pet that has been previously uploaded
+func (c *PetAPIController) GetPetImageById(w http.ResponseWriter, r *http.Request) {
+	petIdParam, err := parseNumericParameter[int64](
+		chi.URLParam(r, "petId"),
+		WithRequire[int64](parseInt64),
+	)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
+		return
+	}
+	result, err := c.service.GetPetImageById(r.Context(), petIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -664,6 +584,86 @@ func (c *PetAPIController) UploadFileArrayOfFiles(w http.ResponseWriter, r *http
 	
 	
 	result, err := c.service.UploadFileArrayOfFiles(r.Context(), petIdParam, additionalMetadataParam, filesParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// GetPetsUsingBooleanQueryParameters - Get the pets by only using boolean query parameters
+func (c *PetAPIController) GetPetsUsingBooleanQueryParameters(w http.ResponseWriter, r *http.Request) {
+	query, err := parseQuery(r.URL.RawQuery)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	var exprParam bool
+	if query.Has("expr") {
+		param, err := parseBoolParameter(
+			query.Get("expr"),
+			WithParse[bool](parseBool),
+		)
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "expr", Err: err}, nil)
+			return
+		}
+
+		exprParam = param
+	} else {
+		c.errorHandler(w, r, &RequiredError{Field: "expr"}, nil)
+		return
+	}
+	var groupingParam bool
+	if query.Has("grouping") {
+		param, err := parseBoolParameter(
+			query.Get("grouping"),
+			WithParse[bool](parseBool),
+		)
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "grouping", Err: err}, nil)
+			return
+		}
+
+		groupingParam = param
+	} else {
+	}
+	var inactiveParam bool
+	if query.Has("inactive") {
+		param, err := parseBoolParameter(
+			query.Get("inactive"),
+			WithParse[bool](parseBool),
+		)
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "inactive", Err: err}, nil)
+			return
+		}
+
+		inactiveParam = param
+	} else {
+		var param bool = false
+		inactiveParam = param
+	}
+	result, err := c.service.GetPetsUsingBooleanQueryParameters(r.Context(), exprParam, groupingParam, inactiveParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// GetPetsByTime - Get the pets by time
+func (c *PetAPIController) GetPetsByTime(w http.ResponseWriter, r *http.Request) {
+	createdTimeParam, err := parseTime(chi.URLParam(r, "createdTime"))
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "createdTime", Err: err}, nil)
+		return
+	}
+	result, err := c.service.GetPetsByTime(r.Context(), createdTimeParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-chi-server/go/api_pet_service.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet_service.go
@@ -29,141 +29,6 @@ func NewPetAPIService() *PetAPIService {
 	return &PetAPIService{}
 }
 
-// AddPet - Add a new pet to the store
-func (s *PetAPIService) AddPet(ctx context.Context, pet Pet) (ImplResponse, error) {
-	// TODO - update AddPet with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, Pet{}) or use other options such as http.Ok ...
-	// return Response(200, Pet{}), nil
-
-	// TODO: Uncomment the next line to return response Response(405, {}) or use other options such as http.Ok ...
-	// return Response(405, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("AddPet method not implemented")
-}
-
-// DeletePet - Deletes a pet
-func (s *PetAPIService) DeletePet(ctx context.Context, petId int64, apiKey string) (ImplResponse, error) {
-	// TODO - update DeletePet with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("DeletePet method not implemented")
-}
-
-// FilterPetsByCategory - Finds Pets
-func (s *PetAPIService) FilterPetsByCategory(ctx context.Context, gender Gender, species Species, notSpecies []Species) (ImplResponse, error) {
-	// TODO - update FilterPetsByCategory with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
-	// return Response(200, []Pet{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("FilterPetsByCategory method not implemented")
-}
-
-// FindPetsByStatus - Finds Pets by status
-func (s *PetAPIService) FindPetsByStatus(ctx context.Context, status []string, inlineEnumPath string, inlineEnum string, defaultInt int32, defaultNum float32, defaultStr string) (ImplResponse, error) {
-	// TODO - update FindPetsByStatus with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
-	// return Response(200, []Pet{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("FindPetsByStatus method not implemented")
-}
-
-// FindPetsByTags - Finds Pets by tags
-// Deprecated
-func (s *PetAPIService) FindPetsByTags(ctx context.Context, tags []string, bornAfter time.Time, bornBefore time.Time, colour Colour) (ImplResponse, error) {
-	// TODO - update FindPetsByTags with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
-	// return Response(200, []Pet{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("FindPetsByTags method not implemented")
-}
-
-// GetPetById - Find pet by ID
-func (s *PetAPIService) GetPetById(ctx context.Context, petId int64) (ImplResponse, error) {
-	// TODO - update GetPetById with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, Pet{}) or use other options such as http.Ok ...
-	// return Response(200, Pet{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("GetPetById method not implemented")
-}
-
-// GetPetImageById - Returns the image for the Pet that has been previously uploaded
-func (s *PetAPIService) GetPetImageById(ctx context.Context, petId int64) (ImplResponse, error) {
-	// TODO - update GetPetImageById with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, *os.File{}) or use other options such as http.Ok ...
-	// return Response(200, *os.File{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("GetPetImageById method not implemented")
-}
-
-// GetPetsByTime - Get the pets by time
-func (s *PetAPIService) GetPetsByTime(ctx context.Context, createdTime time.Time) (ImplResponse, error) {
-	// TODO - update GetPetsByTime with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, ApiResponse{}) or use other options such as http.Ok ...
-	// return Response(200, ApiResponse{}), nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("GetPetsByTime method not implemented")
-}
-
-// GetPetsUsingBooleanQueryParameters - Get the pets by only using boolean query parameters
-func (s *PetAPIService) GetPetsUsingBooleanQueryParameters(ctx context.Context, expr bool, grouping bool, inactive bool) (ImplResponse, error) {
-	// TODO - update GetPetsUsingBooleanQueryParameters with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, ApiResponse{}) or use other options such as http.Ok ...
-	// return Response(200, ApiResponse{}), nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("GetPetsUsingBooleanQueryParameters method not implemented")
-}
-
-// SearchPet - Search Pets by filters
-func (s *PetAPIService) SearchPet(ctx context.Context, age *int64, price *float32, bornAfter *time.Time, old *bool) (ImplResponse, error) {
-	// TODO - update SearchPet with the required logic for this service method.
-	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
-	// return Response(200, []Pet{}), nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("SearchPet method not implemented")
-}
-
 // UpdatePet - Update an existing pet
 func (s *PetAPIService) UpdatePet(ctx context.Context, pet Pet) (ImplResponse, error) {
 	// TODO - update UpdatePet with the required logic for this service method.
@@ -184,6 +49,91 @@ func (s *PetAPIService) UpdatePet(ctx context.Context, pet Pet) (ImplResponse, e
 	return Response(http.StatusNotImplemented, nil), errors.New("UpdatePet method not implemented")
 }
 
+// AddPet - Add a new pet to the store
+func (s *PetAPIService) AddPet(ctx context.Context, pet Pet) (ImplResponse, error) {
+	// TODO - update AddPet with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, Pet{}) or use other options such as http.Ok ...
+	// return Response(200, Pet{}), nil
+
+	// TODO: Uncomment the next line to return response Response(405, {}) or use other options such as http.Ok ...
+	// return Response(405, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("AddPet method not implemented")
+}
+
+// FindPetsByStatus - Finds Pets by status
+func (s *PetAPIService) FindPetsByStatus(ctx context.Context, status []string, inlineEnumPath string, inlineEnum string, defaultInt int32, defaultNum float32, defaultStr string) (ImplResponse, error) {
+	// TODO - update FindPetsByStatus with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
+	// return Response(200, []Pet{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("FindPetsByStatus method not implemented")
+}
+
+// SearchPet - Search Pets by filters
+func (s *PetAPIService) SearchPet(ctx context.Context, age *int64, price *float32, bornAfter *time.Time, old *bool) (ImplResponse, error) {
+	// TODO - update SearchPet with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
+	// return Response(200, []Pet{}), nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("SearchPet method not implemented")
+}
+
+// FindPetsByTags - Finds Pets by tags
+// Deprecated
+func (s *PetAPIService) FindPetsByTags(ctx context.Context, tags []string, bornAfter time.Time, bornBefore time.Time, colour Colour) (ImplResponse, error) {
+	// TODO - update FindPetsByTags with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
+	// return Response(200, []Pet{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("FindPetsByTags method not implemented")
+}
+
+// FilterPetsByCategory - Finds Pets
+func (s *PetAPIService) FilterPetsByCategory(ctx context.Context, gender Gender, species Species, notSpecies []Species) (ImplResponse, error) {
+	// TODO - update FilterPetsByCategory with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, []Pet{}) or use other options such as http.Ok ...
+	// return Response(200, []Pet{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("FilterPetsByCategory method not implemented")
+}
+
+// GetPetById - Find pet by ID
+func (s *PetAPIService) GetPetById(ctx context.Context, petId int64) (ImplResponse, error) {
+	// TODO - update GetPetById with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, Pet{}) or use other options such as http.Ok ...
+	// return Response(200, Pet{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("GetPetById method not implemented")
+}
+
 // UpdatePetWithForm - Updates a pet in the store with form data
 func (s *PetAPIService) UpdatePetWithForm(ctx context.Context, petId int64, name string, status string) (ImplResponse, error) {
 	// TODO - update UpdatePetWithForm with the required logic for this service method.
@@ -193,6 +143,34 @@ func (s *PetAPIService) UpdatePetWithForm(ctx context.Context, petId int64, name
 	// return Response(405, nil),nil
 
 	return Response(http.StatusNotImplemented, nil), errors.New("UpdatePetWithForm method not implemented")
+}
+
+// DeletePet - Deletes a pet
+func (s *PetAPIService) DeletePet(ctx context.Context, petId int64, apiKey string) (ImplResponse, error) {
+	// TODO - update DeletePet with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("DeletePet method not implemented")
+}
+
+// GetPetImageById - Returns the image for the Pet that has been previously uploaded
+func (s *PetAPIService) GetPetImageById(ctx context.Context, petId int64) (ImplResponse, error) {
+	// TODO - update GetPetImageById with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, *os.File{}) or use other options such as http.Ok ...
+	// return Response(200, *os.File{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("GetPetImageById method not implemented")
 }
 
 // UploadFile - uploads an image
@@ -215,4 +193,26 @@ func (s *PetAPIService) UploadFileArrayOfFiles(ctx context.Context, petId int64,
 	// return Response(200, ApiResponse{}), nil
 
 	return Response(http.StatusNotImplemented, nil), errors.New("UploadFileArrayOfFiles method not implemented")
+}
+
+// GetPetsUsingBooleanQueryParameters - Get the pets by only using boolean query parameters
+func (s *PetAPIService) GetPetsUsingBooleanQueryParameters(ctx context.Context, expr bool, grouping bool, inactive bool) (ImplResponse, error) {
+	// TODO - update GetPetsUsingBooleanQueryParameters with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, ApiResponse{}) or use other options such as http.Ok ...
+	// return Response(200, ApiResponse{}), nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("GetPetsUsingBooleanQueryParameters method not implemented")
+}
+
+// GetPetsByTime - Get the pets by time
+func (s *PetAPIService) GetPetsByTime(ctx context.Context, createdTime time.Time) (ImplResponse, error) {
+	// TODO - update GetPetsByTime with the required logic for this service method.
+	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, ApiResponse{}) or use other options such as http.Ok ...
+	// return Response(200, ApiResponse{}), nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("GetPetsByTime method not implemented")
 }

--- a/samples/server/petstore/go-chi-server/go/api_store.go
+++ b/samples/server/petstore/go-chi-server/go/api_store.go
@@ -51,37 +51,32 @@ func NewStoreAPIController(s StoreAPIServicer, opts ...StoreAPIOption) *StoreAPI
 // Routes returns all the api routes for the StoreAPIController
 func (c *StoreAPIController) Routes() Routes {
 	return Routes{
-		"DeleteOrder": Route{
-			strings.ToUpper("Delete"),
-			"/v2/store/order/{orderId}",
-			c.DeleteOrder,
-		},
 		"GetInventory": Route{
 			strings.ToUpper("Get"),
 			"/v2/store/inventory",
 			c.GetInventory,
-		},
-		"GetOrderById": Route{
-			strings.ToUpper("Get"),
-			"/v2/store/order/{orderId}",
-			c.GetOrderById,
 		},
 		"PlaceOrder": Route{
 			strings.ToUpper("Post"),
 			"/v2/store/order",
 			c.PlaceOrder,
 		},
+		"GetOrderById": Route{
+			strings.ToUpper("Get"),
+			"/v2/store/order/{orderId}",
+			c.GetOrderById,
+		},
+		"DeleteOrder": Route{
+			strings.ToUpper("Delete"),
+			"/v2/store/order/{orderId}",
+			c.DeleteOrder,
+		},
 	}
 }
 
-// DeleteOrder - Delete purchase order by ID
-func (c *StoreAPIController) DeleteOrder(w http.ResponseWriter, r *http.Request) {
-	orderIdParam := chi.URLParam(r, "orderId")
-	if orderIdParam == "" {
-		c.errorHandler(w, r, &RequiredError{"orderId"}, nil)
-		return
-	}
-	result, err := c.service.DeleteOrder(r.Context(), orderIdParam)
+// GetInventory - Returns pet inventories by status
+func (c *StoreAPIController) GetInventory(w http.ResponseWriter, r *http.Request) {
+	result, err := c.service.GetInventory(r.Context())
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -91,9 +86,24 @@ func (c *StoreAPIController) DeleteOrder(w http.ResponseWriter, r *http.Request)
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
-// GetInventory - Returns pet inventories by status
-func (c *StoreAPIController) GetInventory(w http.ResponseWriter, r *http.Request) {
-	result, err := c.service.GetInventory(r.Context())
+// PlaceOrder - Place an order for a pet
+func (c *StoreAPIController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
+	orderParam := Order{}
+	d := json.NewDecoder(r.Body)
+	d.DisallowUnknownFields()
+	if err := d.Decode(&orderParam); err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	if err := AssertOrderRequired(orderParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	if err := AssertOrderConstraints(orderParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	result, err := c.service.PlaceOrder(r.Context(), orderParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -125,24 +135,14 @@ func (c *StoreAPIController) GetOrderById(w http.ResponseWriter, r *http.Request
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
-// PlaceOrder - Place an order for a pet
-func (c *StoreAPIController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
-	orderParam := Order{}
-	d := json.NewDecoder(r.Body)
-	d.DisallowUnknownFields()
-	if err := d.Decode(&orderParam); err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+// DeleteOrder - Delete purchase order by ID
+func (c *StoreAPIController) DeleteOrder(w http.ResponseWriter, r *http.Request) {
+	orderIdParam := chi.URLParam(r, "orderId")
+	if orderIdParam == "" {
+		c.errorHandler(w, r, &RequiredError{"orderId"}, nil)
 		return
 	}
-	if err := AssertOrderRequired(orderParam); err != nil {
-		c.errorHandler(w, r, err, nil)
-		return
-	}
-	if err := AssertOrderConstraints(orderParam); err != nil {
-		c.errorHandler(w, r, err, nil)
-		return
-	}
-	result, err := c.service.PlaceOrder(r.Context(), orderParam)
+	result, err := c.service.DeleteOrder(r.Context(), orderIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-chi-server/go/api_store_service.go
+++ b/samples/server/petstore/go-chi-server/go/api_store_service.go
@@ -27,20 +27,6 @@ func NewStoreAPIService() *StoreAPIService {
 	return &StoreAPIService{}
 }
 
-// DeleteOrder - Delete purchase order by ID
-func (s *StoreAPIService) DeleteOrder(ctx context.Context, orderId string) (ImplResponse, error) {
-	// TODO - update DeleteOrder with the required logic for this service method.
-	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("DeleteOrder method not implemented")
-}
-
 // GetInventory - Returns pet inventories by status
 func (s *StoreAPIService) GetInventory(ctx context.Context) (ImplResponse, error) {
 	// TODO - update GetInventory with the required logic for this service method.
@@ -50,6 +36,20 @@ func (s *StoreAPIService) GetInventory(ctx context.Context) (ImplResponse, error
 	// return Response(200, map[string]int32{}), nil
 
 	return Response(http.StatusNotImplemented, nil), errors.New("GetInventory method not implemented")
+}
+
+// PlaceOrder - Place an order for a pet
+func (s *StoreAPIService) PlaceOrder(ctx context.Context, order Order) (ImplResponse, error) {
+	// TODO - update PlaceOrder with the required logic for this service method.
+	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, Order{}) or use other options such as http.Ok ...
+	// return Response(200, Order{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("PlaceOrder method not implemented")
 }
 
 // GetOrderById - Find purchase order by ID
@@ -69,16 +69,16 @@ func (s *StoreAPIService) GetOrderById(ctx context.Context, orderId int64) (Impl
 	return Response(http.StatusNotImplemented, nil), errors.New("GetOrderById method not implemented")
 }
 
-// PlaceOrder - Place an order for a pet
-func (s *StoreAPIService) PlaceOrder(ctx context.Context, order Order) (ImplResponse, error) {
-	// TODO - update PlaceOrder with the required logic for this service method.
+// DeleteOrder - Delete purchase order by ID
+func (s *StoreAPIService) DeleteOrder(ctx context.Context, orderId string) (ImplResponse, error) {
+	// TODO - update DeleteOrder with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, Order{}) or use other options such as http.Ok ...
-	// return Response(200, Order{}), nil
 
 	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
 	// return Response(400, nil),nil
 
-	return Response(http.StatusNotImplemented, nil), errors.New("PlaceOrder method not implemented")
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("DeleteOrder method not implemented")
 }

--- a/samples/server/petstore/go-chi-server/go/api_user.go
+++ b/samples/server/petstore/go-chi-server/go/api_user.go
@@ -66,16 +66,6 @@ func (c *UserAPIController) Routes() Routes {
 			"/v2/user/createWithList",
 			c.CreateUsersWithListInput,
 		},
-		"DeleteUser": Route{
-			strings.ToUpper("Delete"),
-			"/v2/user/{username}",
-			c.DeleteUser,
-		},
-		"GetUserByName": Route{
-			strings.ToUpper("Get"),
-			"/v2/user/{username}",
-			c.GetUserByName,
-		},
 		"LoginUser": Route{
 			strings.ToUpper("Get"),
 			"/v2/user/login",
@@ -86,10 +76,20 @@ func (c *UserAPIController) Routes() Routes {
 			"/v2/user/logout",
 			c.LogoutUser,
 		},
+		"GetUserByName": Route{
+			strings.ToUpper("Get"),
+			"/v2/user/{username}",
+			c.GetUserByName,
+		},
 		"UpdateUser": Route{
 			strings.ToUpper("Put"),
 			"/v2/user/{username}",
 			c.UpdateUser,
+		},
+		"DeleteUser": Route{
+			strings.ToUpper("Delete"),
+			"/v2/user/{username}",
+			c.DeleteUser,
 		},
 	}
 }
@@ -171,59 +171,6 @@ func (c *UserAPIController) CreateUsersWithListInput(w http.ResponseWriter, r *h
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
-// DeleteUser - Delete user
-func (c *UserAPIController) DeleteUser(w http.ResponseWriter, r *http.Request) {
-	query, err := parseQuery(r.URL.RawQuery)
-	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
-		return
-	}
-	usernameParam := chi.URLParam(r, "username")
-	if usernameParam == "" {
-		c.errorHandler(w, r, &RequiredError{"username"}, nil)
-		return
-	}
-	var confirmationParam bool
-	if query.Has("confirmation") {
-		param, err := parseBoolParameter(
-			query.Get("confirmation"),
-			WithParse[bool](parseBool),
-		)
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "confirmation", Err: err}, nil)
-			return
-		}
-
-		confirmationParam = param
-	} else {
-	}
-	result, err := c.service.DeleteUser(r.Context(), usernameParam, confirmationParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
-// GetUserByName - Get user by user name
-func (c *UserAPIController) GetUserByName(w http.ResponseWriter, r *http.Request) {
-	usernameParam := chi.URLParam(r, "username")
-	if usernameParam == "" {
-		c.errorHandler(w, r, &RequiredError{"username"}, nil)
-		return
-	}
-	result, err := c.service.GetUserByName(r.Context(), usernameParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
-}
-
 // LoginUser - Logs user into the system
 func (c *UserAPIController) LoginUser(w http.ResponseWriter, r *http.Request) {
 	query, err := parseQuery(r.URL.RawQuery)
@@ -285,6 +232,23 @@ func (c *UserAPIController) LogoutUser(w http.ResponseWriter, r *http.Request) {
 	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 }
 
+// GetUserByName - Get user by user name
+func (c *UserAPIController) GetUserByName(w http.ResponseWriter, r *http.Request) {
+	usernameParam := chi.URLParam(r, "username")
+	if usernameParam == "" {
+		c.errorHandler(w, r, &RequiredError{"username"}, nil)
+		return
+	}
+	result, err := c.service.GetUserByName(r.Context(), usernameParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
 // UpdateUser - Updated user
 func (c *UserAPIController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	usernameParam := chi.URLParam(r, "username")
@@ -308,6 +272,42 @@ func (c *UserAPIController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	result, err := c.service.UpdateUser(r.Context(), usernameParam, userParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	_ = EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+}
+
+// DeleteUser - Delete user
+func (c *UserAPIController) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	query, err := parseQuery(r.URL.RawQuery)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	usernameParam := chi.URLParam(r, "username")
+	if usernameParam == "" {
+		c.errorHandler(w, r, &RequiredError{"username"}, nil)
+		return
+	}
+	var confirmationParam bool
+	if query.Has("confirmation") {
+		param, err := parseBoolParameter(
+			query.Get("confirmation"),
+			WithParse[bool](parseBool),
+		)
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "confirmation", Err: err}, nil)
+			return
+		}
+
+		confirmationParam = param
+	} else {
+	}
+	result, err := c.service.DeleteUser(r.Context(), usernameParam, confirmationParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-chi-server/go/api_user_service.go
+++ b/samples/server/petstore/go-chi-server/go/api_user_service.go
@@ -60,37 +60,6 @@ func (s *UserAPIService) CreateUsersWithListInput(ctx context.Context, user []Us
 	return Response(http.StatusNotImplemented, nil), errors.New("CreateUsersWithListInput method not implemented")
 }
 
-// DeleteUser - Delete user
-func (s *UserAPIService) DeleteUser(ctx context.Context, username string, confirmation bool) (ImplResponse, error) {
-	// TODO - update DeleteUser with the required logic for this service method.
-	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("DeleteUser method not implemented")
-}
-
-// GetUserByName - Get user by user name
-func (s *UserAPIService) GetUserByName(ctx context.Context, username string) (ImplResponse, error) {
-	// TODO - update GetUserByName with the required logic for this service method.
-	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, User{}) or use other options such as http.Ok ...
-	// return Response(200, User{}), nil
-
-	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
-	// return Response(400, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	// return Response(404, nil),nil
-
-	return Response(http.StatusNotImplemented, nil), errors.New("GetUserByName method not implemented")
-}
-
 // LoginUser - Logs user into the system
 func (s *UserAPIService) LoginUser(ctx context.Context, username string, password string, rememberMe bool) (ImplResponse, error) {
 	// TODO - update LoginUser with the required logic for this service method.
@@ -116,6 +85,23 @@ func (s *UserAPIService) LogoutUser(ctx context.Context) (ImplResponse, error) {
 	return Response(http.StatusNotImplemented, nil), errors.New("LogoutUser method not implemented")
 }
 
+// GetUserByName - Get user by user name
+func (s *UserAPIService) GetUserByName(ctx context.Context, username string) (ImplResponse, error) {
+	// TODO - update GetUserByName with the required logic for this service method.
+	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, User{}) or use other options such as http.Ok ...
+	// return Response(200, User{}), nil
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("GetUserByName method not implemented")
+}
+
 // UpdateUser - Updated user
 func (s *UserAPIService) UpdateUser(ctx context.Context, username string, user User) (ImplResponse, error) {
 	// TODO - update UpdateUser with the required logic for this service method.
@@ -128,4 +114,18 @@ func (s *UserAPIService) UpdateUser(ctx context.Context, username string, user U
 	// return Response(404, nil),nil
 
 	return Response(http.StatusNotImplemented, nil), errors.New("UpdateUser method not implemented")
+}
+
+// DeleteUser - Delete user
+func (s *UserAPIService) DeleteUser(ctx context.Context, username string, confirmation bool) (ImplResponse, error) {
+	// TODO - update DeleteUser with the required logic for this service method.
+	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(400, {}) or use other options such as http.Ok ...
+	// return Response(400, nil),nil
+
+	// TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
+	// return Response(404, nil),nil
+
+	return Response(http.StatusNotImplemented, nil), errors.New("DeleteUser method not implemented")
 }


### PR DESCRIPTION
This PR adds a configuration property (`skipSortingOperations`) to skip sorting the operations alphabetically. Sorting the operations, which is the default behaviour, is fine for most generators but it is an issue for the Go Server generator (where the order of the routes matters).

Fix #19445 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5
