### PR TITLE
zapier: create a search action predicate

### DIFF
--- a/modules/openapi-generator/src/main/resources/zapier/actions.mustache
+++ b/modules/openapi-generator/src/main/resources/zapier/actions.mustache
@@ -3,7 +3,7 @@
 const {{classname}} = require('../{{apiPackage}}/{{classname}}');
 {{/apis}}
 {{/apiInfo}}
-const { triggerMiddleware, isTrigger, searchMiddleware, hasSearchRequisites, isSearchAction } = require('../utils/utils');
+const { triggerMiddleware, isTrigger, searchMiddleware, hasSearchRequisites, isSearchAction, isCreateAction } = require('../utils/utils');
 
 const actions = {
     {{#apiInfo}}
@@ -19,6 +19,6 @@ const actions = {
 
 module.exports = {
     searchActions: () => Object.entries(actions).reduce((actions, [key, value]) => isSearchAction(key) && hasSearchRequisites(value) ? {...actions, [key]: searchMiddleware(value)} : actions, {}),
-    createActions: () => Object.entries(actions).reduce((actions, [key, value]) => !isSearchAction(key) ? {...actions, [key]: value} : actions, {}),
+    createActions: () => Object.entries(actions).reduce((actions, [key, value]) => isCreateAction(key) ? {...actions, [key]: value} : actions, {}),
     triggers: () => Object.entries(actions).reduce((actions, [key, value]) => isTrigger(key) ? {...actions, [key]: triggerMiddleware(value)} : actions, {}),
 }

--- a/modules/openapi-generator/src/main/resources/zapier/api.mustache
+++ b/modules/openapi-generator/src/main/resources/zapier/api.mustache
@@ -84,7 +84,6 @@ module.exports = {
                     method: '{{httpMethod}}',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{=<% %>=}}{{bundle.authData.access_token}}<%={{ }}=%>',
                         {{^isMultipart}}'Content-Type': '{{#consumes}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/consumes}}',{{/isMultipart}}
                         'Accept': '{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}',
                     },

--- a/modules/openapi-generator/src/main/resources/zapier/utils.mustache
+++ b/modules/openapi-generator/src/main/resources/zapier/utils.mustache
@@ -23,6 +23,11 @@ const searchMiddleware = (action) => {
     return action
 }
 
+const isCreateAction = (key) => {
+    // TODO: return true if the key is a "create" action for your API
+    return !isSearchAction(key);
+}
+
 const requestOptionsMiddleware = (z, bundle, requestOptions) => {
   // TODO: modify the request options for all outgoing request to your api
   //       if you are using session authentication without a Bearer token.
@@ -50,4 +55,5 @@ module.exports = {
     requestOptionsMiddleware: requestOptionsMiddleware,
     isTrigger: isTrigger,
     triggerMiddleware: triggerMiddleware,
+    isCreateAction: isCreateAction,
 }

--- a/samples/client/petstore/zapier/apis/PetApi.js
+++ b/samples/client/petstore/zapier/apis/PetApi.js
@@ -26,7 +26,6 @@ module.exports = {
                     method: 'POST',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': 'application/json, application/xml',
                         'Accept': 'application/xml, application/json',
                     },
@@ -75,7 +74,6 @@ module.exports = {
                     method: 'DELETE',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': '',
                         'Accept': '',
                     },
@@ -117,7 +115,6 @@ module.exports = {
                     method: 'GET',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': '',
                         'Accept': 'application/xml, application/json',
                     },
@@ -160,7 +157,6 @@ module.exports = {
                     method: 'GET',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': '',
                         'Accept': 'application/xml, application/json',
                     },
@@ -205,7 +201,6 @@ module.exports = {
                     method: 'GET',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': '',
                         'Accept': 'application/xml, application/json',
                     },
@@ -244,7 +239,6 @@ module.exports = {
                     method: 'PUT',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': 'application/json, application/xml',
                         'Accept': 'application/xml, application/json',
                     },
@@ -298,7 +292,6 @@ module.exports = {
                     method: 'POST',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': 'application/x-www-form-urlencoded',
                         'Accept': '',
                     },
@@ -356,7 +349,6 @@ module.exports = {
                     method: 'POST',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         
                         'Accept': 'application/json',
                     },

--- a/samples/client/petstore/zapier/apis/StoreApi.js
+++ b/samples/client/petstore/zapier/apis/StoreApi.js
@@ -28,7 +28,6 @@ module.exports = {
                     method: 'DELETE',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': '',
                         'Accept': '',
                     },
@@ -65,7 +64,6 @@ module.exports = {
                     method: 'GET',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': '',
                         'Accept': 'application/json',
                     },
@@ -109,7 +107,6 @@ module.exports = {
                     method: 'GET',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': '',
                         'Accept': 'application/xml, application/json',
                     },
@@ -148,7 +145,6 @@ module.exports = {
                     method: 'POST',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': 'application/json',
                         'Accept': 'application/xml, application/json',
                     },

--- a/samples/client/petstore/zapier/apis/UserApi.js
+++ b/samples/client/petstore/zapier/apis/UserApi.js
@@ -23,7 +23,6 @@ module.exports = {
                     method: 'POST',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': 'application/json',
                         'Accept': '',
                     },
@@ -66,7 +65,6 @@ module.exports = {
                     method: 'POST',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': 'application/json',
                         'Accept': '',
                     },
@@ -109,7 +107,6 @@ module.exports = {
                     method: 'POST',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': 'application/json',
                         'Accept': '',
                     },
@@ -153,7 +150,6 @@ module.exports = {
                     method: 'DELETE',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': '',
                         'Accept': '',
                     },
@@ -197,7 +193,6 @@ module.exports = {
                     method: 'GET',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': '',
                         'Accept': 'application/xml, application/json',
                     },
@@ -246,7 +241,6 @@ module.exports = {
                     method: 'GET',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': '',
                         'Accept': 'application/xml, application/json',
                     },
@@ -285,7 +279,6 @@ module.exports = {
                     method: 'GET',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': '',
                         'Accept': '',
                     },
@@ -329,7 +322,6 @@ module.exports = {
                     method: 'PUT',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {
-                        'Authorization': 'Bearer {{bundle.authData.access_token}}',
                         'Content-Type': 'application/json',
                         'Accept': '',
                     },

--- a/samples/client/petstore/zapier/operations/actions.js
+++ b/samples/client/petstore/zapier/operations/actions.js
@@ -1,7 +1,7 @@
 const PetApi = require('../apis/PetApi');
 const StoreApi = require('../apis/StoreApi');
 const UserApi = require('../apis/UserApi');
-const { triggerMiddleware, isTrigger, searchMiddleware, hasSearchRequisites, isSearchAction } = require('../utils/utils');
+const { triggerMiddleware, isTrigger, searchMiddleware, hasSearchRequisites, isSearchAction, isCreateAction } = require('../utils/utils');
 
 const actions = {
     [PetApi.addPet.key]: PetApi.addPet,
@@ -28,6 +28,6 @@ const actions = {
 
 module.exports = {
     searchActions: () => Object.entries(actions).reduce((actions, [key, value]) => isSearchAction(key) && hasSearchRequisites(value) ? {...actions, [key]: searchMiddleware(value)} : actions, {}),
-    createActions: () => Object.entries(actions).reduce((actions, [key, value]) => !isSearchAction(key) ? {...actions, [key]: value} : actions, {}),
+    createActions: () => Object.entries(actions).reduce((actions, [key, value]) => isCreateAction(key) ? {...actions, [key]: value} : actions, {}),
     triggers: () => Object.entries(actions).reduce((actions, [key, value]) => isTrigger(key) ? {...actions, [key]: triggerMiddleware(value)} : actions, {}),
 }

--- a/samples/client/petstore/zapier/utils/utils.js
+++ b/samples/client/petstore/zapier/utils/utils.js
@@ -23,6 +23,11 @@ const searchMiddleware = (action) => {
     return action
 }
 
+const isCreateAction = (key) => {
+    // TODO: return true if the key is a "create" action for your API
+    return !isSearchAction(key);
+}
+
 const requestOptionsMiddleware = (z, bundle, requestOptions) => {
   // TODO: modify the request options for all outgoing request to your api
   //       if you are using session authentication without a Bearer token.
@@ -50,4 +55,5 @@ module.exports = {
     requestOptionsMiddleware: requestOptionsMiddleware,
     isTrigger: isTrigger,
     triggerMiddleware: triggerMiddleware,
+    isCreateAction: isCreateAction,
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

closes https://github.com/OpenAPITools/openapi-generator/issues/19636

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
