### PR TITLE
[java][resttemplate] Fix model combining properties and additional properties

### DIFF
--- a/bin/utils/test_file_list.yaml
+++ b/bin/utils/test_file_list.yaml
@@ -25,6 +25,8 @@
   sha256: 04715cabbe9bd27ff98dd56e3db489ebc9ffbf98d9af104a6707b0a40ab4f8fe
 - filename: "samples/client/echo_api/java/resttemplate/src/test/java/org/openapitools/client/api/AuthApiTest.java"
   sha256: 38193bbad7f3eef087bc1474352e484178b14a2b8c0e0ba0cd4e4960516a14f9
+- filename: "samples/client/petstore/java/resttemplate/src/test/java/org/openapitools/client/JacksonTest.java"
+  sha256: 90e511a75178f26c8b73a6c77d16d7f134c51f959e8c72191bbe935b08436b22
 - filename: "samples/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/api/PetApiTest.java"
   sha256: 24c6a39a9d7327d397dc038c368a19c84f14ed96a69fe28d53719b3eaf0a725c
 - filename: "samples/client/petstore/java/jersey3/src/test/java/org/openapitools/client/api/PetApiTest.java"

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -583,6 +583,14 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         } else if (RESTTEMPLATE.equals(getLibrary())) {
             forceSerializationLibrary(SERIALIZATION_LIBRARY_JACKSON);
             supportingFiles.add(new SupportingFile("auth/Authentication.mustache", authFolder, "Authentication.java"));
+
+            // Composed schemas can have the 'additionalProperties' keyword, as specified in JSON schema.
+            // In principle, this should be enabled by default for all code generators. However due to limitations
+            // in other code generators, support needs to be enabled on a case-by-case basis.
+            // The flag below should be set for all Java libraries, but the templates need to be ported
+            // one by one for each library.
+            supportsAdditionalPropertiesWithComposedSchema = true;
+
         } else if (WEBCLIENT.equals(getLibrary())) {
             forceSerializationLibrary(SERIALIZATION_LIBRARY_JACKSON);
         } else if (RESTCLIENT.equals(getLibrary())) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/additional_properties.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/additional_properties.mustache
@@ -1,0 +1,45 @@
+{{#additionalPropertiesType}}
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, {{{.}}}> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   * @param key the name of the property
+   * @param value the value of the property
+   * @return self reference
+   */
+  @JsonAnySetter
+  public {{classname}} putAdditionalProperty(String key, {{{.}}} value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, {{{.}}}>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) properties.
+   * @return the additional (undeclared) properties
+   */
+  @JsonAnyGetter
+  public Map<String, {{{.}}}> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   * @param key the name of the property
+   * @return the additional (undeclared) property with the specified name
+   */
+  public {{{.}}} getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+{{/additionalPropertiesType}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/model.mustache
@@ -1,0 +1,78 @@
+{{>licenseInfo}}
+
+package {{package}};
+
+{{#useReflectionEqualsHashCode}}
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+{{/useReflectionEqualsHashCode}}
+{{#models}}
+{{#model}}
+{{#additionalPropertiesType}}
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+{{/additionalPropertiesType}}
+{{/model}}
+{{/models}}
+import java.util.Objects;
+import java.util.Arrays;
+{{#imports}}
+import {{import}};
+{{/imports}}
+{{#serializableModel}}
+import java.io.Serializable;
+{{/serializableModel}}
+{{#jackson}}
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+{{#withXml}}
+import com.fasterxml.jackson.dataformat.xml.annotation.*;
+{{/withXml}}
+{{#vendorExtensions.x-has-readonly-properties}}
+import com.fasterxml.jackson.annotation.JsonCreator;
+{{/vendorExtensions.x-has-readonly-properties}}
+{{/jackson}}
+{{#withXml}}
+import {{javaxPackage}}.xml.bind.annotation.*;
+import {{javaxPackage}}.xml.bind.annotation.adapters.*;
+import io.github.threetenjaxb.core.*;
+{{/withXml}}
+{{#jsonb}}
+import java.lang.reflect.Type;
+import {{javaxPackage}}.json.bind.annotation.JsonbTypeDeserializer;
+import {{javaxPackage}}.json.bind.annotation.JsonbTypeSerializer;
+import {{javaxPackage}}.json.bind.serializer.DeserializationContext;
+import {{javaxPackage}}.json.bind.serializer.JsonbDeserializer;
+import {{javaxPackage}}.json.bind.serializer.JsonbSerializer;
+import {{javaxPackage}}.json.bind.serializer.SerializationContext;
+import {{javaxPackage}}.json.stream.JsonGenerator;
+import {{javaxPackage}}.json.stream.JsonParser;
+import {{javaxPackage}}.json.bind.annotation.JsonbProperty;
+{{#vendorExtensions.x-has-readonly-properties}}
+import {{javaxPackage}}.json.bind.annotation.JsonbCreator;
+{{/vendorExtensions.x-has-readonly-properties}}
+{{/jsonb}}
+{{#parcelableModel}}
+import android.os.Parcelable;
+import android.os.Parcel;
+{{/parcelableModel}}
+{{#useBeanValidation}}
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
+{{/useBeanValidation}}
+{{#performBeanValidation}}
+import org.hibernate.validator.constraints.*;
+{{/performBeanValidation}}
+{{#supportUrlQuery}}
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.StringJoiner;
+{{/supportUrlQuery}}
+
+{{#models}}
+{{#model}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>pojo}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}
+{{/model}}
+{{/models}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pojo.mustache
@@ -1,0 +1,620 @@
+/**
+ * {{description}}{{^description}}{{classname}}{{/description}}{{#isDeprecated}}
+ * @deprecated{{/isDeprecated}}
+ */{{#isDeprecated}}
+@Deprecated{{/isDeprecated}}
+{{#swagger1AnnotationLibrary}}
+{{#description}}
+@ApiModel(description = "{{{.}}}")
+{{/description}}
+{{/swagger1AnnotationLibrary}}
+{{#swagger2AnnotationLibrary}}
+{{#description}}
+@Schema(description = "{{{.}}}")
+{{/description}}
+{{/swagger2AnnotationLibrary}}
+{{#jackson}}
+@JsonPropertyOrder({
+{{#vars}}
+  {{classname}}.JSON_PROPERTY_{{nameInSnakeCase}}{{^-last}},{{/-last}}
+{{/vars}}
+})
+{{#isClassnameSanitized}}
+{{^hasDiscriminatorWithNonEmptyMapping}}
+@JsonTypeName("{{name}}")
+{{/hasDiscriminatorWithNonEmptyMapping}}
+{{/isClassnameSanitized}}
+{{/jackson}}
+{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
+{{#vendorExtensions.x-class-extra-annotation}}
+{{{vendorExtensions.x-class-extra-annotation}}}
+{{/vendorExtensions.x-class-extra-annotation}}
+public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{
+{{#serializableModel}}
+  private static final long serialVersionUID = 1L;
+
+{{/serializableModel}}
+  {{#vars}}
+    {{#isEnum}}
+    {{^isContainer}}
+{{>modelInnerEnum}}
+    {{/isContainer}}
+    {{#isContainer}}
+    {{#mostInnerItems}}
+{{>modelInnerEnum}}
+    {{/mostInnerItems}}
+    {{/isContainer}}
+    {{/isEnum}}
+  {{#gson}}
+  public static final String SERIALIZED_NAME_{{nameInSnakeCase}} = "{{baseName}}";
+  {{/gson}}
+  {{#jackson}}
+  public static final String JSON_PROPERTY_{{nameInSnakeCase}} = "{{baseName}}";
+  {{/jackson}}
+  {{#withXml}}
+  @Xml{{#isXmlAttribute}}Attribute{{/isXmlAttribute}}{{^isXmlAttribute}}Element{{/isXmlAttribute}}(name = "{{items.xmlName}}{{^items.xmlName}}{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}{{/items.xmlName}}"{{#xmlNamespace}}, namespace = "{{.}}"{{/xmlNamespace}})
+    {{#isXmlWrapped}}
+  @XmlElementWrapper(name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}"{{#xmlNamespace}}, namespace = "{{.}}"{{/xmlNamespace}})
+    {{/isXmlWrapped}}
+    {{^isXmlAttribute}}
+      {{#isDateTime}}
+  @XmlJavaTypeAdapter(OffsetDateTimeXmlAdapter.class)
+      {{/isDateTime}}
+    {{/isXmlAttribute}}
+  {{/withXml}}
+  {{#gson}}
+  @SerializedName(SERIALIZED_NAME_{{nameInSnakeCase}})
+  {{/gson}}
+  {{>nullable_var_annotations}}
+  {{#vendorExtensions.x-field-extra-annotation}}
+  {{{vendorExtensions.x-field-extra-annotation}}}
+  {{/vendorExtensions.x-field-extra-annotation}}
+  {{#vendorExtensions.x-is-jackson-optional-nullable}}
+  {{#isContainer}}
+  {{#hasChildren}}protected{{/hasChildren}}{{^hasChildren}}private{{/hasChildren}} JsonNullable<{{{datatypeWithEnum}}}> {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>undefined();
+  {{/isContainer}}
+  {{^isContainer}}
+  {{#hasChildren}}protected{{/hasChildren}}{{^hasChildren}}private{{/hasChildren}} JsonNullable<{{{datatypeWithEnum}}}> {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>{{#defaultValue}}of({{{.}}}){{/defaultValue}}{{^defaultValue}}undefined(){{/defaultValue}};
+  {{/isContainer}}
+  {{/vendorExtensions.x-is-jackson-optional-nullable}}
+  {{^vendorExtensions.x-is-jackson-optional-nullable}}
+  {{#isContainer}}
+  {{#hasChildren}}protected{{/hasChildren}}{{^hasChildren}}private{{/hasChildren}} {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+  {{/isContainer}}
+  {{^isContainer}}
+  {{#hasChildren}}protected{{/hasChildren}}{{^hasChildren}}private{{/hasChildren}} {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+  {{/isContainer}}
+  {{/vendorExtensions.x-is-jackson-optional-nullable}}
+
+  {{/vars}}
+  public {{classname}}() {
+    {{#parent}}
+    {{#parcelableModel}}
+    super();{{/parcelableModel}}
+    {{/parent}}
+    {{#gson}}
+    {{#discriminator}}
+    {{#discriminator.isEnum}}
+    this.{{{discriminatorName}}} = this.getClass().getSimpleName();
+    {{/discriminator.isEnum}}
+    {{/discriminator}}
+    {{/gson}}
+  }
+  {{#vendorExtensions.x-has-readonly-properties}}
+  {{^withXml}}
+  /**
+   * Constructor with only readonly parameters{{#generateConstructorWithAllArgs}}{{^vendorExtensions.x-java-all-args-constructor}} and all parameters{{/vendorExtensions.x-java-all-args-constructor}}{{/generateConstructorWithAllArgs}}
+   */
+  {{#jsonb}}@JsonbCreator{{/jsonb}}{{#jackson}}@JsonCreator{{/jackson}}
+  public {{classname}}(
+  {{#readOnlyVars}}
+    {{#jsonb}}@JsonbProperty(value = "{{baseName}}"{{^required}}, nullable = true{{/required}}){{/jsonb}}{{#jackson}}@JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}}){{/jackson}} {{{datatypeWithEnum}}} {{name}}{{^-last}}, {{/-last}}
+  {{/readOnlyVars}}
+  ) {
+    this();
+  {{#readOnlyVars}}
+    this.{{name}} = {{#vendorExtensions.x-is-jackson-optional-nullable}}{{name}} == null ? JsonNullable.<{{{datatypeWithEnum}}}>undefined() : JsonNullable.of({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{name}}{{/vendorExtensions.x-is-jackson-optional-nullable}};
+  {{/readOnlyVars}}
+  }
+  {{/withXml}}
+  {{/vendorExtensions.x-has-readonly-properties}}
+{{#vendorExtensions.x-java-all-args-constructor}}
+
+  /**
+   * Constructor with all args parameters
+   */
+  public {{classname}}({{#vendorExtensions.x-java-all-args-constructor-vars}}{{#jsonb}}@JsonbProperty(value = "{{baseName}}"{{^required}}, nullable = true{{/required}}){{/jsonb}}{{#jackson}}@JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}}){{/jackson}} {{{datatypeWithEnum}}} {{name}}{{^-last}}, {{/-last}}{{/vendorExtensions.x-java-all-args-constructor-vars}}) {
+{{#parent}}
+    super({{#parentVars}}{{name}}{{^-last}}, {{/-last}}{{/parentVars}});
+{{/parent}}
+  {{#vars}}
+    this.{{name}} = {{#vendorExtensions.x-is-jackson-optional-nullable}}{{name}} == null ? JsonNullable.<{{{datatypeWithEnum}}}>undefined() : JsonNullable.of({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{name}}{{/vendorExtensions.x-is-jackson-optional-nullable}};
+{{/vars}}
+  }
+{{/vendorExtensions.x-java-all-args-constructor}}
+
+{{#vars}}
+  {{^isReadOnly}}
+  public {{classname}} {{name}}({{>nullable_var_annotations}} {{{datatypeWithEnum}}} {{name}}) {
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});{{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}this.{{name}} = {{name}};{{/vendorExtensions.x-is-jackson-optional-nullable}}
+    return this;
+  }
+  {{#isArray}}
+
+  public {{classname}} add{{nameInPascalCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}
+    if (this.{{name}} == null || !this.{{name}}.isPresent()) {
+      this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}});
+    }
+    try {
+      this.{{name}}.get().add({{name}}Item);
+    } catch (java.util.NoSuchElementException e) {
+      // this can never happen, as we make sure above that the value is present
+    }
+    return this;
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}
+    if (this.{{name}} == null) {
+      this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}};
+    }
+    this.{{name}}.add({{name}}Item);
+    return this;
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+  }
+  {{/isArray}}
+  {{#isMap}}
+
+  public {{classname}} put{{nameInPascalCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}
+    if (this.{{name}} == null || !this.{{name}}.isPresent()) {
+      this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}}{{^defaultValue}}new HashMap<>(){{/defaultValue}});
+    }
+    try {
+      this.{{name}}.get().put(key, {{name}}Item);
+    } catch (java.util.NoSuchElementException e) {
+      // this can never happen, as we make sure above that the value is present
+    }
+    return this;
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^required}}
+    if (this.{{name}} == null) {
+      this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new HashMap<>(){{/defaultValue}};
+    }
+    {{/required}}
+    this.{{name}}.put(key, {{name}}Item);
+    return this;
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+  }
+  {{/isMap}}
+
+  {{/isReadOnly}}
+  /**
+  {{#description}}
+   * {{.}}
+  {{/description}}
+  {{^description}}
+   * Get {{name}}
+  {{/description}}
+  {{#minimum}}
+   * minimum: {{.}}
+  {{/minimum}}
+  {{#maximum}}
+   * maximum: {{.}}
+  {{/maximum}}
+   * @return {{name}}
+   {{#deprecated}}
+   * @deprecated
+   {{/deprecated}}
+   */
+{{#deprecated}}
+  @Deprecated
+{{/deprecated}}
+  {{>nullable_var_annotations}}
+{{#jsonb}}
+  @JsonbProperty("{{baseName}}")
+{{/jsonb}}
+{{#useBeanValidation}}
+{{>beanValidation}}
+{{/useBeanValidation}}
+{{#swagger1AnnotationLibrary}}
+  @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
+{{/swagger1AnnotationLibrary}}
+{{#swagger2AnnotationLibrary}}
+  @Schema({{#example}}example = "{{{.}}}", {{/example}}requiredMode = {{#required}}Schema.RequiredMode.REQUIRED{{/required}}{{^required}}Schema.RequiredMode.NOT_REQUIRED{{/required}}, description = "{{{description}}}")
+{{/swagger2AnnotationLibrary}}
+{{#vendorExtensions.x-extra-annotation}}
+  {{{vendorExtensions.x-extra-annotation}}}
+{{/vendorExtensions.x-extra-annotation}}
+{{#vendorExtensions.x-is-jackson-optional-nullable}}
+  {{!unannotated, Jackson would pick this up automatically and add it *in addition* to the _JsonNullable getter field}}
+  @JsonIgnore
+{{/vendorExtensions.x-is-jackson-optional-nullable}}
+{{^vendorExtensions.x-is-jackson-optional-nullable}}{{#jackson}}{{> jackson_annotations}}{{/jackson}}{{/vendorExtensions.x-is-jackson-optional-nullable}}
+  public {{{datatypeWithEnum}}} {{getter}}() {
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}
+    {{#isReadOnly}}{{! A readonly attribute doesn't have setter => jackson will set null directly if explicitly returned by API, so make sure we have an empty JsonNullable}}
+    if ({{name}} == null) {
+      {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>{{#defaultValue}}of({{{.}}}){{/defaultValue}}{{^defaultValue}}undefined(){{/defaultValue}};
+    }
+    {{/isReadOnly}}
+    return {{name}}.orElse(null);
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}
+    return {{name}};
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+  }
+
+  {{#vendorExtensions.x-is-jackson-optional-nullable}}
+{{> jackson_annotations}}
+  public JsonNullable<{{{datatypeWithEnum}}}> {{getter}}_JsonNullable() {
+    return {{name}};
+  }
+  {{/vendorExtensions.x-is-jackson-optional-nullable}}{{#vendorExtensions.x-is-jackson-optional-nullable}}
+  @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
+  {{#isReadOnly}}private{{/isReadOnly}}{{^isReadOnly}}public{{/isReadOnly}} void {{setter}}_JsonNullable(JsonNullable<{{{datatypeWithEnum}}}> {{name}}) {
+    {{! For getters/setters that have name differing from attribute name, we must include setter (albeit private) for jackson to be able to set the attribute}}
+    this.{{name}} = {{name}};
+  }
+  {{/vendorExtensions.x-is-jackson-optional-nullable}}
+
+  {{^isReadOnly}}
+{{#vendorExtensions.x-setter-extra-annotation}}  {{{vendorExtensions.x-setter-extra-annotation}}}
+{{/vendorExtensions.x-setter-extra-annotation}}{{#jackson}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{> jackson_annotations}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{/jackson}}  public void {{setter}}({{>nullable_var_annotations}} {{{datatypeWithEnum}}} {{name}}) {
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}
+    this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}
+    this.{{name}} = {{name}};
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+  }
+  {{/isReadOnly}}
+
+  {{/vars}}
+{{>libraries/resttemplate/additional_properties}}
+  {{#parent}}
+  {{#readWriteVars}}
+  {{#isOverridden}}
+  @Override
+  public {{classname}} {{name}}({{>nullable_var_annotations}} {{{datatypeWithEnum}}} {{name}}) {
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}
+    this.{{setter}}(JsonNullable.<{{{datatypeWithEnum}}}>of({{name}}));
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}
+    this.{{setter}}({{name}});
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    return this;
+  }
+
+  {{/isOverridden}}
+  {{/readWriteVars}}
+  {{/parent}}
+  @Override
+  public boolean equals(Object o) {
+  {{#useReflectionEqualsHashCode}}
+    return EqualsBuilder.reflectionEquals(this, o, false, null, true);
+  {{/useReflectionEqualsHashCode}}
+  {{^useReflectionEqualsHashCode}}
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }{{#hasVars}}
+    {{classname}} {{classVarName}} = ({{classname}}) o;
+    return {{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}equalsNullable(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}Objects{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}} &&
+        {{/-last}}{{/vars}}{{#additionalPropertiesType}} &&
+        Objects.equals(this.additionalProperties, {{classVarName}}.additionalProperties){{/additionalPropertiesType}}{{#parent}} &&
+        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+    return {{#parent}}super.equals(o){{/parent}}{{^parent}}true{{/parent}};{{/hasVars}}
+  {{/useReflectionEqualsHashCode}}
+  }{{#vendorExtensions.x-jackson-optional-nullable-helpers}}
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }{{/vendorExtensions.x-jackson-optional-nullable-helpers}}
+
+  @Override
+  public int hashCode() {
+  {{#useReflectionEqualsHashCode}}
+    return HashCodeBuilder.reflectionHashCode(this);
+  {{/useReflectionEqualsHashCode}}
+  {{^useReflectionEqualsHashCode}}
+    return Objects.hash({{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}hashCodeNullable({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{^isByteArray}}{{name}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{name}}){{/isByteArray}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}}, {{/-last}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}}{{#additionalPropertiesType}}, additionalProperties{{/additionalPropertiesType}});
+  {{/useReflectionEqualsHashCode}}
+  }{{#vendorExtensions.x-jackson-optional-nullable-helpers}}
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }{{/vendorExtensions.x-jackson-optional-nullable-helpers}}
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class {{classname}} {\n");
+    {{#parent}}
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    {{/parent}}
+    {{#vars}}
+    sb.append("    {{name}}: ").append({{#isPassword}}"*"{{/isPassword}}{{^isPassword}}toIndentedString({{name}}){{/isPassword}}).append("\n");
+    {{/vars}}
+    {{#additionalPropertiesType}}
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
+    {{/additionalPropertiesType}}
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private{{#jsonb}} static{{/jsonb}} String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+{{#supportUrlQuery}}
+
+  /**
+   * Convert the instance into URL query string.
+   *
+   * @return URL query string
+   */
+  public String toUrlQueryString() {
+    return toUrlQueryString(null);
+  }
+
+  /**
+   * Convert the instance into URL query string.
+   *
+   * @param prefix prefix of the query string
+   * @return URL query string
+   */
+  public String toUrlQueryString(String prefix) {
+    String suffix = "";
+    String containerSuffix = "";
+    String containerPrefix = "";
+    if (prefix == null) {
+      // style=form, explode=true, e.g. /pet?name=cat&type=manx
+      prefix = "";
+    } else {
+      // deepObject style e.g. /pet?id[name]=cat&id[type]=manx
+      prefix = prefix + "[";
+      suffix = "]";
+      containerSuffix = "]";
+      containerPrefix = "[";
+    }
+
+    StringJoiner joiner = new StringJoiner("&");
+
+    {{#allVars}}
+    // add `{{baseName}}` to the URL query string
+    {{#isArray}}
+    {{#items.isPrimitiveType}}
+    {{#uniqueItems}}
+    if ({{getter}}() != null) {
+      int i = 0;
+      for ({{{items.datatypeWithEnum}}} _item : {{getter}}()) {
+        try {
+          joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+              URLEncoder.encode(String.valueOf(_item), "UTF-8").replaceAll("\\+", "%20")));
+        } catch (UnsupportedEncodingException e) {
+          // Should never happen, UTF-8 is always supported
+          throw new RuntimeException(e);
+        }
+      }
+      i++;
+    }
+    {{/uniqueItems}}
+    {{^uniqueItems}}
+    if ({{getter}}() != null) {
+      for (int i = 0; i < {{getter}}().size(); i++) {
+        try {
+          joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+              URLEncoder.encode(String.valueOf({{getter}}().get(i)), "UTF-8").replaceAll("\\+", "%20")));
+        } catch (UnsupportedEncodingException e) {
+          // Should never happen, UTF-8 is always supported
+          throw new RuntimeException(e);
+        }
+      }
+    }
+    {{/uniqueItems}}
+    {{/items.isPrimitiveType}}
+    {{^items.isPrimitiveType}}
+    {{#items.isModel}}
+    {{#uniqueItems}}
+    if ({{getter}}() != null) {
+      int i = 0;
+      for ({{{items.dataType}}} _item : {{getter}}()) {
+        if (_item != null) {
+          joiner.add(_item.toUrlQueryString(String.format("%s{{baseName}}%s%s", prefix, suffix,
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix))));
+        }
+      }
+      i++;
+    }
+    {{/uniqueItems}}
+    {{^uniqueItems}}
+    if ({{getter}}() != null) {
+      for (int i = 0; i < {{getter}}().size(); i++) {
+        if ({{getter}}().get(i) != null) {
+          joiner.add({{getter}}().get(i).toUrlQueryString(String.format("%s{{baseName}}%s%s", prefix, suffix,
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix))));
+        }
+      }
+    }
+    {{/uniqueItems}}
+    {{/items.isModel}}
+    {{^items.isModel}}
+    {{#uniqueItems}}
+    if ({{getter}}() != null) {
+      int i = 0;
+      for ({{{items.dataType}}} _item : {{getter}}()) {
+        if (_item != null) {
+          try {
+            joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+                "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                URLEncoder.encode(String.valueOf(_item), "UTF-8").replaceAll("\\+", "%20")));
+          } catch (UnsupportedEncodingException e) {
+            // Should never happen, UTF-8 is always supported
+            throw new RuntimeException(e);
+          }
+        }
+        i++;
+      }
+    }
+    {{/uniqueItems}}
+    {{^uniqueItems}}
+    if ({{getter}}() != null) {
+      for (int i = 0; i < {{getter}}().size(); i++) {
+        if ({{getter}}().get(i) != null) {
+          try {
+            joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+                "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                URLEncoder.encode(String.valueOf({{getter}}().get(i)), "UTF-8").replaceAll("\\+", "%20")));
+          } catch (UnsupportedEncodingException e) {
+            // Should never happen, UTF-8 is always supported
+            throw new RuntimeException(e);
+          }
+        }
+      }
+    }
+    {{/uniqueItems}}
+    {{/items.isModel}}
+    {{/items.isPrimitiveType}}
+    {{/isArray}}
+    {{^isArray}}
+    {{#isMap}}
+    {{^items.isModel}}
+    if ({{getter}}() != null) {
+      for (String _key : {{getter}}().keySet()) {
+        try {
+          joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, _key, containerSuffix),
+              {{getter}}().get(_key), URLEncoder.encode(String.valueOf({{getter}}().get(_key)), "UTF-8").replaceAll("\\+", "%20")));
+        } catch (UnsupportedEncodingException e) {
+          // Should never happen, UTF-8 is always supported
+          throw new RuntimeException(e);
+        }
+      }
+    }
+    {{/items.isModel}}
+    {{#items.isModel}}
+    if ({{getter}}() != null) {
+      for (String _key : {{getter}}().keySet()) {
+        if ({{getter}}().get(_key) != null) {
+          joiner.add({{getter}}().get(_key).toUrlQueryString(String.format("%s{{baseName}}%s%s", prefix, suffix,
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, _key, containerSuffix))));
+        }
+      }
+    }
+    {{/items.isModel}}
+    {{/isMap}}
+    {{^isMap}}
+    {{#isPrimitiveType}}
+    if ({{getter}}() != null) {
+      try {
+        joiner.add(String.format("%s{{{baseName}}}%s=%s", prefix, suffix, URLEncoder.encode(String.valueOf({{{getter}}}()), "UTF-8").replaceAll("\\+", "%20")));
+      } catch (UnsupportedEncodingException e) {
+        // Should never happen, UTF-8 is always supported
+        throw new RuntimeException(e);
+      }
+    }
+    {{/isPrimitiveType}}
+    {{^isPrimitiveType}}
+    {{#isModel}}
+    if ({{getter}}() != null) {
+      joiner.add({{getter}}().toUrlQueryString(prefix + "{{{baseName}}}" + suffix));
+    }
+    {{/isModel}}
+    {{^isModel}}
+    if ({{getter}}() != null) {
+      try {
+        joiner.add(String.format("%s{{{baseName}}}%s=%s", prefix, suffix, URLEncoder.encode(String.valueOf({{{getter}}}()), "UTF-8").replaceAll("\\+", "%20")));
+      } catch (UnsupportedEncodingException e) {
+        // Should never happen, UTF-8 is always supported
+        throw new RuntimeException(e);
+      }
+    }
+    {{/isModel}}
+    {{/isPrimitiveType}}
+    {{/isMap}}
+    {{/isArray}}
+
+    {{/allVars}}
+    return joiner.toString();
+  }
+{{/supportUrlQuery}}
+{{#parcelableModel}}
+
+  public void writeToParcel(Parcel out, int flags) {
+{{#model}}
+{{#isArray}}
+    out.writeList(this);
+{{/isArray}}
+{{^isArray}}
+{{#parent}}
+    super.writeToParcel(out, flags);
+{{/parent}}
+{{#vars}}
+    out.writeValue({{name}});
+{{/vars}}
+{{/isArray}}
+{{/model}}
+  }
+
+  {{classname}}(Parcel in) {
+{{#isArray}}
+    in.readTypedList(this, {{arrayModelType}}.CREATOR);
+{{/isArray}}
+{{^isArray}}
+{{#parent}}
+    super(in);
+{{/parent}}
+{{#vars}}
+{{#isPrimitiveType}}
+    {{name}} = ({{{datatypeWithEnum}}})in.readValue(null);
+{{/isPrimitiveType}}
+{{^isPrimitiveType}}
+    {{name}} = ({{{datatypeWithEnum}}})in.readValue({{complexType}}.class.getClassLoader());
+{{/isPrimitiveType}}
+{{/vars}}
+{{/isArray}}
+  }
+
+  public int describeContents() {
+    return 0;
+  }
+
+  public static final Parcelable.Creator<{{classname}}> CREATOR = new Parcelable.Creator<{{classname}}>() {
+    public {{classname}} createFromParcel(Parcel in) {
+{{#model}}
+{{#isArray}}
+      {{classname}} result = new {{classname}}();
+      result.addAll(in.readArrayList({{arrayModelType}}.class.getClassLoader()));
+      return result;
+{{/isArray}}
+{{^isArray}}
+      return new {{classname}}(in);
+{{/isArray}}
+{{/model}}
+    }
+    public {{classname}}[] newArray(int size) {
+      return new {{classname}}[size];
+    }
+  };
+{{/parcelableModel}}
+{{#generateBuilders}}
+
+  {{>javaBuilder}}
+{{/generateBuilders}}
+
+}

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/Bird.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/Bird.java
@@ -93,6 +93,7 @@ public class Bird {
     this.color = color;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
@@ -93,6 +93,7 @@ public class Category {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/DataQuery.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/DataQuery.java
@@ -129,6 +129,7 @@ public class DataQuery extends Query {
     this.date = date;
   }
 
+
   @Override
   public DataQuery id(@javax.annotation.Nullable Long id) {
     this.setId(id);

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/DefaultValue.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/DefaultValue.java
@@ -406,6 +406,7 @@ public class DefaultValue {
     this.stringNullable = JsonNullable.<String>of(stringNullable);
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/NumberPropertiesOnly.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/NumberPropertiesOnly.java
@@ -126,6 +126,7 @@ public class NumberPropertiesOnly {
     this._double = _double;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
@@ -271,6 +271,7 @@ public class Pet {
     this.status = status;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/Query.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/Query.java
@@ -141,6 +141,7 @@ public class Query {
     this.outcomes = outcomes;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
@@ -93,6 +93,7 @@ public class Tag {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/TestFormObjectMultipartRequestMarker.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/TestFormObjectMultipartRequestMarker.java
@@ -64,6 +64,7 @@ public class TestFormObjectMultipartRequestMarker {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.java
@@ -154,6 +154,7 @@ public class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter 
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.java
@@ -75,6 +75,7 @@ public class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter {
     this.values = values;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/model/Category.java
@@ -101,6 +101,7 @@ public class Category {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -133,6 +133,7 @@ public class ModelApiResponse {
     this.message = message;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/model/Order.java
@@ -263,6 +263,7 @@ public class Order {
     this.complete = complete;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/model/Pet.java
@@ -285,6 +285,7 @@ public class Pet {
     this.status = status;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/model/Tag.java
@@ -101,6 +101,7 @@ public class Tag {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/model/User.java
@@ -287,6 +287,7 @@ public class User {
     this.userStatus = userStatus;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/model/Category.java
@@ -98,6 +98,7 @@ public class Category {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -130,6 +130,7 @@ public class ModelApiResponse {
     this.message = message;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/model/Order.java
@@ -260,6 +260,7 @@ public class Order {
     this.complete = complete;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/model/Pet.java
@@ -282,6 +282,7 @@ public class Pet {
     this.status = status;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/model/Tag.java
@@ -98,6 +98,7 @@ public class Tag {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/model/User.java
@@ -284,6 +284,7 @@ public class User {
     this.userStatus = userStatus;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/model/Category.java
@@ -97,6 +97,7 @@ public class Category {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -129,6 +129,7 @@ public class ModelApiResponse {
     this.message = message;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/model/Order.java
@@ -259,6 +259,7 @@ public class Order {
     this.complete = complete;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/model/Pet.java
@@ -281,6 +281,7 @@ public class Pet {
     this.status = status;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/model/Tag.java
@@ -97,6 +97,7 @@ public class Tag {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/model/User.java
@@ -283,6 +283,7 @@ public class User {
     this.userStatus = userStatus;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -128,6 +128,7 @@ public class AdditionalPropertiesClass {
     this.mapOfMapProperty = mapOfMapProperty;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AllOfWithSingleRef.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AllOfWithSingleRef.java
@@ -107,6 +107,7 @@ public class AllOfWithSingleRef {
     this.singleRefType = singleRefType;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
@@ -119,6 +119,7 @@ public class Animal {
     this.color = color;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -87,6 +87,7 @@ public class ArrayOfArrayOfNumberOnly {
     this.arrayArrayNumber = arrayArrayNumber;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -87,6 +87,7 @@ public class ArrayOfNumberOnly {
     this.arrayNumber = arrayNumber;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -173,6 +173,7 @@ public class ArrayTest {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -238,6 +238,7 @@ public class Capitalization {
     this.ATT_NAME = ATT_NAME;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
@@ -84,6 +84,7 @@ public class Cat extends Animal {
     this.declawed = declawed;
   }
 
+
   @Override
   public Cat className(@javax.annotation.Nonnull String className) {
     this.setClassName(className);

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
@@ -106,6 +106,7 @@ public class Category {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ChildWithNullable.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ChildWithNullable.java
@@ -85,6 +85,7 @@ public class ChildWithNullable extends ParentWithNullable {
     this.otherProperty = otherProperty;
   }
 
+
   @Override
   public ChildWithNullable type(@javax.annotation.Nullable TypeEnum type) {
     this.setType(type);

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -73,6 +73,7 @@ public class ClassModel {
     this.propertyClass = propertyClass;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
@@ -73,6 +73,7 @@ public class Client {
     this.client = client;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DeprecatedObject.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DeprecatedObject.java
@@ -75,6 +75,7 @@ public class DeprecatedObject {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
@@ -84,6 +84,7 @@ public class Dog extends Animal {
     this.breed = breed;
   }
 
+
   @Override
   public Dog className(@javax.annotation.Nonnull String className) {
     this.setClassName(className);

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -197,6 +197,7 @@ public class EnumArrays {
     this.arrayEnum = arrayEnum;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -482,6 +482,7 @@ public class EnumTest {
     this.outerEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FakeBigDecimalMap200Response.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FakeBigDecimalMap200Response.java
@@ -120,6 +120,7 @@ public class FakeBigDecimalMap200Response {
     this.someMap = someMap;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -120,6 +120,7 @@ public class FileSchemaTestClass {
     this.files = files;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Foo.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Foo.java
@@ -73,6 +73,7 @@ public class Foo {
     this.bar = bar;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FooGetDefaultResponse.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FooGetDefaultResponse.java
@@ -75,6 +75,7 @@ public class FooGetDefaultResponse {
     this.string = string;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -585,6 +585,7 @@ public class FormatTest {
     this.patternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -83,6 +83,7 @@ public class HasOnlyReadOnly {
 
 
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HealthCheckResult.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HealthCheckResult.java
@@ -84,6 +84,7 @@ public class HealthCheckResult {
     this.nullableMessage = JsonNullable.<String>of(nullableMessage);
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
@@ -253,6 +253,7 @@ public class MapTest {
     this.indirectMap = indirectMap;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -155,6 +155,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     this.map = map;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -107,6 +107,7 @@ public class Model200Response {
     this.propertyClass = propertyClass;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -140,6 +140,7 @@ public class ModelApiResponse {
     this.message = message;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelFile.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelFile.java
@@ -74,6 +74,7 @@ public class ModelFile {
     this.sourceURI = sourceURI;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelList.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelList.java
@@ -74,6 +74,7 @@ public class ModelList {
     this._123list = _123list;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -74,6 +74,7 @@ public class ModelReturn {
     this._return = _return;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
@@ -148,6 +148,7 @@ public class Name {
 
 
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -60,7 +64,7 @@ import io.github.threetenjaxb.core.*;
 @XmlRootElement(name = "NullableClass")
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "NullableClass")
-public class NullableClass extends HashMap<String, Object> {
+public class NullableClass {
   public static final String JSON_PROPERTY_INTEGER_PROP = "integer_prop";
   @XmlElement(name = "integer_prop")
   @javax.annotation.Nullable
@@ -123,7 +127,6 @@ public class NullableClass extends HashMap<String, Object> {
   private Map<String, Object> objectItemsNullable = new HashMap<>();
 
   public NullableClass() {
-
   }
 
   public NullableClass integerProp(@javax.annotation.Nullable Integer integerProp) {
@@ -592,6 +595,50 @@ public class NullableClass extends HashMap<String, Object> {
     this.objectItemsNullable = objectItemsNullable;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   * @param key the name of the property
+   * @param value the value of the property
+   * @return self reference
+   */
+  @JsonAnySetter
+  public NullableClass putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) properties.
+   * @return the additional (undeclared) properties
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   * @param key the name of the property
+   * @return the additional (undeclared) property with the specified name
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -613,7 +660,7 @@ public class NullableClass extends HashMap<String, Object> {
         equalsNullable(this.objectNullableProp, nullableClass.objectNullableProp) &&
         equalsNullable(this.objectAndItemsNullableProp, nullableClass.objectAndItemsNullableProp) &&
         Objects.equals(this.objectItemsNullable, nullableClass.objectItemsNullable) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, nullableClass.additionalProperties);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -622,7 +669,7 @@ public class NullableClass extends HashMap<String, Object> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(hashCodeNullable(integerProp), hashCodeNullable(numberProp), hashCodeNullable(booleanProp), hashCodeNullable(stringProp), hashCodeNullable(dateProp), hashCodeNullable(datetimeProp), hashCodeNullable(arrayNullableProp), hashCodeNullable(arrayAndItemsNullableProp), arrayItemsNullable, hashCodeNullable(objectNullableProp), hashCodeNullable(objectAndItemsNullableProp), objectItemsNullable, super.hashCode());
+    return Objects.hash(hashCodeNullable(integerProp), hashCodeNullable(numberProp), hashCodeNullable(booleanProp), hashCodeNullable(stringProp), hashCodeNullable(dateProp), hashCodeNullable(datetimeProp), hashCodeNullable(arrayNullableProp), hashCodeNullable(arrayAndItemsNullableProp), arrayItemsNullable, hashCodeNullable(objectNullableProp), hashCodeNullable(objectAndItemsNullableProp), objectItemsNullable, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -636,7 +683,6 @@ public class NullableClass extends HashMap<String, Object> {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class NullableClass {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    integerProp: ").append(toIndentedString(integerProp)).append("\n");
     sb.append("    numberProp: ").append(toIndentedString(numberProp)).append("\n");
     sb.append("    booleanProp: ").append(toIndentedString(booleanProp)).append("\n");
@@ -649,6 +695,7 @@ public class NullableClass extends HashMap<String, Object> {
     sb.append("    objectNullableProp: ").append(toIndentedString(objectNullableProp)).append("\n");
     sb.append("    objectAndItemsNullableProp: ").append(toIndentedString(objectAndItemsNullableProp)).append("\n");
     sb.append("    objectItemsNullable: ").append(toIndentedString(objectItemsNullable)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -74,6 +74,7 @@ public class NumberOnly {
     this.justNumber = justNumber;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
@@ -193,6 +193,7 @@ public class ObjectWithDeprecatedFields {
     this.bars = bars;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
@@ -282,6 +282,7 @@ public class Order {
     this.complete = complete;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -140,6 +140,7 @@ public class OuterComposite {
     this.myBoolean = myBoolean;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterObjectWithEnumProperty.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterObjectWithEnumProperty.java
@@ -74,6 +74,7 @@ public class OuterObjectWithEnumProperty {
     this.value = value;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -165,6 +165,7 @@ public class ParentWithNullable {
     this.nullableProperty = JsonNullable.<String>of(nullableProperty);
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
@@ -311,6 +311,7 @@ public class Pet {
     this.status = status;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -94,6 +94,7 @@ public class ReadOnlyFirst {
     this.baz = baz;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -74,6 +74,7 @@ public class SpecialModelName {
     this.$specialPropertyName = $specialPropertyName;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
@@ -106,6 +106,7 @@ public class Tag {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TestInlineFreeformAdditionalPropertiesRequest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TestInlineFreeformAdditionalPropertiesRequest.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -20,8 +24,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.HashMap;
-import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.dataformat.xml.annotation.*;
@@ -40,14 +42,13 @@ import io.github.threetenjaxb.core.*;
 @XmlRootElement(name = "TestInlineFreeformAdditionalPropertiesRequest")
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "TestInlineFreeformAdditionalPropertiesRequest")
-public class TestInlineFreeformAdditionalPropertiesRequest extends HashMap<String, Object> {
+public class TestInlineFreeformAdditionalPropertiesRequest {
   public static final String JSON_PROPERTY_SOME_PROPERTY = "someProperty";
   @XmlElement(name = "someProperty")
   @javax.annotation.Nullable
   private String someProperty;
 
   public TestInlineFreeformAdditionalPropertiesRequest() {
-
   }
 
   public TestInlineFreeformAdditionalPropertiesRequest someProperty(@javax.annotation.Nullable String someProperty) {
@@ -77,6 +78,50 @@ public class TestInlineFreeformAdditionalPropertiesRequest extends HashMap<Strin
     this.someProperty = someProperty;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   * @param key the name of the property
+   * @param value the value of the property
+   * @return self reference
+   */
+  @JsonAnySetter
+  public TestInlineFreeformAdditionalPropertiesRequest putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) properties.
+   * @return the additional (undeclared) properties
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   * @param key the name of the property
+   * @return the additional (undeclared) property with the specified name
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -87,20 +132,20 @@ public class TestInlineFreeformAdditionalPropertiesRequest extends HashMap<Strin
     }
     TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest = (TestInlineFreeformAdditionalPropertiesRequest) o;
     return Objects.equals(this.someProperty, testInlineFreeformAdditionalPropertiesRequest.someProperty) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, testInlineFreeformAdditionalPropertiesRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(someProperty, super.hashCode());
+    return Objects.hash(someProperty, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class TestInlineFreeformAdditionalPropertiesRequest {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    someProperty: ").append(toIndentedString(someProperty)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
@@ -304,6 +304,7 @@ public class User {
     this.userStatus = userStatus;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -119,6 +119,7 @@ public class AdditionalPropertiesClass {
     this.mapOfMapProperty = mapOfMapProperty;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AllOfWithSingleRef.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AllOfWithSingleRef.java
@@ -102,6 +102,7 @@ public class AllOfWithSingleRef {
     this.singleRefType = singleRefType;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
@@ -114,6 +114,7 @@ public class Animal {
     this.color = color;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -82,6 +82,7 @@ public class ArrayOfArrayOfNumberOnly {
     this.arrayArrayNumber = arrayArrayNumber;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -82,6 +82,7 @@ public class ArrayOfNumberOnly {
     this.arrayNumber = arrayNumber;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -160,6 +160,7 @@ public class ArrayTest {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -225,6 +225,7 @@ public class Capitalization {
     this.ATT_NAME = ATT_NAME;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
@@ -82,6 +82,7 @@ public class Cat extends Animal {
     this.declawed = declawed;
   }
 
+
   @Override
   public Cat className(@javax.annotation.Nonnull String className) {
     this.setClassName(className);

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
@@ -101,6 +101,7 @@ public class Category {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ChildWithNullable.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ChildWithNullable.java
@@ -83,6 +83,7 @@ public class ChildWithNullable extends ParentWithNullable {
     this.otherProperty = otherProperty;
   }
 
+
   @Override
   public ChildWithNullable type(@javax.annotation.Nullable TypeEnum type) {
     this.setType(type);

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -70,6 +70,7 @@ public class ClassModel {
     this.propertyClass = propertyClass;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
@@ -70,6 +70,7 @@ public class Client {
     this.client = client;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DeprecatedObject.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DeprecatedObject.java
@@ -72,6 +72,7 @@ public class DeprecatedObject {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
@@ -82,6 +82,7 @@ public class Dog extends Animal {
     this.breed = breed;
   }
 
+
   @Override
   public Dog className(@javax.annotation.Nonnull String className) {
     this.setClassName(className);

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -182,6 +182,7 @@ public class EnumArrays {
     this.arrayEnum = arrayEnum;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -448,6 +448,7 @@ public class EnumTest {
     this.outerEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FakeBigDecimalMap200Response.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FakeBigDecimalMap200Response.java
@@ -113,6 +113,7 @@ public class FakeBigDecimalMap200Response {
     this.someMap = someMap;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -113,6 +113,7 @@ public class FileSchemaTestClass {
     this.files = files;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Foo.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Foo.java
@@ -70,6 +70,7 @@ public class Foo {
     this.bar = bar;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FooGetDefaultResponse.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FooGetDefaultResponse.java
@@ -72,6 +72,7 @@ public class FooGetDefaultResponse {
     this.string = string;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -551,6 +551,7 @@ public class FormatTest {
     this.patternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -84,6 +84,7 @@ public class HasOnlyReadOnly {
 
 
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/HealthCheckResult.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/HealthCheckResult.java
@@ -82,6 +82,7 @@ public class HealthCheckResult {
     this.nullableMessage = JsonNullable.<String>of(nullableMessage);
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
@@ -232,6 +232,7 @@ public class MapTest {
     this.indirectMap = indirectMap;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -145,6 +145,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     this.map = map;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -102,6 +102,7 @@ public class Model200Response {
     this.propertyClass = propertyClass;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -133,6 +133,7 @@ public class ModelApiResponse {
     this.message = message;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelFile.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelFile.java
@@ -71,6 +71,7 @@ public class ModelFile {
     this.sourceURI = sourceURI;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelList.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelList.java
@@ -71,6 +71,7 @@ public class ModelList {
     this._123list = _123list;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -71,6 +71,7 @@ public class ModelReturn {
     this._return = _return;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
@@ -153,6 +153,7 @@ public class Name {
 
 
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -53,7 +57,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   NullableClass.JSON_PROPERTY_OBJECT_ITEMS_NULLABLE
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0-SNAPSHOT")
-public class NullableClass extends HashMap<String, Object> {
+public class NullableClass {
   public static final String JSON_PROPERTY_INTEGER_PROP = "integer_prop";
   @javax.annotation.Nullable
   private JsonNullable<Integer> integerProp = JsonNullable.<Integer>undefined();
@@ -103,14 +107,12 @@ public class NullableClass extends HashMap<String, Object> {
   private Map<String, Object> objectItemsNullable;
 
   public NullableClass() {
-
   }
 
   /**
    * Constructor with all args parameters
    */
   public NullableClass(@JsonProperty(JSON_PROPERTY_INTEGER_PROP) Integer integerProp, @JsonProperty(JSON_PROPERTY_NUMBER_PROP) BigDecimal numberProp, @JsonProperty(JSON_PROPERTY_BOOLEAN_PROP) Boolean booleanProp, @JsonProperty(JSON_PROPERTY_STRING_PROP) String stringProp, @JsonProperty(JSON_PROPERTY_DATE_PROP) LocalDate dateProp, @JsonProperty(JSON_PROPERTY_DATETIME_PROP) OffsetDateTime datetimeProp, @JsonProperty(JSON_PROPERTY_ARRAY_NULLABLE_PROP) List<Object> arrayNullableProp, @JsonProperty(JSON_PROPERTY_ARRAY_AND_ITEMS_NULLABLE_PROP) List<Object> arrayAndItemsNullableProp, @JsonProperty(JSON_PROPERTY_ARRAY_ITEMS_NULLABLE) List<Object> arrayItemsNullable, @JsonProperty(JSON_PROPERTY_OBJECT_NULLABLE_PROP) Map<String, Object> objectNullableProp, @JsonProperty(JSON_PROPERTY_OBJECT_AND_ITEMS_NULLABLE_PROP) Map<String, Object> objectAndItemsNullableProp, @JsonProperty(JSON_PROPERTY_OBJECT_ITEMS_NULLABLE) Map<String, Object> objectItemsNullable) {
-    super();
     this.integerProp = integerProp == null ? JsonNullable.<Integer>undefined() : JsonNullable.of(integerProp);
     this.numberProp = numberProp == null ? JsonNullable.<BigDecimal>undefined() : JsonNullable.of(numberProp);
     this.booleanProp = booleanProp == null ? JsonNullable.<Boolean>undefined() : JsonNullable.of(booleanProp);
@@ -569,6 +571,50 @@ public class NullableClass extends HashMap<String, Object> {
     this.objectItemsNullable = objectItemsNullable;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   * @param key the name of the property
+   * @param value the value of the property
+   * @return self reference
+   */
+  @JsonAnySetter
+  public NullableClass putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) properties.
+   * @return the additional (undeclared) properties
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   * @param key the name of the property
+   * @return the additional (undeclared) property with the specified name
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -590,7 +636,7 @@ public class NullableClass extends HashMap<String, Object> {
         equalsNullable(this.objectNullableProp, nullableClass.objectNullableProp) &&
         equalsNullable(this.objectAndItemsNullableProp, nullableClass.objectAndItemsNullableProp) &&
         Objects.equals(this.objectItemsNullable, nullableClass.objectItemsNullable) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, nullableClass.additionalProperties);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -599,7 +645,7 @@ public class NullableClass extends HashMap<String, Object> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(hashCodeNullable(integerProp), hashCodeNullable(numberProp), hashCodeNullable(booleanProp), hashCodeNullable(stringProp), hashCodeNullable(dateProp), hashCodeNullable(datetimeProp), hashCodeNullable(arrayNullableProp), hashCodeNullable(arrayAndItemsNullableProp), arrayItemsNullable, hashCodeNullable(objectNullableProp), hashCodeNullable(objectAndItemsNullableProp), objectItemsNullable, super.hashCode());
+    return Objects.hash(hashCodeNullable(integerProp), hashCodeNullable(numberProp), hashCodeNullable(booleanProp), hashCodeNullable(stringProp), hashCodeNullable(dateProp), hashCodeNullable(datetimeProp), hashCodeNullable(arrayNullableProp), hashCodeNullable(arrayAndItemsNullableProp), arrayItemsNullable, hashCodeNullable(objectNullableProp), hashCodeNullable(objectAndItemsNullableProp), objectItemsNullable, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -613,7 +659,6 @@ public class NullableClass extends HashMap<String, Object> {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class NullableClass {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    integerProp: ").append(toIndentedString(integerProp)).append("\n");
     sb.append("    numberProp: ").append(toIndentedString(numberProp)).append("\n");
     sb.append("    booleanProp: ").append(toIndentedString(booleanProp)).append("\n");
@@ -626,6 +671,7 @@ public class NullableClass extends HashMap<String, Object> {
     sb.append("    objectNullableProp: ").append(toIndentedString(objectNullableProp)).append("\n");
     sb.append("    objectAndItemsNullableProp: ").append(toIndentedString(objectAndItemsNullableProp)).append("\n");
     sb.append("    objectItemsNullable: ").append(toIndentedString(objectItemsNullable)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -71,6 +71,7 @@ public class NumberOnly {
     this.justNumber = justNumber;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
@@ -182,6 +182,7 @@ public class ObjectWithDeprecatedFields {
     this.bars = bars;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
@@ -263,6 +263,7 @@ public class Order {
     this.complete = complete;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -133,6 +133,7 @@ public class OuterComposite {
     this.myBoolean = myBoolean;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterObjectWithEnumProperty.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterObjectWithEnumProperty.java
@@ -71,6 +71,7 @@ public class OuterObjectWithEnumProperty {
     this.value = value;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -158,6 +158,7 @@ public class ParentWithNullable {
     this.nullableProperty = JsonNullable.<String>of(nullableProperty);
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
@@ -287,6 +287,7 @@ public class Pet {
     this.status = status;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -100,6 +100,7 @@ public class ReadOnlyFirst {
     this.baz = baz;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -71,6 +71,7 @@ public class SpecialModelName {
     this.$specialPropertyName = $specialPropertyName;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
@@ -101,6 +101,7 @@ public class Tag {
     this.name = name;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TestInlineFreeformAdditionalPropertiesRequest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TestInlineFreeformAdditionalPropertiesRequest.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -20,8 +24,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.HashMap;
-import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -33,20 +35,18 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 })
 @JsonTypeName("testInlineFreeformAdditionalProperties_request")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0-SNAPSHOT")
-public class TestInlineFreeformAdditionalPropertiesRequest extends HashMap<String, Object> {
+public class TestInlineFreeformAdditionalPropertiesRequest {
   public static final String JSON_PROPERTY_SOME_PROPERTY = "someProperty";
   @javax.annotation.Nullable
   private String someProperty;
 
   public TestInlineFreeformAdditionalPropertiesRequest() {
-
   }
 
   /**
    * Constructor with all args parameters
    */
   public TestInlineFreeformAdditionalPropertiesRequest(@JsonProperty(JSON_PROPERTY_SOME_PROPERTY) String someProperty) {
-    super();
     this.someProperty = someProperty;
   }
 
@@ -75,6 +75,50 @@ public class TestInlineFreeformAdditionalPropertiesRequest extends HashMap<Strin
     this.someProperty = someProperty;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   * @param key the name of the property
+   * @param value the value of the property
+   * @return self reference
+   */
+  @JsonAnySetter
+  public TestInlineFreeformAdditionalPropertiesRequest putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) properties.
+   * @return the additional (undeclared) properties
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   * @param key the name of the property
+   * @return the additional (undeclared) property with the specified name
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -85,20 +129,20 @@ public class TestInlineFreeformAdditionalPropertiesRequest extends HashMap<Strin
     }
     TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest = (TestInlineFreeformAdditionalPropertiesRequest) o;
     return Objects.equals(this.someProperty, testInlineFreeformAdditionalPropertiesRequest.someProperty) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, testInlineFreeformAdditionalPropertiesRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(someProperty, super.hashCode());
+    return Objects.hash(someProperty, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class TestInlineFreeformAdditionalPropertiesRequest {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    someProperty: ").append(toIndentedString(someProperty)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
@@ -287,6 +287,7 @@ public class User {
     this.userStatus = userStatus;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/resttemplate/src/test/java/org/openapitools/client/JacksonTest.java
+++ b/samples/client/petstore/java/resttemplate/src/test/java/org/openapitools/client/JacksonTest.java
@@ -1,0 +1,64 @@
+package org.openapitools.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openapitools.client.model.TestInlineFreeformAdditionalPropertiesRequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JacksonTest {
+
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = JsonMapper.builder()
+                // For determinist serialization results
+                .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+                .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+                .build();
+    }
+
+    @Test
+    void testSerializeAdditionalProperties() throws JsonProcessingException {
+        // Given
+        TestInlineFreeformAdditionalPropertiesRequest model = new TestInlineFreeformAdditionalPropertiesRequest("value")
+                .putAdditionalProperty("someString", "someValue")
+                .putAdditionalProperty("someNumber", 1.23)
+                .putAdditionalProperty("someBoolean", true);
+
+        // When
+        String string = mapper.writeValueAsString(model);
+
+        // Then
+        String expectedString = "{\"someProperty\":\"value\",\"someBoolean\":true,\"someNumber\":1.23,\"someString\":\"someValue\"}";
+        assertEquals(expectedString, string);
+    }
+
+    @Test
+    void testDeserializeAdditionalProperties() throws JsonProcessingException {
+        // Given
+        String string = "{\"someProperty\":\"value\",\"someBoolean\":true,\"someNumber\":1.23,\"someString\":\"someValue\"}";
+
+        // When
+        TestInlineFreeformAdditionalPropertiesRequest model = mapper.readValue(
+                string,
+                TestInlineFreeformAdditionalPropertiesRequest.class
+        );
+
+        // Then
+        TestInlineFreeformAdditionalPropertiesRequest expectedModel = new TestInlineFreeformAdditionalPropertiesRequest("value")
+                .putAdditionalProperty("someString", "someValue")
+                .putAdditionalProperty("someNumber", 1.23)
+                .putAdditionalProperty("someBoolean", true);
+        assertEquals(expectedModel, model);
+
+        TestInlineFreeformAdditionalPropertiesRequest invalidModel = new TestInlineFreeformAdditionalPropertiesRequest("value");
+        assertNotEquals(invalidModel, model);
+    }
+}


### PR DESCRIPTION
When `additionalProperties` is set to `true`, use an `additionalProperties` attribute and `@JsonAnySetter` and `@JsonAnyGetter` annotations instead of extending `HashMap`.

This fixes the issue https://github.com/OpenAPITools/openapi-generator/issues/17361 only for the `resttemplate` library.

I also created the following pull requests to fix the same issue for other libraries:
- https://github.com/OpenAPITools/openapi-generator/pull/19711 for the `webclient` library.
- https://github.com/OpenAPITools/openapi-generator/pull/19713 for the `feign` library.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08) @wing328