### PR TITLE
Fix #19683 : Generated code fails to build with  x86_64-linux-gnu-g++-13

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/helpers-header.mustache
@@ -10,11 +10,11 @@
 
 #include <cstdint>
 #include <ctime>
-#include <string>
-#include <sstream>
-#include <vector>
 #include <map>
 #include <set>
+#include <sstream>
+#include <string>
+#include <vector>
 
 namespace {{helpersNamespace}}
 {

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/helpers-header.mustache
@@ -8,6 +8,7 @@
 #ifndef {{prefix}}Helpers_H_
 #define {{prefix}}Helpers_H_
 
+#include <cstdint>
 #include <ctime>
 #include <string>
 #include <sstream>

--- a/samples/server/petstore/cpp-pistache-everything/model/Helpers.h
+++ b/samples/server/petstore/cpp-pistache-everything/model/Helpers.h
@@ -18,12 +18,13 @@
 #ifndef Helpers_H_
 #define Helpers_H_
 
+#include <cstdint>
 #include <ctime>
-#include <string>
-#include <sstream>
-#include <vector>
 #include <map>
 #include <set>
+#include <sstream>
+#include <string>
+#include <vector>
 
 namespace org::openapitools::server::helpers
 {

--- a/samples/server/petstore/cpp-pistache-nested-schema-refs/model/Helpers.h
+++ b/samples/server/petstore/cpp-pistache-nested-schema-refs/model/Helpers.h
@@ -18,12 +18,13 @@
 #ifndef Helpers_H_
 #define Helpers_H_
 
+#include <cstdint>
 #include <ctime>
-#include <string>
-#include <sstream>
-#include <vector>
 #include <map>
 #include <set>
+#include <sstream>
+#include <string>
+#include <vector>
 
 namespace org::openapitools::server::helpers
 {

--- a/samples/server/petstore/cpp-pistache/model/Helpers.h
+++ b/samples/server/petstore/cpp-pistache/model/Helpers.h
@@ -18,12 +18,13 @@
 #ifndef Helpers_H_
 #define Helpers_H_
 
+#include <cstdint>
 #include <ctime>
-#include <string>
-#include <sstream>
-#include <vector>
 #include <map>
 #include <set>
+#include <sstream>
+#include <string>
+#include <vector>
 
 namespace org::openapitools::server::helpers
 {


### PR DESCRIPTION
This PR fixes #19683 

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

# Mentions
@ravinikam @stkrwork  @etherealjoy @martindelille  @muttleyxd
