### PR TITLE
[Rust Server] Handle arrays in forms

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1520,6 +1520,10 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
         if (Boolean.TRUE.equals(param.isFreeFormObject)) {
             param.vendorExtensions.put("x-format-string", "{:?}");
             example = null;
+        } else if (param.isArray && param.isString) {
+            // This occurs if the parameter is a form property and is Vec<String>
+            param.vendorExtensions.put("x-format-string", "{:?}");
+            example = (param.example != null) ? "&vec![\"" + param.example + "\".to_string()]" : "&Vec::new()";
         } else if (param.isString) {
             param.vendorExtensions.put("x-format-string", "\\\"{}\\\"");
             example = "\"" + ((param.example != null) ? param.example : "") + "\".to_string()";

--- a/modules/openapi-generator/src/main/resources/rust-server/client-request-body-instance.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-request-body-instance.mustache
@@ -28,11 +28,36 @@
         // Consumes form body
     {{#formParams}}
       {{#-first}}
-        let params = &[
+        let mut params = vec![];
       {{/-first}}
-            ("{{{baseName}}}", {{#vendorExtensions}}{{#required}}Some({{#isString}}param_{{{paramName}}}{{/isString}}{{^isString}}format!("{:?}", param_{{{paramName}}}){{/isString}}){{/required}}{{^required}}{{#isString}}param_{{{paramName}}}{{/isString}}{{^isString}}param_{{{paramName}}}.map(|param| format!("{:?}", param)){{/isString}}{{/required}}{{/vendorExtensions}}),
+      {{^required}}
+        if let Some(param_{{{paramName}}}) = param_{{{paramName}}} {
+      {{/required}}
+      {{#isArray}}
+        // style=form,explode=true
+        for param_{{{paramName}}} in param_{{{paramName}}} {
+      {{/isArray}}
+        params.push(("{{{baseName}}}",
+      {{^isString}}
+            format!("{{{vendorExtensions.x-format-string}}}", param_{{{paramName}}})
+      {{/isString}}
+      {{#isString}}
+        {{#isArray}}
+            param_{{{paramName}}}.to_string()
+        {{/isArray}}
+        {{^isArray}}
+            param_{{{paramName}}}
+        {{/isArray}}
+      {{/isString}}
+        ));
+      {{#isArray}}
+        }
+      {{/isArray}}
+      {{^required}}
+        }
+      {{/required}}
       {{#-last}}
-        ];
+
         let body = serde_urlencoded::to_string(params).expect("impossible to fail to serialize");
 
         *request.body_mut() = Body::from(body.into_bytes());

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -495,6 +495,24 @@ paths:
       responses:
         200:
           description: OK
+  /form-test:
+    post:
+      summary: Test a Form Post
+      operationId: FormTest
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                requiredArray:
+                  type: array
+                  items:
+                    type: string
+        required: true
+      responses:
+        '200':
+          description: OK
 
 components:
   securitySchemes:

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 [features]
 default = ["client", "server"]
 client = [
+    "serde_urlencoded",
     "serde_ignored", "regex", "percent-encoding", "lazy_static",
     "hyper", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]
@@ -55,6 +56,7 @@ serde_ignored = {version = "0.1.1", optional = true}
 url = {version = "2.1", optional = true}
 
 # Client-specific
+serde_urlencoded = {version = "0.6.1", optional = true}
 
 # Server, and client callback-specific
 lazy_static = { version = "1.4", optional = true }

--- a/samples/server/petstore/rust-server/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/README.md
@@ -89,6 +89,7 @@ To run a client, follow one of the following simple steps:
 cargo run --example client AnyOfGet
 cargo run --example client CallbackWithHeaderPost
 cargo run --example client ComplexQueryParamGet
+cargo run --example client FormTest
 cargo run --example client GetWithBooleanParameter
 cargo run --example client JsonComplexQueryParamGet
 cargo run --example client MandatoryRequestHeaderGet
@@ -152,6 +153,7 @@ Method | HTTP request | Description
 [****](docs/default_api.md#) | **GET** /any-of | 
 [****](docs/default_api.md#) | **POST** /callback-with-header | 
 [****](docs/default_api.md#) | **GET** /complex-query-param | 
+[**FormTest**](docs/default_api.md#FormTest) | **POST** /form-test | Test a Form Post
 [**GetWithBooleanParameter**](docs/default_api.md#GetWithBooleanParameter) | **GET** /get-with-bool | 
 [****](docs/default_api.md#) | **GET** /json-complex-query-param | 
 [****](docs/default_api.md#) | **GET** /mandatory-request-header | 

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -525,6 +525,19 @@ paths:
       responses:
         "200":
           description: OK
+  /form-test:
+    post:
+      operationId: FormTest
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/FormTest_request'
+        required: true
+      responses:
+        "200":
+          description: OK
+      summary: Test a Form Post
 components:
   schemas:
     AnyOfProperty:
@@ -774,6 +787,13 @@ components:
       anyOf:
       - $ref: '#/components/schemas/StringObject'
       - $ref: '#/components/schemas/UuidObject'
+    FormTest_request:
+      properties:
+        requiredArray:
+          items:
+            type: string
+          type: array
+      type: object
     AnyOfObject_anyOf:
       enum:
       - FOO

--- a/samples/server/petstore/rust-server/output/openapi-v3/bin/cli.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/bin/cli.rs
@@ -8,6 +8,7 @@ use openapi_v3::{
     AnyOfGetResponse,
     CallbackWithHeaderPostResponse,
     ComplexQueryParamGetResponse,
+    FormTestResponse,
     GetWithBooleanParameterResponse,
     JsonComplexQueryParamGetResponse,
     MandatoryRequestHeaderGetResponse,
@@ -100,6 +101,11 @@ enum Operation {
     ComplexQueryParamGet {
         #[structopt(parse(try_from_str = parse_json), long)]
         list_of_strings: Option<Vec<models::StringObject>>,
+    },
+    /// Test a Form Post
+    FormTest {
+        #[structopt(parse(try_from_str = parse_json), long)]
+        required_array: Option<Vec<String>>,
     },
     GetWithBooleanParameter {
         /// Let's check apostrophes get encoded properly!
@@ -316,6 +322,22 @@ async fn main() -> Result<()> {
             match result {
                 ComplexQueryParamGetResponse::Success
                 => "Success\n".to_string()
+                    ,
+            }
+        }
+        Operation::FormTest {
+            required_array,
+        } => {
+            info!("Performing a FormTest request");
+
+            let result = client.form_test(
+                required_array.as_ref(),
+            ).await?;
+            debug!("Result: {:?}", result);
+
+            match result {
+                FormTestResponse::OK
+                => "OK\n".to_string()
                     ,
             }
         }

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
@@ -7,6 +7,7 @@ Method | HTTP request | Description
 ****](default_api.md#) | **GET** /any-of | 
 ****](default_api.md#) | **POST** /callback-with-header | 
 ****](default_api.md#) | **GET** /complex-query-param | 
+**FormTest**](default_api.md#FormTest) | **POST** /form-test | Test a Form Post
 **GetWithBooleanParameter**](default_api.md#GetWithBooleanParameter) | **GET** /get-with-bool | 
 ****](default_api.md#) | **GET** /json-complex-query-param | 
 ****](default_api.md#) | **GET** /mandatory-request-header | 
@@ -118,6 +119,38 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **FormTest**
+> FormTest(optional)
+Test a Form Post
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a map[string]interface{}.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **required_array** | [**String**](String.md)|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/x-www-form-urlencoded
  - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -9,6 +9,7 @@ use openapi_v3::{Api, ApiNoContext, Claims, Client, ContextWrapperExt, models,
                       AnyOfGetResponse,
                       CallbackWithHeaderPostResponse,
                       ComplexQueryParamGetResponse,
+                      FormTestResponse,
                       GetWithBooleanParameterResponse,
                       JsonComplexQueryParamGetResponse,
                       MandatoryRequestHeaderGetResponse,
@@ -66,6 +67,7 @@ fn main() {
                 "AnyOfGet",
                 "CallbackWithHeaderPost",
                 "ComplexQueryParamGet",
+                "FormTest",
                 "GetWithBooleanParameter",
                 "JsonComplexQueryParamGet",
                 "MandatoryRequestHeaderGet",
@@ -181,6 +183,12 @@ fn main() {
         },
         Some("ComplexQueryParamGet") => {
             let result = rt.block_on(client.complex_query_param_get(
+                  Some(&Vec::new())
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        Some("FormTest") => {
+            let result = rt.block_on(client.form_test(
                   Some(&Vec::new())
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
@@ -105,6 +105,7 @@ use openapi_v3::{
     AnyOfGetResponse,
     CallbackWithHeaderPostResponse,
     ComplexQueryParamGetResponse,
+    FormTestResponse,
     GetWithBooleanParameterResponse,
     JsonComplexQueryParamGetResponse,
     MandatoryRequestHeaderGetResponse,
@@ -163,6 +164,16 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         context: &C) -> Result<ComplexQueryParamGetResponse, ApiError>
     {
         info!("complex_query_param_get({:?}) - X-Span-ID: {:?}", list_of_strings, context.get().0.clone());
+        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
+    }
+
+    /// Test a Form Post
+    async fn form_test(
+        &self,
+        required_array: Option<&Vec<String>>,
+        context: &C) -> Result<FormTestResponse, ApiError>
+    {
+        info!("form_test({:?}) - X-Span-ID: {:?}", required_array, context.get().0.clone());
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -39,6 +39,7 @@ use crate::{Api,
      AnyOfGetResponse,
      CallbackWithHeaderPostResponse,
      ComplexQueryParamGetResponse,
+     FormTestResponse,
      GetWithBooleanParameterResponse,
      JsonComplexQueryParamGetResponse,
      MandatoryRequestHeaderGetResponse,
@@ -648,6 +649,96 @@ impl<S, C> Api<C> for Client<S, C> where
             200 => {
                 Ok(
                     ComplexQueryParamGetResponse::Success
+                )
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body()
+                       .take(100)
+                       .into_raw().await;
+                Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn form_test(
+        &self,
+        param_required_array: Option<&Vec<String>>,
+        context: &C) -> Result<FormTestResponse, ApiError>
+    {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/form-test",
+            self.base_path
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("POST")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Err(ApiError(format!("Unable to create request: {}", e)))
+        };
+
+        // Consumes form body
+        let mut params = vec![];
+        if let Some(param_required_array) = param_required_array {
+        // style=form,explode=true
+        for param_required_array in param_required_array {
+        params.push(("requiredArray",
+            format!("{:?}", param_required_array)
+        ));
+        }
+        }
+
+        let body = serde_urlencoded::to_string(params).expect("impossible to fail to serialize");
+
+        *request.body_mut() = Body::from(body.into_bytes());
+
+        let header = "application/x-www-form-urlencoded";
+        request.headers_mut().insert(CONTENT_TYPE, match HeaderValue::from_str(header) {
+            Ok(h) => h,
+            Err(e) => return Err(ApiError(format!("Unable to create header: {} - {}", header, e)))
+        });
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
+        });
+
+        let response = client_service.call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
+
+        match response.status().as_u16() {
+            200 => {
+                Ok(
+                    FormTestResponse::OK
                 )
             }
             code => {

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -49,6 +49,12 @@ pub enum ComplexQueryParamGetResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum FormTestResponse {
+    /// OK
+    OK
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum GetWithBooleanParameterResponse {
     /// OK
     OK
@@ -319,6 +325,12 @@ pub trait Api<C: Send + Sync> {
         list_of_strings: Option<&Vec<models::StringObject>>,
         context: &C) -> Result<ComplexQueryParamGetResponse, ApiError>;
 
+    /// Test a Form Post
+    async fn form_test(
+        &self,
+        required_array: Option<&Vec<String>>,
+        context: &C) -> Result<FormTestResponse, ApiError>;
+
     async fn get_with_boolean_parameter(
         &self,
         iambool: bool,
@@ -472,6 +484,12 @@ pub trait ApiNoContext<C: Send + Sync> {
         &self,
         list_of_strings: Option<&Vec<models::StringObject>>,
         ) -> Result<ComplexQueryParamGetResponse, ApiError>;
+
+    /// Test a Form Post
+    async fn form_test(
+        &self,
+        required_array: Option<&Vec<String>>,
+        ) -> Result<FormTestResponse, ApiError>;
 
     async fn get_with_boolean_parameter(
         &self,
@@ -651,6 +669,16 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     {
         let context = self.context().clone();
         self.api().complex_query_param_get(list_of_strings, &context).await
+    }
+
+    /// Test a Form Post
+    async fn form_test(
+        &self,
+        required_array: Option<&Vec<String>>,
+        ) -> Result<FormTestResponse, ApiError>
+    {
+        let context = self.context().clone();
+        self.api().form_test(required_array, &context).await
     }
 
     async fn get_with_boolean_parameter(

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -24,6 +24,7 @@ use crate::{Api,
      AnyOfGetResponse,
      CallbackWithHeaderPostResponse,
      ComplexQueryParamGetResponse,
+     FormTestResponse,
      GetWithBooleanParameterResponse,
      JsonComplexQueryParamGetResponse,
      MandatoryRequestHeaderGetResponse,
@@ -65,6 +66,7 @@ mod paths {
             r"^/callback-with-header$",
             r"^/complex-query-param$",
             r"^/enum_in_path/(?P<path_param>[^/?#]*)$",
+            r"^/form-test$",
             r"^/get-with-bool$",
             r"^/json-complex-query-param$",
             r"^/mandatory-request-header$",
@@ -101,41 +103,42 @@ mod paths {
             regex::Regex::new(r"^/enum_in_path/(?P<path_param>[^/?#]*)$")
                 .expect("Unable to create regex for ENUM_IN_PATH_PATH_PARAM");
     }
-    pub(crate) static ID_GET_WITH_BOOL: usize = 4;
-    pub(crate) static ID_JSON_COMPLEX_QUERY_PARAM: usize = 5;
-    pub(crate) static ID_MANDATORY_REQUEST_HEADER: usize = 6;
-    pub(crate) static ID_MERGE_PATCH_JSON: usize = 7;
-    pub(crate) static ID_MULTIGET: usize = 8;
-    pub(crate) static ID_MULTIPLE_PATH_PARAMS_WITH_VERY_LONG_PATH_TO_TEST_FORMATTING_PATH_PARAM_A_PATH_PARAM_B: usize = 9;
+    pub(crate) static ID_FORM_TEST: usize = 4;
+    pub(crate) static ID_GET_WITH_BOOL: usize = 5;
+    pub(crate) static ID_JSON_COMPLEX_QUERY_PARAM: usize = 6;
+    pub(crate) static ID_MANDATORY_REQUEST_HEADER: usize = 7;
+    pub(crate) static ID_MERGE_PATCH_JSON: usize = 8;
+    pub(crate) static ID_MULTIGET: usize = 9;
+    pub(crate) static ID_MULTIPLE_PATH_PARAMS_WITH_VERY_LONG_PATH_TO_TEST_FORMATTING_PATH_PARAM_A_PATH_PARAM_B: usize = 10;
     lazy_static! {
         pub static ref REGEX_MULTIPLE_PATH_PARAMS_WITH_VERY_LONG_PATH_TO_TEST_FORMATTING_PATH_PARAM_A_PATH_PARAM_B: regex::Regex =
             #[allow(clippy::invalid_regex)]
             regex::Regex::new(r"^/multiple-path-params-with-very-long-path-to-test-formatting/(?P<path_param_a>[^/?#]*)/(?P<path_param_b>[^/?#]*)$")
                 .expect("Unable to create regex for MULTIPLE_PATH_PARAMS_WITH_VERY_LONG_PATH_TO_TEST_FORMATTING_PATH_PARAM_A_PATH_PARAM_B");
     }
-    pub(crate) static ID_MULTIPLE_AUTH_SCHEME: usize = 10;
-    pub(crate) static ID_ONE_OF: usize = 11;
-    pub(crate) static ID_OPERATION_TWO_FIRST_LETTER_HEADERS: usize = 12;
-    pub(crate) static ID_OVERRIDE_SERVER: usize = 13;
-    pub(crate) static ID_PARAMGET: usize = 14;
-    pub(crate) static ID_READONLY_AUTH_SCHEME: usize = 15;
-    pub(crate) static ID_REGISTER_CALLBACK: usize = 16;
-    pub(crate) static ID_REPOS: usize = 17;
-    pub(crate) static ID_REPOS_REPOID: usize = 18;
+    pub(crate) static ID_MULTIPLE_AUTH_SCHEME: usize = 11;
+    pub(crate) static ID_ONE_OF: usize = 12;
+    pub(crate) static ID_OPERATION_TWO_FIRST_LETTER_HEADERS: usize = 13;
+    pub(crate) static ID_OVERRIDE_SERVER: usize = 14;
+    pub(crate) static ID_PARAMGET: usize = 15;
+    pub(crate) static ID_READONLY_AUTH_SCHEME: usize = 16;
+    pub(crate) static ID_REGISTER_CALLBACK: usize = 17;
+    pub(crate) static ID_REPOS: usize = 18;
+    pub(crate) static ID_REPOS_REPOID: usize = 19;
     lazy_static! {
         pub static ref REGEX_REPOS_REPOID: regex::Regex =
             #[allow(clippy::invalid_regex)]
             regex::Regex::new(r"^/repos/(?P<repoId>[^/?#]*)$")
                 .expect("Unable to create regex for REPOS_REPOID");
     }
-    pub(crate) static ID_REQUIRED_OCTET_STREAM: usize = 19;
-    pub(crate) static ID_RESPONSES_WITH_HEADERS: usize = 20;
-    pub(crate) static ID_RFC7807: usize = 21;
-    pub(crate) static ID_UNTYPED_PROPERTY: usize = 22;
-    pub(crate) static ID_UUID: usize = 23;
-    pub(crate) static ID_XML: usize = 24;
-    pub(crate) static ID_XML_EXTRA: usize = 25;
-    pub(crate) static ID_XML_OTHER: usize = 26;
+    pub(crate) static ID_REQUIRED_OCTET_STREAM: usize = 20;
+    pub(crate) static ID_RESPONSES_WITH_HEADERS: usize = 21;
+    pub(crate) static ID_RFC7807: usize = 22;
+    pub(crate) static ID_UNTYPED_PROPERTY: usize = 23;
+    pub(crate) static ID_UUID: usize = 24;
+    pub(crate) static ID_XML: usize = 25;
+    pub(crate) static ID_XML_EXTRA: usize = 26;
+    pub(crate) static ID_XML_OTHER: usize = 27;
 }
 
 
@@ -419,6 +422,54 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                         }
 
                                         Ok(response)
+            },
+
+            // FormTest - POST /form-test
+            hyper::Method::POST if path.matched(paths::ID_FORM_TEST) => {
+                // Handle body parameters (note that non-required body parameters will ignore garbage
+                // values, rather than causing a 400 response). Produce warning header and logs for
+                // any unused fields.
+                let result = body.into_raw().await;
+                match result {
+                     Ok(body) => {
+                                // Form parameters
+                                let param_required_array =
+                                    None;
+
+
+                                let result = api_impl.form_test(
+                                            param_required_array.as_ref(),
+                                        &context
+                                    ).await;
+                                let mut response = Response::new(Body::empty());
+                                response.headers_mut().insert(
+                                            HeaderName::from_static("x-span-id"),
+                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
+                                                .expect("Unable to create X-Span-ID header value"));
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                FormTestResponse::OK
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
+
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                                *response.body_mut() = Body::from("An internal error occurred");
+                                            },
+                                        }
+
+                                        Ok(response)
+                            },
+                            Err(e) => Ok(Response::builder()
+                                                .status(StatusCode::BAD_REQUEST)
+                                                .body(Body::from(format!("Unable to read body: {}", e)))
+                                                .expect("Unable to create Bad Request response due to unable to read body")),
+                        }
             },
 
             // GetWithBooleanParameter - GET /get-with-bool
@@ -2126,6 +2177,7 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
             _ if path.matched(paths::ID_CALLBACK_WITH_HEADER) => method_not_allowed(),
             _ if path.matched(paths::ID_COMPLEX_QUERY_PARAM) => method_not_allowed(),
             _ if path.matched(paths::ID_ENUM_IN_PATH_PATH_PARAM) => method_not_allowed(),
+            _ if path.matched(paths::ID_FORM_TEST) => method_not_allowed(),
             _ if path.matched(paths::ID_GET_WITH_BOOL) => method_not_allowed(),
             _ if path.matched(paths::ID_JSON_COMPLEX_QUERY_PARAM) => method_not_allowed(),
             _ if path.matched(paths::ID_MANDATORY_REQUEST_HEADER) => method_not_allowed(),
@@ -2173,6 +2225,8 @@ impl<T> RequestParser<T> for ApiRequestParser {
             hyper::Method::POST if path.matched(paths::ID_CALLBACK_WITH_HEADER) => Some("CallbackWithHeaderPost"),
             // ComplexQueryParamGet - GET /complex-query-param
             hyper::Method::GET if path.matched(paths::ID_COMPLEX_QUERY_PARAM) => Some("ComplexQueryParamGet"),
+            // FormTest - POST /form-test
+            hyper::Method::POST if path.matched(paths::ID_FORM_TEST) => Some("FormTest"),
             // GetWithBooleanParameter - GET /get-with-bool
             hyper::Method::GET if path.matched(paths::ID_GET_WITH_BOOL) => Some("GetWithBooleanParameter"),
             // JsonComplexQueryParamGet - GET /json-complex-query-param

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
@@ -1238,22 +1238,70 @@ impl<S, C> Api<C> for Client<S, C> where
         };
 
         // Consumes form body
-        let params = &[
-            ("integer", param_integer.map(|param| format!("{:?}", param))),
-            ("int32", param_int32.map(|param| format!("{:?}", param))),
-            ("int64", param_int64.map(|param| format!("{:?}", param))),
-            ("number", Some(format!("{:?}", param_number))),
-            ("float", param_float.map(|param| format!("{:?}", param))),
-            ("double", Some(format!("{:?}", param_double))),
-            ("string", param_string),
-            ("pattern_without_delimiter", Some(param_pattern_without_delimiter)),
-            ("byte", Some(format!("{:?}", param_byte))),
-            ("binary", param_binary.map(|param| format!("{:?}", param))),
-            ("date", param_date.map(|param| format!("{:?}", param))),
-            ("dateTime", param_date_time.map(|param| format!("{:?}", param))),
-            ("password", param_password),
-            ("callback", param_callback),
-        ];
+        let mut params = vec![];
+        if let Some(param_integer) = param_integer {
+        params.push(("integer",
+            format!("{:?}", param_integer)
+        ));
+        }
+        if let Some(param_int32) = param_int32 {
+        params.push(("int32",
+            format!("{:?}", param_int32)
+        ));
+        }
+        if let Some(param_int64) = param_int64 {
+        params.push(("int64",
+            format!("{:?}", param_int64)
+        ));
+        }
+        params.push(("number",
+            format!("{}", param_number)
+        ));
+        if let Some(param_float) = param_float {
+        params.push(("float",
+            format!("{:?}", param_float)
+        ));
+        }
+        params.push(("double",
+            format!("{}", param_double)
+        ));
+        if let Some(param_string) = param_string {
+        params.push(("string",
+            param_string
+        ));
+        }
+        params.push(("pattern_without_delimiter",
+            param_pattern_without_delimiter
+        ));
+        params.push(("byte",
+            format!("{:?}", param_byte)
+        ));
+        if let Some(param_binary) = param_binary {
+        params.push(("binary",
+            format!("{:?}", param_binary)
+        ));
+        }
+        if let Some(param_date) = param_date {
+        params.push(("date",
+            format!("{:?}", param_date)
+        ));
+        }
+        if let Some(param_date_time) = param_date_time {
+        params.push(("dateTime",
+            format!("{:?}", param_date_time)
+        ));
+        }
+        if let Some(param_password) = param_password {
+        params.push(("password",
+            param_password
+        ));
+        }
+        if let Some(param_callback) = param_callback {
+        params.push(("callback",
+            param_callback
+        ));
+        }
+
         let body = serde_urlencoded::to_string(params).expect("impossible to fail to serialize");
 
         *request.body_mut() = Body::from(body.into_bytes());
@@ -1379,9 +1427,13 @@ impl<S, C> Api<C> for Client<S, C> where
         };
 
         // Consumes form body
-        let params = &[
-            ("enum_form_string", param_enum_form_string.map(|param| format!("{:?}", param))),
-        ];
+        let mut params = vec![];
+        if let Some(param_enum_form_string) = param_enum_form_string {
+        params.push(("enum_form_string",
+            format!("{:?}", param_enum_form_string)
+        ));
+        }
+
         let body = serde_urlencoded::to_string(params).expect("impossible to fail to serialize");
 
         *request.body_mut() = Body::from(body.into_bytes());
@@ -1583,10 +1635,14 @@ impl<S, C> Api<C> for Client<S, C> where
         };
 
         // Consumes form body
-        let params = &[
-            ("param", Some(param_param)),
-            ("param2", Some(param_param2)),
-        ];
+        let mut params = vec![];
+        params.push(("param",
+            param_param
+        ));
+        params.push(("param2",
+            param_param2
+        ));
+
         let body = serde_urlencoded::to_string(params).expect("impossible to fail to serialize");
 
         *request.body_mut() = Body::from(body.into_bytes());
@@ -2470,10 +2526,18 @@ impl<S, C> Api<C> for Client<S, C> where
         };
 
         // Consumes form body
-        let params = &[
-            ("name", param_name),
-            ("status", param_status),
-        ];
+        let mut params = vec![];
+        if let Some(param_name) = param_name {
+        params.push(("name",
+            param_name
+        ));
+        }
+        if let Some(param_status) = param_status {
+        params.push(("status",
+            param_status
+        ));
+        }
+
         let body = serde_urlencoded::to_string(params).expect("impossible to fail to serialize");
 
         *request.body_mut() = Body::from(body.into_bytes());


### PR DESCRIPTION
Add support for arrays in forms (application/x-www-url-form-urlencoded) with the style properties `style=form,explode=true`.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Rust Technical Committee: @frol @farcaller @paladinzh @jacob-pro