### PR TITLE
[PHP] Update enum tests

### DIFF
--- a/samples/client/petstore/php/OpenAPIClient-php/tests/EnumTestTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/EnumTestTest.php
@@ -11,9 +11,13 @@ class EnumTestTest extends TestCase
     {
         $this->assertSame(EnumTest::ENUM_STRING_UPPER, "UPPER");
         $this->assertSame(EnumTest::ENUM_STRING_LOWER, "lower");
-        $this->assertSame(EnumTest::ENUM_INTEGER_1, 1);
+        $this->assertSame(EnumTest::ENUM_STRING_EMPTY, "");
+        $this->assertSame(EnumTest::ENUM_STRING_REQUIRED_UPPER, "UPPER");
+        $this->assertSame(EnumTest::ENUM_STRING_REQUIRED_LOWER, "lower");
+        $this->assertSame(EnumTest::ENUM_STRING_REQUIRED_EMPTY, "");
+        $this->assertSame(EnumTest::ENUM_INTEGER_NUMBER_1, 1);
         $this->assertSame(EnumTest::ENUM_INTEGER_MINUS_1, -1);
-        $this->assertSame(EnumTest::ENUM_NUMBER_1_DOT_1, 1.1);
+        $this->assertSame(EnumTest::ENUM_NUMBER_NUMBER_1_DOT_1, 1.1);
         $this->assertSame(EnumTest::ENUM_NUMBER_MINUS_1_DOT_2, -1.2);
     }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This is a follow-up to https://github.com/OpenAPITools/openapi-generator/pull/19555 that updates the failing enum tests. All test cases in the EnumTestTest class are now passing.

For some reason, other tests that try to use the addPet endpoint are failing with a `405 Method Not Allowed`  error.
I am not sure what the issue is there, but these tests are failing in master, event before the changes from #19555.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
