### PR TITLE
[BUG][python-fastapi] Updated pyyaml and httptools in requirements template to resolve compatibility issues with Python 3.12

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
@@ -12,7 +12,7 @@ graphene==2.1.8
 graphql-core==2.3.2
 graphql-relay==2.0.1
 h11==0.12.0
-httptools==0.1.2
+httptools>=0.3.0,<0.7.0
 httpx==0.24.1
 idna==3.7
 itsdangerous==1.1.0
@@ -23,7 +23,7 @@ promise==2.3
 pydantic>=2
 python-dotenv==0.17.1
 python-multipart==0.0.7
-PyYAML==5.4.1
+PyYAML>=5.4.1,<6.1.0
 requests==2.32.0
 Rx==1.6.1
 starlette==0.36.3

--- a/samples/server/petstore/python-fastapi/requirements.txt
+++ b/samples/server/petstore/python-fastapi/requirements.txt
@@ -12,7 +12,7 @@ graphene==2.1.8
 graphql-core==2.3.2
 graphql-relay==2.0.1
 h11==0.12.0
-httptools==0.1.2
+httptools>=0.3.0,<0.7.0
 httpx==0.24.1
 idna==3.7
 itsdangerous==1.1.0
@@ -23,7 +23,7 @@ promise==2.3
 pydantic>=2
 python-dotenv==0.17.1
 python-multipart==0.0.7
-PyYAML==5.4.1
+PyYAML>=5.4.1,<6.1.0
 requests==2.32.0
 Rx==1.6.1
 starlette==0.36.3


### PR DESCRIPTION
Update the requirements.txt template for the python-fastapi generator to use updated dependency versions:
- Change PyYAML==5.4.1 to PyYAML>=5.4.1,<6.1.0
- Change httptools>=0.1.2 to httptools>=0.3.0,<0.7.0
This should resolve the compatibility issues with Python 3.12 and allow successful installation of the dependencies.

See issue [19665](https://github.com/OpenAPITools/openapi-generator/issues/19665)

@cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10) @multani (2023/10)

Thank you!

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.