### PR TITLE
rust: Implement `Display` instead of `ToString` for enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/model.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/model.mustache
@@ -27,15 +27,15 @@ pub enum {{{classname}}} {
 {{/enumVars}}{{/allowableValues}}
 }
 
-impl ToString for {{{classname}}} {
-    fn to_string(&self) -> String {
-        match self {
+impl std::fmt::Display for {{{classname}}} {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
             {{#allowableValues}}
             {{#enumVars}}
-            Self::{{{name}}} => String::from("{{{value}}}"),
+            Self::{{{name}}} => "{{{value}}}",
             {{/enumVars}}
             {{/allowableValues}}
-        }
+        })
     }
 }
 {{/isInteger}}

--- a/samples/client/petstore/rust/hyper/petstore/src/models/numeric_enum_testing.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/models/numeric_enum_testing.rs
@@ -24,14 +24,14 @@ pub enum NumericEnumTesting {
 
 }
 
-impl ToString for NumericEnumTesting {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0 => String::from("0"),
-            Self::Variant1 => String::from("1"),
-            Self::Variant2 => String::from("2"),
-            Self::Variant3 => String::from("3"),
-        }
+impl std::fmt::Display for NumericEnumTesting {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            Self::Variant0 => "0",
+            Self::Variant1 => "1",
+            Self::Variant2 => "2",
+            Self::Variant3 => "3",
+        })
     }
 }
 impl Default for NumericEnumTesting {

--- a/samples/client/petstore/rust/hyper0x/petstore/src/models/numeric_enum_testing.rs
+++ b/samples/client/petstore/rust/hyper0x/petstore/src/models/numeric_enum_testing.rs
@@ -24,14 +24,14 @@ pub enum NumericEnumTesting {
 
 }
 
-impl ToString for NumericEnumTesting {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0 => String::from("0"),
-            Self::Variant1 => String::from("1"),
-            Self::Variant2 => String::from("2"),
-            Self::Variant3 => String::from("3"),
-        }
+impl std::fmt::Display for NumericEnumTesting {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            Self::Variant0 => "0",
+            Self::Variant1 => "1",
+            Self::Variant2 => "2",
+            Self::Variant3 => "3",
+        })
     }
 }
 impl Default for NumericEnumTesting {

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/numeric_enum_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/numeric_enum_testing.rs
@@ -24,14 +24,14 @@ pub enum NumericEnumTesting {
 
 }
 
-impl ToString for NumericEnumTesting {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0 => String::from("0"),
-            Self::Variant1 => String::from("1"),
-            Self::Variant2 => String::from("2"),
-            Self::Variant3 => String::from("3"),
-        }
+impl std::fmt::Display for NumericEnumTesting {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            Self::Variant0 => "0",
+            Self::Variant1 => "1",
+            Self::Variant2 => "2",
+            Self::Variant3 => "3",
+        })
     }
 }
 impl Default for NumericEnumTesting {

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/models/numeric_enum_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/models/numeric_enum_testing.rs
@@ -24,14 +24,14 @@ pub enum NumericEnumTesting {
 
 }
 
-impl ToString for NumericEnumTesting {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0 => String::from("0"),
-            Self::Variant1 => String::from("1"),
-            Self::Variant2 => String::from("2"),
-            Self::Variant3 => String::from("3"),
-        }
+impl std::fmt::Display for NumericEnumTesting {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            Self::Variant0 => "0",
+            Self::Variant1 => "1",
+            Self::Variant2 => "2",
+            Self::Variant3 => "3",
+        })
     }
 }
 impl Default for NumericEnumTesting {

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/models/numeric_enum_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/models/numeric_enum_testing.rs
@@ -24,14 +24,14 @@ pub enum NumericEnumTesting {
 
 }
 
-impl ToString for NumericEnumTesting {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0 => String::from("0"),
-            Self::Variant1 => String::from("1"),
-            Self::Variant2 => String::from("2"),
-            Self::Variant3 => String::from("3"),
-        }
+impl std::fmt::Display for NumericEnumTesting {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            Self::Variant0 => "0",
+            Self::Variant1 => "1",
+            Self::Variant2 => "2",
+            Self::Variant3 => "3",
+        })
     }
 }
 impl Default for NumericEnumTesting {

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/numeric_enum_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/numeric_enum_testing.rs
@@ -24,14 +24,14 @@ pub enum NumericEnumTesting {
 
 }
 
-impl ToString for NumericEnumTesting {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0 => String::from("0"),
-            Self::Variant1 => String::from("1"),
-            Self::Variant2 => String::from("2"),
-            Self::Variant3 => String::from("3"),
-        }
+impl std::fmt::Display for NumericEnumTesting {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            Self::Variant0 => "0",
+            Self::Variant1 => "1",
+            Self::Variant2 => "2",
+            Self::Variant3 => "3",
+        })
     }
 }
 impl Default for NumericEnumTesting {

--- a/samples/client/petstore/rust/reqwest/petstore/src/models/numeric_enum_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/models/numeric_enum_testing.rs
@@ -24,14 +24,14 @@ pub enum NumericEnumTesting {
 
 }
 
-impl ToString for NumericEnumTesting {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Variant0 => String::from("0"),
-            Self::Variant1 => String::from("1"),
-            Self::Variant2 => String::from("2"),
-            Self::Variant3 => String::from("3"),
-        }
+impl std::fmt::Display for NumericEnumTesting {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            Self::Variant0 => "0",
+            Self::Variant1 => "1",
+            Self::Variant2 => "2",
+            Self::Variant3 => "3",
+        })
     }
 }
 impl Default for NumericEnumTesting {


### PR DESCRIPTION
Rust docs for `ToString` explicitly recommend implementing `Display`:

> This trait is automatically implemented for any type which implements the Display trait. As such, ToString shouldn’t be implemented directly: Display should be implemented instead, and you get the ToString implementation for free.

See: https://doc.rust-lang.org/std/string/trait.ToString.html
See: https://github.com/Nitrokey/nethsm-sdk-rs/pull/33

Since this is about Rust, CC'ing @frol @farcaller @richardwhiuk @paladinzh @jacob-pro

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
