### PR TITLE
feat(typescript): improve docs generation

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api_doc.mustache
@@ -22,27 +22,31 @@ Method | HTTP request | Description
 
 
 ```typescript
-import { {{{moduleName}}} } from '{{{projectName}}}';
-import * as fs from 'fs';
+{{#hasParams}}
+import { createConfiguration, {{classname}} } from '{{{projectName}}}';
+import type { {{classname}}{{operationIdCamelCase}}Request } from '{{{projectName}}}';
+{{/hasParams}}
+{{^hasParams}}
+import { createConfiguration, {{classname}} } from '{{{projectName}}}';
+{{/hasParams}}
 
-const configuration = {{{moduleName}}}.createConfiguration();
-const apiInstance = new {{{moduleName}}}.{{classname}}(configuration);
+const configuration = createConfiguration();
+const apiInstance = new {{classname}}(configuration);
 
 {{#hasParams}}
-let body:{{{moduleName}}}.{{classname}}{{operationIdCamelCase}}Request = {
+const request: {{classname}}{{operationIdCamelCase}}Request = {
 {{#allParams}}
-  // {{{dataType}}}{{#description}} | {{{description}}}{{/description}}{{^required}} (optional){{/required}}
+  {{#description}}  // {{{description}}}{{^required}} (optional){{/required}}{{/description}}
   {{paramName}}: {{{example}}},
 {{/allParams}}
 };
 {{/hasParams}}
 {{^hasParams}}
-let body:any = {};
+const request = {};
 {{/hasParams}}
 
-apiInstance.{{{operationId}}}(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.{{{operationId}}}(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/client/others/typescript/builds/array-of-lists/DefaultApi.md
+++ b/samples/client/others/typescript/builds/array-of-lists/DefaultApi.md
@@ -15,17 +15,15 @@ Method | HTTP request | Description
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.list(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.list(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/client/others/typescript/builds/with-unique-items/DefaultApi.md
+++ b/samples/client/others/typescript/builds/with-unique-items/DefaultApi.md
@@ -15,17 +15,15 @@ Method | HTTP request | Description
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.uniqueItems(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.uniqueItems(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/client/others/typescript/encode-decode/build/DefaultApi.md
+++ b/samples/client/others/typescript/encode-decode/build/DefaultApi.md
@@ -46,17 +46,15 @@ Method | HTTP request | Description
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodeArrayOfArraysGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodeArrayOfArraysGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -93,17 +91,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodeArrayOfGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodeArrayOfGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -140,17 +136,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodeArrayOfMapsOfObjectsGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodeArrayOfMapsOfObjectsGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -187,17 +181,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodeArrayOfNullableGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodeArrayOfNullableGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -234,17 +226,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodeArrayOfNullableObjectsGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodeArrayOfNullableObjectsGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -281,17 +271,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodeCompositeObjectsGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodeCompositeObjectsGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -328,17 +316,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodeMapOfMapsOfObjectsGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodeMapOfMapsOfObjectsGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -375,17 +361,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodeMapOfObjectsGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodeMapOfObjectsGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -422,17 +406,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodeMapOfPrimitiveGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodeMapOfPrimitiveGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -469,17 +451,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodeNullableArrayGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodeNullableArrayGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -516,17 +496,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodeNullableGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodeNullableGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -563,17 +541,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodeObjectGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodeObjectGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -610,17 +586,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodePrimitiveBooleanGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodePrimitiveBooleanGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -657,17 +631,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodePrimitiveIntegerGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodePrimitiveIntegerGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -704,17 +676,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodePrimitiveNumberGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodePrimitiveNumberGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -751,17 +721,15 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.testDecodePrimitiveStringGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testDecodePrimitiveStringGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -798,14 +766,14 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodeArrayOfArraysPostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodeArrayOfArraysPostRequest = {
-  // Array<Array<string>>
+const request: DefaultApiTestEncodeArrayOfArraysPostRequest = {
+  
   requestBody: [
     [
       "string_example",
@@ -813,9 +781,8 @@ let body:.DefaultApiTestEncodeArrayOfArraysPostRequest = {
   ],
 };
 
-apiInstance.testEncodeArrayOfArraysPost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodeArrayOfArraysPost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -855,14 +822,14 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodeArrayOfMapsOfObjectsPostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodeArrayOfMapsOfObjectsPostRequest = {
-  // Array<{ [key: string]: ComplexObject; }>
+const request: DefaultApiTestEncodeArrayOfMapsOfObjectsPostRequest = {
+  
   complexObject: [
     {
       "key": {
@@ -875,9 +842,8 @@ let body:.DefaultApiTestEncodeArrayOfMapsOfObjectsPostRequest = {
   ],
 };
 
-apiInstance.testEncodeArrayOfMapsOfObjectsPost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodeArrayOfMapsOfObjectsPost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -917,14 +883,14 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodeArrayOfNullableObjectsPostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodeArrayOfNullableObjectsPostRequest = {
-  // Array<ComplexObject>
+const request: DefaultApiTestEncodeArrayOfNullableObjectsPostRequest = {
+  
   complexObject: [
     {
       requiredProperty: "requiredProperty_example",
@@ -935,9 +901,8 @@ let body:.DefaultApiTestEncodeArrayOfNullableObjectsPostRequest = {
   ],
 };
 
-apiInstance.testEncodeArrayOfNullableObjectsPost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodeArrayOfNullableObjectsPost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -977,22 +942,21 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodeArrayOfNullablePostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodeArrayOfNullablePostRequest = {
-  // Array<string | null>
+const request: DefaultApiTestEncodeArrayOfNullablePostRequest = {
+  
   requestBody: [
     "requestBody_example",
   ],
 };
 
-apiInstance.testEncodeArrayOfNullablePost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodeArrayOfNullablePost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1032,22 +996,21 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodeArrayOfPostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodeArrayOfPostRequest = {
-  // Array<string>
+const request: DefaultApiTestEncodeArrayOfPostRequest = {
+  
   requestBody: [
     "requestBody_example",
   ],
 };
 
-apiInstance.testEncodeArrayOfPost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodeArrayOfPost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1087,14 +1050,14 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodeCompositeObjectsPostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodeCompositeObjectsPostRequest = {
-  // CompositeObject
+const request: DefaultApiTestEncodeCompositeObjectsPostRequest = {
+  
   compositeObject: {
     optionalNullableInnerObject: {
       requiredProperty: "requiredProperty_example",
@@ -1105,9 +1068,8 @@ let body:.DefaultApiTestEncodeCompositeObjectsPostRequest = {
   },
 };
 
-apiInstance.testEncodeCompositeObjectsPost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodeCompositeObjectsPost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1147,14 +1109,14 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodeMapOfMapsOfObjectsPostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodeMapOfMapsOfObjectsPostRequest = {
-  // { [key: string]: { [key: string]: ComplexObject; }; }
+const request: DefaultApiTestEncodeMapOfMapsOfObjectsPostRequest = {
+  
   requestBody: {
     "key": 
       key: {
@@ -1167,9 +1129,8 @@ let body:.DefaultApiTestEncodeMapOfMapsOfObjectsPostRequest = {
   },
 };
 
-apiInstance.testEncodeMapOfMapsOfObjectsPost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodeMapOfMapsOfObjectsPost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1209,14 +1170,14 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodeMapOfObjectsPostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodeMapOfObjectsPostRequest = {
-  // { [key: string]: ComplexObject | null; }
+const request: DefaultApiTestEncodeMapOfObjectsPostRequest = {
+  
   requestBody: {
     "key": {
       requiredProperty: "requiredProperty_example",
@@ -1227,9 +1188,8 @@ let body:.DefaultApiTestEncodeMapOfObjectsPostRequest = {
   },
 };
 
-apiInstance.testEncodeMapOfObjectsPost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodeMapOfObjectsPost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1269,22 +1229,21 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodeMapOfPrimitivePostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodeMapOfPrimitivePostRequest = {
-  // { [key: string]: string; }
+const request: DefaultApiTestEncodeMapOfPrimitivePostRequest = {
+  
   requestBody: {
     "key": "key_example",
   },
 };
 
-apiInstance.testEncodeMapOfPrimitivePost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodeMapOfPrimitivePost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1324,22 +1283,21 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodeNullableArrayPostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodeNullableArrayPostRequest = {
-  // Array<string> (optional)
+const request: DefaultApiTestEncodeNullableArrayPostRequest = {
+  
   requestBody: [
     "requestBody_example",
   ],
 };
 
-apiInstance.testEncodeNullableArrayPost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodeNullableArrayPost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1379,20 +1337,19 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodeNullablePostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodeNullablePostRequest = {
-  // string (optional)
+const request: DefaultApiTestEncodeNullablePostRequest = {
+  
   body: "body_example",
 };
 
-apiInstance.testEncodeNullablePost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodeNullablePost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1432,14 +1389,14 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodeObjectPostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodeObjectPostRequest = {
-  // ComplexObject
+const request: DefaultApiTestEncodeObjectPostRequest = {
+  
   complexObject: {
     requiredProperty: "requiredProperty_example",
     requiredNullableProperty: "requiredNullableProperty_example",
@@ -1448,9 +1405,8 @@ let body:.DefaultApiTestEncodeObjectPostRequest = {
   },
 };
 
-apiInstance.testEncodeObjectPost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodeObjectPost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1490,20 +1446,19 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodePrimitiveBooleanPostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodePrimitiveBooleanPostRequest = {
-  // boolean
+const request: DefaultApiTestEncodePrimitiveBooleanPostRequest = {
+  
   body: true,
 };
 
-apiInstance.testEncodePrimitiveBooleanPost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodePrimitiveBooleanPost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1543,20 +1498,19 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodePrimitiveIntegerPostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodePrimitiveIntegerPostRequest = {
-  // number
+const request: DefaultApiTestEncodePrimitiveIntegerPostRequest = {
+  
   body: 1,
 };
 
-apiInstance.testEncodePrimitiveIntegerPost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodePrimitiveIntegerPost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1596,20 +1550,19 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodePrimitiveNumberPostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodePrimitiveNumberPostRequest = {
-  // number
+const request: DefaultApiTestEncodePrimitiveNumberPostRequest = {
+  
   body: 3.14,
 };
 
-apiInstance.testEncodePrimitiveNumberPost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodePrimitiveNumberPost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1649,20 +1602,19 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiTestEncodePrimitiveStringPostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiTestEncodePrimitiveStringPostRequest = {
-  // string
+const request: DefaultApiTestEncodePrimitiveStringPostRequest = {
+  
   body: "body_example",
 };
 
-apiInstance.testEncodePrimitiveStringPost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEncodePrimitiveStringPost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/browser/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/PetApi.md
@@ -23,14 +23,14 @@ Method | HTTP request | Description
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiAddPetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiAddPetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiAddPetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -51,9 +51,8 @@ let body:petstore.PetApiAddPetRequest = {
   },
 };
 
-apiInstance.addPet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.addPet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -95,22 +94,21 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiDeletePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiDeletePetRequest = {
-  // number | Pet id to delete
+const request: PetApiDeletePetRequest = {
+    // Pet id to delete
   petId: 1,
-  // string (optional)
+  
   apiKey: "api_key_example",
 };
 
-apiInstance.deletePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deletePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -152,22 +150,21 @@ Multiple status values can be provided with comma separated strings
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByStatusRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByStatusRequest = {
-  // Array<'available' | 'pending' | 'sold'> | Status values that need to be considered for filter
+const request: PetApiFindPetsByStatusRequest = {
+    // Status values that need to be considered for filter
   status: [
     "available",
   ],
 };
 
-apiInstance.findPetsByStatus(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByStatus(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -209,22 +206,21 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByTagsRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByTagsRequest = {
-  // Array<string> | Tags to filter by
+const request: PetApiFindPetsByTagsRequest = {
+    // Tags to filter by
   tags: [
     "tags_example",
   ],
 };
 
-apiInstance.findPetsByTags(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByTags(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -266,20 +262,19 @@ Returns a single pet
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiGetPetByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiGetPetByIdRequest = {
-  // number | ID of pet to return
+const request: PetApiGetPetByIdRequest = {
+    // ID of pet to return
   petId: 1,
 };
 
-apiInstance.getPetById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getPetById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -322,14 +317,14 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiUpdatePetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -350,9 +345,8 @@ let body:petstore.PetApiUpdatePetRequest = {
   },
 };
 
-apiInstance.updatePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -396,24 +390,23 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetWithFormRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetWithFormRequest = {
-  // number | ID of pet that needs to be updated
+const request: PetApiUpdatePetWithFormRequest = {
+    // ID of pet that needs to be updated
   petId: 1,
-  // string | Updated name of the pet (optional)
+    // Updated name of the pet (optional)
   name: "name_example",
-  // string | Updated status of the pet (optional)
+    // Updated status of the pet (optional)
   status: "status_example",
 };
 
-apiInstance.updatePetWithForm(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePetWithForm(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -456,24 +449,23 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUploadFileRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUploadFileRequest = {
-  // number | ID of pet to update
+const request: PetApiUploadFileRequest = {
+    // ID of pet to update
   petId: 1,
-  // string | Additional data to pass to server (optional)
+    // Additional data to pass to server (optional)
   additionalMetadata: "additionalMetadata_example",
-  // HttpFile | file to upload (optional)
+    // file to upload (optional)
   file: { data: Buffer.from(fs.readFileSync('/path/to/file', 'utf-8')), name: '/path/to/file' },
 };
 
-apiInstance.uploadFile(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.uploadFile(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/browser/StoreApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/StoreApi.md
@@ -19,20 +19,19 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiDeleteOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiDeleteOrderRequest = {
-  // string | ID of the order that needs to be deleted
+const request: StoreApiDeleteOrderRequest = {
+    // ID of the order that needs to be deleted
   orderId: "orderId_example",
 };
 
-apiInstance.deleteOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -74,17 +73,15 @@ Returns a map of status codes to quantities
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.getInventory(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getInventory(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -122,20 +119,19 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiGetOrderByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiGetOrderByIdRequest = {
-  // number | ID of pet that needs to be fetched
+const request: StoreApiGetOrderByIdRequest = {
+    // ID of pet that needs to be fetched
   orderId: 1,
 };
 
-apiInstance.getOrderById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getOrderById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -178,14 +174,14 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiPlaceOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiPlaceOrderRequest = {
-  // Order | order placed for purchasing the pet
+const request: StoreApiPlaceOrderRequest = {
+    // order placed for purchasing the pet
   order: {
     id: 1,
     petId: 1,
@@ -196,9 +192,8 @@ let body:petstore.StoreApiPlaceOrderRequest = {
   },
 };
 
-apiInstance.placeOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.placeOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/browser/UserApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/UserApi.md
@@ -23,14 +23,14 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUserRequest = {
-  // User | Created user object
+const request: UserApiCreateUserRequest = {
+    // Created user object
   user: {
     id: 1,
     username: "username_example",
@@ -43,9 +43,8 @@ let body:petstore.UserApiCreateUserRequest = {
   },
 };
 
-apiInstance.createUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -86,14 +85,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithArrayInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithArrayInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -108,9 +107,8 @@ let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithArrayInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithArrayInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -151,14 +149,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithListInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithListInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithListInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -173,9 +171,8 @@ let body:petstore.UserApiCreateUsersWithListInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithListInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithListInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -216,20 +213,19 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiDeleteUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiDeleteUserRequest = {
-  // string | The name that needs to be deleted
+const request: UserApiDeleteUserRequest = {
+    // The name that needs to be deleted
   username: "username_example",
 };
 
-apiInstance.deleteUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -271,20 +267,19 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiGetUserByNameRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiGetUserByNameRequest = {
-  // string | The name that needs to be fetched. Use user1 for testing.
+const request: UserApiGetUserByNameRequest = {
+    // The name that needs to be fetched. Use user1 for testing.
   username: "username_example",
 };
 
-apiInstance.getUserByName(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getUserByName(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -327,22 +322,21 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiLoginUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiLoginUserRequest = {
-  // string | The user name for login
+const request: UserApiLoginUserRequest = {
+    // The user name for login
   username: "CbUUGjjNSwg0_bs9ZayIMrKdgNvb6gvxmPb9GcsM61ate1RA89q3w1l4eH4XxEz.5awLMdeXylwK0lMGUSM4jsrh4dstlnQUN5vVdMLPA",
-  // string | The password for login in clear text
+    // The password for login in clear text
   password: "password_example",
 };
 
-apiInstance.loginUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.loginUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -385,17 +379,15 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.logoutUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.logoutUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -433,16 +425,16 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiUpdateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiUpdateUserRequest = {
-  // string | name that need to be deleted
+const request: UserApiUpdateUserRequest = {
+    // name that need to be deleted
   username: "username_example",
-  // User | Updated user object
+    // Updated user object
   user: {
     id: 1,
     username: "username_example",
@@ -455,9 +447,8 @@ let body:petstore.UserApiUpdateUserRequest = {
   },
 };
 
-apiInstance.updateUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updateUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/DefaultApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/DefaultApi.md
@@ -17,22 +17,21 @@ Method | HTTP request | Description
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiFilePostRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiFilePostRequest = {
-  // FilePostRequest (optional)
+const request: DefaultApiFilePostRequest = {
+  
   filePostRequest: {
     file: null,
   },
 };
 
-apiInstance.filePost(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.filePost(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -72,20 +71,19 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiPetsFilteredPatchRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiPetsFilteredPatchRequest = {
-  // PetsFilteredPatchRequest (optional)
+const request: DefaultApiPetsFilteredPatchRequest = {
+  
   petsFilteredPatchRequest: null,
 };
 
-apiInstance.petsFilteredPatch(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.petsFilteredPatch(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -125,20 +123,19 @@ No authorization required
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
+import type { DefaultApiPetsPatchRequest } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:.DefaultApiPetsPatchRequest = {
-  // PetsPatchRequest (optional)
+const request: DefaultApiPetsPatchRequest = {
+  
   petsPatchRequest: null,
 };
 
-apiInstance.petsPatch(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.petsPatch(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/default/PetApi.md
@@ -23,14 +23,14 @@ Method | HTTP request | Description
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiAddPetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiAddPetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiAddPetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -51,9 +51,8 @@ let body:petstore.PetApiAddPetRequest = {
   },
 };
 
-apiInstance.addPet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.addPet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -95,22 +94,21 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiDeletePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiDeletePetRequest = {
-  // number | Pet id to delete
+const request: PetApiDeletePetRequest = {
+    // Pet id to delete
   petId: 1,
-  // string (optional)
+  
   apiKey: "api_key_example",
 };
 
-apiInstance.deletePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deletePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -152,22 +150,21 @@ Multiple status values can be provided with comma separated strings
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByStatusRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByStatusRequest = {
-  // Array<'available' | 'pending' | 'sold'> | Status values that need to be considered for filter
+const request: PetApiFindPetsByStatusRequest = {
+    // Status values that need to be considered for filter
   status: [
     "available",
   ],
 };
 
-apiInstance.findPetsByStatus(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByStatus(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -209,22 +206,21 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByTagsRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByTagsRequest = {
-  // Array<string> | Tags to filter by
+const request: PetApiFindPetsByTagsRequest = {
+    // Tags to filter by
   tags: [
     "tags_example",
   ],
 };
 
-apiInstance.findPetsByTags(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByTags(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -266,20 +262,19 @@ Returns a single pet
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiGetPetByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiGetPetByIdRequest = {
-  // number | ID of pet to return
+const request: PetApiGetPetByIdRequest = {
+    // ID of pet to return
   petId: 1,
 };
 
-apiInstance.getPetById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getPetById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -322,14 +317,14 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiUpdatePetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -350,9 +345,8 @@ let body:petstore.PetApiUpdatePetRequest = {
   },
 };
 
-apiInstance.updatePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -396,24 +390,23 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetWithFormRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetWithFormRequest = {
-  // number | ID of pet that needs to be updated
+const request: PetApiUpdatePetWithFormRequest = {
+    // ID of pet that needs to be updated
   petId: 1,
-  // string | Updated name of the pet (optional)
+    // Updated name of the pet (optional)
   name: "name_example",
-  // string | Updated status of the pet (optional)
+    // Updated status of the pet (optional)
   status: "status_example",
 };
 
-apiInstance.updatePetWithForm(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePetWithForm(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -456,24 +449,23 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUploadFileRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUploadFileRequest = {
-  // number | ID of pet to update
+const request: PetApiUploadFileRequest = {
+    // ID of pet to update
   petId: 1,
-  // string | Additional data to pass to server (optional)
+    // Additional data to pass to server (optional)
   additionalMetadata: "additionalMetadata_example",
-  // HttpFile | file to upload (optional)
+    // file to upload (optional)
   file: { data: Buffer.from(fs.readFileSync('/path/to/file', 'utf-8')), name: '/path/to/file' },
 };
 
-apiInstance.uploadFile(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.uploadFile(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/StoreApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/default/StoreApi.md
@@ -19,20 +19,19 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiDeleteOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiDeleteOrderRequest = {
-  // string | ID of the order that needs to be deleted
+const request: StoreApiDeleteOrderRequest = {
+    // ID of the order that needs to be deleted
   orderId: "orderId_example",
 };
 
-apiInstance.deleteOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -74,17 +73,15 @@ Returns a map of status codes to quantities
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.getInventory(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getInventory(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -122,20 +119,19 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiGetOrderByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiGetOrderByIdRequest = {
-  // number | ID of pet that needs to be fetched
+const request: StoreApiGetOrderByIdRequest = {
+    // ID of pet that needs to be fetched
   orderId: 1,
 };
 
-apiInstance.getOrderById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getOrderById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -178,14 +174,14 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiPlaceOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiPlaceOrderRequest = {
-  // Order | order placed for purchasing the pet
+const request: StoreApiPlaceOrderRequest = {
+    // order placed for purchasing the pet
   order: {
     id: 1,
     petId: 1,
@@ -196,9 +192,8 @@ let body:petstore.StoreApiPlaceOrderRequest = {
   },
 };
 
-apiInstance.placeOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.placeOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/UserApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/default/UserApi.md
@@ -23,14 +23,14 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUserRequest = {
-  // User | Created user object
+const request: UserApiCreateUserRequest = {
+    // Created user object
   user: {
     id: 1,
     username: "username_example",
@@ -43,9 +43,8 @@ let body:petstore.UserApiCreateUserRequest = {
   },
 };
 
-apiInstance.createUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -86,14 +85,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithArrayInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithArrayInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -108,9 +107,8 @@ let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithArrayInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithArrayInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -151,14 +149,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithListInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithListInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithListInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -173,9 +171,8 @@ let body:petstore.UserApiCreateUsersWithListInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithListInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithListInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -216,20 +213,19 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiDeleteUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiDeleteUserRequest = {
-  // string | The name that needs to be deleted
+const request: UserApiDeleteUserRequest = {
+    // The name that needs to be deleted
   username: "username_example",
 };
 
-apiInstance.deleteUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -271,20 +267,19 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiGetUserByNameRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiGetUserByNameRequest = {
-  // string | The name that needs to be fetched. Use user1 for testing.
+const request: UserApiGetUserByNameRequest = {
+    // The name that needs to be fetched. Use user1 for testing.
   username: "username_example",
 };
 
-apiInstance.getUserByName(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getUserByName(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -327,22 +322,21 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiLoginUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiLoginUserRequest = {
-  // string | The user name for login
+const request: UserApiLoginUserRequest = {
+    // The user name for login
   username: "CbUUGjjNSwg0_bs9ZayIMrKdgNvb6gvxmPb9GcsM61ate1RA89q3w1l4eH4XxEz.5awLMdeXylwK0lMGUSM4jsrh4dstlnQUN5vVdMLPA",
-  // string | The password for login in clear text
+    // The password for login in clear text
   password: "password_example",
 };
 
-apiInstance.loginUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.loginUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -385,17 +379,15 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.logoutUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.logoutUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -433,16 +425,16 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiUpdateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiUpdateUserRequest = {
-  // string | name that need to be deleted
+const request: UserApiUpdateUserRequest = {
+    // name that need to be deleted
   username: "username_example",
-  // User | Updated user object
+    // Updated user object
   user: {
     id: 1,
     username: "username_example",
@@ -455,9 +447,8 @@ let body:petstore.UserApiUpdateUserRequest = {
   },
 };
 
-apiInstance.updateUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updateUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/PetApi.md
@@ -23,14 +23,14 @@ Method | HTTP request | Description
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiAddPetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiAddPetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiAddPetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -51,9 +51,8 @@ let body:petstore.PetApiAddPetRequest = {
   },
 };
 
-apiInstance.addPet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.addPet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -95,22 +94,21 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiDeletePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiDeletePetRequest = {
-  // number | Pet id to delete
+const request: PetApiDeletePetRequest = {
+    // Pet id to delete
   petId: 1,
-  // string (optional)
+  
   apiKey: "api_key_example",
 };
 
-apiInstance.deletePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deletePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -152,22 +150,21 @@ Multiple status values can be provided with comma separated strings
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByStatusRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByStatusRequest = {
-  // Array<'available' | 'pending' | 'sold'> | Status values that need to be considered for filter
+const request: PetApiFindPetsByStatusRequest = {
+    // Status values that need to be considered for filter
   status: [
     "available",
   ],
 };
 
-apiInstance.findPetsByStatus(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByStatus(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -209,22 +206,21 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByTagsRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByTagsRequest = {
-  // Array<string> | Tags to filter by
+const request: PetApiFindPetsByTagsRequest = {
+    // Tags to filter by
   tags: [
     "tags_example",
   ],
 };
 
-apiInstance.findPetsByTags(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByTags(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -266,20 +262,19 @@ Returns a single pet
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiGetPetByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiGetPetByIdRequest = {
-  // number | ID of pet to return
+const request: PetApiGetPetByIdRequest = {
+    // ID of pet to return
   petId: 1,
 };
 
-apiInstance.getPetById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getPetById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -322,14 +317,14 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiUpdatePetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -350,9 +345,8 @@ let body:petstore.PetApiUpdatePetRequest = {
   },
 };
 
-apiInstance.updatePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -396,24 +390,23 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetWithFormRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetWithFormRequest = {
-  // number | ID of pet that needs to be updated
+const request: PetApiUpdatePetWithFormRequest = {
+    // ID of pet that needs to be updated
   petId: 1,
-  // string | Updated name of the pet (optional)
+    // Updated name of the pet (optional)
   name: "name_example",
-  // string | Updated status of the pet (optional)
+    // Updated status of the pet (optional)
   status: "status_example",
 };
 
-apiInstance.updatePetWithForm(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePetWithForm(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -456,24 +449,23 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUploadFileRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUploadFileRequest = {
-  // number | ID of pet to update
+const request: PetApiUploadFileRequest = {
+    // ID of pet to update
   petId: 1,
-  // string | Additional data to pass to server (optional)
+    // Additional data to pass to server (optional)
   additionalMetadata: "additionalMetadata_example",
-  // HttpFile | file to upload (optional)
+    // file to upload (optional)
   file: { data: Buffer.from(fs.readFileSync('/path/to/file', 'utf-8')), name: '/path/to/file' },
 };
 
-apiInstance.uploadFile(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.uploadFile(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno/StoreApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/StoreApi.md
@@ -19,20 +19,19 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiDeleteOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiDeleteOrderRequest = {
-  // string | ID of the order that needs to be deleted
+const request: StoreApiDeleteOrderRequest = {
+    // ID of the order that needs to be deleted
   orderId: "orderId_example",
 };
 
-apiInstance.deleteOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -74,17 +73,15 @@ Returns a map of status codes to quantities
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.getInventory(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getInventory(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -122,20 +119,19 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiGetOrderByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiGetOrderByIdRequest = {
-  // number | ID of pet that needs to be fetched
+const request: StoreApiGetOrderByIdRequest = {
+    // ID of pet that needs to be fetched
   orderId: 1,
 };
 
-apiInstance.getOrderById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getOrderById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -178,14 +174,14 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiPlaceOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiPlaceOrderRequest = {
-  // Order | order placed for purchasing the pet
+const request: StoreApiPlaceOrderRequest = {
+    // order placed for purchasing the pet
   order: {
     id: 1,
     petId: 1,
@@ -196,9 +192,8 @@ let body:petstore.StoreApiPlaceOrderRequest = {
   },
 };
 
-apiInstance.placeOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.placeOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno/UserApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/UserApi.md
@@ -23,14 +23,14 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUserRequest = {
-  // User | Created user object
+const request: UserApiCreateUserRequest = {
+    // Created user object
   user: {
     id: 1,
     username: "username_example",
@@ -43,9 +43,8 @@ let body:petstore.UserApiCreateUserRequest = {
   },
 };
 
-apiInstance.createUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -86,14 +85,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithArrayInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithArrayInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -108,9 +107,8 @@ let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithArrayInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithArrayInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -151,14 +149,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithListInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithListInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithListInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -173,9 +171,8 @@ let body:petstore.UserApiCreateUsersWithListInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithListInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithListInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -216,20 +213,19 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiDeleteUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiDeleteUserRequest = {
-  // string | The name that needs to be deleted
+const request: UserApiDeleteUserRequest = {
+    // The name that needs to be deleted
   username: "username_example",
 };
 
-apiInstance.deleteUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -271,20 +267,19 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiGetUserByNameRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiGetUserByNameRequest = {
-  // string | The name that needs to be fetched. Use user1 for testing.
+const request: UserApiGetUserByNameRequest = {
+    // The name that needs to be fetched. Use user1 for testing.
   username: "username_example",
 };
 
-apiInstance.getUserByName(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getUserByName(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -327,22 +322,21 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiLoginUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiLoginUserRequest = {
-  // string | The user name for login
+const request: UserApiLoginUserRequest = {
+    // The user name for login
   username: "CbUUGjjNSwg0_bs9ZayIMrKdgNvb6gvxmPb9GcsM61ate1RA89q3w1l4eH4XxEz.5awLMdeXylwK0lMGUSM4jsrh4dstlnQUN5vVdMLPA",
-  // string | The password for login in clear text
+    // The password for login in clear text
   password: "password_example",
 };
 
-apiInstance.loginUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.loginUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -385,17 +379,15 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.logoutUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.logoutUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -433,16 +425,16 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiUpdateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiUpdateUserRequest = {
-  // string | name that need to be deleted
+const request: UserApiUpdateUserRequest = {
+    // name that need to be deleted
   username: "username_example",
-  // User | Updated user object
+    // Updated user object
   user: {
     id: 1,
     username: "username_example",
@@ -455,9 +447,8 @@ let body:petstore.UserApiUpdateUserRequest = {
   },
 };
 
-apiInstance.updateUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updateUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/PetApi.md
@@ -23,14 +23,14 @@ Method | HTTP request | Description
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiAddPetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiAddPetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiAddPetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -51,9 +51,8 @@ let body:petstore.PetApiAddPetRequest = {
   },
 };
 
-apiInstance.addPet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.addPet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -95,22 +94,21 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiDeletePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiDeletePetRequest = {
-  // number | Pet id to delete
+const request: PetApiDeletePetRequest = {
+    // Pet id to delete
   petId: 1,
-  // string (optional)
+  
   apiKey: "api_key_example",
 };
 
-apiInstance.deletePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deletePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -152,22 +150,21 @@ Multiple status values can be provided with comma separated strings
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByStatusRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByStatusRequest = {
-  // Array<'available' | 'pending' | 'sold'> | Status values that need to be considered for filter
+const request: PetApiFindPetsByStatusRequest = {
+    // Status values that need to be considered for filter
   status: [
     "available",
   ],
 };
 
-apiInstance.findPetsByStatus(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByStatus(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -209,22 +206,21 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByTagsRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByTagsRequest = {
-  // Array<string> | Tags to filter by
+const request: PetApiFindPetsByTagsRequest = {
+    // Tags to filter by
   tags: [
     "tags_example",
   ],
 };
 
-apiInstance.findPetsByTags(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByTags(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -266,20 +262,19 @@ Returns a single pet
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiGetPetByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiGetPetByIdRequest = {
-  // number | ID of pet to return
+const request: PetApiGetPetByIdRequest = {
+    // ID of pet to return
   petId: 1,
 };
 
-apiInstance.getPetById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getPetById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -322,14 +317,14 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiUpdatePetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -350,9 +345,8 @@ let body:petstore.PetApiUpdatePetRequest = {
   },
 };
 
-apiInstance.updatePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -396,24 +390,23 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetWithFormRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetWithFormRequest = {
-  // number | ID of pet that needs to be updated
+const request: PetApiUpdatePetWithFormRequest = {
+    // ID of pet that needs to be updated
   petId: 1,
-  // string | Updated name of the pet (optional)
+    // Updated name of the pet (optional)
   name: "name_example",
-  // string | Updated status of the pet (optional)
+    // Updated status of the pet (optional)
   status: "status_example",
 };
 
-apiInstance.updatePetWithForm(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePetWithForm(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -456,24 +449,23 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUploadFileRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUploadFileRequest = {
-  // number | ID of pet to update
+const request: PetApiUploadFileRequest = {
+    // ID of pet to update
   petId: 1,
-  // string | Additional data to pass to server (optional)
+    // Additional data to pass to server (optional)
   additionalMetadata: "additionalMetadata_example",
-  // HttpFile | file to upload (optional)
+    // file to upload (optional)
   file: { data: Buffer.from(fs.readFileSync('/path/to/file', 'utf-8')), name: '/path/to/file' },
 };
 
-apiInstance.uploadFile(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.uploadFile(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/StoreApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/StoreApi.md
@@ -19,20 +19,19 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiDeleteOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiDeleteOrderRequest = {
-  // string | ID of the order that needs to be deleted
+const request: StoreApiDeleteOrderRequest = {
+    // ID of the order that needs to be deleted
   orderId: "orderId_example",
 };
 
-apiInstance.deleteOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -74,17 +73,15 @@ Returns a map of status codes to quantities
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.getInventory(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getInventory(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -122,20 +119,19 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiGetOrderByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiGetOrderByIdRequest = {
-  // number | ID of pet that needs to be fetched
+const request: StoreApiGetOrderByIdRequest = {
+    // ID of pet that needs to be fetched
   orderId: 1,
 };
 
-apiInstance.getOrderById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getOrderById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -178,14 +174,14 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiPlaceOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiPlaceOrderRequest = {
-  // Order | order placed for purchasing the pet
+const request: StoreApiPlaceOrderRequest = {
+    // order placed for purchasing the pet
   order: {
     id: 1,
     petId: 1,
@@ -196,9 +192,8 @@ let body:petstore.StoreApiPlaceOrderRequest = {
   },
 };
 
-apiInstance.placeOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.placeOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/UserApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/UserApi.md
@@ -23,14 +23,14 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUserRequest = {
-  // User | Created user object
+const request: UserApiCreateUserRequest = {
+    // Created user object
   user: {
     id: 1,
     username: "username_example",
@@ -43,9 +43,8 @@ let body:petstore.UserApiCreateUserRequest = {
   },
 };
 
-apiInstance.createUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -86,14 +85,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithArrayInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithArrayInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -108,9 +107,8 @@ let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithArrayInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithArrayInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -151,14 +149,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithListInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithListInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithListInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -173,9 +171,8 @@ let body:petstore.UserApiCreateUsersWithListInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithListInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithListInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -216,20 +213,19 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiDeleteUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiDeleteUserRequest = {
-  // string | The name that needs to be deleted
+const request: UserApiDeleteUserRequest = {
+    // The name that needs to be deleted
   username: "username_example",
 };
 
-apiInstance.deleteUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -271,20 +267,19 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiGetUserByNameRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiGetUserByNameRequest = {
-  // string | The name that needs to be fetched. Use user1 for testing.
+const request: UserApiGetUserByNameRequest = {
+    // The name that needs to be fetched. Use user1 for testing.
   username: "username_example",
 };
 
-apiInstance.getUserByName(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getUserByName(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -327,22 +322,21 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiLoginUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiLoginUserRequest = {
-  // string | The user name for login
+const request: UserApiLoginUserRequest = {
+    // The user name for login
   username: "CbUUGjjNSwg0_bs9ZayIMrKdgNvb6gvxmPb9GcsM61ate1RA89q3w1l4eH4XxEz.5awLMdeXylwK0lMGUSM4jsrh4dstlnQUN5vVdMLPA",
-  // string | The password for login in clear text
+    // The password for login in clear text
   password: "password_example",
 };
 
-apiInstance.loginUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.loginUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -385,17 +379,15 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.logoutUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.logoutUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -433,16 +425,16 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiUpdateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiUpdateUserRequest = {
-  // string | name that need to be deleted
+const request: UserApiUpdateUserRequest = {
+    // name that need to be deleted
   username: "username_example",
-  // User | Updated user object
+    // Updated user object
   user: {
     id: 1,
     username: "username_example",
@@ -455,9 +447,8 @@ let body:petstore.UserApiUpdateUserRequest = {
   },
 };
 
-apiInstance.updateUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updateUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/AnotherFakeApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/AnotherFakeApi.md
@@ -16,22 +16,21 @@ To test special tags and operation ID starting with number
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, AnotherFakeApi } from 'ts-petstore-client';
+import type { AnotherFakeApi123testSpecialTagsRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.AnotherFakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new AnotherFakeApi(configuration);
 
-let body:petstore.AnotherFakeApi123testSpecialTagsRequest = {
-  // Client | client model
+const request: AnotherFakeApi123testSpecialTagsRequest = {
+    // client model
   client: {
     client: "client_example",
   },
 };
 
-apiInstance._123testSpecialTags(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance._123testSpecialTags(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/DefaultApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/DefaultApi.md
@@ -15,17 +15,15 @@ Method | HTTP request | Description
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.fooGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.fooGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/FakeApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/FakeApi.md
@@ -33,17 +33,15 @@ for Java apache and Java native, test toUrlQueryString for maps with BegDecimal 
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.fakeBigDecimalMap(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.fakeBigDecimalMap(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -80,17 +78,15 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.fakeHealthGet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.fakeHealthGet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -127,14 +123,14 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiFakeHttpSignatureTestRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiFakeHttpSignatureTestRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: FakeApiFakeHttpSignatureTestRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -153,15 +149,14 @@ let body:petstore.FakeApiFakeHttpSignatureTestRequest = {
     ],
     status: "available",
   },
-  // string | query parameter (optional)
+    // query parameter (optional)
   query1: "query_1_example",
-  // string | header parameter (optional)
+    // header parameter (optional)
   header1: "header_1_example",
 };
 
-apiInstance.fakeHttpSignatureTest(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.fakeHttpSignatureTest(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -204,20 +199,19 @@ Test serialization of outer boolean types
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiFakeOuterBooleanSerializeRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiFakeOuterBooleanSerializeRequest = {
-  // boolean | Input boolean as post body (optional)
+const request: FakeApiFakeOuterBooleanSerializeRequest = {
+    // Input boolean as post body (optional)
   body: true,
 };
 
-apiInstance.fakeOuterBooleanSerialize(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.fakeOuterBooleanSerialize(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -258,14 +252,14 @@ Test serialization of object with outer number type
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiFakeOuterCompositeSerializeRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiFakeOuterCompositeSerializeRequest = {
-  // OuterComposite | Input composite as post body (optional)
+const request: FakeApiFakeOuterCompositeSerializeRequest = {
+    // Input composite as post body (optional)
   outerComposite: {
     myNumber: 3.14,
     myString: "myString_example",
@@ -273,9 +267,8 @@ let body:petstore.FakeApiFakeOuterCompositeSerializeRequest = {
   },
 };
 
-apiInstance.fakeOuterCompositeSerialize(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.fakeOuterCompositeSerialize(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -316,20 +309,19 @@ Test serialization of outer number types
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiFakeOuterNumberSerializeRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiFakeOuterNumberSerializeRequest = {
-  // number | Input number as post body (optional)
+const request: FakeApiFakeOuterNumberSerializeRequest = {
+    // Input number as post body (optional)
   body: 3.14,
 };
 
-apiInstance.fakeOuterNumberSerialize(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.fakeOuterNumberSerialize(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -370,20 +362,19 @@ Test serialization of outer string types
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiFakeOuterStringSerializeRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiFakeOuterStringSerializeRequest = {
-  // string | Input string as post body (optional)
+const request: FakeApiFakeOuterStringSerializeRequest = {
+    // Input string as post body (optional)
   body: "body_example",
 };
 
-apiInstance.fakeOuterStringSerialize(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.fakeOuterStringSerialize(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -424,22 +415,21 @@ Test serialization of enum (int) properties with examples
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiFakePropertyEnumIntegerSerializeRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiFakePropertyEnumIntegerSerializeRequest = {
-  // OuterObjectWithEnumProperty | Input enum (int) as post body
+const request: FakeApiFakePropertyEnumIntegerSerializeRequest = {
+    // Input enum (int) as post body
   outerObjectWithEnumProperty: {
     value: 2,
   },
 };
 
-apiInstance.fakePropertyEnumIntegerSerialize(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.fakePropertyEnumIntegerSerialize(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -480,20 +470,19 @@ For this test, the body has to be a binary file.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiTestBodyWithBinaryRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiTestBodyWithBinaryRequest = {
-  // HttpFile | image to upload
+const request: FakeApiTestBodyWithBinaryRequest = {
+    // image to upload
   body: { data: Buffer.from(fs.readFileSync('/path/to/file', 'utf-8')), name: '/path/to/file' },
 };
 
-apiInstance.testBodyWithBinary(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testBodyWithBinary(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -534,14 +523,14 @@ For this test, the body for this request must reference a schema named `File`.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiTestBodyWithFileSchemaRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiTestBodyWithFileSchemaRequest = {
-  // FileSchemaTestClass
+const request: FakeApiTestBodyWithFileSchemaRequest = {
+  
   fileSchemaTestClass: {
     file: {
       sourceURI: "sourceURI_example",
@@ -554,9 +543,8 @@ let body:petstore.FakeApiTestBodyWithFileSchemaRequest = {
   },
 };
 
-apiInstance.testBodyWithFileSchema(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testBodyWithFileSchema(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -596,16 +584,16 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiTestBodyWithQueryParamsRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiTestBodyWithQueryParamsRequest = {
-  // string
+const request: FakeApiTestBodyWithQueryParamsRequest = {
+  
   query: "query_example",
-  // User
+  
   user: {
     id: 1,
     username: "username_example",
@@ -618,9 +606,8 @@ let body:petstore.FakeApiTestBodyWithQueryParamsRequest = {
   },
 };
 
-apiInstance.testBodyWithQueryParams(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testBodyWithQueryParams(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -662,22 +649,21 @@ To test \"client\" model
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiTestClientModelRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiTestClientModelRequest = {
-  // Client | client model
+const request: FakeApiTestClientModelRequest = {
+    // client model
   client: {
     client: "client_example",
   },
 };
 
-apiInstance.testClientModel(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testClientModel(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -718,46 +704,45 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiTestEndpointParametersRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiTestEndpointParametersRequest = {
-  // number | None
+const request: FakeApiTestEndpointParametersRequest = {
+    // None
   number: 32.1,
-  // number | None
+    // None
   _double: 67.8,
-  // string | None
+    // None
   patternWithoutDelimiter: "AUR,rZ#UM/?R,Fp^l6$ARjbhJk C>",
-  // string | None
+    // None
   _byte: 'YQ==',
-  // number | None (optional)
+    // None (optional)
   integer: 10,
-  // number | None (optional)
+    // None (optional)
   int32: 20,
-  // number | None (optional)
+    // None (optional)
   int64: 1,
-  // number | None (optional)
+    // None (optional)
   _float: 3.14,
-  // string | None (optional)
+    // None (optional)
   string: "/a/i",
-  // HttpFile | None (optional)
+    // None (optional)
   binary: { data: Buffer.from(fs.readFileSync('/path/to/file', 'utf-8')), name: '/path/to/file' },
-  // string | None (optional)
+    // None (optional)
   date: new Date('1970-01-01').toISOString().split('T')[0];,
-  // Date | None (optional)
+    // None (optional)
   dateTime: new Date('1970-01-01T00:00:00.00Z'),
-  // string | None (optional)
+    // None (optional)
   password: "password_example",
-  // string | None (optional)
+    // None (optional)
   callback: "callback_example",
 };
 
-apiInstance.testEndpointParameters(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEndpointParameters(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -812,44 +797,43 @@ To test enum parameters
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiTestEnumParametersRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiTestEnumParametersRequest = {
-  // Array<'>' | '$'> | Header parameter enum test (string array) (optional)
+const request: FakeApiTestEnumParametersRequest = {
+    // Header parameter enum test (string array) (optional)
   enumHeaderStringArray: [
     "$",
   ],
-  // '_abc' | '-efg' | '(xyz)' | Header parameter enum test (string) (optional)
+    // Header parameter enum test (string) (optional)
   enumHeaderString: "-efg",
-  // Array<'>' | '$'> | Query parameter enum test (string array) (optional)
+    // Query parameter enum test (string array) (optional)
   enumQueryStringArray: [
     "$",
   ],
-  // '_abc' | '-efg' | '(xyz)' | Query parameter enum test (string) (optional)
+    // Query parameter enum test (string) (optional)
   enumQueryString: "-efg",
-  // 1 | -2 | Query parameter enum test (double) (optional)
+    // Query parameter enum test (double) (optional)
   enumQueryInteger: 1,
-  // 1.1 | -1.2 | Query parameter enum test (double) (optional)
+    // Query parameter enum test (double) (optional)
   enumQueryDouble: 1.1,
-  // Array<EnumClass> (optional)
+  
   enumQueryModelArray: [
     "-efg",
   ],
-  // Array<string> | Form parameter enum test (string array) (optional)
+    // Form parameter enum test (string array) (optional)
   enumFormStringArray: [
     "$",
   ],
-  // string | Form parameter enum test (string) (optional)
+    // Form parameter enum test (string) (optional)
   enumFormString: "-efg",
 };
 
-apiInstance.testEnumParameters(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testEnumParameters(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -899,30 +883,29 @@ Fake endpoint to test group parameters (optional)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiTestGroupParametersRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiTestGroupParametersRequest = {
-  // number | Required String in group parameters
+const request: FakeApiTestGroupParametersRequest = {
+    // Required String in group parameters
   requiredStringGroup: 1,
-  // boolean | Required Boolean in group parameters
+    // Required Boolean in group parameters
   requiredBooleanGroup: true,
-  // number | Required Integer in group parameters
+    // Required Integer in group parameters
   requiredInt64Group: 1,
-  // number | String in group parameters (optional)
+    // String in group parameters (optional)
   stringGroup: 1,
-  // boolean | Boolean in group parameters (optional)
+    // Boolean in group parameters (optional)
   booleanGroup: true,
-  // number | Integer in group parameters (optional)
+    // Integer in group parameters (optional)
   int64Group: 1,
 };
 
-apiInstance.testGroupParameters(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testGroupParameters(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -968,22 +951,21 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiTestInlineAdditionalPropertiesRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiTestInlineAdditionalPropertiesRequest = {
-  // { [key: string]: string; } | request body
+const request: FakeApiTestInlineAdditionalPropertiesRequest = {
+    // request body
   requestBody: {
     "key": "key_example",
   },
 };
 
-apiInstance.testInlineAdditionalProperties(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testInlineAdditionalProperties(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1024,22 +1006,21 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiTestJsonFormDataRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiTestJsonFormDataRequest = {
-  // string | field1
+const request: FakeApiTestJsonFormDataRequest = {
+    // field1
   param: "param_example",
-  // string | field2
+    // field2
   param2: "param2_example",
 };
 
-apiInstance.testJsonFormData(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testJsonFormData(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -1081,44 +1062,43 @@ To test the collection format in query parameters
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeApi } from 'ts-petstore-client';
+import type { FakeApiTestQueryParameterCollectionFormatRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeApi(configuration);
 
-let body:petstore.FakeApiTestQueryParameterCollectionFormatRequest = {
-  // Array<string>
+const request: FakeApiTestQueryParameterCollectionFormatRequest = {
+  
   pipe: [
     "pipe_example",
   ],
-  // Array<string>
+  
   ioutil: [
     "ioutil_example",
   ],
-  // Array<string>
+  
   http: [
     "http_example",
   ],
-  // Array<string>
+  
   url: [
     "url_example",
   ],
-  // Array<string>
+  
   context: [
     "context_example",
   ],
-  // string
+  
   allowEmpty: "allowEmpty_example",
-  // { [key: string]: string; } (optional)
+  
   language: {
     "key": "key_example",
   },
 };
 
-apiInstance.testQueryParameterCollectionFormat(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testQueryParameterCollectionFormat(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/FakeClassnameTags123Api.md
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/FakeClassnameTags123Api.md
@@ -16,22 +16,21 @@ To test class name in snake case
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, FakeClassnameTags123Api } from 'ts-petstore-client';
+import type { FakeClassnameTags123ApiTestClassnameRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.FakeClassnameTags123Api(configuration);
+const configuration = createConfiguration();
+const apiInstance = new FakeClassnameTags123Api(configuration);
 
-let body:petstore.FakeClassnameTags123ApiTestClassnameRequest = {
-  // Client | client model
+const request: FakeClassnameTags123ApiTestClassnameRequest = {
+    // client model
   client: {
     client: "client_example",
   },
 };
 
-apiInstance.testClassname(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.testClassname(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/PetApi.md
@@ -24,14 +24,14 @@ Method | HTTP request | Description
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiAddPetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiAddPetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiAddPetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -52,9 +52,8 @@ let body:petstore.PetApiAddPetRequest = {
   },
 };
 
-apiInstance.addPet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.addPet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -96,22 +95,21 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiDeletePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiDeletePetRequest = {
-  // number | Pet id to delete
+const request: PetApiDeletePetRequest = {
+    // Pet id to delete
   petId: 1,
-  // string (optional)
+  
   apiKey: "api_key_example",
 };
 
-apiInstance.deletePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deletePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -154,22 +152,21 @@ Multiple status values can be provided with comma separated strings
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByStatusRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByStatusRequest = {
-  // Array<'available' | 'pending' | 'sold'> | Status values that need to be considered for filter
+const request: PetApiFindPetsByStatusRequest = {
+    // Status values that need to be considered for filter
   status: [
     "available",
   ],
 };
 
-apiInstance.findPetsByStatus(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByStatus(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -211,22 +208,21 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByTagsRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByTagsRequest = {
-  // Set<string> | Tags to filter by
+const request: PetApiFindPetsByTagsRequest = {
+    // Tags to filter by
   tags: [
     "tags_example",
   ],
 };
 
-apiInstance.findPetsByTags(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByTags(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -268,20 +264,19 @@ Returns a single pet
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiGetPetByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiGetPetByIdRequest = {
-  // number | ID of pet to return
+const request: PetApiGetPetByIdRequest = {
+    // ID of pet to return
   petId: 1,
 };
 
-apiInstance.getPetById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getPetById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -324,14 +319,14 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiUpdatePetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -352,9 +347,8 @@ let body:petstore.PetApiUpdatePetRequest = {
   },
 };
 
-apiInstance.updatePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -398,24 +392,23 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetWithFormRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetWithFormRequest = {
-  // number | ID of pet that needs to be updated
+const request: PetApiUpdatePetWithFormRequest = {
+    // ID of pet that needs to be updated
   petId: 1,
-  // string | Updated name of the pet (optional)
+    // Updated name of the pet (optional)
   name: "name_example",
-  // string | Updated status of the pet (optional)
+    // Updated status of the pet (optional)
   status: "status_example",
 };
 
-apiInstance.updatePetWithForm(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePetWithForm(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -459,24 +452,23 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUploadFileRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUploadFileRequest = {
-  // number | ID of pet to update
+const request: PetApiUploadFileRequest = {
+    // ID of pet to update
   petId: 1,
-  // string | Additional data to pass to server (optional)
+    // Additional data to pass to server (optional)
   additionalMetadata: "additionalMetadata_example",
-  // HttpFile | file to upload (optional)
+    // file to upload (optional)
   file: { data: Buffer.from(fs.readFileSync('/path/to/file', 'utf-8')), name: '/path/to/file' },
 };
 
-apiInstance.uploadFile(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.uploadFile(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -519,24 +511,23 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUploadFileWithRequiredFileRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUploadFileWithRequiredFileRequest = {
-  // number | ID of pet to update
+const request: PetApiUploadFileWithRequiredFileRequest = {
+    // ID of pet to update
   petId: 1,
-  // HttpFile | file to upload
+    // file to upload
   requiredFile: { data: Buffer.from(fs.readFileSync('/path/to/file', 'utf-8')), name: '/path/to/file' },
-  // string | Additional data to pass to server (optional)
+    // Additional data to pass to server (optional)
   additionalMetadata: "additionalMetadata_example",
 };
 
-apiInstance.uploadFileWithRequiredFile(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.uploadFileWithRequiredFile(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/StoreApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/StoreApi.md
@@ -19,20 +19,19 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiDeleteOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiDeleteOrderRequest = {
-  // string | ID of the order that needs to be deleted
+const request: StoreApiDeleteOrderRequest = {
+    // ID of the order that needs to be deleted
   orderId: "order_id_example",
 };
 
-apiInstance.deleteOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -74,17 +73,15 @@ Returns a map of status codes to quantities
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.getInventory(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getInventory(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -122,20 +119,19 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiGetOrderByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiGetOrderByIdRequest = {
-  // number | ID of pet that needs to be fetched
+const request: StoreApiGetOrderByIdRequest = {
+    // ID of pet that needs to be fetched
   orderId: 1,
 };
 
-apiInstance.getOrderById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getOrderById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -178,14 +174,14 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiPlaceOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiPlaceOrderRequest = {
-  // Order | order placed for purchasing the pet
+const request: StoreApiPlaceOrderRequest = {
+    // order placed for purchasing the pet
   order: {
     id: 1,
     petId: 1,
@@ -196,9 +192,8 @@ let body:petstore.StoreApiPlaceOrderRequest = {
   },
 };
 
-apiInstance.placeOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.placeOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/UserApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/UserApi.md
@@ -23,14 +23,14 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUserRequest = {
-  // User | Created user object
+const request: UserApiCreateUserRequest = {
+    // Created user object
   user: {
     id: 1,
     username: "username_example",
@@ -43,9 +43,8 @@ let body:petstore.UserApiCreateUserRequest = {
   },
 };
 
-apiInstance.createUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -86,14 +85,14 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithArrayInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithArrayInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -108,9 +107,8 @@ let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithArrayInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithArrayInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -151,14 +149,14 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithListInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithListInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithListInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -173,9 +171,8 @@ let body:petstore.UserApiCreateUsersWithListInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithListInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithListInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -216,20 +213,19 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiDeleteUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiDeleteUserRequest = {
-  // string | The name that needs to be deleted
+const request: UserApiDeleteUserRequest = {
+    // The name that needs to be deleted
   username: "username_example",
 };
 
-apiInstance.deleteUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -271,20 +267,19 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiGetUserByNameRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiGetUserByNameRequest = {
-  // string | The name that needs to be fetched. Use user1 for testing.
+const request: UserApiGetUserByNameRequest = {
+    // The name that needs to be fetched. Use user1 for testing.
   username: "username_example",
 };
 
-apiInstance.getUserByName(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getUserByName(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -327,22 +322,21 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiLoginUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiLoginUserRequest = {
-  // string | The user name for login
+const request: UserApiLoginUserRequest = {
+    // The user name for login
   username: "username_example",
-  // string | The password for login in clear text
+    // The password for login in clear text
   password: "password_example",
 };
 
-apiInstance.loginUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.loginUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -385,17 +379,15 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.logoutUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.logoutUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -433,16 +425,16 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiUpdateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiUpdateUserRequest = {
-  // string | name that need to be deleted
+const request: UserApiUpdateUserRequest = {
+    // name that need to be deleted
   username: "username_example",
-  // User | Updated user object
+    // Updated user object
   user: {
     id: 1,
     username: "username_example",
@@ -455,9 +447,8 @@ let body:petstore.UserApiUpdateUserRequest = {
   },
 };
 
-apiInstance.updateUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updateUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/PetApi.md
@@ -23,14 +23,14 @@ Method | HTTP request | Description
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiAddPetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiAddPetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiAddPetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -51,9 +51,8 @@ let body:petstore.PetApiAddPetRequest = {
   },
 };
 
-apiInstance.addPet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.addPet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -95,22 +94,21 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiDeletePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiDeletePetRequest = {
-  // number | Pet id to delete
+const request: PetApiDeletePetRequest = {
+    // Pet id to delete
   petId: 1,
-  // string (optional)
+  
   apiKey: "api_key_example",
 };
 
-apiInstance.deletePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deletePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -152,22 +150,21 @@ Multiple status values can be provided with comma separated strings
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByStatusRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByStatusRequest = {
-  // Array<'available' | 'pending' | 'sold'> | Status values that need to be considered for filter
+const request: PetApiFindPetsByStatusRequest = {
+    // Status values that need to be considered for filter
   status: [
     "available",
   ],
 };
 
-apiInstance.findPetsByStatus(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByStatus(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -209,22 +206,21 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByTagsRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByTagsRequest = {
-  // Array<string> | Tags to filter by
+const request: PetApiFindPetsByTagsRequest = {
+    // Tags to filter by
   tags: [
     "tags_example",
   ],
 };
 
-apiInstance.findPetsByTags(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByTags(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -266,20 +262,19 @@ Returns a single pet
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiGetPetByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiGetPetByIdRequest = {
-  // number | ID of pet to return
+const request: PetApiGetPetByIdRequest = {
+    // ID of pet to return
   petId: 1,
 };
 
-apiInstance.getPetById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getPetById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -322,14 +317,14 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiUpdatePetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -350,9 +345,8 @@ let body:petstore.PetApiUpdatePetRequest = {
   },
 };
 
-apiInstance.updatePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -396,24 +390,23 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetWithFormRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetWithFormRequest = {
-  // number | ID of pet that needs to be updated
+const request: PetApiUpdatePetWithFormRequest = {
+    // ID of pet that needs to be updated
   petId: 1,
-  // string | Updated name of the pet (optional)
+    // Updated name of the pet (optional)
   name: "name_example",
-  // string | Updated status of the pet (optional)
+    // Updated status of the pet (optional)
   status: "status_example",
 };
 
-apiInstance.updatePetWithForm(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePetWithForm(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -456,24 +449,23 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUploadFileRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUploadFileRequest = {
-  // number | ID of pet to update
+const request: PetApiUploadFileRequest = {
+    // ID of pet to update
   petId: 1,
-  // string | Additional data to pass to server (optional)
+    // Additional data to pass to server (optional)
   additionalMetadata: "additionalMetadata_example",
-  // HttpFile | file to upload (optional)
+    // file to upload (optional)
   file: { data: Buffer.from(fs.readFileSync('/path/to/file', 'utf-8')), name: '/path/to/file' },
 };
 
-apiInstance.uploadFile(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.uploadFile(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/StoreApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/StoreApi.md
@@ -19,20 +19,19 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiDeleteOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiDeleteOrderRequest = {
-  // string | ID of the order that needs to be deleted
+const request: StoreApiDeleteOrderRequest = {
+    // ID of the order that needs to be deleted
   orderId: "orderId_example",
 };
 
-apiInstance.deleteOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -74,17 +73,15 @@ Returns a map of status codes to quantities
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.getInventory(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getInventory(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -122,20 +119,19 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiGetOrderByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiGetOrderByIdRequest = {
-  // number | ID of pet that needs to be fetched
+const request: StoreApiGetOrderByIdRequest = {
+    // ID of pet that needs to be fetched
   orderId: 1,
 };
 
-apiInstance.getOrderById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getOrderById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -178,14 +174,14 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiPlaceOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiPlaceOrderRequest = {
-  // Order | order placed for purchasing the pet
+const request: StoreApiPlaceOrderRequest = {
+    // order placed for purchasing the pet
   order: {
     id: 1,
     petId: 1,
@@ -196,9 +192,8 @@ let body:petstore.StoreApiPlaceOrderRequest = {
   },
 };
 
-apiInstance.placeOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.placeOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/UserApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/UserApi.md
@@ -23,14 +23,14 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUserRequest = {
-  // User | Created user object
+const request: UserApiCreateUserRequest = {
+    // Created user object
   user: {
     id: 1,
     username: "username_example",
@@ -43,9 +43,8 @@ let body:petstore.UserApiCreateUserRequest = {
   },
 };
 
-apiInstance.createUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -86,14 +85,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithArrayInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithArrayInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -108,9 +107,8 @@ let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithArrayInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithArrayInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -151,14 +149,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithListInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithListInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithListInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -173,9 +171,8 @@ let body:petstore.UserApiCreateUsersWithListInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithListInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithListInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -216,20 +213,19 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiDeleteUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiDeleteUserRequest = {
-  // string | The name that needs to be deleted
+const request: UserApiDeleteUserRequest = {
+    // The name that needs to be deleted
   username: "username_example",
 };
 
-apiInstance.deleteUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -271,20 +267,19 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiGetUserByNameRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiGetUserByNameRequest = {
-  // string | The name that needs to be fetched. Use user1 for testing.
+const request: UserApiGetUserByNameRequest = {
+    // The name that needs to be fetched. Use user1 for testing.
   username: "username_example",
 };
 
-apiInstance.getUserByName(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getUserByName(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -327,22 +322,21 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiLoginUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiLoginUserRequest = {
-  // string | The user name for login
+const request: UserApiLoginUserRequest = {
+    // The user name for login
   username: "CbUUGjjNSwg0_bs9ZayIMrKdgNvb6gvxmPb9GcsM61ate1RA89q3w1l4eH4XxEz.5awLMdeXylwK0lMGUSM4jsrh4dstlnQUN5vVdMLPA",
-  // string | The password for login in clear text
+    // The password for login in clear text
   password: "password_example",
 };
 
-apiInstance.loginUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.loginUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -385,17 +379,15 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.logoutUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.logoutUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -433,16 +425,16 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiUpdateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiUpdateUserRequest = {
-  // string | name that need to be deleted
+const request: UserApiUpdateUserRequest = {
+    // name that need to be deleted
   username: "username_example",
-  // User | Updated user object
+    // Updated user object
   user: {
     id: 1,
     username: "username_example",
@@ -455,9 +447,8 @@ let body:petstore.UserApiUpdateUserRequest = {
   },
 };
 
-apiInstance.updateUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updateUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/PetApi.md
@@ -23,14 +23,14 @@ Method | HTTP request | Description
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiAddPetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiAddPetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiAddPetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -51,9 +51,8 @@ let body:petstore.PetApiAddPetRequest = {
   },
 };
 
-apiInstance.addPet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.addPet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -95,22 +94,21 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiDeletePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiDeletePetRequest = {
-  // number | Pet id to delete
+const request: PetApiDeletePetRequest = {
+    // Pet id to delete
   petId: 1,
-  // string (optional)
+  
   apiKey: "api_key_example",
 };
 
-apiInstance.deletePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deletePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -152,22 +150,21 @@ Multiple status values can be provided with comma separated strings
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByStatusRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByStatusRequest = {
-  // Array<'available' | 'pending' | 'sold'> | Status values that need to be considered for filter
+const request: PetApiFindPetsByStatusRequest = {
+    // Status values that need to be considered for filter
   status: [
     "available",
   ],
 };
 
-apiInstance.findPetsByStatus(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByStatus(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -209,22 +206,21 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByTagsRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByTagsRequest = {
-  // Array<string> | Tags to filter by
+const request: PetApiFindPetsByTagsRequest = {
+    // Tags to filter by
   tags: [
     "tags_example",
   ],
 };
 
-apiInstance.findPetsByTags(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByTags(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -266,20 +262,19 @@ Returns a single pet
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiGetPetByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiGetPetByIdRequest = {
-  // number | ID of pet to return
+const request: PetApiGetPetByIdRequest = {
+    // ID of pet to return
   petId: 1,
 };
 
-apiInstance.getPetById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getPetById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -322,14 +317,14 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiUpdatePetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -350,9 +345,8 @@ let body:petstore.PetApiUpdatePetRequest = {
   },
 };
 
-apiInstance.updatePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -396,24 +390,23 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetWithFormRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetWithFormRequest = {
-  // number | ID of pet that needs to be updated
+const request: PetApiUpdatePetWithFormRequest = {
+    // ID of pet that needs to be updated
   petId: 1,
-  // string | Updated name of the pet (optional)
+    // Updated name of the pet (optional)
   name: "name_example",
-  // string | Updated status of the pet (optional)
+    // Updated status of the pet (optional)
   status: "status_example",
 };
 
-apiInstance.updatePetWithForm(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePetWithForm(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -456,24 +449,23 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUploadFileRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUploadFileRequest = {
-  // number | ID of pet to update
+const request: PetApiUploadFileRequest = {
+    // ID of pet to update
   petId: 1,
-  // string | Additional data to pass to server (optional)
+    // Additional data to pass to server (optional)
   additionalMetadata: "additionalMetadata_example",
-  // HttpFile | file to upload (optional)
+    // file to upload (optional)
   file: { data: Buffer.from(fs.readFileSync('/path/to/file', 'utf-8')), name: '/path/to/file' },
 };
 
-apiInstance.uploadFile(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.uploadFile(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/StoreApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/StoreApi.md
@@ -19,20 +19,19 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiDeleteOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiDeleteOrderRequest = {
-  // string | ID of the order that needs to be deleted
+const request: StoreApiDeleteOrderRequest = {
+    // ID of the order that needs to be deleted
   orderId: "orderId_example",
 };
 
-apiInstance.deleteOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -74,17 +73,15 @@ Returns a map of status codes to quantities
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.getInventory(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getInventory(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -122,20 +119,19 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiGetOrderByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiGetOrderByIdRequest = {
-  // number | ID of pet that needs to be fetched
+const request: StoreApiGetOrderByIdRequest = {
+    // ID of pet that needs to be fetched
   orderId: 1,
 };
 
-apiInstance.getOrderById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getOrderById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -178,14 +174,14 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiPlaceOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiPlaceOrderRequest = {
-  // Order | order placed for purchasing the pet
+const request: StoreApiPlaceOrderRequest = {
+    // order placed for purchasing the pet
   order: {
     id: 1,
     petId: 1,
@@ -196,9 +192,8 @@ let body:petstore.StoreApiPlaceOrderRequest = {
   },
 };
 
-apiInstance.placeOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.placeOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/UserApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/UserApi.md
@@ -23,14 +23,14 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUserRequest = {
-  // User | Created user object
+const request: UserApiCreateUserRequest = {
+    // Created user object
   user: {
     id: 1,
     username: "username_example",
@@ -43,9 +43,8 @@ let body:petstore.UserApiCreateUserRequest = {
   },
 };
 
-apiInstance.createUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -86,14 +85,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithArrayInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithArrayInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -108,9 +107,8 @@ let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithArrayInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithArrayInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -151,14 +149,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithListInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithListInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithListInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -173,9 +171,8 @@ let body:petstore.UserApiCreateUsersWithListInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithListInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithListInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -216,20 +213,19 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiDeleteUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiDeleteUserRequest = {
-  // string | The name that needs to be deleted
+const request: UserApiDeleteUserRequest = {
+    // The name that needs to be deleted
   username: "username_example",
 };
 
-apiInstance.deleteUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -271,20 +267,19 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiGetUserByNameRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiGetUserByNameRequest = {
-  // string | The name that needs to be fetched. Use user1 for testing.
+const request: UserApiGetUserByNameRequest = {
+    // The name that needs to be fetched. Use user1 for testing.
   username: "username_example",
 };
 
-apiInstance.getUserByName(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getUserByName(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -327,22 +322,21 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiLoginUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiLoginUserRequest = {
-  // string | The user name for login
+const request: UserApiLoginUserRequest = {
+    // The user name for login
   username: "CbUUGjjNSwg0_bs9ZayIMrKdgNvb6gvxmPb9GcsM61ate1RA89q3w1l4eH4XxEz.5awLMdeXylwK0lMGUSM4jsrh4dstlnQUN5vVdMLPA",
-  // string | The password for login in clear text
+    // The password for login in clear text
   password: "password_example",
 };
 
-apiInstance.loginUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.loginUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -385,17 +379,15 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.logoutUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.logoutUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -433,16 +425,16 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiUpdateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiUpdateUserRequest = {
-  // string | name that need to be deleted
+const request: UserApiUpdateUserRequest = {
+    // name that need to be deleted
   username: "username_example",
-  // User | Updated user object
+    // Updated user object
   user: {
     id: 1,
     username: "username_example",
@@ -455,9 +447,8 @@ let body:petstore.UserApiUpdateUserRequest = {
   },
 };
 
-apiInstance.updateUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updateUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/DefaultApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/DefaultApi.md
@@ -15,17 +15,15 @@ Method | HTTP request | Description
 
 
 ```typescript
-import {  } from '';
-import * as fs from 'fs';
+import { createConfiguration, DefaultApi } from '';
 
-const configuration = .createConfiguration();
-const apiInstance = new .DefaultApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new DefaultApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.uniqueItems(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.uniqueItems(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/PetApi.md
@@ -23,14 +23,14 @@ Method | HTTP request | Description
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiAddPetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiAddPetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiAddPetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -51,9 +51,8 @@ let body:petstore.PetApiAddPetRequest = {
   },
 };
 
-apiInstance.addPet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.addPet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -95,22 +94,21 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiDeletePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiDeletePetRequest = {
-  // number | Pet id to delete
+const request: PetApiDeletePetRequest = {
+    // Pet id to delete
   petId: 1,
-  // string (optional)
+  
   apiKey: "api_key_example",
 };
 
-apiInstance.deletePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deletePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -152,22 +150,21 @@ Multiple status values can be provided with comma separated strings
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByStatusRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByStatusRequest = {
-  // Array<'available' | 'pending' | 'sold'> | Status values that need to be considered for filter
+const request: PetApiFindPetsByStatusRequest = {
+    // Status values that need to be considered for filter
   status: [
     "available",
   ],
 };
 
-apiInstance.findPetsByStatus(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByStatus(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -209,22 +206,21 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiFindPetsByTagsRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiFindPetsByTagsRequest = {
-  // Array<string> | Tags to filter by
+const request: PetApiFindPetsByTagsRequest = {
+    // Tags to filter by
   tags: [
     "tags_example",
   ],
 };
 
-apiInstance.findPetsByTags(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.findPetsByTags(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -266,20 +262,19 @@ Returns a single pet
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiGetPetByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiGetPetByIdRequest = {
-  // number | ID of pet to return
+const request: PetApiGetPetByIdRequest = {
+    // ID of pet to return
   petId: 1,
 };
 
-apiInstance.getPetById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getPetById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -322,14 +317,14 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetRequest = {
-  // Pet | Pet object that needs to be added to the store
+const request: PetApiUpdatePetRequest = {
+    // Pet object that needs to be added to the store
   pet: {
     id: 1,
     category: {
@@ -350,9 +345,8 @@ let body:petstore.PetApiUpdatePetRequest = {
   },
 };
 
-apiInstance.updatePet(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePet(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -396,24 +390,23 @@ Name | Type | Description  | Notes
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUpdatePetWithFormRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUpdatePetWithFormRequest = {
-  // number | ID of pet that needs to be updated
+const request: PetApiUpdatePetWithFormRequest = {
+    // ID of pet that needs to be updated
   petId: 1,
-  // string | Updated name of the pet (optional)
+    // Updated name of the pet (optional)
   name: "name_example",
-  // string | Updated status of the pet (optional)
+    // Updated status of the pet (optional)
   status: "status_example",
 };
 
-apiInstance.updatePetWithForm(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updatePetWithForm(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -456,24 +449,23 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, PetApi } from 'ts-petstore-client';
+import type { PetApiUploadFileRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.PetApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new PetApi(configuration);
 
-let body:petstore.PetApiUploadFileRequest = {
-  // number | ID of pet to update
+const request: PetApiUploadFileRequest = {
+    // ID of pet to update
   petId: 1,
-  // string | Additional data to pass to server (optional)
+    // Additional data to pass to server (optional)
   additionalMetadata: "additionalMetadata_example",
-  // HttpFile | file to upload (optional)
+    // file to upload (optional)
   file: { data: Buffer.from(fs.readFileSync('/path/to/file', 'utf-8')), name: '/path/to/file' },
 };
 
-apiInstance.uploadFile(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.uploadFile(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/StoreApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/StoreApi.md
@@ -19,20 +19,19 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiDeleteOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiDeleteOrderRequest = {
-  // string | ID of the order that needs to be deleted
+const request: StoreApiDeleteOrderRequest = {
+    // ID of the order that needs to be deleted
   orderId: "orderId_example",
 };
 
-apiInstance.deleteOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -74,17 +73,15 @@ Returns a map of status codes to quantities
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.getInventory(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getInventory(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -122,20 +119,19 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiGetOrderByIdRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiGetOrderByIdRequest = {
-  // number | ID of pet that needs to be fetched
+const request: StoreApiGetOrderByIdRequest = {
+    // ID of pet that needs to be fetched
   orderId: 1,
 };
 
-apiInstance.getOrderById(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getOrderById(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -178,14 +174,14 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, StoreApi } from 'ts-petstore-client';
+import type { StoreApiPlaceOrderRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.StoreApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new StoreApi(configuration);
 
-let body:petstore.StoreApiPlaceOrderRequest = {
-  // Order | order placed for purchasing the pet
+const request: StoreApiPlaceOrderRequest = {
+    // order placed for purchasing the pet
   order: {
     id: 1,
     petId: 1,
@@ -196,9 +192,8 @@ let body:petstore.StoreApiPlaceOrderRequest = {
   },
 };
 
-apiInstance.placeOrder(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.placeOrder(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/UserApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/UserApi.md
@@ -23,14 +23,14 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUserRequest = {
-  // User | Created user object
+const request: UserApiCreateUserRequest = {
+    // Created user object
   user: {
     id: 1,
     username: "username_example",
@@ -43,9 +43,8 @@ let body:petstore.UserApiCreateUserRequest = {
   },
 };
 
-apiInstance.createUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -86,14 +85,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithArrayInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithArrayInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -108,9 +107,8 @@ let body:petstore.UserApiCreateUsersWithArrayInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithArrayInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithArrayInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -151,14 +149,14 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiCreateUsersWithListInputRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiCreateUsersWithListInputRequest = {
-  // Array<User> | List of user object
+const request: UserApiCreateUsersWithListInputRequest = {
+    // List of user object
   user: [
     {
       id: 1,
@@ -173,9 +171,8 @@ let body:petstore.UserApiCreateUsersWithListInputRequest = {
   ],
 };
 
-apiInstance.createUsersWithListInput(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.createUsersWithListInput(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -216,20 +213,19 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiDeleteUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiDeleteUserRequest = {
-  // string | The name that needs to be deleted
+const request: UserApiDeleteUserRequest = {
+    // The name that needs to be deleted
   username: "username_example",
 };
 
-apiInstance.deleteUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.deleteUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -271,20 +267,19 @@ void (empty response body)
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiGetUserByNameRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiGetUserByNameRequest = {
-  // string | The name that needs to be fetched. Use user1 for testing.
+const request: UserApiGetUserByNameRequest = {
+    // The name that needs to be fetched. Use user1 for testing.
   username: "username_example",
 };
 
-apiInstance.getUserByName(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.getUserByName(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -327,22 +322,21 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiLoginUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiLoginUserRequest = {
-  // string | The user name for login
+const request: UserApiLoginUserRequest = {
+    // The user name for login
   username: "CbUUGjjNSwg0_bs9ZayIMrKdgNvb6gvxmPb9GcsM61ate1RA89q3w1l4eH4XxEz.5awLMdeXylwK0lMGUSM4jsrh4dstlnQUN5vVdMLPA",
-  // string | The password for login in clear text
+    // The password for login in clear text
   password: "password_example",
 };
 
-apiInstance.loginUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.loginUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -385,17 +379,15 @@ No authorization required
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:any = {};
+const request = {};
 
-apiInstance.logoutUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.logoutUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 
@@ -433,16 +425,16 @@ This can only be done by the logged in user.
 
 
 ```typescript
-import { petstore } from 'ts-petstore-client';
-import * as fs from 'fs';
+import { createConfiguration, UserApi } from 'ts-petstore-client';
+import type { UserApiUpdateUserRequest } from 'ts-petstore-client';
 
-const configuration = petstore.createConfiguration();
-const apiInstance = new petstore.UserApi(configuration);
+const configuration = createConfiguration();
+const apiInstance = new UserApi(configuration);
 
-let body:petstore.UserApiUpdateUserRequest = {
-  // string | name that need to be deleted
+const request: UserApiUpdateUserRequest = {
+    // name that need to be deleted
   username: "username_example",
-  // User | Updated user object
+    // Updated user object
   user: {
     id: 1,
     username: "username_example",
@@ -455,9 +447,8 @@ let body:petstore.UserApiUpdateUserRequest = {
   },
 };
 
-apiInstance.updateUser(body).then((data:any) => {
-  console.log('API called successfully. Returned data: ' + data);
-}).catch((error:any) => console.error(error));
+const data = await apiInstance.updateUser(request);
+console.log('API called successfully. Returned data:', data);
 ```
 
 


### PR DESCRIPTION
This improves the docs for generated typescript code a bit:

<img width="1334" alt="Screenshot 2024-09-27 at 2 00 57 AM" src="https://github.com/user-attachments/assets/eba54718-d0b4-41ca-98e3-a5d6fd52052f">


The [split diff](https://github.com/OpenAPITools/openapi-generator/pull/19699/files?diff=split&w=0) is way more readable for this pull request than the unified diff.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language,  @macjohnny 
