### PR TITLE
style(typescript): use `Headers` type

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -63,6 +63,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -81,7 +83,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
     {{#platforms}}
@@ -135,7 +137,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -224,7 +226,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -235,8 +237,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -316,7 +318,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {

--- a/samples/client/others/typescript/builds/array-of-lists/http/http.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/http/http.ts
@@ -33,6 +33,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -44,7 +46,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
 
@@ -93,7 +95,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -160,7 +162,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -171,8 +173,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -245,7 +247,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {

--- a/samples/client/others/typescript/builds/with-unique-items/http/http.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/http/http.ts
@@ -33,6 +33,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -44,7 +46,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
 
@@ -93,7 +95,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -160,7 +162,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -171,8 +173,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -245,7 +247,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {

--- a/samples/client/others/typescript/encode-decode/build/http/http.ts
+++ b/samples/client/others/typescript/encode-decode/build/http/http.ts
@@ -41,6 +41,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -52,7 +54,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
     private agent: http.Agent | https.Agent | undefined = undefined;
@@ -102,7 +104,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -166,7 +168,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -177,8 +179,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -242,7 +244,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {

--- a/samples/openapi3/client/petstore/typescript/builds/browser/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/http/http.ts
@@ -33,6 +33,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -44,7 +46,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
 
@@ -93,7 +95,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -160,7 +162,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -171,8 +173,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -245,7 +247,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
@@ -33,6 +33,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -44,7 +46,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
 
@@ -93,7 +95,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -160,7 +162,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -171,8 +173,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -245,7 +247,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {

--- a/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
@@ -41,6 +41,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -52,7 +54,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
     private agent: http.Agent | https.Agent | undefined = undefined;
@@ -102,7 +104,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -166,7 +168,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -177,8 +179,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -242,7 +244,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {

--- a/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
@@ -32,6 +32,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -43,7 +45,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
 
@@ -92,7 +94,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -148,7 +150,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -159,8 +161,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -233,7 +235,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/http/http.ts
@@ -32,6 +32,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -43,7 +45,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
 
@@ -92,7 +94,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -148,7 +150,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -159,8 +161,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -233,7 +235,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/http/http.ts
@@ -41,6 +41,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -52,7 +54,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
     private agent: http.Agent | https.Agent | undefined = undefined;
@@ -102,7 +104,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -166,7 +168,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -177,8 +179,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -242,7 +244,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
@@ -41,6 +41,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -52,7 +54,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
     private agent: http.Agent | https.Agent | undefined = undefined;
@@ -102,7 +104,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -166,7 +168,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -177,8 +179,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -242,7 +244,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
@@ -33,6 +33,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -44,7 +46,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
 
@@ -93,7 +95,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -160,7 +162,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -171,8 +173,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -245,7 +247,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/http/http.ts
@@ -33,6 +33,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -44,7 +46,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
 
@@ -93,7 +95,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -160,7 +162,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -171,8 +173,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -245,7 +247,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
@@ -41,6 +41,8 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+type Headers = Record<string, string>;
+
 function ensureAbsoluteUrl(url: string) {
     if (url.startsWith("http://") || url.startsWith("https://")) {
         return url;
@@ -52,7 +54,7 @@ function ensureAbsoluteUrl(url: string) {
  * Represents an HTTP request context
  */
 export class RequestContext {
-    private headers: { [key: string]: string } = {};
+    private headers: Headers = {};
     private body: RequestBody = undefined;
     private url: URL;
     private agent: http.Agent | https.Agent | undefined = undefined;
@@ -102,7 +104,7 @@ export class RequestContext {
         return this.httpMethod;
     }
 
-    public getHeaders(): { [key: string]: string } {
+    public getHeaders(): Headers {
         return this.headers;
     }
 
@@ -166,7 +168,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody
     ) {}
 
@@ -177,8 +179,8 @@ export class ResponseContext {
      * Parameter names are converted to lower case
      * The first parameter is returned with the key `""`
      */
-    public getParsedHeader(headerName: string): { [parameter: string]: string } {
-        const result: { [parameter: string]: string } = {};
+    public getParsedHeader(headerName: string): Headers {
+        const result: Headers = {};
         if (!this.headers[headerName]) {
             return result;
         }
@@ -242,7 +244,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
-        public headers: { [key: string]: string },
+        public headers: Headers,
         public body: ResponseBody,
         public data: T,
     ) {


### PR DESCRIPTION
Replaces all inline occurrences of `{ [key:string]: string }` with a convenience type.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @macjohnny 
