### PR TITLE
[Javascript] Add initialization of default vars to constructor

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/partial_model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/partial_model_generic.mustache
@@ -26,7 +26,8 @@ class {{classname}} {{#parent}}{{^parentModel}}{{#vendorExtensions.x-is-array}}e
      * Only for internal use.
      */{{/emitJSDoc}}
     static initialize(obj{{#vendorExtensions.x-all-required}}, {{name}}{{/vendorExtensions.x-all-required}}) { {{#vars}}{{#required}}
-        {{#defaultValue}}obj['{{baseName}}'] = {{name}} || {{{defaultValue}}};{{/defaultValue}}{{^defaultValue}}obj['{{baseName}}'] = {{name}};{{/defaultValue}}{{/required}}{{/vars}}
+        {{#defaultValue}}obj['{{baseName}}'] = {{name}} || {{{defaultValue}}};{{/defaultValue}}{{^defaultValue}}obj['{{baseName}}'] = {{name}};{{/defaultValue}}{{/required}}{{#defaultValue}}{{^required}}
+        obj['{{baseName}}'] = {{{defaultValue}}};{{/required}}{{/defaultValue}}{{/vars}}
     }
 
     {{#emitJSDoc}}/**

--- a/samples/client/petstore/javascript-apollo/src/model/Animal.js
+++ b/samples/client/petstore/javascript-apollo/src/model/Animal.js
@@ -36,6 +36,7 @@ class Animal {
      */
     static initialize(obj, className) { 
         obj['className'] = className;
+        obj['color'] = 'red';
     }
 
     /**

--- a/samples/client/petstore/javascript-apollo/src/model/Foo.js
+++ b/samples/client/petstore/javascript-apollo/src/model/Foo.js
@@ -34,6 +34,7 @@ class Foo {
      * Only for internal use.
      */
     static initialize(obj) { 
+        obj['bar'] = 'bar';
     }
 
     /**

--- a/samples/client/petstore/javascript-apollo/src/model/Order.js
+++ b/samples/client/petstore/javascript-apollo/src/model/Order.js
@@ -34,6 +34,7 @@ class Order {
      * Only for internal use.
      */
     static initialize(obj) { 
+        obj['complete'] = false;
     }
 
     /**

--- a/samples/client/petstore/javascript-es6/src/model/Animal.js
+++ b/samples/client/petstore/javascript-es6/src/model/Animal.js
@@ -36,6 +36,7 @@ class Animal {
      */
     static initialize(obj, className) { 
         obj['className'] = className;
+        obj['color'] = 'red';
     }
 
     /**

--- a/samples/client/petstore/javascript-es6/src/model/Foo.js
+++ b/samples/client/petstore/javascript-es6/src/model/Foo.js
@@ -34,6 +34,7 @@ class Foo {
      * Only for internal use.
      */
     static initialize(obj) { 
+        obj['bar'] = 'bar';
     }
 
     /**

--- a/samples/client/petstore/javascript-es6/src/model/Order.js
+++ b/samples/client/petstore/javascript-es6/src/model/Order.js
@@ -34,6 +34,7 @@ class Order {
      * Only for internal use.
      */
     static initialize(obj) { 
+        obj['complete'] = false;
     }
 
     /**

--- a/samples/client/petstore/javascript-promise-es6/src/model/Animal.js
+++ b/samples/client/petstore/javascript-promise-es6/src/model/Animal.js
@@ -36,6 +36,7 @@ class Animal {
      */
     static initialize(obj, className) { 
         obj['className'] = className;
+        obj['color'] = 'red';
     }
 
     /**

--- a/samples/client/petstore/javascript-promise-es6/src/model/Foo.js
+++ b/samples/client/petstore/javascript-promise-es6/src/model/Foo.js
@@ -34,6 +34,7 @@ class Foo {
      * Only for internal use.
      */
     static initialize(obj) { 
+        obj['bar'] = 'bar';
     }
 
     /**

--- a/samples/client/petstore/javascript-promise-es6/src/model/Order.js
+++ b/samples/client/petstore/javascript-promise-es6/src/model/Order.js
@@ -34,6 +34,7 @@ class Order {
      * Only for internal use.
      */
     static initialize(obj) { 
+        obj['complete'] = false;
     }
 
     /**


### PR DESCRIPTION
Add initialization of default vars to constructor in model template.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Related issue: https://github.com/OpenAPITools/openapi-generator/issues/19604

@CodeNinjai @frol  @cliffano 