### PR TITLE
[typescript-axios] fix: enum datatype jsdoc (#19570)

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelEnum.mustache
@@ -1,7 +1,7 @@
 /**
  * {{{description}}}
  * @export
- * @enum {string}
+ * @enum {{=<% %>=}}{<%&dataType%>}<%={{ }}=%>
  */
 {{#isBoolean}}
 export type {{classname}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}}

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
@@ -1322,7 +1322,7 @@ export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof Ou
 /**
  * 
  * @export
- * @enum {string}
+ * @enum {number}
  */
 
 export const OuterEnumInteger = {
@@ -1337,7 +1337,7 @@ export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInt
 /**
  * 
  * @export
- * @enum {string}
+ * @enum {number}
  */
 
 export const OuterEnumIntegerDefaultValue = {

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
@@ -1009,7 +1009,7 @@ export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof Ou
 /**
  * 
  * @export
- * @enum {string}
+ * @enum {number}
  */
 
 export const OuterEnumInteger = {
@@ -1024,7 +1024,7 @@ export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInt
 /**
  * 
  * @export
- * @enum {string}
+ * @enum {number}
  */
 
 export const OuterEnumIntegerDefaultValue = {


### PR DESCRIPTION
fix: https://github.com/OpenAPITools/openapi-generator/issues/19570

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
