### PR TITLE
[csharp][java] Fix enum discriminator default value

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3558,6 +3558,13 @@ public class DefaultCodegen implements CodegenConfig {
                         .orElseGet(() -> typeMapping.get("string"));
         discriminator.setPropertyType(propertyType);
 
+        // check to see if the discriminator property is an enum string
+        boolean isEnum = Optional
+                .ofNullable(discriminatorFound(schemaName, schema, discriminatorPropertyName, new TreeSet<>()))
+                .map(CodegenProperty::getIsEnum)
+                .orElse(false);
+        discriminator.setIsEnum(isEnum);
+
         discriminator.setMapping(sourceDiscriminator.getMapping());
         List<MappedModel> uniqueDescendants = new ArrayList<>();
         if (sourceDiscriminator.getMapping() != null && !sourceDiscriminator.getMapping().isEmpty()) {
@@ -3608,12 +3615,6 @@ public class DefaultCodegen implements CodegenConfig {
             Collections.sort(uniqueDescendants);
         }
         discriminator.getMappedModels().addAll(uniqueDescendants);
-
-        boolean isEnum = Optional
-                .ofNullable(discriminatorFound(schemaName, schema, discriminatorPropertyName, new TreeSet<>()))
-                .map(CodegenProperty::getIsEnum)
-                .orElse(false);
-        discriminator.setIsEnum(isEnum);
 
         return discriminator;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3128,7 +3128,7 @@ public class DefaultCodegen implements CodegenConfig {
     protected static String getEnumValueForProperty(
             String modelName, CodegenDiscriminator discriminator, CodegenProperty var) {
         if (!discriminator.getIsEnum() && !var.isEnum) {
-            return null;
+            return var.defaultValue;
         }
         Map<String, String> mapping = Optional.ofNullable(discriminator.getMapping()).orElseGet(Collections::emptyMap);
         for (Map.Entry<String, String> e : mapping.entrySet()) {
@@ -3139,10 +3139,10 @@ public class DefaultCodegen implements CodegenConfig {
         }
         Object values = var.allowableValues.get("values");
         if (!(values instanceof List<?>)) {
-            return null;
+            return var.defaultValue;
         }
         List<?> valueList = (List<?>) values;
-        return valueList.stream().filter(o -> o.equals(modelName)).map(o -> (String) o).findAny().orElse(null);
+        return valueList.stream().filter(o -> o.equals(modelName)).map(o -> (String) o).findAny().orElse(var.defaultValue);
     }
 
     protected void SortModelPropertiesByRequiredFlag(CodegenModel model) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3539,7 +3539,7 @@ public class DefaultCodegen implements CodegenConfig {
                 Optional<Schema> refSchema = Optional.ofNullable(discriminatorSchema.get().get$ref())
                         .map(ModelUtils::getSimpleRef)
                         .map(n -> ModelUtils.getSchema(openAPI, n));
-                Schema correctSchema = refSchema.orElse(s);
+                Schema correctSchema = refSchema.orElse(discriminatorSchema.get());
                 if (correctSchema instanceof StringSchema && correctSchema.getEnum() != null && !correctSchema.getEnum().isEmpty()) {
                     discriminator.setIsEnum(true);
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3114,6 +3114,19 @@ public class DefaultCodegen implements CodegenConfig {
         return m;
     }
 
+    /**
+     * Sets the default value for an enum discriminator property in the provided {@link CodegenModel}.
+     * <p>
+     * If the model's discriminator is defined, this method identifies the discriminator properties among the model's
+     * variables and assigns the default value to reflect the corresponding enum value for the model type.
+     * </p>
+     * <p>
+     * Example: If the discriminator is for type `Animal`, and the model is `Cat`, the default value
+     * will be set to `Animal.Cat` for the properties that have the same name as the discriminator.
+     * </p>
+     *
+     * @param model the {@link CodegenModel} whose discriminator property default value is to be set
+     */
     protected static void setEnumDiscriminatorDefaultValue(CodegenModel model) {
         if (model.discriminator == null) {
             return;
@@ -3125,6 +3138,19 @@ public class DefaultCodegen implements CodegenConfig {
                 .forEach(v -> v.defaultValue = getEnumValueForProperty(model.schemaName, model.discriminator, v));
     }
 
+    /**
+     * Retrieves the appropriate default value for an enum discriminator property based on the model name.
+     * <p>
+     * If the discriminator has a mapping defined, it attempts to find a mapping for the model name.
+     * Otherwise, it defaults to one of the allowable enum value associated with the property.
+     * If no suitable value is found, the original default value of the property is returned.
+     * </p>
+     *
+     * @param modelName     the name of the model to determine the default value for
+     * @param discriminator the {@link CodegenDiscriminator} containing the mapping and enum details
+     * @param var           the {@link CodegenProperty} representing the discriminator property
+     * @return the default value for the enum discriminator property, or its original default value if none is found
+     */
     protected static String getEnumValueForProperty(
             String modelName, CodegenDiscriminator discriminator, CodegenProperty var) {
         if (!discriminator.getIsEnum() && !var.isEnum) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3216,7 +3216,6 @@ public class DefaultCodegen implements CodegenConfig {
      */
     private CodegenProperty discriminatorFound(String composedSchemaName, Schema sc, String discPropName, Set<String> visitedSchemas) {
         Schema refSchema = ModelUtils.getReferencedSchema(openAPI, sc);
-        ModelUtils.getSimpleRef(sc.get$ref());
         String schemaName = Optional.ofNullable(composedSchemaName)
                 .or(() -> Optional.ofNullable(refSchema.getName()))
                 .or(() -> Optional.ofNullable(sc.get$ref()).map(ModelUtils::getSimpleRef))
@@ -3258,7 +3257,9 @@ public class DefaultCodegen implements CodegenConfig {
                 for (Object oneOf : composedSchema.getOneOf()) {
                     Schema oneOfSchema = (Schema) oneOf;
                     String modelName = ModelUtils.getSimpleRef((oneOfSchema).get$ref());
-                    CodegenProperty thisCp = discriminatorFound(oneOfSchema.getName(), oneOfSchema, discPropName, visitedSchemas);
+                    // Must use a copied set as the oneOf schemas can point to the same discriminator.
+                    Set<String> visitedSchemasCopy = new TreeSet<>(visitedSchemas);
+                    CodegenProperty thisCp = discriminatorFound(oneOfSchema.getName(), oneOfSchema, discPropName, visitedSchemasCopy);
                     if (thisCp == null) {
                         once(LOGGER).warn(
                                 "'{}' defines discriminator '{}', but the referenced OneOf schema '{}' is missing {}",
@@ -3282,7 +3283,9 @@ public class DefaultCodegen implements CodegenConfig {
                 for (Object anyOf : composedSchema.getAnyOf()) {
                     Schema anyOfSchema = (Schema) anyOf;
                     String modelName = ModelUtils.getSimpleRef(anyOfSchema.get$ref());
-                    CodegenProperty thisCp = discriminatorFound(anyOfSchema.getName(), anyOfSchema, discPropName, visitedSchemas);
+                    // Must use a copied set as the anyOf schemas can point to the same discriminator.
+                    Set<String> visitedSchemasCopy = new TreeSet<>(visitedSchemas);
+                    CodegenProperty thisCp = discriminatorFound(anyOfSchema.getName(), anyOfSchema, discPropName, visitedSchemasCopy);
                     if (thisCp == null) {
                         once(LOGGER).warn(
                                 "'{}' defines discriminator '{}', but the referenced AnyOf schema '{}' is missing {}",

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1700,6 +1700,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
         // additional import for different cases
         addAdditionalImports(codegenModel, codegenModel.getComposedSchemas());
+        setEnumDiscriminatorDefaultValue(codegenModel);
         return codegenModel;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -439,9 +439,19 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
                 }
 
                 for (final CodegenProperty property : codegenModel.readWriteVars) {
-                    if (property.defaultValue == null && parentCodegenModel.discriminator != null && property.name.equals(parentCodegenModel.discriminator.getPropertyName())) {
-                        if (parentCodegenModel.discriminator.getIsEnum()) {
-                            property.defaultValue = toEnumDefaultValue(property, name);
+                    CodegenDiscriminator discriminator = parentCodegenModel.discriminator;
+                    if (property.defaultValue == null && discriminator != null && property.name.equals(discriminator.getPropertyName())) {
+                        if (discriminator.getIsEnum()) {
+                            String enumValue = name;
+                            Map<String, String> mapping = Optional.ofNullable(discriminator.getMapping()).orElseGet(Collections::emptyMap);
+                            for (Map.Entry<String, String> e : mapping.entrySet()) {
+                                String schemaName = e.getValue().indexOf('/') < 0 ? e.getValue() : ModelUtils.getSimpleRef(e.getValue());
+                                if (name.equals(schemaName)) {
+                                    enumValue = e.getKey();
+                                    break;
+                                }
+                            }
+                            property.defaultValue = toEnumDefaultValue(property, enumValue);
                         } else {
                             property.defaultValue = "\"" + name + "\"";
                         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -440,7 +440,11 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
 
                 for (final CodegenProperty property : codegenModel.readWriteVars) {
                     if (property.defaultValue == null && parentCodegenModel.discriminator != null && property.name.equals(parentCodegenModel.discriminator.getPropertyName())) {
-                        property.defaultValue = "\"" + name + "\"";
+                        if (parentCodegenModel.discriminator.getIsEnum()) {
+                            property.defaultValue = toEnumDefaultValue(property, name);
+                        } else {
+                            property.defaultValue = "\"" + name + "\"";
+                        }
                     }
                 }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -440,21 +440,22 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
 
                 for (final CodegenProperty property : codegenModel.readWriteVars) {
                     CodegenDiscriminator discriminator = parentCodegenModel.discriminator;
-                    if (property.defaultValue == null && discriminator != null && property.name.equals(discriminator.getPropertyName())) {
-                        if (discriminator.getIsEnum()) {
-                            String enumValue = name;
-                            Map<String, String> mapping = Optional.ofNullable(discriminator.getMapping()).orElseGet(Collections::emptyMap);
-                            for (Map.Entry<String, String> e : mapping.entrySet()) {
-                                String schemaName = e.getValue().indexOf('/') < 0 ? e.getValue() : ModelUtils.getSimpleRef(e.getValue());
-                                if (name.equals(schemaName)) {
-                                    enumValue = e.getKey();
-                                    break;
-                                }
+                    if (property.defaultValue != null || discriminator == null || !property.name.equals(discriminator.getPropertyName())) {
+                        continue;
+                    }
+                    if (discriminator.getIsEnum()) {
+                        String enumValue = name;
+                        Map<String, String> mapping = Optional.ofNullable(discriminator.getMapping()).orElseGet(Collections::emptyMap);
+                        for (Map.Entry<String, String> e : mapping.entrySet()) {
+                            String schemaName = e.getValue().indexOf('/') < 0 ? e.getValue() : ModelUtils.getSimpleRef(e.getValue());
+                            if (name.equals(schemaName)) {
+                                enumValue = e.getKey();
+                                break;
                             }
-                            property.defaultValue = toEnumDefaultValue(property, enumValue);
-                        } else {
-                            property.defaultValue = "\"" + name + "\"";
                         }
+                        property.defaultValue = toEnumDefaultValue(property, enumValue);
+                    } else {
+                        property.defaultValue = "\"" + name + "\"";
                     }
                 }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -425,6 +425,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
     public CodegenModel fromModel(String name, Schema model) {
         Map<String, Schema> allDefinitions = ModelUtils.getSchemas(this.openAPI);
         CodegenModel codegenModel = super.fromModel(name, model);
+        setEnumDiscriminatorDefaultValue(codegenModel);
         if (allDefinitions != null && codegenModel != null && codegenModel.parent != null) {
             final Schema<?> parentModel = allDefinitions.get(toModelName(codegenModel.parent));
             if (parentModel != null) {
@@ -439,22 +440,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
                 }
 
                 for (final CodegenProperty property : codegenModel.readWriteVars) {
-                    CodegenDiscriminator discriminator = parentCodegenModel.discriminator;
-                    if (property.defaultValue != null || discriminator == null || !property.name.equals(discriminator.getPropertyName())) {
-                        continue;
-                    }
-                    if (discriminator.getIsEnum()) {
-                        String enumValue = name;
-                        Map<String, String> mapping = Optional.ofNullable(discriminator.getMapping()).orElseGet(Collections::emptyMap);
-                        for (Map.Entry<String, String> e : mapping.entrySet()) {
-                            String schemaName = e.getValue().indexOf('/') < 0 ? e.getValue() : ModelUtils.getSimpleRef(e.getValue());
-                            if (name.equals(schemaName)) {
-                                enumValue = e.getKey();
-                                break;
-                            }
-                        }
-                        property.defaultValue = toEnumDefaultValue(property, enumValue);
-                    } else {
+                    if (property.defaultValue == null && parentCodegenModel.discriminator != null && property.name.equals(parentCodegenModel.discriminator.getPropertyName())) {
                         property.defaultValue = "\"" + name + "\"";
                     }
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1595,6 +1595,11 @@ public class ModelUtils {
      * @return the name of the parent model
      */
     public static List<String> getAllParentsName(Schema composedSchema, Map<String, Schema> allSchemas, boolean includeAncestors) {
+        return getAllParentsName(composedSchema, allSchemas, includeAncestors, new HashSet<>());
+    }
+
+    public static List<String> getAllParentsName(
+            Schema composedSchema, Map<String, Schema> allSchemas, boolean includeAncestors, Set<String> seenNames) {
         List<Schema> interfaces = getInterfaces(composedSchema);
         List<String> names = new ArrayList<String>();
 
@@ -1603,6 +1608,10 @@ public class ModelUtils {
                 // get the actual schema
                 if (StringUtils.isNotEmpty(schema.get$ref())) {
                     String parentName = getSimpleRef(schema.get$ref());
+                    if (seenNames.contains(parentName)) {
+                        continue;
+                    }
+                    seenNames.add(parentName);
                     Schema s = allSchemas.get(parentName);
                     if (s == null) {
                         LOGGER.error("Failed to obtain schema from {}", parentName);
@@ -1611,7 +1620,7 @@ public class ModelUtils {
                         // discriminator.propertyName is used or x-parent is used
                         names.add(parentName);
                         if (includeAncestors && isComposedSchema(s)) {
-                            names.addAll(getAllParentsName(s, allSchemas, true));
+                            names.addAll(getAllParentsName(s, allSchemas, true, seenNames));
                         }
                     } else {
                         // not a parent since discriminator.propertyName is not set

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1598,7 +1598,8 @@ public class ModelUtils {
         return getAllParentsName(composedSchema, allSchemas, includeAncestors, new HashSet<>());
     }
 
-    public static List<String> getAllParentsName(
+    // Use a set of seen names to avoid infinite recursion
+    private static List<String> getAllParentsName(
             Schema composedSchema, Map<String, Schema> allSchemas, boolean includeAncestors, Set<String> seenNames) {
         List<Schema> interfaces = getInterfaces(composedSchema);
         List<String> names = new ArrayList<String>();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pojo.mustache
@@ -80,6 +80,11 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     {{/parcelableModel}}
     {{/parent}}
     {{#discriminator}}
+    {{#discriminator.isEnum}}
+{{#readWriteVars}}{{#isDiscriminator}}{{#defaultValue}}
+    this.{{name}} = {{defaultValue}};
+{{/defaultValue}}{{/isDiscriminator}}{{/readWriteVars}}
+    {{/discriminator.isEnum}}
     {{^discriminator.isEnum}}
     this.{{{discriminatorName}}} = this.getClass().getSimpleName();
     {{/discriminator.isEnum}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
@@ -159,20 +159,26 @@ public class CSharpClientCodegenTest {
         Map<String, File> files = defaultGenerator.generate().stream()
                 .collect(Collectors.toMap(File::getPath, Function.identity()));
 
-        Map<String, String> expectedMapping = Map.of(
-                "Catty", "Cat",
-                "Lizzy", "Lizard",
-                "Dog", "Dog"
+        Map<String, String> expectedContents = Map.of(
+                "Cat", "PetTypeEnum petType = PetTypeEnum.Catty",
+                "Dog", "PetTypeEnum petType = PetTypeEnum.Dog",
+                "Gecko", "PetTypeEnum petType = PetTypeEnum.Gecko",
+                "Chameleon", "PetTypeEnum petType = PetTypeEnum.Camo",
+                "MiniVan", "CarType carType = CarType.MiniVan",
+                "CargoVan", "CarType carType = CarType.CargoVan",
+                "SUV", "CarType carType = CarType.SUV",
+                "Truck", "CarType carType = CarType.Truck"
+
         );
-        for (Map.Entry<String, String> e : expectedMapping.entrySet()) {
-            String modelName = e.getValue();
-            String enumValue = e.getKey();
+        for (Map.Entry<String, String> e : expectedContents.entrySet()) {
+            String modelName = e.getKey();
+            String expectedContent = e.getValue();
             File file = files.get(Paths
                     .get(output.getAbsolutePath(), "src", "Org.OpenAPITools", "Model", modelName + ".cs")
                     .toString()
             );
             assertNotNull(file, "Could not find file for model: " + modelName);
-            assertFileContains(file.toPath(), "AnimalType petType = AnimalType." + enumValue);
+            assertFileContains(file.toPath(), expectedContent);
         }
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
@@ -140,4 +140,31 @@ public class CSharpClientCodegenTest {
         assertFileContains(modelFile.toPath(),
                 " Dictionary<string, ResponseResultsValue> results = default(Dictionary<string, ResponseResultsValue>");
     }
+
+    @Test
+    public void testEnumDiscriminatorDefaultValueIsNotString() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec(
+            "src/test/resources/3_0/enum_discriminator_inheritance.yaml");
+        final DefaultGenerator defaultGenerator = new DefaultGenerator();
+        final ClientOptInput clientOptInput = new ClientOptInput();
+        clientOptInput.openAPI(openAPI);
+        CSharpClientCodegen cSharpClientCodegen = new CSharpClientCodegen();
+        cSharpClientCodegen.setOutputDir(output.getAbsolutePath());
+        cSharpClientCodegen.setAutosetConstants(true);
+        clientOptInput.config(cSharpClientCodegen);
+        defaultGenerator.opts(clientOptInput);
+
+      Map<String, File> files = defaultGenerator.generate().stream()
+            .collect(Collectors.toMap(File::getPath, Function.identity()));
+
+        File modelFile = files.get(Paths
+            .get(output.getAbsolutePath(), "src", "Org.OpenAPITools", "Model", "FooEntity.cs")
+            .toString()
+        );
+        assertNotNull(modelFile);
+        assertFileContains(modelFile.toPath(),
+            "public FooEntity(TypeEnum type = TypeEnum.FooEntity) : base(type)");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
@@ -167,7 +167,8 @@ public class CSharpClientCodegenTest {
                 "MiniVan", "CarType carType = CarType.MiniVan",
                 "CargoVan", "CarType carType = CarType.CargoVan",
                 "SUV", "CarType carType = CarType.SUV",
-                "Truck", "CarType carType = CarType.Truck"
+                "Truck", "CarType carType = CarType.Truck",
+                "Sedan", "CarType carType = CarType.Sedan"
 
         );
         for (Map.Entry<String, String> e : expectedContents.entrySet()) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
@@ -160,11 +160,10 @@ public class CSharpClientCodegenTest {
             .collect(Collectors.toMap(File::getPath, Function.identity()));
 
         File modelFile = files.get(Paths
-            .get(output.getAbsolutePath(), "src", "Org.OpenAPITools", "Model", "FooEntity.cs")
+            .get(output.getAbsolutePath(), "src", "Org.OpenAPITools", "Model", "Cat.cs")
             .toString()
         );
         assertNotNull(modelFile);
-        assertFileContains(modelFile.toPath(),
-            "public FooEntity(TypeEnum type = TypeEnum.FooEntity) : base(type)");
+        assertFileContains(modelFile.toPath(), "AnimalType petType = AnimalType.Cat");
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
@@ -146,7 +146,7 @@ public class CSharpClientCodegenTest {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
         final OpenAPI openAPI = TestUtils.parseFlattenSpec(
-            "src/test/resources/3_0/enum_discriminator_inheritance.yaml");
+                "src/test/resources/3_0/enum_discriminator_inheritance.yaml");
         final DefaultGenerator defaultGenerator = new DefaultGenerator();
         final ClientOptInput clientOptInput = new ClientOptInput();
         clientOptInput.openAPI(openAPI);
@@ -156,14 +156,23 @@ public class CSharpClientCodegenTest {
         clientOptInput.config(cSharpClientCodegen);
         defaultGenerator.opts(clientOptInput);
 
-      Map<String, File> files = defaultGenerator.generate().stream()
-            .collect(Collectors.toMap(File::getPath, Function.identity()));
+        Map<String, File> files = defaultGenerator.generate().stream()
+                .collect(Collectors.toMap(File::getPath, Function.identity()));
 
-        File modelFile = files.get(Paths
-            .get(output.getAbsolutePath(), "src", "Org.OpenAPITools", "Model", "Cat.cs")
-            .toString()
+        Map<String, String> expectedMapping = Map.of(
+                "Catty", "Cat",
+                "Lizzy", "Lizard",
+                "Dog", "Dog"
         );
-        assertNotNull(modelFile);
-        assertFileContains(modelFile.toPath(), "AnimalType petType = AnimalType.Cat");
+        for (Map.Entry<String, String> e : expectedMapping.entrySet()) {
+            String modelName = e.getValue();
+            String enumValue = e.getKey();
+            File file = files.get(Paths
+                    .get(output.getAbsolutePath(), "src", "Org.OpenAPITools", "Model", modelName + ".cs")
+                    .toString()
+            );
+            assertNotNull(file, "Could not find file for model: " + modelName);
+            assertFileContains(file.toPath(), "AnimalType petType = AnimalType." + enumValue);
+        }
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2297,10 +2297,20 @@ public class JavaClientCodegenTest {
         Map<String, File> files = new DefaultGenerator().opts(new ClientOptInput().openAPI(openAPI).config(codegen))
             .generate().stream().collect(Collectors.toMap(File::getName, Function.identity()));
 
-        File fooEntityFile = files.get("Cat.java");
-        assertNotNull(fooEntityFile);
-        assertThat(fooEntityFile).content()
-            .doesNotContain("this.petType = this.getClass().getSimpleName();");
+        List<String> entities = List.of(
+                "Cat",
+                "Dog",
+                "Gecko",
+                "Chameleon",
+                "MiniVan",
+                "CargoVan",
+                "SUV",
+                "Truck");
+        for (String entity : entities) {
+            File entityFile = files.get(entity + ".java");
+            assertNotNull(entityFile);
+            assertThat(entityFile).content().doesNotContain("Type = this.getClass().getSimpleName();");
+        }
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2287,15 +2287,16 @@ public class JavaClientCodegenTest {
         assertNull(files.get("pom.xml"));
     }
 
-    @Test public void testEnumDiscriminatorDefaultValueIsNotString() throws IOException {
+    @Test
+    public void testEnumDiscriminatorDefaultValueIsNotString() {
         final Path output = newTempFolder();
         final OpenAPI openAPI = TestUtils.parseFlattenSpec(
-            "src/test/resources/3_0/enum_discriminator_inheritance.yaml");
+                "src/test/resources/3_0/enum_discriminator_inheritance.yaml");
         JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.setOutputDir(output.toString());
 
         Map<String, File> files = new DefaultGenerator().opts(new ClientOptInput().openAPI(openAPI).config(codegen))
-            .generate().stream().collect(Collectors.toMap(File::getName, Function.identity()));
+                .generate().stream().collect(Collectors.toMap(File::getName, Function.identity()));
 
         List<String> entities = List.of(
                 "Cat",

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2298,20 +2298,25 @@ public class JavaClientCodegenTest {
         Map<String, File> files = new DefaultGenerator().opts(new ClientOptInput().openAPI(openAPI).config(codegen))
                 .generate().stream().collect(Collectors.toMap(File::getName, Function.identity()));
 
-        List<String> entities = List.of(
-                "Cat",
-                "Dog",
-                "Gecko",
-                "Chameleon",
-                "MiniVan",
-                "CargoVan",
-                "SUV",
-                "Truck",
-                "Sedan");
-        for (String entity : entities) {
-            File entityFile = files.get(entity + ".java");
+        Map<String, String> expectedContents = Map.of(
+                "Cat", "this.petType = PetTypeEnum.CATTY",
+                "Dog", "this.petType = PetTypeEnum.DOG",
+                "Gecko", "this.petType = PetTypeEnum.GECKO",
+                "Chameleon", "this.petType = PetTypeEnum.CAMO",
+                "MiniVan", "this.carType = CarType.MINI_VAN",
+                "CargoVan", "this.carType = CarType.CARGO_VAN",
+                "SUV", "this.carType = CarType.SUV",
+                "Truck", "this.carType = CarType.TRUCK",
+                "Sedan", "this.carType = CarType.SEDAN"
+
+        );
+        for (Map.Entry<String, String> e : expectedContents.entrySet()) {
+            String modelName = e.getKey();
+            String expectedContent = e.getValue();
+            File entityFile = files.get(modelName + ".java");
             assertNotNull(entityFile);
             assertThat(entityFile).content().doesNotContain("Type = this.getClass().getSimpleName();");
+            assertThat(entityFile).content().contains(expectedContent);
         }
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2301,7 +2301,6 @@ public class JavaClientCodegenTest {
         assertNotNull(fooEntityFile);
         assertThat(fooEntityFile).content()
             .doesNotContain("this.type = this.getClass().getSimpleName();");
-        System.out.println(Files.readString(fooEntityFile.toPath()));
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2287,6 +2287,23 @@ public class JavaClientCodegenTest {
         assertNull(files.get("pom.xml"));
     }
 
+    @Test public void testEnumDiscriminatorDefaultValueIsNotString() throws IOException {
+        final Path output = newTempFolder();
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec(
+            "src/test/resources/3_0/enum_discriminator_inheritance.yaml");
+        JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setOutputDir(output.toString());
+
+        Map<String, File> files = new DefaultGenerator().opts(new ClientOptInput().openAPI(openAPI).config(codegen))
+            .generate().stream().collect(Collectors.toMap(File::getName, Function.identity()));
+
+        File fooEntityFile = files.get("FooEntity.java");
+        assertNotNull(fooEntityFile);
+        assertThat(fooEntityFile).content()
+            .doesNotContain("this.type = this.getClass().getSimpleName();");
+        System.out.println(Files.readString(fooEntityFile.toPath()));
+    }
+
     @Test
     public void testRestTemplateHandleURIEnum() {
         String[] expectedInnerEnumLines = new String[] {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2305,7 +2305,8 @@ public class JavaClientCodegenTest {
                 "MiniVan",
                 "CargoVan",
                 "SUV",
-                "Truck");
+                "Truck",
+                "Sedan");
         for (String entity : entities) {
             File entityFile = files.get(entity + ".java");
             assertNotNull(entityFile);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2297,10 +2297,10 @@ public class JavaClientCodegenTest {
         Map<String, File> files = new DefaultGenerator().opts(new ClientOptInput().openAPI(openAPI).config(codegen))
             .generate().stream().collect(Collectors.toMap(File::getName, Function.identity()));
 
-        File fooEntityFile = files.get("FooEntity.java");
+        File fooEntityFile = files.get("Cat.java");
         assertNotNull(fooEntityFile);
         assertThat(fooEntityFile).content()
-            .doesNotContain("this.type = this.getClass().getSimpleName();");
+            .doesNotContain("this.petType = this.getClass().getSimpleName();");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
@@ -5,6 +5,7 @@ info:
 paths:
   "/animal":
     get:
+      operationId: animalGet
       responses:
         '200':
           description: OK

--- a/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
@@ -21,13 +21,17 @@ components:
           $ref: '#/components/schemas/AnimalType'
       discriminator:
         propertyName: petType
+        # Mapping with implicit (Dog), explicit ref (Catty -> Cat), and explicit schema name (Lizzy -> Lizard)
+        mapping:
+          Catty: '#/components/schemas/Cat'
+          Lizzy: 'Lizard'
       required:
         - petType
     AnimalType:
       type: string
       enum:
         - Dog
-        - Cat
+        - Catty
     Cat:
       type: object
       allOf:
@@ -41,4 +45,11 @@ components:
         - $ref: '#/components/schemas/Animal'
       properties:
         bark:
+          type: string
+    Lizard:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Animal'
+      properties:
+        lovesRocks:
           type: string

--- a/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
@@ -32,6 +32,7 @@ components:
       enum:
         - Dog
         - Catty
+        - Lizzy
     Cat:
       type: object
       allOf:

--- a/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.3
+info:
+  title: Test entity with enum discriminator
+  version: v1
+paths:
+  "/event":
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Entity"
+components:
+  schemas:
+    Entity:
+      required:
+        - type
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - FOO
+            - BAR
+      description: Entity
+      discriminator:
+        propertyName: type
+        mapping:
+          FOO: "#/components/schemas/FooEntity"
+    FooEntity:
+      required:
+        - type
+      type: object
+      description: Foo entity
+      allOf:
+        - "$ref": "#/components/schemas/Entity"

--- a/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
@@ -17,22 +17,22 @@ components:
     Animal:
       type: object
       properties:
+        # Inline enum type
         petType:
-          $ref: '#/components/schemas/AnimalType'
+          type: string
+          enum:
+            - Dog
+            - Catty
+            - Gecko
+            - Camo
       discriminator:
         propertyName: petType
-        # Mapping with implicit (Dog), explicit ref (Catty -> Cat), and explicit schema name (Lizzy -> Lizard)
+        # Mapping with implicit (Dog, Gecko), explicit ref (Catty -> Cat), and explicit schema name (Camo -> Chameleon)
         mapping:
           Catty: '#/components/schemas/Cat'
-          Lizzy: 'Lizard'
+          Camo: 'Chameleon'
       required:
         - petType
-    AnimalType:
-      type: string
-      enum:
-        - Dog
-        - Catty
-        - Lizzy
     Cat:
       type: object
       allOf:
@@ -48,9 +48,81 @@ components:
         bark:
           type: string
     Lizard:
+      oneOf:
+        - $ref: '#/components/schemas/Gecko'
+        - $ref: '#/components/schemas/Chameleon'
+    Gecko:
       type: object
       allOf:
         - $ref: '#/components/schemas/Animal'
       properties:
         lovesRocks:
           type: string
+    Chameleon:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Animal'
+      properties:
+        currentColor:
+          type: string
+    # Car inheritance tree: Car -> Truck -> SUV
+    #                       Car -> Van -> MiniVan
+    #                       Car -> Van -> CargoVan
+    Car:
+      type: object
+      required:
+        - carType
+      # Discriminator carType not defined in Car properties, but in child properties
+      discriminator:
+        propertyName: carType
+    CarType:
+      type: string
+      enum:
+        - Truck
+        - SUV
+        - Sedan
+        - MiniVan
+        - CargoVan
+    Truck:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Car'
+      properties:
+        carType:
+          $ref: '#/components/schemas/CarType'
+      required:
+        - carType
+    SUV:
+      type: object
+      # SUV gets its discriminator property from Truck
+      allOf:
+        - $ref: '#/components/schemas/Truck'
+    Sedan:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Car'
+      properties:
+        carType:
+          $ref: '#/components/schemas/CarType'
+    Van:
+      oneOf:
+        - $ref: '#/components/schemas/MiniVan'
+        - $ref: '#/components/schemas/CargoVan'
+    MiniVan:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Car'
+      properties:
+        carType:
+          $ref: '#/components/schemas/CarType'
+      required:
+        - carType
+    CargoVan:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Car'
+      properties:
+        carType:
+          $ref: '#/components/schemas/CarType'
+      required:
+        - carType

--- a/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
@@ -1,9 +1,9 @@
 openapi: 3.0.3
 info:
-  title: Test entity with enum discriminator
+  title: Test schema with enum discriminator
   version: v1
 paths:
-  "/event":
+  "/animal":
     get:
       responses:
         '200':
@@ -11,28 +11,34 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Entity"
+                "$ref": "#/components/schemas/Animal"
 components:
   schemas:
-    Entity:
-      required:
-        - type
+    Animal:
       type: object
       properties:
-        type:
-          type: string
-          enum:
-            - FOO
-            - BAR
-      description: Entity
+        petType:
+          $ref: '#/components/schemas/AnimalType'
       discriminator:
-        propertyName: type
-        mapping:
-          FOO: "#/components/schemas/FooEntity"
-    FooEntity:
+        propertyName: petType
       required:
-        - type
+        - petType
+    AnimalType:
+      type: string
+      enum:
+        - Dog
+        - Cat
+    Cat:
       type: object
-      description: Foo entity
       allOf:
-        - "$ref": "#/components/schemas/Entity"
+        - $ref: '#/components/schemas/Animal'
+      properties:
+        meow:
+          type: string
+    Dog:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Animal'
+      properties:
+        bark:
+          type: string

--- a/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml
@@ -68,6 +68,7 @@ components:
     # Car inheritance tree: Car -> Truck -> SUV
     #                       Car -> Van -> MiniVan
     #                       Car -> Van -> CargoVan
+    #                       Car -> Sedan
     Car:
       type: object
       required:
@@ -101,6 +102,8 @@ components:
       type: object
       allOf:
         - $ref: '#/components/schemas/Car'
+      required:
+        - carType
       properties:
         carType:
           $ref: '#/components/schemas/CarType'

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumStringDiscriminator.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumStringDiscriminator.java
@@ -107,6 +107,7 @@ public class EnumStringDiscriminator {
   protected EnumStrTypeEnum enumStrType;
 
   public EnumStringDiscriminator() {
+
   }
 
   public EnumStringDiscriminator enumStrType(EnumStrTypeEnum enumStrType) {


### PR DESCRIPTION
When you define a schema with an enum discriminator and you use allOf to include the parent schema in the child schema the current generated code fails to compile due to the generator thinking the discriminator is of type string instead of enum.

This is mentioned in some issues I could find which this PR should fix:
#12412 #16073 #16672 #19194 #19261

These PRs attempt to solve it, but they have some flaws.
#10959 #16394

This was tested with `java` and `csharp` generators which both have issues. Other generators might also have issues with this if they implement custom logic of handling default values of enums like the `csharp` generator currently does.

The issue in the code lied in the fact that when checking whether or not the discriminator is an enum it only checks the properties of the child schema, however the property might be defined in the referenced parent schema.
```java
        // The schema here might not have the discriminator type property.
        if (schema.getProperties() != null &&
                schema.getProperties().get(discriminatorPropertyName) instanceof StringSchema) {
            StringSchema s = (StringSchema) schema.getProperties().get(discriminatorPropertyName);
            if (s.getEnum() != null && !s.getEnum().isEmpty()) { // it's an enum string
                discriminator.setIsEnum(true);
            }
        }
```

This can be verified by running the added tests against the current master and observe them fail.

~~The code was modified to return the referenced schema in addition to the discriminator when searching for it recursively and when checking for the property check both in the child schema and the schema that defines the discriminator.~~

~~I am unsure if it is possible to have a situation where the property is neither in the child schema or the schema with the discriminator, but in an intermediary in the ref chain. This would be uncommon and I am unsure if it is possible with the current code, but I don't understand it well enough to tell whether this is possible or if it is a valid spec. Perhaps it would be better to traverse up the allOf reference chain, but I an not familiar enough with how objects can be defined with combinations of allOf, anyOf and oneOf. At least this implementation avoids another recursive traversal of the schema tree. Let me know if this should be changed or if the new implementation is good enough.~~

I changed the code to check all parents and all descendants for the discriminator property. This should cover most if not all possible use cases. Here is the schema I used with a mix of anyOf, allOf and oneOf mappings:
https://github.com/OpenAPITools/openapi-generator/blob/452e95b4939a6d0cd4fe203f6c9180e733a9919f/modules/openapi-generator/src/test/resources/3_0/enum_discriminator_inheritance.yaml#L1-L128


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
