### PR TITLE
[aspnetcore] Fix issue #19592 regarding swagger xml comments

### DIFF
--- a/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Startup.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Startup.mustache
@@ -119,7 +119,7 @@ namespace {{packageName}}
                         Version = "{{{version}}}{{^version}}v1{{/version}}",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     {{#basePathWithoutHost}}
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("{{{.}}}");

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Startup.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("/v2");
 

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Startup.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("/v2");
 

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Startup.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("/v2");
 

--- a/samples/server/petstore/aspnetcore-6.0-NewtonsoftFalse/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-6.0-NewtonsoftFalse/src/Org.OpenAPITools/Startup.cs
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("/v2");
 

--- a/samples/server/petstore/aspnetcore-6.0-nullableReferenceTypes/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-6.0-nullableReferenceTypes/src/Org.OpenAPITools/Startup.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("/v2");
 

--- a/samples/server/petstore/aspnetcore-6.0-pocoModels/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-6.0-pocoModels/src/Org.OpenAPITools/Startup.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("/v2");
 

--- a/samples/server/petstore/aspnetcore-6.0-project4Models/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-6.0-project4Models/src/Org.OpenAPITools/Startup.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("/v2");
 

--- a/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Startup.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("/v2");
 

--- a/samples/server/petstore/aspnetcore-8.0-NewtonsoftFalse/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-8.0-NewtonsoftFalse/src/Org.OpenAPITools/Startup.cs
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("/v2");
 

--- a/samples/server/petstore/aspnetcore-8.0-nullableReferenceTypes/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-8.0-nullableReferenceTypes/src/Org.OpenAPITools/Startup.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("/v2");
 

--- a/samples/server/petstore/aspnetcore-8.0-pocoModels/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-8.0-pocoModels/src/Org.OpenAPITools/Startup.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("/v2");
 

--- a/samples/server/petstore/aspnetcore-8.0-project4Models/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-8.0-project4Models/src/Org.OpenAPITools/Startup.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("/v2");
 

--- a/samples/server/petstore/aspnetcore-8.0/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-8.0/src/Org.OpenAPITools/Startup.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
+                    c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetExecutingAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the OpenAPI document generated
                     c.DocumentFilter<BasePathFilter>("/v2");
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This fixes issue #19592. Tested by building and applying the fix to the example given in the issue and verified working.
Steps ran from the failure state in the issue (present in sibling directory, hence  `../`):
```
java -jar ../openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g aspnetcore -i openapi.yaml
dotnet test src/Org.OpenAPITools.Tests
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
