### PR TITLE
[Java] [apache-httpclient] Fix issue with toString causing wrong value with collections

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/api.mustache
@@ -99,7 +99,7 @@ public class {{classname}} extends BaseApi {
     {{/required}}{{/allParams}}
     // create path and map variables
     String localVarPath = "{{{path}}}"{{#pathParams}}
-      .replaceAll("\\{" + "{{baseName}}" + "\\}", apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+      .replaceAll("\\{" + "{{baseName}}" + "\\}", apiClient.escapeString(apiClient.parameterToString({{{paramName}}}))){{/pathParams}};
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/PathApi.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/PathApi.java
@@ -92,10 +92,10 @@ public class PathApi extends BaseApi {
     
     // create path and map variables
     String localVarPath = "/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}"
-      .replaceAll("\\{" + "path_string" + "\\}", apiClient.escapeString(pathString.toString()))
-      .replaceAll("\\{" + "path_integer" + "\\}", apiClient.escapeString(pathInteger.toString()))
-      .replaceAll("\\{" + "enum_nonref_string_path" + "\\}", apiClient.escapeString(enumNonrefStringPath.toString()))
-      .replaceAll("\\{" + "enum_ref_string_path" + "\\}", apiClient.escapeString(enumRefStringPath.toString()));
+      .replaceAll("\\{" + "path_string" + "\\}", apiClient.escapeString(apiClient.parameterToString(pathString)))
+      .replaceAll("\\{" + "path_integer" + "\\}", apiClient.escapeString(apiClient.parameterToString(pathInteger)))
+      .replaceAll("\\{" + "enum_nonref_string_path" + "\\}", apiClient.escapeString(apiClient.parameterToString(enumNonrefStringPath)))
+      .replaceAll("\\{" + "enum_ref_string_path" + "\\}", apiClient.escapeString(apiClient.parameterToString(enumRefStringPath)));
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/api/PetApi.java
@@ -145,7 +145,7 @@ public class PetApi extends BaseApi {
     
     // create path and map variables
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;
@@ -375,7 +375,7 @@ public class PetApi extends BaseApi {
     
     // create path and map variables
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;
@@ -523,7 +523,7 @@ public class PetApi extends BaseApi {
     
     // create path and map variables
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;
@@ -605,7 +605,7 @@ if (status != null)
     
     // create path and map variables
     String localVarPath = "/pet/{petId}/uploadImage"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;
@@ -693,7 +693,7 @@ if (_file != null)
     
     // create path and map variables
     String localVarPath = "/fake/{petId}/uploadImageWithRequiredFile"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -69,7 +69,7 @@ public class StoreApi extends BaseApi {
     
     // create path and map variables
     String localVarPath = "/store/order/{order_id}"
-      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(apiClient.parameterToString(orderId)));
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;
@@ -210,7 +210,7 @@ public class StoreApi extends BaseApi {
     
     // create path and map variables
     String localVarPath = "/store/order/{order_id}"
-      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(apiClient.parameterToString(orderId)));
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/api/UserApi.java
@@ -283,7 +283,7 @@ public class UserApi extends BaseApi {
     
     // create path and map variables
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(apiClient.parameterToString(username)));
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;
@@ -357,7 +357,7 @@ public class UserApi extends BaseApi {
     
     // create path and map variables
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(apiClient.parameterToString(username)));
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;
@@ -584,7 +584,7 @@ public class UserApi extends BaseApi {
     
     // create path and map variables
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(apiClient.parameterToString(username)));
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;


### PR DESCRIPTION
With collections, calling toString will result in the value becoming [a,b] instead of just a,b.

Using the existing apiClient::parameterToString method ensures it gets parsed correctly if it is a collection

---

Currently apache-httpclient does not comply with OAS 3.0 regarding parameter serialization of path variables:
![image](https://github.com/user-attachments/assets/02c9f0b7-b419-41cf-993c-613e6d5d6e35)
https://swagger.io/docs/specification/serialization/

With an apache-httpclient calling a generated client for an endpoint `/users/3,4,5` will cause it to call `/users/[3,4,5]` because of the toString() being called on the collection.

This PR will fix that.

#### Example
Using the current apache-httpclient template causes the following code to be generated:
![image](https://github.com/user-attachments/assets/dcf6f26a-7124-4c3c-8aa7-2798ad0bb776)

Obviously it will never end well, calling toString() on a collection. So, instead, I changed the template to call `apiClient.parameterToString()` since this method will parse it correctly, and is also the method used for formatting query parameters. After my change, the generated code will be the following:
![image](https://github.com/user-attachments/assets/2ba23990-2bbe-413b-952c-a2e58c28afb6)

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


