### PR TITLE
[PHP] Add missing qualifier for enum parameters

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -18,6 +18,7 @@ package org.openapitools.codegen.languages;
 
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.io.FilenameUtils;
@@ -382,6 +383,11 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             return "\\" + modelPackage + "\\" + name;
         }
         return super.getTypeDeclaration(name);
+    }
+
+    @Override
+    protected String getParameterDataType(Parameter parameter, Schema schema) {
+        return getTypeDeclaration(schema);
     }
 
     @Override

--- a/modules/openapi-generator/src/test/resources/3_0/php-nextgen/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/php-nextgen/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1303,6 +1303,42 @@ paths:
       responses:
         200:
           description: The instance started successfully
+  /fake/enum/endpoint:
+    get:
+      tags:
+        - fake
+      summary: test endpoint with enum parameter
+      operationId: fake-enum-endpoint
+      parameters:
+        - name: enum-class
+          in: query
+          description: enum class parameter
+          required: true
+          schema:
+              $ref: '#/components/schemas/EnumClass'
+        - name: enum-class-array
+          in: query
+          description: enum class parameter
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/EnumClass'
+        - name: enum-class-map
+          in: query
+          description: enum class parameter
+          required: true
+          schema:
+            type: object
+            additionalProperties:
+              $ref: '#/components/schemas/EnumClass'
+      responses:
+        200:
+          description: The instance started successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnumClass'
 servers:
   - url: 'http://{server}.swagger.io:{port}/v2'
     description: petstore server

--- a/modules/openapi-generator/src/test/resources/3_0/php/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/php/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1327,6 +1327,42 @@ paths:
       responses:
         200:
           description: OK
+  /fake/enum/endpoint:
+    get:
+      tags:
+        - fake
+      summary: test endpoint with enum parameter
+      operationId: fake-enum-endpoint
+      parameters:
+        - name: enum-class
+          in: query
+          description: enum class parameter
+          required: true
+          schema:
+            $ref: '#/components/schemas/EnumClass'
+        - name: enum-class-array
+          in: query
+          description: enum class parameter
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/EnumClass'
+        - name: enum-class-map
+          in: query
+          description: enum class parameter
+          required: true
+          schema:
+            type: object
+            additionalProperties:
+              $ref: '#/components/schemas/EnumClass'
+      responses:
+        200:
+          description: The instance started successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnumClass'
 servers:
   - url: 'http://{server}.swagger.io:{port}/v2'
     description: petstore server

--- a/samples/client/echo_api/php-nextgen-streaming/docs/Api/HeaderApi.md
+++ b/samples/client/echo_api/php-nextgen-streaming/docs/Api/HeaderApi.md
@@ -34,7 +34,7 @@ $integer_header = 56; // int
 $boolean_header = True; // bool
 $string_header = 'string_header_example'; // string
 $enum_nonref_string_header = 'enum_nonref_string_header_example'; // string
-$enum_ref_string_header = new \OpenAPI\Client\Model\StringEnumRef(); // StringEnumRef
+$enum_ref_string_header = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\StringEnumRef(); // \OpenAPI\Client\Model\StringEnumRef
 
 try {
     $result = $apiInstance->testHeaderIntegerBooleanStringEnums($integer_header, $boolean_header, $string_header, $enum_nonref_string_header, $enum_ref_string_header);
@@ -52,7 +52,7 @@ try {
 | **boolean_header** | **bool**|  | [optional] |
 | **string_header** | **string**|  | [optional] |
 | **enum_nonref_string_header** | **string**|  | [optional] |
-| **enum_ref_string_header** | [**StringEnumRef**](../Model/.md)|  | [optional] |
+| **enum_ref_string_header** | [**\OpenAPI\Client\Model\StringEnumRef**](../Model/.md)|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/php-nextgen-streaming/docs/Api/PathApi.md
+++ b/samples/client/echo_api/php-nextgen-streaming/docs/Api/PathApi.md
@@ -33,7 +33,7 @@ $apiInstance = new OpenAPI\Client\Api\PathApi(
 $path_string = 'path_string_example'; // string
 $path_integer = 56; // int
 $enum_nonref_string_path = 'enum_nonref_string_path_example'; // string
-$enum_ref_string_path = new \OpenAPI\Client\Model\StringEnumRef(); // StringEnumRef
+$enum_ref_string_path = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\StringEnumRef(); // \OpenAPI\Client\Model\StringEnumRef
 
 try {
     $result = $apiInstance->testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath($path_string, $path_integer, $enum_nonref_string_path, $enum_ref_string_path);
@@ -50,7 +50,7 @@ try {
 | **path_string** | **string**|  | |
 | **path_integer** | **int**|  | |
 | **enum_nonref_string_path** | **string**|  | |
-| **enum_ref_string_path** | [**StringEnumRef**](../Model/.md)|  | |
+| **enum_ref_string_path** | [**\OpenAPI\Client\Model\StringEnumRef**](../Model/.md)|  | |
 
 ### Return type
 

--- a/samples/client/echo_api/php-nextgen-streaming/docs/Api/QueryApi.md
+++ b/samples/client/echo_api/php-nextgen-streaming/docs/Api/QueryApi.md
@@ -40,7 +40,7 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     new GuzzleHttp\Client()
 );
 $enum_nonref_string_query = 'enum_nonref_string_query_example'; // string
-$enum_ref_string_query = new \OpenAPI\Client\Model\StringEnumRef(); // StringEnumRef
+$enum_ref_string_query = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\StringEnumRef(); // \OpenAPI\Client\Model\StringEnumRef
 
 try {
     $result = $apiInstance->testEnumRefString($enum_nonref_string_query, $enum_ref_string_query);
@@ -55,7 +55,7 @@ try {
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **enum_nonref_string_query** | **string**|  | [optional] |
-| **enum_ref_string_query** | [**StringEnumRef**](../Model/.md)|  | [optional] |
+| **enum_ref_string_query** | [**\OpenAPI\Client\Model\StringEnumRef**](../Model/.md)|  | [optional] |
 
 ### Return type
 
@@ -217,7 +217,7 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$query_object = new \OpenAPI\Client\Model\Pet(); // Pet
+$query_object = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\Pet(); // \OpenAPI\Client\Model\Pet
 
 try {
     $result = $apiInstance->testQueryStyleDeepObjectExplodeTrueObject($query_object);
@@ -231,7 +231,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **query_object** | [**Pet**](../Model/.md)|  | [optional] |
+| **query_object** | [**\OpenAPI\Client\Model\Pet**](../Model/.md)|  | [optional] |
 
 ### Return type
 
@@ -273,7 +273,7 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$query_object = new \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(); // TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter
+$query_object = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(); // \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter
 
 try {
     $result = $apiInstance->testQueryStyleDeepObjectExplodeTrueObjectAllOf($query_object);
@@ -287,7 +287,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **query_object** | [**TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter**](../Model/.md)|  | [optional] |
+| **query_object** | [**\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter**](../Model/.md)|  | [optional] |
 
 ### Return type
 
@@ -441,7 +441,7 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$query_object = new \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(); // TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter
+$query_object = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(); // \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter
 
 try {
     $result = $apiInstance->testQueryStyleFormExplodeTrueArrayString($query_object);
@@ -455,7 +455,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **query_object** | [**TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter**](../Model/.md)|  | [optional] |
+| **query_object** | [**\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter**](../Model/.md)|  | [optional] |
 
 ### Return type
 
@@ -497,7 +497,7 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$query_object = new \OpenAPI\Client\Model\Pet(); // Pet
+$query_object = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\Pet(); // \OpenAPI\Client\Model\Pet
 
 try {
     $result = $apiInstance->testQueryStyleFormExplodeTrueObject($query_object);
@@ -511,7 +511,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **query_object** | [**Pet**](../Model/.md)|  | [optional] |
+| **query_object** | [**\OpenAPI\Client\Model\Pet**](../Model/.md)|  | [optional] |
 
 ### Return type
 
@@ -553,7 +553,7 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$query_object = new \OpenAPI\Client\Model\DataQuery(); // DataQuery
+$query_object = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\DataQuery(); // \OpenAPI\Client\Model\DataQuery
 
 try {
     $result = $apiInstance->testQueryStyleFormExplodeTrueObjectAllOf($query_object);
@@ -567,7 +567,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **query_object** | [**DataQuery**](../Model/.md)|  | [optional] |
+| **query_object** | [**\OpenAPI\Client\Model\DataQuery**](../Model/.md)|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
@@ -132,7 +132,7 @@ class HeaderApi
      * @param  bool|null $boolean_header boolean_header (optional)
      * @param  string|null $string_header string_header (optional)
      * @param  string|null $enum_nonref_string_header enum_nonref_string_header (optional)
-     * @param  StringEnumRef|null $enum_ref_string_header enum_ref_string_header (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_header enum_ref_string_header (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -144,7 +144,7 @@ class HeaderApi
         ?bool $boolean_header = null,
         ?string $string_header = null,
         ?string $enum_nonref_string_header = null,
-        ?StringEnumRef $enum_ref_string_header = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_header = null,
         string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): string
     {
@@ -161,7 +161,7 @@ class HeaderApi
      * @param  bool|null $boolean_header (optional)
      * @param  string|null $string_header (optional)
      * @param  string|null $enum_nonref_string_header (optional)
-     * @param  StringEnumRef|null $enum_ref_string_header (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_header (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -173,7 +173,7 @@ class HeaderApi
         ?bool $boolean_header = null,
         ?string $string_header = null,
         ?string $enum_nonref_string_header = null,
-        ?StringEnumRef $enum_ref_string_header = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_header = null,
         string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): array
     {
@@ -296,7 +296,7 @@ class HeaderApi
      * @param  bool|null $boolean_header (optional)
      * @param  string|null $string_header (optional)
      * @param  string|null $enum_nonref_string_header (optional)
-     * @param  StringEnumRef|null $enum_ref_string_header (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_header (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -307,7 +307,7 @@ class HeaderApi
         ?bool $boolean_header = null,
         ?string $string_header = null,
         ?string $enum_nonref_string_header = null,
-        ?StringEnumRef $enum_ref_string_header = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_header = null,
         string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): PromiseInterface
     {
@@ -328,7 +328,7 @@ class HeaderApi
      * @param  bool|null $boolean_header (optional)
      * @param  string|null $string_header (optional)
      * @param  string|null $enum_nonref_string_header (optional)
-     * @param  StringEnumRef|null $enum_ref_string_header (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_header (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -389,7 +389,7 @@ class HeaderApi
      * @param  bool|null $boolean_header (optional)
      * @param  string|null $string_header (optional)
      * @param  string|null $enum_nonref_string_header (optional)
-     * @param  StringEnumRef|null $enum_ref_string_header (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_header (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
@@ -131,7 +131,7 @@ class PathApi
      * @param  string $path_string path_string (required)
      * @param  int $path_integer path_integer (required)
      * @param  string $enum_nonref_string_path enum_nonref_string_path (required)
-     * @param  StringEnumRef $enum_ref_string_path enum_ref_string_path (required)
+     * @param  \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path enum_ref_string_path (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -142,7 +142,7 @@ class PathApi
         string $path_string,
         int $path_integer,
         string $enum_nonref_string_path,
-        StringEnumRef $enum_ref_string_path,
+        \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path,
         string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): string
     {
@@ -158,7 +158,7 @@ class PathApi
      * @param  string $path_string (required)
      * @param  int $path_integer (required)
      * @param  string $enum_nonref_string_path (required)
-     * @param  StringEnumRef $enum_ref_string_path (required)
+     * @param  \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -169,7 +169,7 @@ class PathApi
         string $path_string,
         int $path_integer,
         string $enum_nonref_string_path,
-        StringEnumRef $enum_ref_string_path,
+        \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path,
         string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): array
     {
@@ -291,7 +291,7 @@ class PathApi
      * @param  string $path_string (required)
      * @param  int $path_integer (required)
      * @param  string $enum_nonref_string_path (required)
-     * @param  StringEnumRef $enum_ref_string_path (required)
+     * @param  \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -301,7 +301,7 @@ class PathApi
         string $path_string,
         int $path_integer,
         string $enum_nonref_string_path,
-        StringEnumRef $enum_ref_string_path,
+        \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path,
         string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): PromiseInterface
     {
@@ -321,7 +321,7 @@ class PathApi
      * @param  string $path_string (required)
      * @param  int $path_integer (required)
      * @param  string $enum_nonref_string_path (required)
-     * @param  StringEnumRef $enum_ref_string_path (required)
+     * @param  \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -380,7 +380,7 @@ class PathApi
      * @param  string $path_string (required)
      * @param  int $path_integer (required)
      * @param  string $enum_nonref_string_path (required)
-     * @param  StringEnumRef $enum_ref_string_path (required)
+     * @param  \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -156,7 +156,7 @@ class QueryApi
      * Test query parameter(s)
      *
      * @param  string|null $enum_nonref_string_query enum_nonref_string_query (optional)
-     * @param  StringEnumRef|null $enum_ref_string_query enum_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_query enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -165,7 +165,7 @@ class QueryApi
      */
     public function testEnumRefString(
         ?string $enum_nonref_string_query = null,
-        ?StringEnumRef $enum_ref_string_query = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): string
     {
@@ -179,7 +179,7 @@ class QueryApi
      * Test query parameter(s)
      *
      * @param  string|null $enum_nonref_string_query (optional)
-     * @param  StringEnumRef|null $enum_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -188,7 +188,7 @@ class QueryApi
      */
     public function testEnumRefStringWithHttpInfo(
         ?string $enum_nonref_string_query = null,
-        ?StringEnumRef $enum_ref_string_query = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): array
     {
@@ -308,7 +308,7 @@ class QueryApi
      * Test query parameter(s)
      *
      * @param  string|null $enum_nonref_string_query (optional)
-     * @param  StringEnumRef|null $enum_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -316,7 +316,7 @@ class QueryApi
      */
     public function testEnumRefStringAsync(
         ?string $enum_nonref_string_query = null,
-        ?StringEnumRef $enum_ref_string_query = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): PromiseInterface
     {
@@ -334,7 +334,7 @@ class QueryApi
      * Test query parameter(s)
      *
      * @param  string|null $enum_nonref_string_query (optional)
-     * @param  StringEnumRef|null $enum_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -389,7 +389,7 @@ class QueryApi
      * Create request for operation 'testEnumRefString'
      *
      * @param  string|null $enum_nonref_string_query (optional)
-     * @param  StringEnumRef|null $enum_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -1206,7 +1206,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -1214,7 +1214,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleDeepObjectExplodeTrueObject(
-        ?Pet $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'][0]
     ): string
     {
@@ -1227,7 +1227,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -1235,7 +1235,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectWithHttpInfo(
-        ?Pet $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'][0]
     ): array
     {
@@ -1354,14 +1354,14 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAsync(
-        ?Pet $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'][0]
     ): PromiseInterface
     {
@@ -1378,7 +1378,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -1431,7 +1431,7 @@ class QueryApi
     /**
      * Create request for operation 'testQueryStyleDeepObjectExplodeTrueObject'
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -1523,7 +1523,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -1531,7 +1531,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAllOf(
-        ?TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'][0]
     ): string
     {
@@ -1544,7 +1544,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -1552,7 +1552,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAllOfWithHttpInfo(
-        ?TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'][0]
     ): array
     {
@@ -1671,14 +1671,14 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAllOfAsync(
-        ?TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'][0]
     ): PromiseInterface
     {
@@ -1695,7 +1695,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -1748,7 +1748,7 @@ class QueryApi
     /**
      * Create request for operation 'testQueryStyleDeepObjectExplodeTrueObjectAllOf'
      *
-     * @param  TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -2474,7 +2474,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueArrayString'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -2482,7 +2482,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeTrueArrayString(
-        ?TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueArrayString'][0]
     ): string
     {
@@ -2495,7 +2495,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueArrayString'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -2503,7 +2503,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeTrueArrayStringWithHttpInfo(
-        ?TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueArrayString'][0]
     ): array
     {
@@ -2622,14 +2622,14 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueArrayString'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeTrueArrayStringAsync(
-        ?TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueArrayString'][0]
     ): PromiseInterface
     {
@@ -2646,7 +2646,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueArrayString'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -2699,7 +2699,7 @@ class QueryApi
     /**
      * Create request for operation 'testQueryStyleFormExplodeTrueArrayString'
      *
-     * @param  TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueArrayString'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -2791,7 +2791,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -2799,7 +2799,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeTrueObject(
-        ?Pet $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObject'][0]
     ): string
     {
@@ -2812,7 +2812,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -2820,7 +2820,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeTrueObjectWithHttpInfo(
-        ?Pet $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObject'][0]
     ): array
     {
@@ -2939,14 +2939,14 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeTrueObjectAsync(
-        ?Pet $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObject'][0]
     ): PromiseInterface
     {
@@ -2963,7 +2963,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -3016,7 +3016,7 @@ class QueryApi
     /**
      * Create request for operation 'testQueryStyleFormExplodeTrueObject'
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -3108,7 +3108,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  DataQuery|null $query_object query_object (optional)
+     * @param  \OpenAPI\Client\Model\DataQuery|null $query_object query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -3116,7 +3116,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeTrueObjectAllOf(
-        ?DataQuery $query_object = null,
+        ?\OpenAPI\Client\Model\DataQuery $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'][0]
     ): string
     {
@@ -3129,7 +3129,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  DataQuery|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\DataQuery|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -3137,7 +3137,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeTrueObjectAllOfWithHttpInfo(
-        ?DataQuery $query_object = null,
+        ?\OpenAPI\Client\Model\DataQuery $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'][0]
     ): array
     {
@@ -3256,14 +3256,14 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  DataQuery|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\DataQuery|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeTrueObjectAllOfAsync(
-        ?DataQuery $query_object = null,
+        ?\OpenAPI\Client\Model\DataQuery $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'][0]
     ): PromiseInterface
     {
@@ -3280,7 +3280,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  DataQuery|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\DataQuery|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -3333,7 +3333,7 @@ class QueryApi
     /**
      * Create request for operation 'testQueryStyleFormExplodeTrueObjectAllOf'
      *
-     * @param  DataQuery|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\DataQuery|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException

--- a/samples/client/echo_api/php-nextgen/docs/Api/HeaderApi.md
+++ b/samples/client/echo_api/php-nextgen/docs/Api/HeaderApi.md
@@ -34,7 +34,7 @@ $integer_header = 56; // int
 $boolean_header = True; // bool
 $string_header = 'string_header_example'; // string
 $enum_nonref_string_header = 'enum_nonref_string_header_example'; // string
-$enum_ref_string_header = new \OpenAPI\Client\Model\StringEnumRef(); // StringEnumRef
+$enum_ref_string_header = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\StringEnumRef(); // \OpenAPI\Client\Model\StringEnumRef
 
 try {
     $result = $apiInstance->testHeaderIntegerBooleanStringEnums($integer_header, $boolean_header, $string_header, $enum_nonref_string_header, $enum_ref_string_header);
@@ -52,7 +52,7 @@ try {
 | **boolean_header** | **bool**|  | [optional] |
 | **string_header** | **string**|  | [optional] |
 | **enum_nonref_string_header** | **string**|  | [optional] |
-| **enum_ref_string_header** | [**StringEnumRef**](../Model/.md)|  | [optional] |
+| **enum_ref_string_header** | [**\OpenAPI\Client\Model\StringEnumRef**](../Model/.md)|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/php-nextgen/docs/Api/PathApi.md
+++ b/samples/client/echo_api/php-nextgen/docs/Api/PathApi.md
@@ -33,7 +33,7 @@ $apiInstance = new OpenAPI\Client\Api\PathApi(
 $path_string = 'path_string_example'; // string
 $path_integer = 56; // int
 $enum_nonref_string_path = 'enum_nonref_string_path_example'; // string
-$enum_ref_string_path = new \OpenAPI\Client\Model\StringEnumRef(); // StringEnumRef
+$enum_ref_string_path = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\StringEnumRef(); // \OpenAPI\Client\Model\StringEnumRef
 
 try {
     $result = $apiInstance->testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath($path_string, $path_integer, $enum_nonref_string_path, $enum_ref_string_path);
@@ -50,7 +50,7 @@ try {
 | **path_string** | **string**|  | |
 | **path_integer** | **int**|  | |
 | **enum_nonref_string_path** | **string**|  | |
-| **enum_ref_string_path** | [**StringEnumRef**](../Model/.md)|  | |
+| **enum_ref_string_path** | [**\OpenAPI\Client\Model\StringEnumRef**](../Model/.md)|  | |
 
 ### Return type
 

--- a/samples/client/echo_api/php-nextgen/docs/Api/QueryApi.md
+++ b/samples/client/echo_api/php-nextgen/docs/Api/QueryApi.md
@@ -40,7 +40,7 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     new GuzzleHttp\Client()
 );
 $enum_nonref_string_query = 'enum_nonref_string_query_example'; // string
-$enum_ref_string_query = new \OpenAPI\Client\Model\StringEnumRef(); // StringEnumRef
+$enum_ref_string_query = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\StringEnumRef(); // \OpenAPI\Client\Model\StringEnumRef
 
 try {
     $result = $apiInstance->testEnumRefString($enum_nonref_string_query, $enum_ref_string_query);
@@ -55,7 +55,7 @@ try {
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **enum_nonref_string_query** | **string**|  | [optional] |
-| **enum_ref_string_query** | [**StringEnumRef**](../Model/.md)|  | [optional] |
+| **enum_ref_string_query** | [**\OpenAPI\Client\Model\StringEnumRef**](../Model/.md)|  | [optional] |
 
 ### Return type
 
@@ -217,7 +217,7 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$query_object = new \OpenAPI\Client\Model\Pet(); // Pet
+$query_object = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\Pet(); // \OpenAPI\Client\Model\Pet
 
 try {
     $result = $apiInstance->testQueryStyleDeepObjectExplodeTrueObject($query_object);
@@ -231,7 +231,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **query_object** | [**Pet**](../Model/.md)|  | [optional] |
+| **query_object** | [**\OpenAPI\Client\Model\Pet**](../Model/.md)|  | [optional] |
 
 ### Return type
 
@@ -273,7 +273,7 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$query_object = new \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(); // TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter
+$query_object = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(); // \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter
 
 try {
     $result = $apiInstance->testQueryStyleDeepObjectExplodeTrueObjectAllOf($query_object);
@@ -287,7 +287,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **query_object** | [**TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter**](../Model/.md)|  | [optional] |
+| **query_object** | [**\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter**](../Model/.md)|  | [optional] |
 
 ### Return type
 
@@ -441,7 +441,7 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$query_object = new \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(); // TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter
+$query_object = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(); // \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter
 
 try {
     $result = $apiInstance->testQueryStyleFormExplodeTrueArrayString($query_object);
@@ -455,7 +455,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **query_object** | [**TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter**](../Model/.md)|  | [optional] |
+| **query_object** | [**\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter**](../Model/.md)|  | [optional] |
 
 ### Return type
 
@@ -497,7 +497,7 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$query_object = new \OpenAPI\Client\Model\Pet(); // Pet
+$query_object = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\Pet(); // \OpenAPI\Client\Model\Pet
 
 try {
     $result = $apiInstance->testQueryStyleFormExplodeTrueObject($query_object);
@@ -511,7 +511,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **query_object** | [**Pet**](../Model/.md)|  | [optional] |
+| **query_object** | [**\OpenAPI\Client\Model\Pet**](../Model/.md)|  | [optional] |
 
 ### Return type
 
@@ -553,7 +553,7 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$query_object = new \OpenAPI\Client\Model\DataQuery(); // DataQuery
+$query_object = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\DataQuery(); // \OpenAPI\Client\Model\DataQuery
 
 try {
     $result = $apiInstance->testQueryStyleFormExplodeTrueObjectAllOf($query_object);
@@ -567,7 +567,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **query_object** | [**DataQuery**](../Model/.md)|  | [optional] |
+| **query_object** | [**\OpenAPI\Client\Model\DataQuery**](../Model/.md)|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
@@ -132,7 +132,7 @@ class HeaderApi
      * @param  bool|null $boolean_header boolean_header (optional)
      * @param  string|null $string_header string_header (optional)
      * @param  string|null $enum_nonref_string_header enum_nonref_string_header (optional)
-     * @param  StringEnumRef|null $enum_ref_string_header enum_ref_string_header (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_header enum_ref_string_header (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -144,7 +144,7 @@ class HeaderApi
         ?bool $boolean_header = null,
         ?string $string_header = null,
         ?string $enum_nonref_string_header = null,
-        ?StringEnumRef $enum_ref_string_header = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_header = null,
         string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): string
     {
@@ -161,7 +161,7 @@ class HeaderApi
      * @param  bool|null $boolean_header (optional)
      * @param  string|null $string_header (optional)
      * @param  string|null $enum_nonref_string_header (optional)
-     * @param  StringEnumRef|null $enum_ref_string_header (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_header (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -173,7 +173,7 @@ class HeaderApi
         ?bool $boolean_header = null,
         ?string $string_header = null,
         ?string $enum_nonref_string_header = null,
-        ?StringEnumRef $enum_ref_string_header = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_header = null,
         string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): array
     {
@@ -296,7 +296,7 @@ class HeaderApi
      * @param  bool|null $boolean_header (optional)
      * @param  string|null $string_header (optional)
      * @param  string|null $enum_nonref_string_header (optional)
-     * @param  StringEnumRef|null $enum_ref_string_header (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_header (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -307,7 +307,7 @@ class HeaderApi
         ?bool $boolean_header = null,
         ?string $string_header = null,
         ?string $enum_nonref_string_header = null,
-        ?StringEnumRef $enum_ref_string_header = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_header = null,
         string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): PromiseInterface
     {
@@ -328,7 +328,7 @@ class HeaderApi
      * @param  bool|null $boolean_header (optional)
      * @param  string|null $string_header (optional)
      * @param  string|null $enum_nonref_string_header (optional)
-     * @param  StringEnumRef|null $enum_ref_string_header (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_header (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -389,7 +389,7 @@ class HeaderApi
      * @param  bool|null $boolean_header (optional)
      * @param  string|null $string_header (optional)
      * @param  string|null $enum_nonref_string_header (optional)
-     * @param  StringEnumRef|null $enum_ref_string_header (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_header (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException

--- a/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
@@ -131,7 +131,7 @@ class PathApi
      * @param  string $path_string path_string (required)
      * @param  int $path_integer path_integer (required)
      * @param  string $enum_nonref_string_path enum_nonref_string_path (required)
-     * @param  StringEnumRef $enum_ref_string_path enum_ref_string_path (required)
+     * @param  \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path enum_ref_string_path (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -142,7 +142,7 @@ class PathApi
         string $path_string,
         int $path_integer,
         string $enum_nonref_string_path,
-        StringEnumRef $enum_ref_string_path,
+        \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path,
         string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): string
     {
@@ -158,7 +158,7 @@ class PathApi
      * @param  string $path_string (required)
      * @param  int $path_integer (required)
      * @param  string $enum_nonref_string_path (required)
-     * @param  StringEnumRef $enum_ref_string_path (required)
+     * @param  \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -169,7 +169,7 @@ class PathApi
         string $path_string,
         int $path_integer,
         string $enum_nonref_string_path,
-        StringEnumRef $enum_ref_string_path,
+        \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path,
         string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): array
     {
@@ -291,7 +291,7 @@ class PathApi
      * @param  string $path_string (required)
      * @param  int $path_integer (required)
      * @param  string $enum_nonref_string_path (required)
-     * @param  StringEnumRef $enum_ref_string_path (required)
+     * @param  \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -301,7 +301,7 @@ class PathApi
         string $path_string,
         int $path_integer,
         string $enum_nonref_string_path,
-        StringEnumRef $enum_ref_string_path,
+        \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path,
         string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): PromiseInterface
     {
@@ -321,7 +321,7 @@ class PathApi
      * @param  string $path_string (required)
      * @param  int $path_integer (required)
      * @param  string $enum_nonref_string_path (required)
-     * @param  StringEnumRef $enum_ref_string_path (required)
+     * @param  \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -380,7 +380,7 @@ class PathApi
      * @param  string $path_string (required)
      * @param  int $path_integer (required)
      * @param  string $enum_nonref_string_path (required)
-     * @param  StringEnumRef $enum_ref_string_path (required)
+     * @param  \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -156,7 +156,7 @@ class QueryApi
      * Test query parameter(s)
      *
      * @param  string|null $enum_nonref_string_query enum_nonref_string_query (optional)
-     * @param  StringEnumRef|null $enum_ref_string_query enum_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_query enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -165,7 +165,7 @@ class QueryApi
      */
     public function testEnumRefString(
         ?string $enum_nonref_string_query = null,
-        ?StringEnumRef $enum_ref_string_query = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): string
     {
@@ -179,7 +179,7 @@ class QueryApi
      * Test query parameter(s)
      *
      * @param  string|null $enum_nonref_string_query (optional)
-     * @param  StringEnumRef|null $enum_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -188,7 +188,7 @@ class QueryApi
      */
     public function testEnumRefStringWithHttpInfo(
         ?string $enum_nonref_string_query = null,
-        ?StringEnumRef $enum_ref_string_query = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): array
     {
@@ -308,7 +308,7 @@ class QueryApi
      * Test query parameter(s)
      *
      * @param  string|null $enum_nonref_string_query (optional)
-     * @param  StringEnumRef|null $enum_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -316,7 +316,7 @@ class QueryApi
      */
     public function testEnumRefStringAsync(
         ?string $enum_nonref_string_query = null,
-        ?StringEnumRef $enum_ref_string_query = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): PromiseInterface
     {
@@ -334,7 +334,7 @@ class QueryApi
      * Test query parameter(s)
      *
      * @param  string|null $enum_nonref_string_query (optional)
-     * @param  StringEnumRef|null $enum_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -389,7 +389,7 @@ class QueryApi
      * Create request for operation 'testEnumRefString'
      *
      * @param  string|null $enum_nonref_string_query (optional)
-     * @param  StringEnumRef|null $enum_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\StringEnumRef|null $enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -1206,7 +1206,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -1214,7 +1214,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleDeepObjectExplodeTrueObject(
-        ?Pet $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'][0]
     ): string
     {
@@ -1227,7 +1227,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -1235,7 +1235,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectWithHttpInfo(
-        ?Pet $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'][0]
     ): array
     {
@@ -1354,14 +1354,14 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAsync(
-        ?Pet $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'][0]
     ): PromiseInterface
     {
@@ -1378,7 +1378,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -1431,7 +1431,7 @@ class QueryApi
     /**
      * Create request for operation 'testQueryStyleDeepObjectExplodeTrueObject'
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -1523,7 +1523,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -1531,7 +1531,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAllOf(
-        ?TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'][0]
     ): string
     {
@@ -1544,7 +1544,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -1552,7 +1552,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAllOfWithHttpInfo(
-        ?TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'][0]
     ): array
     {
@@ -1671,14 +1671,14 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAllOfAsync(
-        ?TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'][0]
     ): PromiseInterface
     {
@@ -1695,7 +1695,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -1748,7 +1748,7 @@ class QueryApi
     /**
      * Create request for operation 'testQueryStyleDeepObjectExplodeTrueObjectAllOf'
      *
-     * @param  TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -2474,7 +2474,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueArrayString'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -2482,7 +2482,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeTrueArrayString(
-        ?TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueArrayString'][0]
     ): string
     {
@@ -2495,7 +2495,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueArrayString'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -2503,7 +2503,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeTrueArrayStringWithHttpInfo(
-        ?TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueArrayString'][0]
     ): array
     {
@@ -2622,14 +2622,14 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueArrayString'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeTrueArrayStringAsync(
-        ?TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueArrayString'][0]
     ): PromiseInterface
     {
@@ -2646,7 +2646,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueArrayString'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -2699,7 +2699,7 @@ class QueryApi
     /**
      * Create request for operation 'testQueryStyleFormExplodeTrueArrayString'
      *
-     * @param  TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueArrayString'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -2791,7 +2791,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -2799,7 +2799,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeTrueObject(
-        ?Pet $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObject'][0]
     ): string
     {
@@ -2812,7 +2812,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -2820,7 +2820,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeTrueObjectWithHttpInfo(
-        ?Pet $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObject'][0]
     ): array
     {
@@ -2939,14 +2939,14 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeTrueObjectAsync(
-        ?Pet $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObject'][0]
     ): PromiseInterface
     {
@@ -2963,7 +2963,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -3016,7 +3016,7 @@ class QueryApi
     /**
      * Create request for operation 'testQueryStyleFormExplodeTrueObject'
      *
-     * @param  Pet|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\Pet|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObject'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -3108,7 +3108,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  DataQuery|null $query_object query_object (optional)
+     * @param  \OpenAPI\Client\Model\DataQuery|null $query_object query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -3116,7 +3116,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeTrueObjectAllOf(
-        ?DataQuery $query_object = null,
+        ?\OpenAPI\Client\Model\DataQuery $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'][0]
     ): string
     {
@@ -3129,7 +3129,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  DataQuery|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\DataQuery|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -3137,7 +3137,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeTrueObjectAllOfWithHttpInfo(
-        ?DataQuery $query_object = null,
+        ?\OpenAPI\Client\Model\DataQuery $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'][0]
     ): array
     {
@@ -3256,14 +3256,14 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  DataQuery|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\DataQuery|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeTrueObjectAllOfAsync(
-        ?DataQuery $query_object = null,
+        ?\OpenAPI\Client\Model\DataQuery $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'][0]
     ): PromiseInterface
     {
@@ -3280,7 +3280,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
-     * @param  DataQuery|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\DataQuery|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
@@ -3333,7 +3333,7 @@ class QueryApi
     /**
      * Create request for operation 'testQueryStyleFormExplodeTrueObjectAllOf'
      *
-     * @param  DataQuery|null $query_object (optional)
+     * @param  \OpenAPI\Client\Model\DataQuery|null $query_object (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/README.md
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/README.md
@@ -74,6 +74,7 @@ Class | Method | HTTP request | Description
 *AnotherFakeApi* | [**call123TestSpecialTags**](docs/Api/AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
 *DefaultApi* | [**fooGet**](docs/Api/DefaultApi.md#fooget) | **GET** /foo | 
 *FakeApi* | [**fakeBigDecimalMap**](docs/Api/FakeApi.md#fakebigdecimalmap) | **GET** /fake/BigDecimalMap | 
+*FakeApi* | [**fakeEnumEndpoint**](docs/Api/FakeApi.md#fakeenumendpoint) | **GET** /fake/enum/endpoint | test endpoint with enum parameter
 *FakeApi* | [**fakeHealthGet**](docs/Api/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
 *FakeApi* | [**fakeHttpSignatureTest**](docs/Api/FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
 *FakeApi* | [**fakeOuterBooleanSerialize**](docs/Api/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -5,6 +5,7 @@ All URIs are relative to http://petstore.swagger.io:80/v2, except if the operati
 | Method | HTTP request | Description |
 | ------------- | ------------- | ------------- |
 | [**fakeBigDecimalMap()**](FakeApi.md#fakeBigDecimalMap) | **GET** /fake/BigDecimalMap |  |
+| [**fakeEnumEndpoint()**](FakeApi.md#fakeEnumEndpoint) | **GET** /fake/enum/endpoint | test endpoint with enum parameter |
 | [**fakeHealthGet()**](FakeApi.md#fakeHealthGet) | **GET** /fake/health | Health check endpoint |
 | [**fakeHttpSignatureTest()**](FakeApi.md#fakeHttpSignatureTest) | **GET** /fake/http-signature-test | test http signature authentication |
 | [**fakeOuterBooleanSerialize()**](FakeApi.md#fakeOuterBooleanSerialize) | **POST** /fake/outer/boolean |  |
@@ -76,6 +77,64 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: `*/*`
+
+[[Back to top]](#) [[Back to API list]](../../README.md#endpoints)
+[[Back to Model list]](../../README.md#models)
+[[Back to README]](../../README.md)
+
+## `fakeEnumEndpoint()`
+
+```php
+fakeEnumEndpoint($enum_class, $enum_class_array, $enum_class_map): \OpenAPI\Client\Model\EnumClass
+```
+
+test endpoint with enum parameter
+
+### Example
+
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+
+
+$apiInstance = new OpenAPI\Client\Api\FakeApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client()
+);
+$enum_class = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass(); // \OpenAPI\Client\Model\EnumClass | enum class parameter
+$enum_class_array = array(new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass()); // \OpenAPI\Client\Model\EnumClass[] | enum class parameter
+$enum_class_map = array('key' => new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass()); // array<string,\OpenAPI\Client\Model\EnumClass> | enum class parameter
+
+try {
+    $result = $apiInstance->fakeEnumEndpoint($enum_class, $enum_class_array, $enum_class_map);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling FakeApi->fakeEnumEndpoint: ', $e->getMessage(), PHP_EOL;
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
+| **enum_class** | [**\OpenAPI\Client\Model\EnumClass**](../Model/.md)| enum class parameter | |
+| **enum_class_array** | [**\OpenAPI\Client\Model\EnumClass[]**](../Model/\OpenAPI\Client\Model\EnumClass.md)| enum class parameter | |
+| **enum_class_map** | [**array<string,\OpenAPI\Client\Model\EnumClass>**](../Model/\OpenAPI\Client\Model\EnumClass.md)| enum class parameter | |
+
+### Return type
+
+[**\OpenAPI\Client\Model\EnumClass**](../Model/EnumClass.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: `application/json`
 
 [[Back to top]](#) [[Back to API list]](../../README.md#endpoints)
 [[Back to Model list]](../../README.md#models)

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -74,6 +74,9 @@ class FakeApi
         'fakeBigDecimalMap' => [
             'application/json',
         ],
+        'fakeEnumEndpoint' => [
+            'application/json',
+        ],
         'fakeHealthGet' => [
             'application/json',
         ],
@@ -424,6 +427,381 @@ class FakeApi
 
         $headers = $this->headerSelector->selectHeaders(
             ['*/*', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'GET',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation fakeEnumEndpoint
+     *
+     * test endpoint with enum parameter
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeEnumEndpoint'] to see the possible values for this operation
+     *
+     * @throws ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws InvalidArgumentException
+     * @return \OpenAPI\Client\Model\EnumClass
+     */
+    public function fakeEnumEndpoint(
+        \OpenAPI\Client\Model\EnumClass $enum_class,
+        array $enum_class_array,
+        array $enum_class_map,
+        string $contentType = self::contentTypes['fakeEnumEndpoint'][0]
+    ): \OpenAPI\Client\Model\EnumClass
+    {
+        list($response) = $this->fakeEnumEndpointWithHttpInfo($enum_class, $enum_class_array, $enum_class_map, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation fakeEnumEndpointWithHttpInfo
+     *
+     * test endpoint with enum parameter
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeEnumEndpoint'] to see the possible values for this operation
+     *
+     * @throws ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws InvalidArgumentException
+     * @return array of \OpenAPI\Client\Model\EnumClass, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function fakeEnumEndpointWithHttpInfo(
+        \OpenAPI\Client\Model\EnumClass $enum_class,
+        array $enum_class_array,
+        array $enum_class_map,
+        string $contentType = self::contentTypes['fakeEnumEndpoint'][0]
+    ): array
+    {
+        $request = $this->fakeEnumEndpointRequest($enum_class, $enum_class_array, $enum_class_map, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            switch($statusCode) {
+                case 200:
+                    if (in_array('\OpenAPI\Client\Model\EnumClass', ['\SplFileObject', '\Psr\Http\Message\StreamInterface'])) {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('\OpenAPI\Client\Model\EnumClass' !== 'string') {
+                            try {
+                                $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                            } catch (\JsonException $exception) {
+                                throw new ApiException(
+                                    sprintf(
+                                        'Error JSON decoding server response (%s)',
+                                        $request->getUri()
+                                    ),
+                                    $statusCode,
+                                    $response->getHeaders(),
+                                    $content
+                                );
+                            }
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\OpenAPI\Client\Model\EnumClass', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = '\OpenAPI\Client\Model\EnumClass';
+            if (in_array($returnType, ['\SplFileObject', '\Psr\Http\Message\StreamInterface'])) {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    try {
+                        $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                    } catch (\JsonException $exception) {
+                        throw new ApiException(
+                            sprintf(
+                                'Error JSON decoding server response (%s)',
+                                $request->getUri()
+                            ),
+                            $statusCode,
+                            $response->getHeaders(),
+                            $content
+                        );
+                    }
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\OpenAPI\Client\Model\EnumClass',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation fakeEnumEndpointAsync
+     *
+     * test endpoint with enum parameter
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeEnumEndpoint'] to see the possible values for this operation
+     *
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
+     */
+    public function fakeEnumEndpointAsync(
+        \OpenAPI\Client\Model\EnumClass $enum_class,
+        array $enum_class_array,
+        array $enum_class_map,
+        string $contentType = self::contentTypes['fakeEnumEndpoint'][0]
+    ): PromiseInterface
+    {
+        return $this->fakeEnumEndpointAsyncWithHttpInfo($enum_class, $enum_class_array, $enum_class_map, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation fakeEnumEndpointAsyncWithHttpInfo
+     *
+     * test endpoint with enum parameter
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeEnumEndpoint'] to see the possible values for this operation
+     *
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
+     */
+    public function fakeEnumEndpointAsyncWithHttpInfo(
+        $enum_class,
+        $enum_class_array,
+        $enum_class_map,
+        string $contentType = self::contentTypes['fakeEnumEndpoint'][0]
+    ): PromiseInterface
+    {
+        $returnType = '\OpenAPI\Client\Model\EnumClass';
+        $request = $this->fakeEnumEndpointRequest($enum_class, $enum_class_array, $enum_class_map, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if (in_array($returnType, ['\SplFileObject', '\Psr\Http\Message\StreamInterface'])) {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'fakeEnumEndpoint'
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeEnumEndpoint'] to see the possible values for this operation
+     *
+     * @throws InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    public function fakeEnumEndpointRequest(
+        $enum_class,
+        $enum_class_array,
+        $enum_class_map,
+        string $contentType = self::contentTypes['fakeEnumEndpoint'][0]
+    ): Request
+    {
+
+        // verify the required parameter 'enum_class' is set
+        if ($enum_class === null || (is_array($enum_class) && count($enum_class) === 0)) {
+            throw new InvalidArgumentException(
+                'Missing the required parameter $enum_class when calling fakeEnumEndpoint'
+            );
+        }
+
+        // verify the required parameter 'enum_class_array' is set
+        if ($enum_class_array === null || (is_array($enum_class_array) && count($enum_class_array) === 0)) {
+            throw new InvalidArgumentException(
+                'Missing the required parameter $enum_class_array when calling fakeEnumEndpoint'
+            );
+        }
+
+        // verify the required parameter 'enum_class_map' is set
+        if ($enum_class_map === null || (is_array($enum_class_map) && count($enum_class_map) === 0)) {
+            throw new InvalidArgumentException(
+                'Missing the required parameter $enum_class_map when calling fakeEnumEndpoint'
+            );
+        }
+
+
+        $resourcePath = '/fake/enum/endpoint';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $enum_class,
+            'enum-class', // param base name
+            'EnumClass', // openApiType
+            'form', // style
+            true, // explode
+            true // required
+        ) ?? []);
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $enum_class_array,
+            'enum-class-array', // param base name
+            'array', // openApiType
+            'form', // style
+            true, // explode
+            true // required
+        ) ?? []);
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $enum_class_map,
+            'enum-class-map', // param base name
+            'object', // openApiType
+            'form', // style
+            true, // explode
+            true // required
+        ) ?? []);
+
+
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
             $contentType,
             $multipart
         );

--- a/samples/client/petstore/php/OpenAPIClient-php/README.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/README.md
@@ -75,6 +75,7 @@ Class | Method | HTTP request | Description
 *AnotherFakeApi* | [**call123TestSpecialTags**](docs/Api/AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
 *DefaultApi* | [**fooGet**](docs/Api/DefaultApi.md#fooget) | **GET** /foo | 
 *FakeApi* | [**fakeBigDecimalMap**](docs/Api/FakeApi.md#fakebigdecimalmap) | **GET** /fake/BigDecimalMap | 
+*FakeApi* | [**fakeEnumEndpoint**](docs/Api/FakeApi.md#fakeenumendpoint) | **GET** /fake/enum/endpoint | test endpoint with enum parameter
 *FakeApi* | [**fakeHealthGet**](docs/Api/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
 *FakeApi* | [**fakeHttpSignatureTest**](docs/Api/FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
 *FakeApi* | [**fakeOuterBooleanSerialize**](docs/Api/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -5,6 +5,7 @@ All URIs are relative to http://petstore.swagger.io:80/v2, except if the operati
 | Method | HTTP request | Description |
 | ------------- | ------------- | ------------- |
 | [**fakeBigDecimalMap()**](FakeApi.md#fakeBigDecimalMap) | **GET** /fake/BigDecimalMap |  |
+| [**fakeEnumEndpoint()**](FakeApi.md#fakeEnumEndpoint) | **GET** /fake/enum/endpoint | test endpoint with enum parameter |
 | [**fakeHealthGet()**](FakeApi.md#fakeHealthGet) | **GET** /fake/health | Health check endpoint |
 | [**fakeHttpSignatureTest()**](FakeApi.md#fakeHttpSignatureTest) | **GET** /fake/http-signature-test | test http signature authentication |
 | [**fakeOuterBooleanSerialize()**](FakeApi.md#fakeOuterBooleanSerialize) | **POST** /fake/outer/boolean |  |
@@ -76,6 +77,64 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: `*/*`
+
+[[Back to top]](#) [[Back to API list]](../../README.md#endpoints)
+[[Back to Model list]](../../README.md#models)
+[[Back to README]](../../README.md)
+
+## `fakeEnumEndpoint()`
+
+```php
+fakeEnumEndpoint($enum_class, $enum_class_array, $enum_class_map): \OpenAPI\Client\Model\EnumClass
+```
+
+test endpoint with enum parameter
+
+### Example
+
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+
+
+$apiInstance = new OpenAPI\Client\Api\FakeApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client()
+);
+$enum_class = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass(); // \OpenAPI\Client\Model\EnumClass | enum class parameter
+$enum_class_array = array(new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass()); // \OpenAPI\Client\Model\EnumClass[] | enum class parameter
+$enum_class_map = array('key' => new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass()); // array<string,\OpenAPI\Client\Model\EnumClass> | enum class parameter
+
+try {
+    $result = $apiInstance->fakeEnumEndpoint($enum_class, $enum_class_array, $enum_class_map);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling FakeApi->fakeEnumEndpoint: ', $e->getMessage(), PHP_EOL;
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
+| **enum_class** | [**\OpenAPI\Client\Model\EnumClass**](../Model/.md)| enum class parameter | |
+| **enum_class_array** | [**\OpenAPI\Client\Model\EnumClass[]**](../Model/\OpenAPI\Client\Model\EnumClass.md)| enum class parameter | |
+| **enum_class_map** | [**array<string,\OpenAPI\Client\Model\EnumClass>**](../Model/\OpenAPI\Client\Model\EnumClass.md)| enum class parameter | |
+
+### Return type
+
+[**\OpenAPI\Client\Model\EnumClass**](../Model/EnumClass.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: `application/json`
 
 [[Back to top]](#) [[Back to API list]](../../README.md#endpoints)
 [[Back to Model list]](../../README.md#models)

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -74,6 +74,9 @@ class FakeApi
         'fakeBigDecimalMap' => [
             'application/json',
         ],
+        'fakeEnumEndpoint' => [
+            'application/json',
+        ],
         'fakeHealthGet' => [
             'application/json',
         ],
@@ -414,6 +417,356 @@ class FakeApi
 
         $headers = $this->headerSelector->selectHeaders(
             ['*/*', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'GET',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation fakeEnumEndpoint
+     *
+     * test endpoint with enum parameter
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeEnumEndpoint'] to see the possible values for this operation
+     *
+     * @throws \OpenAPI\Client\ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws \InvalidArgumentException
+     * @return \OpenAPI\Client\Model\EnumClass
+     */
+    public function fakeEnumEndpoint($enum_class, $enum_class_array, $enum_class_map, string $contentType = self::contentTypes['fakeEnumEndpoint'][0])
+    {
+        list($response) = $this->fakeEnumEndpointWithHttpInfo($enum_class, $enum_class_array, $enum_class_map, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation fakeEnumEndpointWithHttpInfo
+     *
+     * test endpoint with enum parameter
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeEnumEndpoint'] to see the possible values for this operation
+     *
+     * @throws \OpenAPI\Client\ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws \InvalidArgumentException
+     * @return array of \OpenAPI\Client\Model\EnumClass, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function fakeEnumEndpointWithHttpInfo($enum_class, $enum_class_array, $enum_class_map, string $contentType = self::contentTypes['fakeEnumEndpoint'][0])
+    {
+        $request = $this->fakeEnumEndpointRequest($enum_class, $enum_class_array, $enum_class_map, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            switch($statusCode) {
+                case 200:
+                    if ('\OpenAPI\Client\Model\EnumClass' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('\OpenAPI\Client\Model\EnumClass' !== 'string') {
+                            try {
+                                $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                            } catch (\JsonException $exception) {
+                                throw new ApiException(
+                                    sprintf(
+                                        'Error JSON decoding server response (%s)',
+                                        $request->getUri()
+                                    ),
+                                    $statusCode,
+                                    $response->getHeaders(),
+                                    $content
+                                );
+                            }
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\OpenAPI\Client\Model\EnumClass', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = '\OpenAPI\Client\Model\EnumClass';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    try {
+                        $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                    } catch (\JsonException $exception) {
+                        throw new ApiException(
+                            sprintf(
+                                'Error JSON decoding server response (%s)',
+                                $request->getUri()
+                            ),
+                            $statusCode,
+                            $response->getHeaders(),
+                            $content
+                        );
+                    }
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\OpenAPI\Client\Model\EnumClass',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation fakeEnumEndpointAsync
+     *
+     * test endpoint with enum parameter
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeEnumEndpoint'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function fakeEnumEndpointAsync($enum_class, $enum_class_array, $enum_class_map, string $contentType = self::contentTypes['fakeEnumEndpoint'][0])
+    {
+        return $this->fakeEnumEndpointAsyncWithHttpInfo($enum_class, $enum_class_array, $enum_class_map, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation fakeEnumEndpointAsyncWithHttpInfo
+     *
+     * test endpoint with enum parameter
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeEnumEndpoint'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function fakeEnumEndpointAsyncWithHttpInfo($enum_class, $enum_class_array, $enum_class_map, string $contentType = self::contentTypes['fakeEnumEndpoint'][0])
+    {
+        $returnType = '\OpenAPI\Client\Model\EnumClass';
+        $request = $this->fakeEnumEndpointRequest($enum_class, $enum_class_array, $enum_class_map, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'fakeEnumEndpoint'
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeEnumEndpoint'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    public function fakeEnumEndpointRequest($enum_class, $enum_class_array, $enum_class_map, string $contentType = self::contentTypes['fakeEnumEndpoint'][0])
+    {
+
+        // verify the required parameter 'enum_class' is set
+        if ($enum_class === null || (is_array($enum_class) && count($enum_class) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $enum_class when calling fakeEnumEndpoint'
+            );
+        }
+
+        // verify the required parameter 'enum_class_array' is set
+        if ($enum_class_array === null || (is_array($enum_class_array) && count($enum_class_array) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $enum_class_array when calling fakeEnumEndpoint'
+            );
+        }
+
+        // verify the required parameter 'enum_class_map' is set
+        if ($enum_class_map === null || (is_array($enum_class_map) && count($enum_class_map) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $enum_class_map when calling fakeEnumEndpoint'
+            );
+        }
+
+
+        $resourcePath = '/fake/enum/endpoint';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $enum_class,
+            'enum-class', // param base name
+            'EnumClass', // openApiType
+            'form', // style
+            true, // explode
+            true // required
+        ) ?? []);
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $enum_class_array,
+            'enum-class-array', // param base name
+            'array', // openApiType
+            'form', // style
+            true, // explode
+            true // required
+        ) ?? []);
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $enum_class_map,
+            'enum-class-map', // param base name
+            'object', // openApiType
+            'form', // style
+            true, // explode
+            true // required
+        ) ?? []);
+
+
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
             $contentType,
             $multipart
         );

--- a/samples/client/petstore/php/psr-18/README.md
+++ b/samples/client/petstore/php/psr-18/README.md
@@ -86,6 +86,7 @@ Class | Method | HTTP request | Description
 *AnotherFakeApi* | [**call123TestSpecialTags**](docs/Api/AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
 *DefaultApi* | [**fooGet**](docs/Api/DefaultApi.md#fooget) | **GET** /foo | 
 *FakeApi* | [**fakeBigDecimalMap**](docs/Api/FakeApi.md#fakebigdecimalmap) | **GET** /fake/BigDecimalMap | 
+*FakeApi* | [**fakeEnumEndpoint**](docs/Api/FakeApi.md#fakeenumendpoint) | **GET** /fake/enum/endpoint | test endpoint with enum parameter
 *FakeApi* | [**fakeHealthGet**](docs/Api/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
 *FakeApi* | [**fakeHttpSignatureTest**](docs/Api/FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
 *FakeApi* | [**fakeOuterBooleanSerialize**](docs/Api/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 

--- a/samples/client/petstore/php/psr-18/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/psr-18/docs/Api/FakeApi.md
@@ -5,6 +5,7 @@ All URIs are relative to http://petstore.swagger.io:80/v2.
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**fakeBigDecimalMap()**](FakeApi.md#fakeBigDecimalMap) | **GET** /fake/BigDecimalMap | 
+[**fakeEnumEndpoint()**](FakeApi.md#fakeEnumEndpoint) | **GET** /fake/enum/endpoint | test endpoint with enum parameter
 [**fakeHealthGet()**](FakeApi.md#fakeHealthGet) | **GET** /fake/health | Health check endpoint
 [**fakeHttpSignatureTest()**](FakeApi.md#fakeHttpSignatureTest) | **GET** /fake/http-signature-test | test http signature authentication
 [**fakeOuterBooleanSerialize()**](FakeApi.md#fakeOuterBooleanSerialize) | **POST** /fake/outer/boolean | 
@@ -76,6 +77,64 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: `*/*`
+
+[[Back to top]](#) [[Back to API list]](../../README.md#endpoints)
+[[Back to Model list]](../../README.md#models)
+[[Back to README]](../../README.md)
+
+## `fakeEnumEndpoint()`
+
+```php
+fakeEnumEndpoint($enum_class, $enum_class_array, $enum_class_map): \OpenAPI\Client\Model\EnumClass
+```
+
+test endpoint with enum parameter
+
+### Example
+
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+
+
+$apiInstance = new OpenAPI\Client\Api\FakeApi(
+    // If you want use custom http client, pass your client which implements `Psr\Http\Client\ClientInterface`.
+    // This is optional, `Psr18ClientDiscovery` will be used to find http client. For instance `GuzzleHttp\Client` implements that interface
+    new GuzzleHttp\Client()
+);
+$enum_class = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass(); // \OpenAPI\Client\Model\EnumClass | enum class parameter
+$enum_class_array = array(new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass()); // \OpenAPI\Client\Model\EnumClass[] | enum class parameter
+$enum_class_map = array('key' => new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass()); // array<string,\OpenAPI\Client\Model\EnumClass> | enum class parameter
+
+try {
+    $result = $apiInstance->fakeEnumEndpoint($enum_class, $enum_class_array, $enum_class_map);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling FakeApi->fakeEnumEndpoint: ', $e->getMessage(), PHP_EOL;
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **enum_class** | [**\OpenAPI\Client\Model\EnumClass**](../Model/.md)| enum class parameter |
+ **enum_class_array** | [**\OpenAPI\Client\Model\EnumClass[]**](../Model/\OpenAPI\Client\Model\EnumClass.md)| enum class parameter |
+ **enum_class_map** | [**array<string,\OpenAPI\Client\Model\EnumClass>**](../Model/\OpenAPI\Client\Model\EnumClass.md)| enum class parameter |
+
+### Return type
+
+[**\OpenAPI\Client\Model\EnumClass**](../Model/EnumClass.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: `application/json`
 
 [[Back to top]](#) [[Back to API list]](../../README.md#endpoints)
 [[Back to Model list]](../../README.md#models)

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
@@ -400,6 +400,307 @@ class FakeApi
     }
 
     /**
+     * Operation fakeEnumEndpoint
+     *
+     * test endpoint with enum parameter
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     *
+     * @throws \OpenAPI\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return \OpenAPI\Client\Model\EnumClass
+     */
+    public function fakeEnumEndpoint($enum_class, $enum_class_array, $enum_class_map)
+    {
+        list($response) = $this->fakeEnumEndpointWithHttpInfo($enum_class, $enum_class_array, $enum_class_map);
+        return $response;
+    }
+
+    /**
+     * Operation fakeEnumEndpointWithHttpInfo
+     *
+     * test endpoint with enum parameter
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     *
+     * @throws \OpenAPI\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of \OpenAPI\Client\Model\EnumClass, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function fakeEnumEndpointWithHttpInfo($enum_class, $enum_class_array, $enum_class_map)
+    {
+        $request = $this->fakeEnumEndpointRequest($enum_class, $enum_class_array, $enum_class_map);
+
+        try {
+            try {
+                $response = $this->httpClient->sendRequest($request);
+            } catch (HttpException $e) {
+                $response = $e->getResponse();
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $response->getStatusCode(),
+                        (string) $request->getUri()
+                    ),
+                    $request,
+                    $response,
+                    $e
+                );
+            } catch (ClientExceptionInterface $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    $request,
+                    null,
+                    $e
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            switch($statusCode) {
+                case 200:
+                    if ('\OpenAPI\Client\Model\EnumClass' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\OpenAPI\Client\Model\EnumClass', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = '\OpenAPI\Client\Model\EnumClass';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\OpenAPI\Client\Model\EnumClass',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation fakeEnumEndpointAsync
+     *
+     * test endpoint with enum parameter
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return Promise
+     */
+    public function fakeEnumEndpointAsync($enum_class, $enum_class_array, $enum_class_map)
+    {
+        return $this->fakeEnumEndpointAsyncWithHttpInfo($enum_class, $enum_class_array, $enum_class_map)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation fakeEnumEndpointAsyncWithHttpInfo
+     *
+     * test endpoint with enum parameter
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return Promise
+     */
+    public function fakeEnumEndpointAsyncWithHttpInfo($enum_class, $enum_class_array, $enum_class_map)
+    {
+        $returnType = '\OpenAPI\Client\Model\EnumClass';
+        $request = $this->fakeEnumEndpointRequest($enum_class, $enum_class_array, $enum_class_map);
+
+        return $this->httpAsyncClient->sendAsyncRequest($request)
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function (HttpException $exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $exception->getRequest(),
+                        $exception->getResponse(),
+                        $exception
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'fakeEnumEndpoint'
+     *
+     * @param  \OpenAPI\Client\Model\EnumClass $enum_class enum class parameter (required)
+     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_class_array enum class parameter (required)
+     * @param  array<string,\OpenAPI\Client\Model\EnumClass> $enum_class_map enum class parameter (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return RequestInterface
+     */
+    public function fakeEnumEndpointRequest($enum_class, $enum_class_array, $enum_class_map)
+    {
+        // verify the required parameter 'enum_class' is set
+        if ($enum_class === null || (is_array($enum_class) && count($enum_class) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $enum_class when calling fakeEnumEndpoint'
+            );
+        }
+        // verify the required parameter 'enum_class_array' is set
+        if ($enum_class_array === null || (is_array($enum_class_array) && count($enum_class_array) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $enum_class_array when calling fakeEnumEndpoint'
+            );
+        }
+        // verify the required parameter 'enum_class_map' is set
+        if ($enum_class_map === null || (is_array($enum_class_map) && count($enum_class_map) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $enum_class_map when calling fakeEnumEndpoint'
+            );
+        }
+
+        $resourcePath = '/fake/enum/endpoint';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = null;
+        $multipart = false;
+
+        // query params
+        if ($enum_class !== null) {
+            if('form' === 'form' && is_array($enum_class)) {
+                foreach($enum_class as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['enum-class'] = $enum_class;
+            }
+        }
+        // query params
+        if ($enum_class_array !== null) {
+            if('form' === 'form' && is_array($enum_class_array)) {
+                foreach($enum_class_array as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['enum-class-array'] = $enum_class_array;
+            }
+        }
+        // query params
+        if ($enum_class_map !== null) {
+            if('form' === 'form' && is_array($enum_class_map)) {
+                foreach($enum_class_map as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['enum-class-map'] = $enum_class_map;
+            }
+        }
+
+
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json'],
+            '',
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = json_encode($formParams);
+
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+
+        $uri = $this->createUri($operationHost, $resourcePath, $queryParams);
+
+        return $this->createRequest('GET', $uri, $headers, $httpBody);
+    }
+
+    /**
      * Operation fakeHealthGet
      *
      * Health check endpoint


### PR DESCRIPTION
If you have an endpoint that takes a single instance of an enum as a parameter, its Qualifier (e.g. \OpenAPI\Client\Model) is missing in both the PHPDoc and the function parameter types. This PR fixes that. (See [this method in the echo_api](https://github.com/OpenAPITools/openapi-generator/compare/master...JulianVennen:php-nextgen-imports?expand=1#diff-923b9e098e2ef9b0ceac697463aea0ed6daabf653afcd7bb76fd910009d2df68) for an example).
This PR fixes that by adding an override for getParameterDataType in the AbstractPHPGenerator.

For [some documentation files](https://github.com/OpenAPITools/openapi-generator/compare/master...JulianVennen:php-nextgen-imports?expand=1#diff-767f5a48a015abb767a1fad9e304a3dd2e840a0314da23f451111be94ae11657R514) this causes a duplicated qualifier, but I am pretty sure this happens because these classes do not have a baseType (that is used in the generator when setting the example value). This can also be seen because the link to the documentation file for these models (in the table following it) is just `../Model/.md` which is generated from `../Model/{{baseType}}.md`.
For enum arrays and maps, this duplicated qualifier already exists before the changes I made.
I was not able to figure out what would cause this to be null/empty, but it seems unrelated to this PR.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon