### PR TITLE
[php-symfony] Fix enum not serialized with value like '0'

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/model_generic.mustache
@@ -52,7 +52,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}
     */
     public function getSerialized{{nameInPascalCase}}(): string|null
     {
-        return $this->{{name}}?->value ? (string) $this->{{name}}->value : null;
+        return !is_null($this->{{name}}?->value) ? (string) $this->{{name}}->value : null;
     }
 
     /**


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR fixes #19562. I did run the scripts to regenerate the samples, but it appears there is no symfony sample that triggers this code path.

I decided to use `!is_null(...)` instead of the suggested `is_string(...)` because that would break all integer enums.
Both `is_null` and `is_string` would cause a PHP warning if the variable was not set, but I think we can ignore that since it is always set to the default value or null (if no default value exists) in the template.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon
