### PR TITLE
Remove calculateRequestOrder Function and fix bug

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
@@ -21,6 +21,7 @@ import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.dashize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
+import java.lang.*;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
@@ -707,10 +708,8 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
                 Optional<DataExtractSubstituteParameter> dataExtract = getDataExtractSubstituteParameter(
                         dataExtractSubstituteParams, operationId);
 
-                // calculate order for this current request
-                Integer requestOrder = calculateRequestOrder(operationGroupingOrder, requests.size());
-
-                requests.put(requestOrder, new HTTPRequest(
+                // create requests
+                requests.putIfAbsent(requests.size(), new HTTPRequest(
                     operationId,
                     method.toString().toLowerCase(Locale.ROOT),
                     path,
@@ -933,7 +932,7 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
             existingHTTPRequestGroup.addRequests(requests);
             existingHTTPRequestGroup.addVariables(variables);
         } else {
-            requestGroups.put(groupName, new HTTPRequestGroup(groupName, variables, requests));
+            requestGroups.putIfAbsent(groupName, new HTTPRequestGroup(groupName, variables, requests));
         }
     }
 
@@ -1127,36 +1126,6 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
         }
     }
 
-    /**
-     * Calculate order for this current request
-     *
-     * @param operationGroupingOrder
-     * @param requestsSize
-     * @return request order
-     */
-    private Integer calculateRequestOrder(OptionalInt operationGroupingOrder, int requestsSize) {
-        int requestOrder;
-
-        if (operationGroupingOrder.isPresent()) {
-            requestOrder = operationGroupingOrder.getAsInt() - 1;
-
-        } else {
-            switch (requestsSize) {
-                case 0:
-                case 1:
-                    requestOrder = requestsSize;
-                    break;
-
-                default:
-                    requestOrder = (requestsSize - 1);
-                    break;
-            }
-        }
-
-        return requestOrder;
-    }
-
-    //
 
     /**
      * Any variables not defined yet but used for subsequent data extraction must be

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
@@ -21,7 +21,6 @@ import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.dashize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
-import java.lang.*;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;


### PR DESCRIPTION
### Summary
This PR removes the `calculateRequestOrder` function. The previous function was deemed unnecessary due to its redundant logic and lack of unique functionality.

### Changes made
- Removed function
- Removed call to `calculateRequestOrder` function, which calculated the order of requests based on `operationGroupingOrder` and `requestsSize`.

- Updated request creation logic:
  - Changed request creation logic to use `requests.size()` as the key in `requests.putIfAbsent()`, ensuring that each new request is added with a unique identifier based on the current size of the request map.

### Reason for change
- The original implementation included unnecessary complexity that generated a bug that only generated 2 operations if they were on the same path.

### Tests
- All existing tests have been run to ensure that no functionality has been affected by this change.
- Requests are added correctly without being removed, and existing functionality remains intact.

### Related issue
- Fixes issue #19110

### Reviewers
- Please review the changes and provide feedback on the removal of the feature.

Translated with DeepL.com (free version)