### PR TITLE
Implemented missing definitions of declared methods inside modelbase-header.mustache, added two missing body of methods definitions

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-header.mustache
@@ -255,7 +255,7 @@ bool ModelBase::fromString( const utility::string_t& val, std::shared_ptr<T>& ou
     bool ok = false;
     if(outVal == nullptr)
     {
-        outVal = std::shared_ptr<T>(new T());
+        outVal = std::make_shared<T>();
     }
     if( outVal != nullptr )
     {
@@ -335,7 +335,7 @@ bool ModelBase::fromJson( const web::json::value& val, std::shared_ptr<T> &outVa
     bool ok = false;
     if(outVal == nullptr)
     {
-        outVal = std::shared_ptr<T>(new T());
+        outVal = std::make_shared<T>();
     }
     if( outVal != nullptr )
     {
@@ -406,13 +406,13 @@ bool ModelBase::fromJson( const web::json::value& jval, std::map<utility::string
 template <typename T>
 std::shared_ptr<HttpContent> ModelBase::toHttpContent(const utility::string_t& name, const std::shared_ptr<T>& value , const utility::string_t& contentType )
 {
-    std::shared_ptr<HttpContent> content( new HttpContent );
+    std::shared_ptr<HttpContent> content = std::make_shared<HttpContent>();
     if (value != nullptr )
     {
         content->setName( name );
         content->setContentDisposition( utility::conversions::to_string_t("form-data") );
         content->setContentType( contentType );
-        content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string( value->toJson().serialize() ) ) ) );
+        content->setData( std::make_shared<std::stringstream>( utility::conversions::to_utf8string(value->toJson().serialize()) ) );
     }
     return content;
 }
@@ -421,33 +421,33 @@ template <typename T>
 std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& name, const std::vector<T>& value, const utility::string_t& contentType )
 {
     web::json::value json_array = ModelBase::toJson(value);
-    std::shared_ptr<HttpContent> content( new HttpContent );
+    std::shared_ptr<HttpContent> content = std::make_shared<HttpContent>();
     content->setName( name );
     content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
-    content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(json_array.serialize()) ) ) );
+    content->setData( std::make_shared<std::stringstream>( utility::conversions::to_utf8string(json_array.serialize()) ) );
     return content;
 }
 template <typename T>
 std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& name, const std::set<T>& value, const utility::string_t& contentType )
 {
     web::json::value json_array = ModelBase::toJson(value);
-    std::shared_ptr<HttpContent> content(new HttpContent);
+    std::shared_ptr<HttpContent> content = std::make_shared<HttpContent>();
     content->setName(name);
     content->setContentDisposition(utility::conversions::to_string_t("form-data"));
     content->setContentType(contentType);
-    content->setData(std::shared_ptr<std::istream>(new std::stringstream(utility::conversions::to_utf8string(json_array.serialize()))));
+    content->setData( std::make_shared<std::stringstream>( utility::conversions::to_utf8string(json_array.serialize()) ) );
     return content;
 }
 template <typename T>
 std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& name, const std::map<utility::string_t, T>& value, const utility::string_t& contentType )
 {
     web::json::value jobj = ModelBase::toJson(value);
-    std::shared_ptr<HttpContent> content( new HttpContent );
+    std::shared_ptr<HttpContent> content = std::make_shared<HttpContent>();
     content->setName( name );
     content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
-    content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(jobj.serialize()) ) ) );
+    content->setData( std::make_shared<std::stringstream>( utility::conversions::to_utf8string(jobj.serialize()) ) );
     return content;
 }
 template <typename T>
@@ -457,7 +457,7 @@ bool ModelBase::fromHttpContent( std::shared_ptr<HttpContent> val,  std::shared_
     if(val == nullptr) return false;
     if( outVal == nullptr )
     {
-        outVal = std::shared_ptr<T>(new T());
+        outVal = std::make_shared<T>();
     }
     ModelBase::fromHttpContent(val, str);
     return fromString(str, outVal);

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-header.mustache
@@ -264,6 +264,72 @@ bool ModelBase::fromString( const utility::string_t& val, std::shared_ptr<T>& ou
     return ok;
 }
 template<typename T>
+bool ModelBase::fromString(const utility::string_t& val, std::vector<T>& outVal )
+{
+    bool ok = true;
+    web::json::value jsonValue = web::json::value::parse(val);
+    if (jsonValue.is_array())
+    {
+        for (const web::json::value& jitem : jsonValue.as_array())
+        {
+            T item;
+            ok &= fromJson(jitem, item);
+            outVal.push_back(item);
+        }
+    }
+    else
+    {
+        T item;
+        ok = fromJson(jsonValue, item);
+        outVal.push_back(item);
+    }
+    return ok;
+}
+template<typename T>
+bool ModelBase::fromString(const utility::string_t& val, std::set<T>& outVal )
+{
+    bool ok = true;
+    web::json::value jsonValue = web::json::value::parse(val);
+    if (jsonValue.is_array())
+    {
+        for (const web::json::value& jitem : jsonValue.as_array())
+        {
+            T item;
+            ok &= fromJson(jitem, item);
+            outVal.insert(item);
+        }
+    }
+    else
+    {
+        T item;
+        ok = fromJson(jsonValue, item);
+        outVal.insert(item);
+    }
+    return ok;
+}
+template<typename T>
+bool ModelBase::fromString(const utility::string_t& val, std::map<utility::string_t, T>& outVal )
+{
+    bool ok = false;
+    web::json::value jsonValue = web::json::value::parse(val);
+    if (jsonValue.is_array())
+    {
+        for (const web::json::value& jitem : jsonValue.as_array())
+        {
+            T item;
+            ok &= fromJson(jitem, item);
+            outVal.insert({ val, item });
+        }
+    }
+    else
+    {
+        T item;
+        ok = fromJson(jsonValue, item);
+        outVal.insert({ val, item });
+    }
+    return ok;
+}
+template<typename T>
 bool ModelBase::fromJson( const web::json::value& val, std::shared_ptr<T> &outVal )
 {
     bool ok = false;
@@ -293,6 +359,27 @@ bool ModelBase::fromJson( const web::json::value& val, std::vector<T> &outVal )
     else
     {
         ok = false;
+    }
+    return ok;
+}
+template<typename T>
+bool ModelBase::fromJson(const web::json::value& val, std::set<T>& outVal )
+{
+    bool ok = true;
+    if (val.is_array())
+    {
+        for (const web::json::value& jitem : val.as_array())
+        {
+            T item;
+            ok &= fromJson(jitem, item);
+            outVal.insert(item);
+        }
+    }
+    else
+    {
+        T item;
+        ok = fromJson(val, item);
+        outVal.insert(item);
     }
     return ok;
 }
@@ -341,7 +428,17 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
     content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(json_array.serialize()) ) ) );
     return content;
 }
-
+template <typename T>
+std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& name, const std::set<T>& value, const utility::string_t& contentType )
+{
+    web::json::value json_array = ModelBase::toJson(value);
+    std::shared_ptr<HttpContent> content(new HttpContent);
+    content->setName(name);
+    content->setContentDisposition(utility::conversions::to_string_t("form-data"));
+    content->setContentType(contentType);
+    content->setData(std::shared_ptr<std::istream>(new std::stringstream(utility::conversions::to_utf8string(json_array.serialize()))));
+    return content;
+}
 template <typename T>
 std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& name, const std::map<utility::string_t, T>& value, const utility::string_t& contentType )
 {
@@ -366,14 +463,28 @@ bool ModelBase::fromHttpContent( std::shared_ptr<HttpContent> val,  std::shared_
     return fromString(str, outVal);
 }
 template <typename T>
-bool ModelBase::fromHttpContent( std::shared_ptr<HttpContent> val, std::vector<T> & )
+bool ModelBase::fromHttpContent( std::shared_ptr<HttpContent> val, std::vector<T> & outVal )
 {
-    return true;
+    utility::string_t str;
+    if (val == nullptr) return false;
+    ModelBase::fromHttpContent(val, str);
+    return fromString(str, outVal);
 }
 template <typename T>
-bool ModelBase::fromHttpContent( std::shared_ptr<HttpContent> val, std::map<utility::string_t, T> & )
+bool ModelBase::fromHttpContent(std::shared_ptr<HttpContent> val, std::set<T>& outVal )
 {
-    return true;
+    utility::string_t str;
+    if (val == nullptr) return false;
+    ModelBase::fromHttpContent(val, str);
+    return fromString(str, outVal);
+}
+template <typename T>
+bool ModelBase::fromHttpContent( std::shared_ptr<HttpContent> val, std::map<utility::string_t, T> & outVal )
+{
+    utility::string_t str;
+    if (val == nullptr) return false;
+    ModelBase::fromHttpContent(val, str);
+    return fromString(str, outVal);
 }
 {{#modelNamespaceDeclarations}}
 }

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/ModelBase.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/ModelBase.h
@@ -266,7 +266,7 @@ bool ModelBase::fromString( const utility::string_t& val, std::shared_ptr<T>& ou
     bool ok = false;
     if(outVal == nullptr)
     {
-        outVal = std::shared_ptr<T>(new T());
+        outVal = std::make_shared<T>();
     }
     if( outVal != nullptr )
     {
@@ -346,7 +346,7 @@ bool ModelBase::fromJson( const web::json::value& val, std::shared_ptr<T> &outVa
     bool ok = false;
     if(outVal == nullptr)
     {
-        outVal = std::shared_ptr<T>(new T());
+        outVal = std::make_shared<T>();
     }
     if( outVal != nullptr )
     {
@@ -417,13 +417,13 @@ bool ModelBase::fromJson( const web::json::value& jval, std::map<utility::string
 template <typename T>
 std::shared_ptr<HttpContent> ModelBase::toHttpContent(const utility::string_t& name, const std::shared_ptr<T>& value , const utility::string_t& contentType )
 {
-    std::shared_ptr<HttpContent> content( new HttpContent );
+    std::shared_ptr<HttpContent> content = std::make_shared<HttpContent>();
     if (value != nullptr )
     {
         content->setName( name );
         content->setContentDisposition( utility::conversions::to_string_t("form-data") );
         content->setContentType( contentType );
-        content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string( value->toJson().serialize() ) ) ) );
+        content->setData( std::make_shared<std::stringstream>( utility::conversions::to_utf8string(value->toJson().serialize()) ) );
     }
     return content;
 }
@@ -432,33 +432,33 @@ template <typename T>
 std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& name, const std::vector<T>& value, const utility::string_t& contentType )
 {
     web::json::value json_array = ModelBase::toJson(value);
-    std::shared_ptr<HttpContent> content( new HttpContent );
+    std::shared_ptr<HttpContent> content = std::make_shared<HttpContent>();
     content->setName( name );
     content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
-    content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(json_array.serialize()) ) ) );
+    content->setData( std::make_shared<std::stringstream>( utility::conversions::to_utf8string(json_array.serialize()) ) );
     return content;
 }
 template <typename T>
 std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& name, const std::set<T>& value, const utility::string_t& contentType )
 {
     web::json::value json_array = ModelBase::toJson(value);
-    std::shared_ptr<HttpContent> content(new HttpContent);
+    std::shared_ptr<HttpContent> content = std::make_shared<HttpContent>();
     content->setName(name);
     content->setContentDisposition(utility::conversions::to_string_t("form-data"));
     content->setContentType(contentType);
-    content->setData(std::shared_ptr<std::istream>(new std::stringstream(utility::conversions::to_utf8string(json_array.serialize()))));
+    content->setData( std::make_shared<std::stringstream>( utility::conversions::to_utf8string(json_array.serialize()) ) );
     return content;
 }
 template <typename T>
 std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& name, const std::map<utility::string_t, T>& value, const utility::string_t& contentType )
 {
     web::json::value jobj = ModelBase::toJson(value);
-    std::shared_ptr<HttpContent> content( new HttpContent );
+    std::shared_ptr<HttpContent> content = std::make_shared<HttpContent>();
     content->setName( name );
     content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
-    content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(jobj.serialize()) ) ) );
+    content->setData( std::make_shared<std::stringstream>( utility::conversions::to_utf8string(jobj.serialize()) ) );
     return content;
 }
 template <typename T>
@@ -468,7 +468,7 @@ bool ModelBase::fromHttpContent( std::shared_ptr<HttpContent> val,  std::shared_
     if(val == nullptr) return false;
     if( outVal == nullptr )
     {
-        outVal = std::shared_ptr<T>(new T());
+        outVal = std::make_shared<T>();
     }
     ModelBase::fromHttpContent(val, str);
     return fromString(str, outVal);

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/ModelBase.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/ModelBase.h
@@ -275,6 +275,72 @@ bool ModelBase::fromString( const utility::string_t& val, std::shared_ptr<T>& ou
     return ok;
 }
 template<typename T>
+bool ModelBase::fromString(const utility::string_t& val, std::vector<T>& outVal )
+{
+    bool ok = true;
+    web::json::value jsonValue = web::json::value::parse(val);
+    if (jsonValue.is_array())
+    {
+        for (const web::json::value& jitem : jsonValue.as_array())
+        {
+            T item;
+            ok &= fromJson(jitem, item);
+            outVal.push_back(item);
+        }
+    }
+    else
+    {
+        T item;
+        ok = fromJson(jsonValue, item);
+        outVal.push_back(item);
+    }
+    return ok;
+}
+template<typename T>
+bool ModelBase::fromString(const utility::string_t& val, std::set<T>& outVal )
+{
+    bool ok = true;
+    web::json::value jsonValue = web::json::value::parse(val);
+    if (jsonValue.is_array())
+    {
+        for (const web::json::value& jitem : jsonValue.as_array())
+        {
+            T item;
+            ok &= fromJson(jitem, item);
+            outVal.insert(item);
+        }
+    }
+    else
+    {
+        T item;
+        ok = fromJson(jsonValue, item);
+        outVal.insert(item);
+    }
+    return ok;
+}
+template<typename T>
+bool ModelBase::fromString(const utility::string_t& val, std::map<utility::string_t, T>& outVal )
+{
+    bool ok = false;
+    web::json::value jsonValue = web::json::value::parse(val);
+    if (jsonValue.is_array())
+    {
+        for (const web::json::value& jitem : jsonValue.as_array())
+        {
+            T item;
+            ok &= fromJson(jitem, item);
+            outVal.insert({ val, item });
+        }
+    }
+    else
+    {
+        T item;
+        ok = fromJson(jsonValue, item);
+        outVal.insert({ val, item });
+    }
+    return ok;
+}
+template<typename T>
 bool ModelBase::fromJson( const web::json::value& val, std::shared_ptr<T> &outVal )
 {
     bool ok = false;
@@ -304,6 +370,27 @@ bool ModelBase::fromJson( const web::json::value& val, std::vector<T> &outVal )
     else
     {
         ok = false;
+    }
+    return ok;
+}
+template<typename T>
+bool ModelBase::fromJson(const web::json::value& val, std::set<T>& outVal )
+{
+    bool ok = true;
+    if (val.is_array())
+    {
+        for (const web::json::value& jitem : val.as_array())
+        {
+            T item;
+            ok &= fromJson(jitem, item);
+            outVal.insert(item);
+        }
+    }
+    else
+    {
+        T item;
+        ok = fromJson(val, item);
+        outVal.insert(item);
     }
     return ok;
 }
@@ -352,7 +439,17 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
     content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(json_array.serialize()) ) ) );
     return content;
 }
-
+template <typename T>
+std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& name, const std::set<T>& value, const utility::string_t& contentType )
+{
+    web::json::value json_array = ModelBase::toJson(value);
+    std::shared_ptr<HttpContent> content(new HttpContent);
+    content->setName(name);
+    content->setContentDisposition(utility::conversions::to_string_t("form-data"));
+    content->setContentType(contentType);
+    content->setData(std::shared_ptr<std::istream>(new std::stringstream(utility::conversions::to_utf8string(json_array.serialize()))));
+    return content;
+}
 template <typename T>
 std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& name, const std::map<utility::string_t, T>& value, const utility::string_t& contentType )
 {
@@ -377,14 +474,28 @@ bool ModelBase::fromHttpContent( std::shared_ptr<HttpContent> val,  std::shared_
     return fromString(str, outVal);
 }
 template <typename T>
-bool ModelBase::fromHttpContent( std::shared_ptr<HttpContent> val, std::vector<T> & )
+bool ModelBase::fromHttpContent( std::shared_ptr<HttpContent> val, std::vector<T> & outVal )
 {
-    return true;
+    utility::string_t str;
+    if (val == nullptr) return false;
+    ModelBase::fromHttpContent(val, str);
+    return fromString(str, outVal);
 }
 template <typename T>
-bool ModelBase::fromHttpContent( std::shared_ptr<HttpContent> val, std::map<utility::string_t, T> & )
+bool ModelBase::fromHttpContent(std::shared_ptr<HttpContent> val, std::set<T>& outVal )
 {
-    return true;
+    utility::string_t str;
+    if (val == nullptr) return false;
+    ModelBase::fromHttpContent(val, str);
+    return fromString(str, outVal);
+}
+template <typename T>
+bool ModelBase::fromHttpContent( std::shared_ptr<HttpContent> val, std::map<utility::string_t, T> & outVal )
+{
+    utility::string_t str;
+    if (val == nullptr) return false;
+    ModelBase::fromHttpContent(val, str);
+    return fromString(str, outVal);
 }
 }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fix #19566 implemented missing definitions of declared methods inside [modelbase-header.mustache](modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-header.mustache) for the cpp-rest-sdk-client
I have also added two missing body of methods definitions

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@ravinikam @stkrwork @etherealjoy @MartinDelille @muttleyxd 