### PR TITLE
feat(typescript): write `minimum`, `maxmimum` and `default` to JSDoc

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/types/ObjectParamAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/ObjectParamAPI.mustache
@@ -21,6 +21,15 @@ export interface {{classname}}{{operationIdCamelCase}}Request {
     {{#allParams}}
     /**
      * {{description}}
+     {{#minimum}}
+     * Minimum: {{minimum}}
+     {{/minimum}}
+     {{#maximum}}
+     * Maximum: {{maximum}}
+     {{/maximum}}
+     {{#defaultValue}}
+     * Defaults to: {{defaultValue}}
+     {{/defaultValue}}
      * @type {{dataType}}
      * @memberof {{classname}}{{nickname}}
      */

--- a/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
@@ -58,7 +58,7 @@ export class Observable{{classname}} {
      * {{&summary}}
      {{/summary}}
      {{#allParams}}
-     * @param {{paramName}} {{description}}
+     * @param {{#required}}{{paramName}}{{/required}}{{^required}}[{{paramName}}]{{/required}}{{#description}} {{description}}{{/description}}
      {{/allParams}}
      */
     public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Observable<HttpInfo<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
@@ -88,7 +88,7 @@ export class Observable{{classname}} {
      * {{&summary}}
      {{/summary}}
      {{#allParams}}
-     * @param {{paramName}} {{description}}
+     * @param {{#required}}{{paramName}}{{/required}}{{^required}}[{{paramName}}]{{/required}}{{#description}} {{description}}{{/description}}
      {{/allParams}}
      */
     public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Observable<{{{returnType}}}{{^returnType}}void{{/returnType}}> {

--- a/modules/openapi-generator/src/main/resources/typescript/types/PromiseAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/PromiseAPI.mustache
@@ -48,7 +48,7 @@ export class Promise{{classname}} {
      * {{&summary}}
      {{/summary}}
      {{#allParams}}
-     * @param {{paramName}} {{description}}
+     * @param {{#required}}{{paramName}}{{/required}}{{^required}}[{{paramName}}]{{/required}}{{#description}} {{description}}{{/description}}
      {{/allParams}}
      */
     public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Promise<HttpInfo<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
@@ -64,7 +64,7 @@ export class Promise{{classname}} {
      * {{&summary}}
      {{/summary}}
      {{#allParams}}
-     * @param {{paramName}} {{description}}
+     * @param {{#required}}{{paramName}}{{/required}}{{^required}}[{{paramName}}]{{/required}}{{#description}} {{description}}{{/description}}
      {{/allParams}}
      */
     public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Promise<{{{returnType}}}{{^returnType}}void{{/returnType}}> {

--- a/samples/client/others/typescript/encode-decode/build/types/ObservableAPI.ts
+++ b/samples/client/others/typescript/encode-decode/build/types/ObservableAPI.ts
@@ -454,7 +454,7 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeArrayOfArraysPostWithHttpInfo(requestBody: Array<Array<string>>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodeArrayOfArraysPost(requestBody, _options);
@@ -476,14 +476,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeArrayOfArraysPost(requestBody: Array<Array<string>>, _options?: Configuration): Observable<void> {
         return this.testEncodeArrayOfArraysPostWithHttpInfo(requestBody, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param complexObject 
+     * @param complexObject
      */
     public testEncodeArrayOfMapsOfObjectsPostWithHttpInfo(complexObject: Array<{ [key: string]: ComplexObject; }>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodeArrayOfMapsOfObjectsPost(complexObject, _options);
@@ -505,14 +505,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param complexObject 
+     * @param complexObject
      */
     public testEncodeArrayOfMapsOfObjectsPost(complexObject: Array<{ [key: string]: ComplexObject; }>, _options?: Configuration): Observable<void> {
         return this.testEncodeArrayOfMapsOfObjectsPostWithHttpInfo(complexObject, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param complexObject 
+     * @param complexObject
      */
     public testEncodeArrayOfNullableObjectsPostWithHttpInfo(complexObject: Array<ComplexObject>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodeArrayOfNullableObjectsPost(complexObject, _options);
@@ -534,14 +534,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param complexObject 
+     * @param complexObject
      */
     public testEncodeArrayOfNullableObjectsPost(complexObject: Array<ComplexObject>, _options?: Configuration): Observable<void> {
         return this.testEncodeArrayOfNullableObjectsPostWithHttpInfo(complexObject, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeArrayOfNullablePostWithHttpInfo(requestBody: Array<string | null>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodeArrayOfNullablePost(requestBody, _options);
@@ -563,14 +563,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeArrayOfNullablePost(requestBody: Array<string | null>, _options?: Configuration): Observable<void> {
         return this.testEncodeArrayOfNullablePostWithHttpInfo(requestBody, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeArrayOfPostWithHttpInfo(requestBody: Array<string>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodeArrayOfPost(requestBody, _options);
@@ -592,14 +592,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeArrayOfPost(requestBody: Array<string>, _options?: Configuration): Observable<void> {
         return this.testEncodeArrayOfPostWithHttpInfo(requestBody, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param compositeObject 
+     * @param compositeObject
      */
     public testEncodeCompositeObjectsPostWithHttpInfo(compositeObject: CompositeObject, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodeCompositeObjectsPost(compositeObject, _options);
@@ -621,14 +621,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param compositeObject 
+     * @param compositeObject
      */
     public testEncodeCompositeObjectsPost(compositeObject: CompositeObject, _options?: Configuration): Observable<void> {
         return this.testEncodeCompositeObjectsPostWithHttpInfo(compositeObject, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeMapOfMapsOfObjectsPostWithHttpInfo(requestBody: { [key: string]: { [key: string]: ComplexObject; }; }, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodeMapOfMapsOfObjectsPost(requestBody, _options);
@@ -650,14 +650,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeMapOfMapsOfObjectsPost(requestBody: { [key: string]: { [key: string]: ComplexObject; }; }, _options?: Configuration): Observable<void> {
         return this.testEncodeMapOfMapsOfObjectsPostWithHttpInfo(requestBody, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeMapOfObjectsPostWithHttpInfo(requestBody: { [key: string]: ComplexObject | null; }, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodeMapOfObjectsPost(requestBody, _options);
@@ -679,14 +679,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeMapOfObjectsPost(requestBody: { [key: string]: ComplexObject | null; }, _options?: Configuration): Observable<void> {
         return this.testEncodeMapOfObjectsPostWithHttpInfo(requestBody, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeMapOfPrimitivePostWithHttpInfo(requestBody: { [key: string]: string; }, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodeMapOfPrimitivePost(requestBody, _options);
@@ -708,14 +708,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeMapOfPrimitivePost(requestBody: { [key: string]: string; }, _options?: Configuration): Observable<void> {
         return this.testEncodeMapOfPrimitivePostWithHttpInfo(requestBody, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param requestBody 
+     * @param [requestBody]
      */
     public testEncodeNullableArrayPostWithHttpInfo(requestBody?: Array<string>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodeNullableArrayPost(requestBody, _options);
@@ -737,14 +737,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param [requestBody]
      */
     public testEncodeNullableArrayPost(requestBody?: Array<string>, _options?: Configuration): Observable<void> {
         return this.testEncodeNullableArrayPostWithHttpInfo(requestBody, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param body 
+     * @param [body]
      */
     public testEncodeNullablePostWithHttpInfo(body?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodeNullablePost(body, _options);
@@ -766,14 +766,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param [body]
      */
     public testEncodeNullablePost(body?: string, _options?: Configuration): Observable<void> {
         return this.testEncodeNullablePostWithHttpInfo(body, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param complexObject 
+     * @param complexObject
      */
     public testEncodeObjectPostWithHttpInfo(complexObject: ComplexObject, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodeObjectPost(complexObject, _options);
@@ -795,14 +795,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param complexObject 
+     * @param complexObject
      */
     public testEncodeObjectPost(complexObject: ComplexObject, _options?: Configuration): Observable<void> {
         return this.testEncodeObjectPostWithHttpInfo(complexObject, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveBooleanPostWithHttpInfo(body: boolean, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodePrimitiveBooleanPost(body, _options);
@@ -824,14 +824,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveBooleanPost(body: boolean, _options?: Configuration): Observable<void> {
         return this.testEncodePrimitiveBooleanPostWithHttpInfo(body, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveIntegerPostWithHttpInfo(body: number, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodePrimitiveIntegerPost(body, _options);
@@ -853,14 +853,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveIntegerPost(body: number, _options?: Configuration): Observable<void> {
         return this.testEncodePrimitiveIntegerPostWithHttpInfo(body, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveNumberPostWithHttpInfo(body: number, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodePrimitiveNumberPost(body, _options);
@@ -882,14 +882,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveNumberPost(body: number, _options?: Configuration): Observable<void> {
         return this.testEncodePrimitiveNumberPostWithHttpInfo(body, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveStringPostWithHttpInfo(body: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEncodePrimitiveStringPost(body, _options);
@@ -911,7 +911,7 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveStringPost(body: string, _options?: Configuration): Observable<void> {
         return this.testEncodePrimitiveStringPostWithHttpInfo(body, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));

--- a/samples/client/others/typescript/encode-decode/build/types/PromiseAPI.ts
+++ b/samples/client/others/typescript/encode-decode/build/types/PromiseAPI.ts
@@ -242,7 +242,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeArrayOfArraysPostWithHttpInfo(requestBody: Array<Array<string>>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodeArrayOfArraysPostWithHttpInfo(requestBody, _options);
@@ -250,7 +250,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeArrayOfArraysPost(requestBody: Array<Array<string>>, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodeArrayOfArraysPost(requestBody, _options);
@@ -258,7 +258,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param complexObject 
+     * @param complexObject
      */
     public testEncodeArrayOfMapsOfObjectsPostWithHttpInfo(complexObject: Array<{ [key: string]: ComplexObject; }>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodeArrayOfMapsOfObjectsPostWithHttpInfo(complexObject, _options);
@@ -266,7 +266,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param complexObject 
+     * @param complexObject
      */
     public testEncodeArrayOfMapsOfObjectsPost(complexObject: Array<{ [key: string]: ComplexObject; }>, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodeArrayOfMapsOfObjectsPost(complexObject, _options);
@@ -274,7 +274,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param complexObject 
+     * @param complexObject
      */
     public testEncodeArrayOfNullableObjectsPostWithHttpInfo(complexObject: Array<ComplexObject>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodeArrayOfNullableObjectsPostWithHttpInfo(complexObject, _options);
@@ -282,7 +282,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param complexObject 
+     * @param complexObject
      */
     public testEncodeArrayOfNullableObjectsPost(complexObject: Array<ComplexObject>, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodeArrayOfNullableObjectsPost(complexObject, _options);
@@ -290,7 +290,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeArrayOfNullablePostWithHttpInfo(requestBody: Array<string | null>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodeArrayOfNullablePostWithHttpInfo(requestBody, _options);
@@ -298,7 +298,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeArrayOfNullablePost(requestBody: Array<string | null>, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodeArrayOfNullablePost(requestBody, _options);
@@ -306,7 +306,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeArrayOfPostWithHttpInfo(requestBody: Array<string>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodeArrayOfPostWithHttpInfo(requestBody, _options);
@@ -314,7 +314,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeArrayOfPost(requestBody: Array<string>, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodeArrayOfPost(requestBody, _options);
@@ -322,7 +322,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param compositeObject 
+     * @param compositeObject
      */
     public testEncodeCompositeObjectsPostWithHttpInfo(compositeObject: CompositeObject, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodeCompositeObjectsPostWithHttpInfo(compositeObject, _options);
@@ -330,7 +330,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param compositeObject 
+     * @param compositeObject
      */
     public testEncodeCompositeObjectsPost(compositeObject: CompositeObject, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodeCompositeObjectsPost(compositeObject, _options);
@@ -338,7 +338,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeMapOfMapsOfObjectsPostWithHttpInfo(requestBody: { [key: string]: { [key: string]: ComplexObject; }; }, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodeMapOfMapsOfObjectsPostWithHttpInfo(requestBody, _options);
@@ -346,7 +346,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeMapOfMapsOfObjectsPost(requestBody: { [key: string]: { [key: string]: ComplexObject; }; }, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodeMapOfMapsOfObjectsPost(requestBody, _options);
@@ -354,7 +354,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeMapOfObjectsPostWithHttpInfo(requestBody: { [key: string]: ComplexObject | null; }, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodeMapOfObjectsPostWithHttpInfo(requestBody, _options);
@@ -362,7 +362,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeMapOfObjectsPost(requestBody: { [key: string]: ComplexObject | null; }, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodeMapOfObjectsPost(requestBody, _options);
@@ -370,7 +370,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeMapOfPrimitivePostWithHttpInfo(requestBody: { [key: string]: string; }, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodeMapOfPrimitivePostWithHttpInfo(requestBody, _options);
@@ -378,7 +378,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param requestBody
      */
     public testEncodeMapOfPrimitivePost(requestBody: { [key: string]: string; }, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodeMapOfPrimitivePost(requestBody, _options);
@@ -386,7 +386,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param [requestBody]
      */
     public testEncodeNullableArrayPostWithHttpInfo(requestBody?: Array<string>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodeNullableArrayPostWithHttpInfo(requestBody, _options);
@@ -394,7 +394,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param requestBody 
+     * @param [requestBody]
      */
     public testEncodeNullableArrayPost(requestBody?: Array<string>, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodeNullableArrayPost(requestBody, _options);
@@ -402,7 +402,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param [body]
      */
     public testEncodeNullablePostWithHttpInfo(body?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodeNullablePostWithHttpInfo(body, _options);
@@ -410,7 +410,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param [body]
      */
     public testEncodeNullablePost(body?: string, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodeNullablePost(body, _options);
@@ -418,7 +418,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param complexObject 
+     * @param complexObject
      */
     public testEncodeObjectPostWithHttpInfo(complexObject: ComplexObject, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodeObjectPostWithHttpInfo(complexObject, _options);
@@ -426,7 +426,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param complexObject 
+     * @param complexObject
      */
     public testEncodeObjectPost(complexObject: ComplexObject, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodeObjectPost(complexObject, _options);
@@ -434,7 +434,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveBooleanPostWithHttpInfo(body: boolean, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodePrimitiveBooleanPostWithHttpInfo(body, _options);
@@ -442,7 +442,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveBooleanPost(body: boolean, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodePrimitiveBooleanPost(body, _options);
@@ -450,7 +450,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveIntegerPostWithHttpInfo(body: number, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodePrimitiveIntegerPostWithHttpInfo(body, _options);
@@ -458,7 +458,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveIntegerPost(body: number, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodePrimitiveIntegerPost(body, _options);
@@ -466,7 +466,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveNumberPostWithHttpInfo(body: number, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodePrimitiveNumberPostWithHttpInfo(body, _options);
@@ -474,7 +474,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveNumberPost(body: number, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodePrimitiveNumberPost(body, _options);
@@ -482,7 +482,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveStringPostWithHttpInfo(body: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEncodePrimitiveStringPostWithHttpInfo(body, _options);
@@ -490,7 +490,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param body 
+     * @param body
      */
     public testEncodePrimitiveStringPost(body: string, _options?: Configuration): Promise<void> {
         const result = this.api.testEncodePrimitiveStringPost(body, _options);

--- a/samples/openapi3/client/petstore/typescript/builds/browser/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/types/ObjectParamAPI.ts
@@ -23,12 +23,14 @@ export interface PetApiAddPetRequest {
 export interface PetApiDeletePetRequest {
     /**
      * Pet id to delete
+     * Defaults to: undefined
      * @type number
      * @memberof PetApideletePet
      */
     petId: number
     /**
      * 
+     * Defaults to: undefined
      * @type string
      * @memberof PetApideletePet
      */
@@ -38,6 +40,7 @@ export interface PetApiDeletePetRequest {
 export interface PetApiFindPetsByStatusRequest {
     /**
      * Status values that need to be considered for filter
+     * Defaults to: undefined
      * @type Array&lt;&#39;available&#39; | &#39;pending&#39; | &#39;sold&#39;&gt;
      * @memberof PetApifindPetsByStatus
      */
@@ -47,6 +50,7 @@ export interface PetApiFindPetsByStatusRequest {
 export interface PetApiFindPetsByTagsRequest {
     /**
      * Tags to filter by
+     * Defaults to: undefined
      * @type Array&lt;string&gt;
      * @memberof PetApifindPetsByTags
      */
@@ -56,6 +60,7 @@ export interface PetApiFindPetsByTagsRequest {
 export interface PetApiGetPetByIdRequest {
     /**
      * ID of pet to return
+     * Defaults to: undefined
      * @type number
      * @memberof PetApigetPetById
      */
@@ -74,18 +79,21 @@ export interface PetApiUpdatePetRequest {
 export interface PetApiUpdatePetWithFormRequest {
     /**
      * ID of pet that needs to be updated
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiupdatePetWithForm
      */
     petId: number
     /**
      * Updated name of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
     name?: string
     /**
      * Updated status of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
@@ -95,18 +103,21 @@ export interface PetApiUpdatePetWithFormRequest {
 export interface PetApiUploadFileRequest {
     /**
      * ID of pet to update
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiuploadFile
      */
     petId: number
     /**
      * Additional data to pass to server
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiuploadFile
      */
     additionalMetadata?: string
     /**
      * file to upload
+     * Defaults to: undefined
      * @type HttpFile
      * @memberof PetApiuploadFile
      */
@@ -272,6 +283,7 @@ import { StoreApiRequestFactory, StoreApiResponseProcessor} from "../apis/StoreA
 export interface StoreApiDeleteOrderRequest {
     /**
      * ID of the order that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof StoreApideleteOrder
      */
@@ -284,6 +296,9 @@ export interface StoreApiGetInventoryRequest {
 export interface StoreApiGetOrderByIdRequest {
     /**
      * ID of pet that needs to be fetched
+     * Minimum: 1
+     * Maximum: 5
+     * Defaults to: undefined
      * @type number
      * @memberof StoreApigetOrderById
      */
@@ -413,6 +428,7 @@ export interface UserApiCreateUsersWithListInputRequest {
 export interface UserApiDeleteUserRequest {
     /**
      * The name that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApideleteUser
      */
@@ -422,6 +438,7 @@ export interface UserApiDeleteUserRequest {
 export interface UserApiGetUserByNameRequest {
     /**
      * The name that needs to be fetched. Use user1 for testing.
+     * Defaults to: undefined
      * @type string
      * @memberof UserApigetUserByName
      */
@@ -431,12 +448,14 @@ export interface UserApiGetUserByNameRequest {
 export interface UserApiLoginUserRequest {
     /**
      * The user name for login
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
     username: string
     /**
      * The password for login in clear text
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
@@ -449,6 +468,7 @@ export interface UserApiLogoutUserRequest {
 export interface UserApiUpdateUserRequest {
     /**
      * name that need to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiupdateUser
      */

--- a/samples/openapi3/client/petstore/typescript/builds/browser/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/types/ObservableAPI.ts
@@ -62,7 +62,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
@@ -87,7 +87,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
         return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -229,8 +229,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
@@ -255,8 +255,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
         return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -266,8 +266,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
@@ -292,8 +292,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
         return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));

--- a/samples/openapi3/client/petstore/typescript/builds/browser/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/types/PromiseAPI.ts
@@ -45,7 +45,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
@@ -56,7 +56,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
         const result = this.api.deletePet(petId, apiKey, _options);
@@ -147,8 +147,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
@@ -159,8 +159,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
@@ -171,8 +171,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
@@ -183,8 +183,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse> {
         const result = this.api.uploadFile(petId, additionalMetadata, file, _options);

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/ObservableAPI.ts
@@ -27,7 +27,7 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param filePostRequest 
+     * @param [filePostRequest]
      */
     public filePostWithHttpInfo(filePostRequest?: FilePostRequest, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.filePost(filePostRequest, _options);
@@ -49,14 +49,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param filePostRequest 
+     * @param [filePostRequest]
      */
     public filePost(filePostRequest?: FilePostRequest, _options?: Configuration): Observable<void> {
         return this.filePostWithHttpInfo(filePostRequest, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param petsFilteredPatchRequest 
+     * @param [petsFilteredPatchRequest]
      */
     public petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.petsFilteredPatch(petsFilteredPatchRequest, _options);
@@ -78,14 +78,14 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param petsFilteredPatchRequest 
+     * @param [petsFilteredPatchRequest]
      */
     public petsFilteredPatch(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Observable<void> {
         return this.petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param petsPatchRequest 
+     * @param [petsPatchRequest]
      */
     public petsPatchWithHttpInfo(petsPatchRequest?: PetsPatchRequest, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.petsPatch(petsPatchRequest, _options);
@@ -107,7 +107,7 @@ export class ObservableDefaultApi {
     }
 
     /**
-     * @param petsPatchRequest 
+     * @param [petsPatchRequest]
      */
     public petsPatch(petsPatchRequest?: PetsPatchRequest, _options?: Configuration): Observable<void> {
         return this.petsPatchWithHttpInfo(petsPatchRequest, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/PromiseAPI.ts
@@ -23,7 +23,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param filePostRequest 
+     * @param [filePostRequest]
      */
     public filePostWithHttpInfo(filePostRequest?: FilePostRequest, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.filePostWithHttpInfo(filePostRequest, _options);
@@ -31,7 +31,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param filePostRequest 
+     * @param [filePostRequest]
      */
     public filePost(filePostRequest?: FilePostRequest, _options?: Configuration): Promise<void> {
         const result = this.api.filePost(filePostRequest, _options);
@@ -39,7 +39,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param petsFilteredPatchRequest 
+     * @param [petsFilteredPatchRequest]
      */
     public petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest, _options);
@@ -47,7 +47,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param petsFilteredPatchRequest 
+     * @param [petsFilteredPatchRequest]
      */
     public petsFilteredPatch(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Promise<void> {
         const result = this.api.petsFilteredPatch(petsFilteredPatchRequest, _options);
@@ -55,7 +55,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param petsPatchRequest 
+     * @param [petsPatchRequest]
      */
     public petsPatchWithHttpInfo(petsPatchRequest?: PetsPatchRequest, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.petsPatchWithHttpInfo(petsPatchRequest, _options);
@@ -63,7 +63,7 @@ export class PromiseDefaultApi {
     }
 
     /**
-     * @param petsPatchRequest 
+     * @param [petsPatchRequest]
      */
     public petsPatch(petsPatchRequest?: PetsPatchRequest, _options?: Configuration): Promise<void> {
         const result = this.api.petsPatch(petsPatchRequest, _options);

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/ObjectParamAPI.ts
@@ -23,12 +23,14 @@ export interface PetApiAddPetRequest {
 export interface PetApiDeletePetRequest {
     /**
      * Pet id to delete
+     * Defaults to: undefined
      * @type number
      * @memberof PetApideletePet
      */
     petId: number
     /**
      * 
+     * Defaults to: undefined
      * @type string
      * @memberof PetApideletePet
      */
@@ -38,6 +40,7 @@ export interface PetApiDeletePetRequest {
 export interface PetApiFindPetsByStatusRequest {
     /**
      * Status values that need to be considered for filter
+     * Defaults to: undefined
      * @type Array&lt;&#39;available&#39; | &#39;pending&#39; | &#39;sold&#39;&gt;
      * @memberof PetApifindPetsByStatus
      */
@@ -47,6 +50,7 @@ export interface PetApiFindPetsByStatusRequest {
 export interface PetApiFindPetsByTagsRequest {
     /**
      * Tags to filter by
+     * Defaults to: undefined
      * @type Array&lt;string&gt;
      * @memberof PetApifindPetsByTags
      */
@@ -56,6 +60,7 @@ export interface PetApiFindPetsByTagsRequest {
 export interface PetApiGetPetByIdRequest {
     /**
      * ID of pet to return
+     * Defaults to: undefined
      * @type number
      * @memberof PetApigetPetById
      */
@@ -74,18 +79,21 @@ export interface PetApiUpdatePetRequest {
 export interface PetApiUpdatePetWithFormRequest {
     /**
      * ID of pet that needs to be updated
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiupdatePetWithForm
      */
     petId: number
     /**
      * Updated name of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
     name?: string
     /**
      * Updated status of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
@@ -95,18 +103,21 @@ export interface PetApiUpdatePetWithFormRequest {
 export interface PetApiUploadFileRequest {
     /**
      * ID of pet to update
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiuploadFile
      */
     petId: number
     /**
      * Additional data to pass to server
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiuploadFile
      */
     additionalMetadata?: string
     /**
      * file to upload
+     * Defaults to: undefined
      * @type HttpFile
      * @memberof PetApiuploadFile
      */
@@ -272,6 +283,7 @@ import { StoreApiRequestFactory, StoreApiResponseProcessor} from "../apis/StoreA
 export interface StoreApiDeleteOrderRequest {
     /**
      * ID of the order that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof StoreApideleteOrder
      */
@@ -284,6 +296,9 @@ export interface StoreApiGetInventoryRequest {
 export interface StoreApiGetOrderByIdRequest {
     /**
      * ID of pet that needs to be fetched
+     * Minimum: 1
+     * Maximum: 5
+     * Defaults to: undefined
      * @type number
      * @memberof StoreApigetOrderById
      */
@@ -413,6 +428,7 @@ export interface UserApiCreateUsersWithListInputRequest {
 export interface UserApiDeleteUserRequest {
     /**
      * The name that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApideleteUser
      */
@@ -422,6 +438,7 @@ export interface UserApiDeleteUserRequest {
 export interface UserApiGetUserByNameRequest {
     /**
      * The name that needs to be fetched. Use user1 for testing.
+     * Defaults to: undefined
      * @type string
      * @memberof UserApigetUserByName
      */
@@ -431,12 +448,14 @@ export interface UserApiGetUserByNameRequest {
 export interface UserApiLoginUserRequest {
     /**
      * The user name for login
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
     username: string
     /**
      * The password for login in clear text
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
@@ -449,6 +468,7 @@ export interface UserApiLogoutUserRequest {
 export interface UserApiUpdateUserRequest {
     /**
      * name that need to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiupdateUser
      */

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
@@ -62,7 +62,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
@@ -87,7 +87,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
         return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -229,8 +229,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
@@ -255,8 +255,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
         return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -266,8 +266,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
@@ -292,8 +292,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
         return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/PromiseAPI.ts
@@ -45,7 +45,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
@@ -56,7 +56,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
         const result = this.api.deletePet(petId, apiKey, _options);
@@ -147,8 +147,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
@@ -159,8 +159,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
@@ -171,8 +171,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
@@ -183,8 +183,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse> {
         const result = this.api.uploadFile(petId, additionalMetadata, file, _options);

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/ObjectParamAPI.ts
@@ -23,12 +23,14 @@ export interface PetApiAddPetRequest {
 export interface PetApiDeletePetRequest {
     /**
      * Pet id to delete
+     * Defaults to: undefined
      * @type number
      * @memberof PetApideletePet
      */
     petId: number
     /**
      * 
+     * Defaults to: undefined
      * @type string
      * @memberof PetApideletePet
      */
@@ -38,6 +40,7 @@ export interface PetApiDeletePetRequest {
 export interface PetApiFindPetsByStatusRequest {
     /**
      * Status values that need to be considered for filter
+     * Defaults to: undefined
      * @type Array&lt;&#39;available&#39; | &#39;pending&#39; | &#39;sold&#39;&gt;
      * @memberof PetApifindPetsByStatus
      */
@@ -47,6 +50,7 @@ export interface PetApiFindPetsByStatusRequest {
 export interface PetApiFindPetsByTagsRequest {
     /**
      * Tags to filter by
+     * Defaults to: undefined
      * @type Array&lt;string&gt;
      * @memberof PetApifindPetsByTags
      */
@@ -56,6 +60,7 @@ export interface PetApiFindPetsByTagsRequest {
 export interface PetApiGetPetByIdRequest {
     /**
      * ID of pet to return
+     * Defaults to: undefined
      * @type number
      * @memberof PetApigetPetById
      */
@@ -74,18 +79,21 @@ export interface PetApiUpdatePetRequest {
 export interface PetApiUpdatePetWithFormRequest {
     /**
      * ID of pet that needs to be updated
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiupdatePetWithForm
      */
     petId: number
     /**
      * Updated name of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
     name?: string
     /**
      * Updated status of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
@@ -95,18 +103,21 @@ export interface PetApiUpdatePetWithFormRequest {
 export interface PetApiUploadFileRequest {
     /**
      * ID of pet to update
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiuploadFile
      */
     petId: number
     /**
      * Additional data to pass to server
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiuploadFile
      */
     additionalMetadata?: string
     /**
      * file to upload
+     * Defaults to: undefined
      * @type HttpFile
      * @memberof PetApiuploadFile
      */
@@ -272,6 +283,7 @@ import { StoreApiRequestFactory, StoreApiResponseProcessor} from "../apis/StoreA
 export interface StoreApiDeleteOrderRequest {
     /**
      * ID of the order that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof StoreApideleteOrder
      */
@@ -284,6 +296,9 @@ export interface StoreApiGetInventoryRequest {
 export interface StoreApiGetOrderByIdRequest {
     /**
      * ID of pet that needs to be fetched
+     * Minimum: 1
+     * Maximum: 5
+     * Defaults to: undefined
      * @type number
      * @memberof StoreApigetOrderById
      */
@@ -413,6 +428,7 @@ export interface UserApiCreateUsersWithListInputRequest {
 export interface UserApiDeleteUserRequest {
     /**
      * The name that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApideleteUser
      */
@@ -422,6 +438,7 @@ export interface UserApiDeleteUserRequest {
 export interface UserApiGetUserByNameRequest {
     /**
      * The name that needs to be fetched. Use user1 for testing.
+     * Defaults to: undefined
      * @type string
      * @memberof UserApigetUserByName
      */
@@ -431,12 +448,14 @@ export interface UserApiGetUserByNameRequest {
 export interface UserApiLoginUserRequest {
     /**
      * The user name for login
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
     username: string
     /**
      * The password for login in clear text
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
@@ -449,6 +468,7 @@ export interface UserApiLogoutUserRequest {
 export interface UserApiUpdateUserRequest {
     /**
      * name that need to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiupdateUser
      */

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/ObservableAPI.ts
@@ -62,7 +62,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
@@ -87,7 +87,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
         return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -229,8 +229,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
@@ -255,8 +255,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
         return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -266,8 +266,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
@@ -292,8 +292,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
         return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/PromiseAPI.ts
@@ -45,7 +45,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
@@ -56,7 +56,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
         const result = this.api.deletePet(petId, apiKey, _options);
@@ -147,8 +147,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
@@ -159,8 +159,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
@@ -171,8 +171,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
@@ -183,8 +183,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse> {
         const result = this.api.uploadFile(petId, additionalMetadata, file, _options);

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/types/ObjectParamAPI.ts
@@ -23,12 +23,14 @@ export interface PetApiAddPetRequest {
 export interface PetApiDeletePetRequest {
     /**
      * Pet id to delete
+     * Defaults to: undefined
      * @type number
      * @memberof PetApideletePet
      */
     petId: number
     /**
      * 
+     * Defaults to: undefined
      * @type string
      * @memberof PetApideletePet
      */
@@ -38,6 +40,7 @@ export interface PetApiDeletePetRequest {
 export interface PetApiFindPetsByStatusRequest {
     /**
      * Status values that need to be considered for filter
+     * Defaults to: undefined
      * @type Array&lt;&#39;available&#39; | &#39;pending&#39; | &#39;sold&#39;&gt;
      * @memberof PetApifindPetsByStatus
      */
@@ -47,6 +50,7 @@ export interface PetApiFindPetsByStatusRequest {
 export interface PetApiFindPetsByTagsRequest {
     /**
      * Tags to filter by
+     * Defaults to: undefined
      * @type Array&lt;string&gt;
      * @memberof PetApifindPetsByTags
      */
@@ -56,6 +60,7 @@ export interface PetApiFindPetsByTagsRequest {
 export interface PetApiGetPetByIdRequest {
     /**
      * ID of pet to return
+     * Defaults to: undefined
      * @type number
      * @memberof PetApigetPetById
      */
@@ -74,18 +79,21 @@ export interface PetApiUpdatePetRequest {
 export interface PetApiUpdatePetWithFormRequest {
     /**
      * ID of pet that needs to be updated
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiupdatePetWithForm
      */
     petId: number
     /**
      * Updated name of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
     name?: string
     /**
      * Updated status of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
@@ -95,18 +103,21 @@ export interface PetApiUpdatePetWithFormRequest {
 export interface PetApiUploadFileRequest {
     /**
      * ID of pet to update
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiuploadFile
      */
     petId: number
     /**
      * Additional data to pass to server
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiuploadFile
      */
     additionalMetadata?: string
     /**
      * file to upload
+     * Defaults to: undefined
      * @type HttpFile
      * @memberof PetApiuploadFile
      */
@@ -272,6 +283,7 @@ import { StoreApiRequestFactory, StoreApiResponseProcessor} from "../apis/StoreA
 export interface StoreApiDeleteOrderRequest {
     /**
      * ID of the order that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof StoreApideleteOrder
      */
@@ -284,6 +296,9 @@ export interface StoreApiGetInventoryRequest {
 export interface StoreApiGetOrderByIdRequest {
     /**
      * ID of pet that needs to be fetched
+     * Minimum: 1
+     * Maximum: 5
+     * Defaults to: undefined
      * @type number
      * @memberof StoreApigetOrderById
      */
@@ -413,6 +428,7 @@ export interface UserApiCreateUsersWithListInputRequest {
 export interface UserApiDeleteUserRequest {
     /**
      * The name that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApideleteUser
      */
@@ -422,6 +438,7 @@ export interface UserApiDeleteUserRequest {
 export interface UserApiGetUserByNameRequest {
     /**
      * The name that needs to be fetched. Use user1 for testing.
+     * Defaults to: undefined
      * @type string
      * @memberof UserApigetUserByName
      */
@@ -431,12 +448,14 @@ export interface UserApiGetUserByNameRequest {
 export interface UserApiLoginUserRequest {
     /**
      * The user name for login
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
     username: string
     /**
      * The password for login in clear text
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
@@ -449,6 +468,7 @@ export interface UserApiLogoutUserRequest {
 export interface UserApiUpdateUserRequest {
     /**
      * name that need to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiupdateUser
      */

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/types/ObservableAPI.ts
@@ -62,7 +62,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
@@ -87,7 +87,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
         return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -229,8 +229,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
@@ -255,8 +255,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
         return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -266,8 +266,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
@@ -292,8 +292,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
         return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/types/PromiseAPI.ts
@@ -45,7 +45,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
@@ -56,7 +56,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
         const result = this.api.deletePet(petId, apiKey, _options);
@@ -147,8 +147,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
@@ -159,8 +159,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
@@ -171,8 +171,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
@@ -183,8 +183,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse> {
         const result = this.api.uploadFile(petId, additionalMetadata, file, _options);

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/types/ObjectParamAPI.ts
@@ -135,12 +135,14 @@ export interface FakeApiFakeHttpSignatureTestRequest {
     pet: Pet
     /**
      * query parameter
+     * Defaults to: undefined
      * @type string
      * @memberof FakeApifakeHttpSignatureTest
      */
     query1?: string
     /**
      * header parameter
+     * Defaults to: undefined
      * @type string
      * @memberof FakeApifakeHttpSignatureTest
      */
@@ -213,6 +215,7 @@ export interface FakeApiTestBodyWithFileSchemaRequest {
 export interface FakeApiTestBodyWithQueryParamsRequest {
     /**
      * 
+     * Defaults to: undefined
      * @type string
      * @memberof FakeApitestBodyWithQueryParams
      */
@@ -237,84 +240,107 @@ export interface FakeApiTestClientModelRequest {
 export interface FakeApiTestEndpointParametersRequest {
     /**
      * None
+     * Minimum: 32.1
+     * Maximum: 543.2
+     * Defaults to: undefined
      * @type number
      * @memberof FakeApitestEndpointParameters
      */
     number: number
     /**
      * None
+     * Minimum: 67.8
+     * Maximum: 123.4
+     * Defaults to: undefined
      * @type number
      * @memberof FakeApitestEndpointParameters
      */
     _double: number
     /**
      * None
+     * Defaults to: undefined
      * @type string
      * @memberof FakeApitestEndpointParameters
      */
     patternWithoutDelimiter: string
     /**
      * None
+     * Defaults to: undefined
      * @type string
      * @memberof FakeApitestEndpointParameters
      */
     _byte: string
     /**
      * None
+     * Minimum: 10
+     * Maximum: 100
+     * Defaults to: undefined
      * @type number
      * @memberof FakeApitestEndpointParameters
      */
     integer?: number
     /**
      * None
+     * Minimum: 20
+     * Maximum: 200
+     * Defaults to: undefined
      * @type number
      * @memberof FakeApitestEndpointParameters
      */
     int32?: number
     /**
      * None
+     * Defaults to: undefined
      * @type number
      * @memberof FakeApitestEndpointParameters
      */
     int64?: number
     /**
      * None
+     * Maximum: 987.6
+     * Defaults to: undefined
      * @type number
      * @memberof FakeApitestEndpointParameters
      */
     _float?: number
     /**
      * None
+     * Defaults to: undefined
      * @type string
      * @memberof FakeApitestEndpointParameters
      */
     string?: string
     /**
      * None
+     * Defaults to: undefined
      * @type HttpFile
      * @memberof FakeApitestEndpointParameters
      */
     binary?: HttpFile
     /**
      * None
+     * Defaults to: undefined
      * @type string
      * @memberof FakeApitestEndpointParameters
      */
     date?: string
     /**
      * None
+     * Defaults to: undefined
      * @type Date
      * @memberof FakeApitestEndpointParameters
      */
     dateTime?: Date
     /**
      * None
+     * Defaults to: undefined
      * @type string
      * @memberof FakeApitestEndpointParameters
      */
     password?: string
     /**
      * None
+     * Defaults to: undefined
      * @type string
      * @memberof FakeApitestEndpointParameters
      */
@@ -324,54 +350,63 @@ export interface FakeApiTestEndpointParametersRequest {
 export interface FakeApiTestEnumParametersRequest {
     /**
      * Header parameter enum test (string array)
+     * Defaults to: undefined
      * @type Array&lt;&#39;&gt;&#39; | &#39;$&#39;&gt;
      * @memberof FakeApitestEnumParameters
      */
     enumHeaderStringArray?: Array<'>' | '$'>
     /**
      * Header parameter enum test (string)
+     * Defaults to: &#39;-efg&#39;
      * @type &#39;_abc&#39; | &#39;-efg&#39; | &#39;(xyz)&#39;
      * @memberof FakeApitestEnumParameters
      */
     enumHeaderString?: '_abc' | '-efg' | '(xyz)'
     /**
      * Query parameter enum test (string array)
+     * Defaults to: undefined
      * @type Array&lt;&#39;&gt;&#39; | &#39;$&#39;&gt;
      * @memberof FakeApitestEnumParameters
      */
     enumQueryStringArray?: Array<'>' | '$'>
     /**
      * Query parameter enum test (string)
+     * Defaults to: &#39;-efg&#39;
      * @type &#39;_abc&#39; | &#39;-efg&#39; | &#39;(xyz)&#39;
      * @memberof FakeApitestEnumParameters
      */
     enumQueryString?: '_abc' | '-efg' | '(xyz)'
     /**
      * Query parameter enum test (double)
+     * Defaults to: undefined
      * @type 1 | -2
      * @memberof FakeApitestEnumParameters
      */
     enumQueryInteger?: 1 | -2
     /**
      * Query parameter enum test (double)
+     * Defaults to: undefined
      * @type 1.1 | -1.2
      * @memberof FakeApitestEnumParameters
      */
     enumQueryDouble?: 1.1 | -1.2
     /**
      * 
+     * Defaults to: undefined
      * @type Array&lt;EnumClass&gt;
      * @memberof FakeApitestEnumParameters
      */
     enumQueryModelArray?: Array<EnumClass>
     /**
      * Form parameter enum test (string array)
+     * Defaults to: &#39;$&#39;
      * @type Array&lt;string&gt;
      * @memberof FakeApitestEnumParameters
      */
     enumFormStringArray?: Array<string>
     /**
      * Form parameter enum test (string)
+     * Defaults to: &#39;-efg&#39;
      * @type string
      * @memberof FakeApitestEnumParameters
      */
@@ -381,36 +416,42 @@ export interface FakeApiTestEnumParametersRequest {
 export interface FakeApiTestGroupParametersRequest {
     /**
      * Required String in group parameters
+     * Defaults to: undefined
      * @type number
      * @memberof FakeApitestGroupParameters
      */
     requiredStringGroup: number
     /**
      * Required Boolean in group parameters
+     * Defaults to: undefined
      * @type boolean
      * @memberof FakeApitestGroupParameters
      */
     requiredBooleanGroup: boolean
     /**
      * Required Integer in group parameters
+     * Defaults to: undefined
      * @type number
      * @memberof FakeApitestGroupParameters
      */
     requiredInt64Group: number
     /**
      * String in group parameters
+     * Defaults to: undefined
      * @type number
      * @memberof FakeApitestGroupParameters
      */
     stringGroup?: number
     /**
      * Boolean in group parameters
+     * Defaults to: undefined
      * @type boolean
      * @memberof FakeApitestGroupParameters
      */
     booleanGroup?: boolean
     /**
      * Integer in group parameters
+     * Defaults to: undefined
      * @type number
      * @memberof FakeApitestGroupParameters
      */
@@ -429,12 +470,14 @@ export interface FakeApiTestInlineAdditionalPropertiesRequest {
 export interface FakeApiTestJsonFormDataRequest {
     /**
      * field1
+     * Defaults to: undefined
      * @type string
      * @memberof FakeApitestJsonFormData
      */
     param: string
     /**
      * field2
+     * Defaults to: undefined
      * @type string
      * @memberof FakeApitestJsonFormData
      */
@@ -444,42 +487,49 @@ export interface FakeApiTestJsonFormDataRequest {
 export interface FakeApiTestQueryParameterCollectionFormatRequest {
     /**
      * 
+     * Defaults to: undefined
      * @type Array&lt;string&gt;
      * @memberof FakeApitestQueryParameterCollectionFormat
      */
     pipe: Array<string>
     /**
      * 
+     * Defaults to: undefined
      * @type Array&lt;string&gt;
      * @memberof FakeApitestQueryParameterCollectionFormat
      */
     ioutil: Array<string>
     /**
      * 
+     * Defaults to: undefined
      * @type Array&lt;string&gt;
      * @memberof FakeApitestQueryParameterCollectionFormat
      */
     http: Array<string>
     /**
      * 
+     * Defaults to: undefined
      * @type Array&lt;string&gt;
      * @memberof FakeApitestQueryParameterCollectionFormat
      */
     url: Array<string>
     /**
      * 
+     * Defaults to: undefined
      * @type Array&lt;string&gt;
      * @memberof FakeApitestQueryParameterCollectionFormat
      */
     context: Array<string>
     /**
      * 
+     * Defaults to: undefined
      * @type string
      * @memberof FakeApitestQueryParameterCollectionFormat
      */
     allowEmpty: string
     /**
      * 
+     * Defaults to: undefined
      * @type { [key: string]: string; }
      * @memberof FakeApitestQueryParameterCollectionFormat
      */
@@ -847,12 +897,14 @@ export interface PetApiAddPetRequest {
 export interface PetApiDeletePetRequest {
     /**
      * Pet id to delete
+     * Defaults to: undefined
      * @type number
      * @memberof PetApideletePet
      */
     petId: number
     /**
      * 
+     * Defaults to: undefined
      * @type string
      * @memberof PetApideletePet
      */
@@ -862,6 +914,7 @@ export interface PetApiDeletePetRequest {
 export interface PetApiFindPetsByStatusRequest {
     /**
      * Status values that need to be considered for filter
+     * Defaults to: undefined
      * @type Array&lt;&#39;available&#39; | &#39;pending&#39; | &#39;sold&#39;&gt;
      * @memberof PetApifindPetsByStatus
      */
@@ -871,6 +924,7 @@ export interface PetApiFindPetsByStatusRequest {
 export interface PetApiFindPetsByTagsRequest {
     /**
      * Tags to filter by
+     * Defaults to: undefined
      * @type Set&lt;string&gt;
      * @memberof PetApifindPetsByTags
      */
@@ -880,6 +934,7 @@ export interface PetApiFindPetsByTagsRequest {
 export interface PetApiGetPetByIdRequest {
     /**
      * ID of pet to return
+     * Defaults to: undefined
      * @type number
      * @memberof PetApigetPetById
      */
@@ -898,18 +953,21 @@ export interface PetApiUpdatePetRequest {
 export interface PetApiUpdatePetWithFormRequest {
     /**
      * ID of pet that needs to be updated
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiupdatePetWithForm
      */
     petId: number
     /**
      * Updated name of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
     name?: string
     /**
      * Updated status of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
@@ -919,18 +977,21 @@ export interface PetApiUpdatePetWithFormRequest {
 export interface PetApiUploadFileRequest {
     /**
      * ID of pet to update
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiuploadFile
      */
     petId: number
     /**
      * Additional data to pass to server
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiuploadFile
      */
     additionalMetadata?: string
     /**
      * file to upload
+     * Defaults to: undefined
      * @type HttpFile
      * @memberof PetApiuploadFile
      */
@@ -940,18 +1001,21 @@ export interface PetApiUploadFileRequest {
 export interface PetApiUploadFileWithRequiredFileRequest {
     /**
      * ID of pet to update
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiuploadFileWithRequiredFile
      */
     petId: number
     /**
      * file to upload
+     * Defaults to: undefined
      * @type HttpFile
      * @memberof PetApiuploadFileWithRequiredFile
      */
     requiredFile: HttpFile
     /**
      * Additional data to pass to server
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiuploadFileWithRequiredFile
      */
@@ -1135,6 +1199,7 @@ import { StoreApiRequestFactory, StoreApiResponseProcessor} from "../apis/StoreA
 export interface StoreApiDeleteOrderRequest {
     /**
      * ID of the order that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof StoreApideleteOrder
      */
@@ -1147,6 +1212,9 @@ export interface StoreApiGetInventoryRequest {
 export interface StoreApiGetOrderByIdRequest {
     /**
      * ID of pet that needs to be fetched
+     * Minimum: 1
+     * Maximum: 5
+     * Defaults to: undefined
      * @type number
      * @memberof StoreApigetOrderById
      */
@@ -1276,6 +1344,7 @@ export interface UserApiCreateUsersWithListInputRequest {
 export interface UserApiDeleteUserRequest {
     /**
      * The name that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApideleteUser
      */
@@ -1285,6 +1354,7 @@ export interface UserApiDeleteUserRequest {
 export interface UserApiGetUserByNameRequest {
     /**
      * The name that needs to be fetched. Use user1 for testing.
+     * Defaults to: undefined
      * @type string
      * @memberof UserApigetUserByName
      */
@@ -1294,12 +1364,14 @@ export interface UserApiGetUserByNameRequest {
 export interface UserApiLoginUserRequest {
     /**
      * The user name for login
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
     username: string
     /**
      * The password for login in clear text
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
@@ -1312,6 +1384,7 @@ export interface UserApiLogoutUserRequest {
 export interface UserApiUpdateUserRequest {
     /**
      * name that need to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiupdateUser
      */

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/types/ObservableAPI.ts
@@ -223,8 +223,8 @@ export class ObservableFakeApi {
     /**
      * test http signature authentication
      * @param pet Pet object that needs to be added to the store
-     * @param query1 query parameter
-     * @param header1 header parameter
+     * @param [query1] query parameter
+     * @param [header1] header parameter
      */
     public fakeHttpSignatureTestWithHttpInfo(pet: Pet, query1?: string, header1?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.fakeHttpSignatureTest(pet, query1, header1, _options);
@@ -248,8 +248,8 @@ export class ObservableFakeApi {
     /**
      * test http signature authentication
      * @param pet Pet object that needs to be added to the store
-     * @param query1 query parameter
-     * @param header1 header parameter
+     * @param [query1] query parameter
+     * @param [header1] header parameter
      */
     public fakeHttpSignatureTest(pet: Pet, query1?: string, header1?: string, _options?: Configuration): Observable<void> {
         return this.fakeHttpSignatureTestWithHttpInfo(pet, query1, header1, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -257,7 +257,7 @@ export class ObservableFakeApi {
 
     /**
      * Test serialization of outer boolean types
-     * @param body Input boolean as post body
+     * @param [body] Input boolean as post body
      */
     public fakeOuterBooleanSerializeWithHttpInfo(body?: boolean, _options?: Configuration): Observable<HttpInfo<boolean>> {
         const requestContextPromise = this.requestFactory.fakeOuterBooleanSerialize(body, _options);
@@ -280,7 +280,7 @@ export class ObservableFakeApi {
 
     /**
      * Test serialization of outer boolean types
-     * @param body Input boolean as post body
+     * @param [body] Input boolean as post body
      */
     public fakeOuterBooleanSerialize(body?: boolean, _options?: Configuration): Observable<boolean> {
         return this.fakeOuterBooleanSerializeWithHttpInfo(body, _options).pipe(map((apiResponse: HttpInfo<boolean>) => apiResponse.data));
@@ -288,7 +288,7 @@ export class ObservableFakeApi {
 
     /**
      * Test serialization of object with outer number type
-     * @param outerComposite Input composite as post body
+     * @param [outerComposite] Input composite as post body
      */
     public fakeOuterCompositeSerializeWithHttpInfo(outerComposite?: OuterComposite, _options?: Configuration): Observable<HttpInfo<OuterComposite>> {
         const requestContextPromise = this.requestFactory.fakeOuterCompositeSerialize(outerComposite, _options);
@@ -311,7 +311,7 @@ export class ObservableFakeApi {
 
     /**
      * Test serialization of object with outer number type
-     * @param outerComposite Input composite as post body
+     * @param [outerComposite] Input composite as post body
      */
     public fakeOuterCompositeSerialize(outerComposite?: OuterComposite, _options?: Configuration): Observable<OuterComposite> {
         return this.fakeOuterCompositeSerializeWithHttpInfo(outerComposite, _options).pipe(map((apiResponse: HttpInfo<OuterComposite>) => apiResponse.data));
@@ -319,7 +319,7 @@ export class ObservableFakeApi {
 
     /**
      * Test serialization of outer number types
-     * @param body Input number as post body
+     * @param [body] Input number as post body
      */
     public fakeOuterNumberSerializeWithHttpInfo(body?: number, _options?: Configuration): Observable<HttpInfo<number>> {
         const requestContextPromise = this.requestFactory.fakeOuterNumberSerialize(body, _options);
@@ -342,7 +342,7 @@ export class ObservableFakeApi {
 
     /**
      * Test serialization of outer number types
-     * @param body Input number as post body
+     * @param [body] Input number as post body
      */
     public fakeOuterNumberSerialize(body?: number, _options?: Configuration): Observable<number> {
         return this.fakeOuterNumberSerializeWithHttpInfo(body, _options).pipe(map((apiResponse: HttpInfo<number>) => apiResponse.data));
@@ -350,7 +350,7 @@ export class ObservableFakeApi {
 
     /**
      * Test serialization of outer string types
-     * @param body Input string as post body
+     * @param [body] Input string as post body
      */
     public fakeOuterStringSerializeWithHttpInfo(body?: string, _options?: Configuration): Observable<HttpInfo<string>> {
         const requestContextPromise = this.requestFactory.fakeOuterStringSerialize(body, _options);
@@ -373,7 +373,7 @@ export class ObservableFakeApi {
 
     /**
      * Test serialization of outer string types
-     * @param body Input string as post body
+     * @param [body] Input string as post body
      */
     public fakeOuterStringSerialize(body?: string, _options?: Configuration): Observable<string> {
         return this.fakeOuterStringSerializeWithHttpInfo(body, _options).pipe(map((apiResponse: HttpInfo<string>) => apiResponse.data));
@@ -443,7 +443,7 @@ export class ObservableFakeApi {
 
     /**
      * For this test, the body for this request must reference a schema named `File`.
-     * @param fileSchemaTestClass 
+     * @param fileSchemaTestClass
      */
     public testBodyWithFileSchemaWithHttpInfo(fileSchemaTestClass: FileSchemaTestClass, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testBodyWithFileSchema(fileSchemaTestClass, _options);
@@ -466,15 +466,15 @@ export class ObservableFakeApi {
 
     /**
      * For this test, the body for this request must reference a schema named `File`.
-     * @param fileSchemaTestClass 
+     * @param fileSchemaTestClass
      */
     public testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, _options?: Configuration): Observable<void> {
         return this.testBodyWithFileSchemaWithHttpInfo(fileSchemaTestClass, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
-     * @param query 
-     * @param user 
+     * @param query
+     * @param user
      */
     public testBodyWithQueryParamsWithHttpInfo(query: string, user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testBodyWithQueryParams(query, user, _options);
@@ -496,8 +496,8 @@ export class ObservableFakeApi {
     }
 
     /**
-     * @param query 
-     * @param user 
+     * @param query
+     * @param user
      */
     public testBodyWithQueryParams(query: string, user: User, _options?: Configuration): Observable<void> {
         return this.testBodyWithQueryParamsWithHttpInfo(query, user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -543,16 +543,16 @@ export class ObservableFakeApi {
      * @param _double None
      * @param patternWithoutDelimiter None
      * @param _byte None
-     * @param integer None
-     * @param int32 None
-     * @param int64 None
-     * @param _float None
-     * @param string None
-     * @param binary None
-     * @param date None
-     * @param dateTime None
-     * @param password None
-     * @param callback None
+     * @param [integer] None
+     * @param [int32] None
+     * @param [int64] None
+     * @param [_float] None
+     * @param [string] None
+     * @param [binary] None
+     * @param [date] None
+     * @param [dateTime] None
+     * @param [password] None
+     * @param [callback] None
      */
     public testEndpointParametersWithHttpInfo(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: HttpFile, date?: string, dateTime?: Date, password?: string, callback?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, _options);
@@ -580,16 +580,16 @@ export class ObservableFakeApi {
      * @param _double None
      * @param patternWithoutDelimiter None
      * @param _byte None
-     * @param integer None
-     * @param int32 None
-     * @param int64 None
-     * @param _float None
-     * @param string None
-     * @param binary None
-     * @param date None
-     * @param dateTime None
-     * @param password None
-     * @param callback None
+     * @param [integer] None
+     * @param [int32] None
+     * @param [int64] None
+     * @param [_float] None
+     * @param [string] None
+     * @param [binary] None
+     * @param [date] None
+     * @param [dateTime] None
+     * @param [password] None
+     * @param [callback] None
      */
     public testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: HttpFile, date?: string, dateTime?: Date, password?: string, callback?: string, _options?: Configuration): Observable<void> {
         return this.testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -598,15 +598,15 @@ export class ObservableFakeApi {
     /**
      * To test enum parameters
      * To test enum parameters
-     * @param enumHeaderStringArray Header parameter enum test (string array)
-     * @param enumHeaderString Header parameter enum test (string)
-     * @param enumQueryStringArray Query parameter enum test (string array)
-     * @param enumQueryString Query parameter enum test (string)
-     * @param enumQueryInteger Query parameter enum test (double)
-     * @param enumQueryDouble Query parameter enum test (double)
-     * @param enumQueryModelArray 
-     * @param enumFormStringArray Form parameter enum test (string array)
-     * @param enumFormString Form parameter enum test (string)
+     * @param [enumHeaderStringArray] Header parameter enum test (string array)
+     * @param [enumHeaderString] Header parameter enum test (string)
+     * @param [enumQueryStringArray] Query parameter enum test (string array)
+     * @param [enumQueryString] Query parameter enum test (string)
+     * @param [enumQueryInteger] Query parameter enum test (double)
+     * @param [enumQueryDouble] Query parameter enum test (double)
+     * @param [enumQueryModelArray]
+     * @param [enumFormStringArray] Form parameter enum test (string array)
+     * @param [enumFormString] Form parameter enum test (string)
      */
     public testEnumParametersWithHttpInfo(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumQueryModelArray?: Array<EnumClass>, enumFormStringArray?: Array<string>, enumFormString?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumQueryModelArray, enumFormStringArray, enumFormString, _options);
@@ -630,15 +630,15 @@ export class ObservableFakeApi {
     /**
      * To test enum parameters
      * To test enum parameters
-     * @param enumHeaderStringArray Header parameter enum test (string array)
-     * @param enumHeaderString Header parameter enum test (string)
-     * @param enumQueryStringArray Query parameter enum test (string array)
-     * @param enumQueryString Query parameter enum test (string)
-     * @param enumQueryInteger Query parameter enum test (double)
-     * @param enumQueryDouble Query parameter enum test (double)
-     * @param enumQueryModelArray 
-     * @param enumFormStringArray Form parameter enum test (string array)
-     * @param enumFormString Form parameter enum test (string)
+     * @param [enumHeaderStringArray] Header parameter enum test (string array)
+     * @param [enumHeaderString] Header parameter enum test (string)
+     * @param [enumQueryStringArray] Query parameter enum test (string array)
+     * @param [enumQueryString] Query parameter enum test (string)
+     * @param [enumQueryInteger] Query parameter enum test (double)
+     * @param [enumQueryDouble] Query parameter enum test (double)
+     * @param [enumQueryModelArray]
+     * @param [enumFormStringArray] Form parameter enum test (string array)
+     * @param [enumFormString] Form parameter enum test (string)
      */
     public testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumQueryModelArray?: Array<EnumClass>, enumFormStringArray?: Array<string>, enumFormString?: string, _options?: Configuration): Observable<void> {
         return this.testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumQueryModelArray, enumFormStringArray, enumFormString, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -650,9 +650,9 @@ export class ObservableFakeApi {
      * @param requiredStringGroup Required String in group parameters
      * @param requiredBooleanGroup Required Boolean in group parameters
      * @param requiredInt64Group Required Integer in group parameters
-     * @param stringGroup String in group parameters
-     * @param booleanGroup Boolean in group parameters
-     * @param int64Group Integer in group parameters
+     * @param [stringGroup] String in group parameters
+     * @param [booleanGroup] Boolean in group parameters
+     * @param [int64Group] Integer in group parameters
      */
     public testGroupParametersWithHttpInfo(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, _options);
@@ -679,9 +679,9 @@ export class ObservableFakeApi {
      * @param requiredStringGroup Required String in group parameters
      * @param requiredBooleanGroup Required Boolean in group parameters
      * @param requiredInt64Group Required Integer in group parameters
-     * @param stringGroup String in group parameters
-     * @param booleanGroup Boolean in group parameters
-     * @param int64Group Integer in group parameters
+     * @param [stringGroup] String in group parameters
+     * @param [booleanGroup] Boolean in group parameters
+     * @param [int64Group] Integer in group parameters
      */
     public testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, _options?: Configuration): Observable<void> {
         return this.testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -757,13 +757,13 @@ export class ObservableFakeApi {
 
     /**
      * To test the collection format in query parameters
-     * @param pipe 
-     * @param ioutil 
-     * @param http 
-     * @param url 
-     * @param context 
-     * @param allowEmpty 
-     * @param language 
+     * @param pipe
+     * @param ioutil
+     * @param http
+     * @param url
+     * @param context
+     * @param allowEmpty
+     * @param [language]
      */
     public testQueryParameterCollectionFormatWithHttpInfo(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, allowEmpty: string, language?: { [key: string]: string; }, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language, _options);
@@ -786,13 +786,13 @@ export class ObservableFakeApi {
 
     /**
      * To test the collection format in query parameters
-     * @param pipe 
-     * @param ioutil 
-     * @param http 
-     * @param url 
-     * @param context 
-     * @param allowEmpty 
-     * @param language 
+     * @param pipe
+     * @param ioutil
+     * @param http
+     * @param url
+     * @param context
+     * @param allowEmpty
+     * @param [language]
      */
     public testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, allowEmpty: string, language?: { [key: string]: string; }, _options?: Configuration): Observable<void> {
         return this.testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, allowEmpty, language, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -904,7 +904,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
@@ -929,7 +929,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
         return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -1071,8 +1071,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
@@ -1097,8 +1097,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
         return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -1108,8 +1108,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
@@ -1134,8 +1134,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
         return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));
@@ -1146,7 +1146,7 @@ export class ObservablePetApi {
      * uploads an image (required)
      * @param petId ID of pet to update
      * @param requiredFile file to upload
-     * @param additionalMetadata Additional data to pass to server
+     * @param [additionalMetadata] Additional data to pass to server
      */
     public uploadFileWithRequiredFileWithHttpInfo(petId: number, requiredFile: HttpFile, additionalMetadata?: string, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, _options);
@@ -1172,7 +1172,7 @@ export class ObservablePetApi {
      * uploads an image (required)
      * @param petId ID of pet to update
      * @param requiredFile file to upload
-     * @param additionalMetadata Additional data to pass to server
+     * @param [additionalMetadata] Additional data to pass to server
      */
     public uploadFileWithRequiredFile(petId: number, requiredFile: HttpFile, additionalMetadata?: string, _options?: Configuration): Observable<ApiResponse> {
         return this.uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/types/PromiseAPI.ts
@@ -169,8 +169,8 @@ export class PromiseFakeApi {
     /**
      * test http signature authentication
      * @param pet Pet object that needs to be added to the store
-     * @param query1 query parameter
-     * @param header1 header parameter
+     * @param [query1] query parameter
+     * @param [header1] header parameter
      */
     public fakeHttpSignatureTestWithHttpInfo(pet: Pet, query1?: string, header1?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.fakeHttpSignatureTestWithHttpInfo(pet, query1, header1, _options);
@@ -180,8 +180,8 @@ export class PromiseFakeApi {
     /**
      * test http signature authentication
      * @param pet Pet object that needs to be added to the store
-     * @param query1 query parameter
-     * @param header1 header parameter
+     * @param [query1] query parameter
+     * @param [header1] header parameter
      */
     public fakeHttpSignatureTest(pet: Pet, query1?: string, header1?: string, _options?: Configuration): Promise<void> {
         const result = this.api.fakeHttpSignatureTest(pet, query1, header1, _options);
@@ -190,7 +190,7 @@ export class PromiseFakeApi {
 
     /**
      * Test serialization of outer boolean types
-     * @param body Input boolean as post body
+     * @param [body] Input boolean as post body
      */
     public fakeOuterBooleanSerializeWithHttpInfo(body?: boolean, _options?: Configuration): Promise<HttpInfo<boolean>> {
         const result = this.api.fakeOuterBooleanSerializeWithHttpInfo(body, _options);
@@ -199,7 +199,7 @@ export class PromiseFakeApi {
 
     /**
      * Test serialization of outer boolean types
-     * @param body Input boolean as post body
+     * @param [body] Input boolean as post body
      */
     public fakeOuterBooleanSerialize(body?: boolean, _options?: Configuration): Promise<boolean> {
         const result = this.api.fakeOuterBooleanSerialize(body, _options);
@@ -208,7 +208,7 @@ export class PromiseFakeApi {
 
     /**
      * Test serialization of object with outer number type
-     * @param outerComposite Input composite as post body
+     * @param [outerComposite] Input composite as post body
      */
     public fakeOuterCompositeSerializeWithHttpInfo(outerComposite?: OuterComposite, _options?: Configuration): Promise<HttpInfo<OuterComposite>> {
         const result = this.api.fakeOuterCompositeSerializeWithHttpInfo(outerComposite, _options);
@@ -217,7 +217,7 @@ export class PromiseFakeApi {
 
     /**
      * Test serialization of object with outer number type
-     * @param outerComposite Input composite as post body
+     * @param [outerComposite] Input composite as post body
      */
     public fakeOuterCompositeSerialize(outerComposite?: OuterComposite, _options?: Configuration): Promise<OuterComposite> {
         const result = this.api.fakeOuterCompositeSerialize(outerComposite, _options);
@@ -226,7 +226,7 @@ export class PromiseFakeApi {
 
     /**
      * Test serialization of outer number types
-     * @param body Input number as post body
+     * @param [body] Input number as post body
      */
     public fakeOuterNumberSerializeWithHttpInfo(body?: number, _options?: Configuration): Promise<HttpInfo<number>> {
         const result = this.api.fakeOuterNumberSerializeWithHttpInfo(body, _options);
@@ -235,7 +235,7 @@ export class PromiseFakeApi {
 
     /**
      * Test serialization of outer number types
-     * @param body Input number as post body
+     * @param [body] Input number as post body
      */
     public fakeOuterNumberSerialize(body?: number, _options?: Configuration): Promise<number> {
         const result = this.api.fakeOuterNumberSerialize(body, _options);
@@ -244,7 +244,7 @@ export class PromiseFakeApi {
 
     /**
      * Test serialization of outer string types
-     * @param body Input string as post body
+     * @param [body] Input string as post body
      */
     public fakeOuterStringSerializeWithHttpInfo(body?: string, _options?: Configuration): Promise<HttpInfo<string>> {
         const result = this.api.fakeOuterStringSerializeWithHttpInfo(body, _options);
@@ -253,7 +253,7 @@ export class PromiseFakeApi {
 
     /**
      * Test serialization of outer string types
-     * @param body Input string as post body
+     * @param [body] Input string as post body
      */
     public fakeOuterStringSerialize(body?: string, _options?: Configuration): Promise<string> {
         const result = this.api.fakeOuterStringSerialize(body, _options);
@@ -298,7 +298,7 @@ export class PromiseFakeApi {
 
     /**
      * For this test, the body for this request must reference a schema named `File`.
-     * @param fileSchemaTestClass 
+     * @param fileSchemaTestClass
      */
     public testBodyWithFileSchemaWithHttpInfo(fileSchemaTestClass: FileSchemaTestClass, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testBodyWithFileSchemaWithHttpInfo(fileSchemaTestClass, _options);
@@ -307,7 +307,7 @@ export class PromiseFakeApi {
 
     /**
      * For this test, the body for this request must reference a schema named `File`.
-     * @param fileSchemaTestClass 
+     * @param fileSchemaTestClass
      */
     public testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, _options?: Configuration): Promise<void> {
         const result = this.api.testBodyWithFileSchema(fileSchemaTestClass, _options);
@@ -315,8 +315,8 @@ export class PromiseFakeApi {
     }
 
     /**
-     * @param query 
-     * @param user 
+     * @param query
+     * @param user
      */
     public testBodyWithQueryParamsWithHttpInfo(query: string, user: User, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testBodyWithQueryParamsWithHttpInfo(query, user, _options);
@@ -324,8 +324,8 @@ export class PromiseFakeApi {
     }
 
     /**
-     * @param query 
-     * @param user 
+     * @param query
+     * @param user
      */
     public testBodyWithQueryParams(query: string, user: User, _options?: Configuration): Promise<void> {
         const result = this.api.testBodyWithQueryParams(query, user, _options);
@@ -359,16 +359,16 @@ export class PromiseFakeApi {
      * @param _double None
      * @param patternWithoutDelimiter None
      * @param _byte None
-     * @param integer None
-     * @param int32 None
-     * @param int64 None
-     * @param _float None
-     * @param string None
-     * @param binary None
-     * @param date None
-     * @param dateTime None
-     * @param password None
-     * @param callback None
+     * @param [integer] None
+     * @param [int32] None
+     * @param [int64] None
+     * @param [_float] None
+     * @param [string] None
+     * @param [binary] None
+     * @param [date] None
+     * @param [dateTime] None
+     * @param [password] None
+     * @param [callback] None
      */
     public testEndpointParametersWithHttpInfo(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: HttpFile, date?: string, dateTime?: Date, password?: string, callback?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, _options);
@@ -382,16 +382,16 @@ export class PromiseFakeApi {
      * @param _double None
      * @param patternWithoutDelimiter None
      * @param _byte None
-     * @param integer None
-     * @param int32 None
-     * @param int64 None
-     * @param _float None
-     * @param string None
-     * @param binary None
-     * @param date None
-     * @param dateTime None
-     * @param password None
-     * @param callback None
+     * @param [integer] None
+     * @param [int32] None
+     * @param [int64] None
+     * @param [_float] None
+     * @param [string] None
+     * @param [binary] None
+     * @param [date] None
+     * @param [dateTime] None
+     * @param [password] None
+     * @param [callback] None
      */
     public testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: HttpFile, date?: string, dateTime?: Date, password?: string, callback?: string, _options?: Configuration): Promise<void> {
         const result = this.api.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, _options);
@@ -401,15 +401,15 @@ export class PromiseFakeApi {
     /**
      * To test enum parameters
      * To test enum parameters
-     * @param enumHeaderStringArray Header parameter enum test (string array)
-     * @param enumHeaderString Header parameter enum test (string)
-     * @param enumQueryStringArray Query parameter enum test (string array)
-     * @param enumQueryString Query parameter enum test (string)
-     * @param enumQueryInteger Query parameter enum test (double)
-     * @param enumQueryDouble Query parameter enum test (double)
-     * @param enumQueryModelArray 
-     * @param enumFormStringArray Form parameter enum test (string array)
-     * @param enumFormString Form parameter enum test (string)
+     * @param [enumHeaderStringArray] Header parameter enum test (string array)
+     * @param [enumHeaderString] Header parameter enum test (string)
+     * @param [enumQueryStringArray] Query parameter enum test (string array)
+     * @param [enumQueryString] Query parameter enum test (string)
+     * @param [enumQueryInteger] Query parameter enum test (double)
+     * @param [enumQueryDouble] Query parameter enum test (double)
+     * @param [enumQueryModelArray]
+     * @param [enumFormStringArray] Form parameter enum test (string array)
+     * @param [enumFormString] Form parameter enum test (string)
      */
     public testEnumParametersWithHttpInfo(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumQueryModelArray?: Array<EnumClass>, enumFormStringArray?: Array<string>, enumFormString?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumQueryModelArray, enumFormStringArray, enumFormString, _options);
@@ -419,15 +419,15 @@ export class PromiseFakeApi {
     /**
      * To test enum parameters
      * To test enum parameters
-     * @param enumHeaderStringArray Header parameter enum test (string array)
-     * @param enumHeaderString Header parameter enum test (string)
-     * @param enumQueryStringArray Query parameter enum test (string array)
-     * @param enumQueryString Query parameter enum test (string)
-     * @param enumQueryInteger Query parameter enum test (double)
-     * @param enumQueryDouble Query parameter enum test (double)
-     * @param enumQueryModelArray 
-     * @param enumFormStringArray Form parameter enum test (string array)
-     * @param enumFormString Form parameter enum test (string)
+     * @param [enumHeaderStringArray] Header parameter enum test (string array)
+     * @param [enumHeaderString] Header parameter enum test (string)
+     * @param [enumQueryStringArray] Query parameter enum test (string array)
+     * @param [enumQueryString] Query parameter enum test (string)
+     * @param [enumQueryInteger] Query parameter enum test (double)
+     * @param [enumQueryDouble] Query parameter enum test (double)
+     * @param [enumQueryModelArray]
+     * @param [enumFormStringArray] Form parameter enum test (string array)
+     * @param [enumFormString] Form parameter enum test (string)
      */
     public testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumQueryModelArray?: Array<EnumClass>, enumFormStringArray?: Array<string>, enumFormString?: string, _options?: Configuration): Promise<void> {
         const result = this.api.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumQueryModelArray, enumFormStringArray, enumFormString, _options);
@@ -440,9 +440,9 @@ export class PromiseFakeApi {
      * @param requiredStringGroup Required String in group parameters
      * @param requiredBooleanGroup Required Boolean in group parameters
      * @param requiredInt64Group Required Integer in group parameters
-     * @param stringGroup String in group parameters
-     * @param booleanGroup Boolean in group parameters
-     * @param int64Group Integer in group parameters
+     * @param [stringGroup] String in group parameters
+     * @param [booleanGroup] Boolean in group parameters
+     * @param [int64Group] Integer in group parameters
      */
     public testGroupParametersWithHttpInfo(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, _options);
@@ -455,9 +455,9 @@ export class PromiseFakeApi {
      * @param requiredStringGroup Required String in group parameters
      * @param requiredBooleanGroup Required Boolean in group parameters
      * @param requiredInt64Group Required Integer in group parameters
-     * @param stringGroup String in group parameters
-     * @param booleanGroup Boolean in group parameters
-     * @param int64Group Integer in group parameters
+     * @param [stringGroup] String in group parameters
+     * @param [booleanGroup] Boolean in group parameters
+     * @param [int64Group] Integer in group parameters
      */
     public testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, _options?: Configuration): Promise<void> {
         const result = this.api.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, _options);
@@ -508,13 +508,13 @@ export class PromiseFakeApi {
 
     /**
      * To test the collection format in query parameters
-     * @param pipe 
-     * @param ioutil 
-     * @param http 
-     * @param url 
-     * @param context 
-     * @param allowEmpty 
-     * @param language 
+     * @param pipe
+     * @param ioutil
+     * @param http
+     * @param url
+     * @param context
+     * @param allowEmpty
+     * @param [language]
      */
     public testQueryParameterCollectionFormatWithHttpInfo(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, allowEmpty: string, language?: { [key: string]: string; }, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, allowEmpty, language, _options);
@@ -523,13 +523,13 @@ export class PromiseFakeApi {
 
     /**
      * To test the collection format in query parameters
-     * @param pipe 
-     * @param ioutil 
-     * @param http 
-     * @param url 
-     * @param context 
-     * @param allowEmpty 
-     * @param language 
+     * @param pipe
+     * @param ioutil
+     * @param http
+     * @param url
+     * @param context
+     * @param allowEmpty
+     * @param [language]
      */
     public testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, allowEmpty: string, language?: { [key: string]: string; }, _options?: Configuration): Promise<void> {
         const result = this.api.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language, _options);
@@ -618,7 +618,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
@@ -629,7 +629,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
         const result = this.api.deletePet(petId, apiKey, _options);
@@ -720,8 +720,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
@@ -732,8 +732,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
@@ -744,8 +744,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
@@ -756,8 +756,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse> {
         const result = this.api.uploadFile(petId, additionalMetadata, file, _options);
@@ -769,7 +769,7 @@ export class PromisePetApi {
      * uploads an image (required)
      * @param petId ID of pet to update
      * @param requiredFile file to upload
-     * @param additionalMetadata Additional data to pass to server
+     * @param [additionalMetadata] Additional data to pass to server
      */
     public uploadFileWithRequiredFileWithHttpInfo(petId: number, requiredFile: HttpFile, additionalMetadata?: string, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata, _options);
@@ -781,7 +781,7 @@ export class PromisePetApi {
      * uploads an image (required)
      * @param petId ID of pet to update
      * @param requiredFile file to upload
-     * @param additionalMetadata Additional data to pass to server
+     * @param [additionalMetadata] Additional data to pass to server
      */
     public uploadFileWithRequiredFile(petId: number, requiredFile: HttpFile, additionalMetadata?: string, _options?: Configuration): Promise<ApiResponse> {
         const result = this.api.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, _options);

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObjectParamAPI.ts
@@ -23,12 +23,14 @@ export interface PetApiAddPetRequest {
 export interface PetApiDeletePetRequest {
     /**
      * Pet id to delete
+     * Defaults to: undefined
      * @type number
      * @memberof PetApideletePet
      */
     petId: number
     /**
      * 
+     * Defaults to: undefined
      * @type string
      * @memberof PetApideletePet
      */
@@ -38,6 +40,7 @@ export interface PetApiDeletePetRequest {
 export interface PetApiFindPetsByStatusRequest {
     /**
      * Status values that need to be considered for filter
+     * Defaults to: undefined
      * @type Array&lt;&#39;available&#39; | &#39;pending&#39; | &#39;sold&#39;&gt;
      * @memberof PetApifindPetsByStatus
      */
@@ -47,6 +50,7 @@ export interface PetApiFindPetsByStatusRequest {
 export interface PetApiFindPetsByTagsRequest {
     /**
      * Tags to filter by
+     * Defaults to: undefined
      * @type Array&lt;string&gt;
      * @memberof PetApifindPetsByTags
      */
@@ -56,6 +60,7 @@ export interface PetApiFindPetsByTagsRequest {
 export interface PetApiGetPetByIdRequest {
     /**
      * ID of pet to return
+     * Defaults to: undefined
      * @type number
      * @memberof PetApigetPetById
      */
@@ -74,18 +79,21 @@ export interface PetApiUpdatePetRequest {
 export interface PetApiUpdatePetWithFormRequest {
     /**
      * ID of pet that needs to be updated
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiupdatePetWithForm
      */
     petId: number
     /**
      * Updated name of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
     name?: string
     /**
      * Updated status of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
@@ -95,18 +103,21 @@ export interface PetApiUpdatePetWithFormRequest {
 export interface PetApiUploadFileRequest {
     /**
      * ID of pet to update
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiuploadFile
      */
     petId: number
     /**
      * Additional data to pass to server
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiuploadFile
      */
     additionalMetadata?: string
     /**
      * file to upload
+     * Defaults to: undefined
      * @type HttpFile
      * @memberof PetApiuploadFile
      */
@@ -272,6 +283,7 @@ import { StoreApiRequestFactory, StoreApiResponseProcessor} from "../apis/StoreA
 export interface StoreApiDeleteOrderRequest {
     /**
      * ID of the order that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof StoreApideleteOrder
      */
@@ -284,6 +296,9 @@ export interface StoreApiGetInventoryRequest {
 export interface StoreApiGetOrderByIdRequest {
     /**
      * ID of pet that needs to be fetched
+     * Minimum: 1
+     * Maximum: 5
+     * Defaults to: undefined
      * @type number
      * @memberof StoreApigetOrderById
      */
@@ -413,6 +428,7 @@ export interface UserApiCreateUsersWithListInputRequest {
 export interface UserApiDeleteUserRequest {
     /**
      * The name that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApideleteUser
      */
@@ -422,6 +438,7 @@ export interface UserApiDeleteUserRequest {
 export interface UserApiGetUserByNameRequest {
     /**
      * The name that needs to be fetched. Use user1 for testing.
+     * Defaults to: undefined
      * @type string
      * @memberof UserApigetUserByName
      */
@@ -431,12 +448,14 @@ export interface UserApiGetUserByNameRequest {
 export interface UserApiLoginUserRequest {
     /**
      * The user name for login
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
     username: string
     /**
      * The password for login in clear text
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
@@ -449,6 +468,7 @@ export interface UserApiLogoutUserRequest {
 export interface UserApiUpdateUserRequest {
     /**
      * name that need to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiupdateUser
      */

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
@@ -67,7 +67,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
@@ -92,7 +92,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
         return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -234,8 +234,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
@@ -260,8 +260,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
         return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -271,8 +271,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
@@ -297,8 +297,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
         return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/PromiseAPI.ts
@@ -50,7 +50,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
@@ -61,7 +61,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
         const result = this.api.deletePet(petId, apiKey, _options);
@@ -152,8 +152,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
@@ -164,8 +164,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
@@ -176,8 +176,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
@@ -188,8 +188,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse> {
         const result = this.api.uploadFile(petId, additionalMetadata, file, _options);

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObjectParamAPI.ts
@@ -23,12 +23,14 @@ export interface PetApiAddPetRequest {
 export interface PetApiDeletePetRequest {
     /**
      * Pet id to delete
+     * Defaults to: undefined
      * @type number
      * @memberof PetApideletePet
      */
     petId: number
     /**
      * 
+     * Defaults to: undefined
      * @type string
      * @memberof PetApideletePet
      */
@@ -38,6 +40,7 @@ export interface PetApiDeletePetRequest {
 export interface PetApiFindPetsByStatusRequest {
     /**
      * Status values that need to be considered for filter
+     * Defaults to: undefined
      * @type Array&lt;&#39;available&#39; | &#39;pending&#39; | &#39;sold&#39;&gt;
      * @memberof PetApifindPetsByStatus
      */
@@ -47,6 +50,7 @@ export interface PetApiFindPetsByStatusRequest {
 export interface PetApiFindPetsByTagsRequest {
     /**
      * Tags to filter by
+     * Defaults to: undefined
      * @type Array&lt;string&gt;
      * @memberof PetApifindPetsByTags
      */
@@ -56,6 +60,7 @@ export interface PetApiFindPetsByTagsRequest {
 export interface PetApiGetPetByIdRequest {
     /**
      * ID of pet to return
+     * Defaults to: undefined
      * @type number
      * @memberof PetApigetPetById
      */
@@ -74,18 +79,21 @@ export interface PetApiUpdatePetRequest {
 export interface PetApiUpdatePetWithFormRequest {
     /**
      * ID of pet that needs to be updated
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiupdatePetWithForm
      */
     petId: number
     /**
      * Updated name of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
     name?: string
     /**
      * Updated status of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
@@ -95,18 +103,21 @@ export interface PetApiUpdatePetWithFormRequest {
 export interface PetApiUploadFileRequest {
     /**
      * ID of pet to update
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiuploadFile
      */
     petId: number
     /**
      * Additional data to pass to server
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiuploadFile
      */
     additionalMetadata?: string
     /**
      * file to upload
+     * Defaults to: undefined
      * @type HttpFile
      * @memberof PetApiuploadFile
      */
@@ -272,6 +283,7 @@ import { StoreApiRequestFactory, StoreApiResponseProcessor} from "../apis/StoreA
 export interface StoreApiDeleteOrderRequest {
     /**
      * ID of the order that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof StoreApideleteOrder
      */
@@ -284,6 +296,9 @@ export interface StoreApiGetInventoryRequest {
 export interface StoreApiGetOrderByIdRequest {
     /**
      * ID of pet that needs to be fetched
+     * Minimum: 1
+     * Maximum: 5
+     * Defaults to: undefined
      * @type number
      * @memberof StoreApigetOrderById
      */
@@ -413,6 +428,7 @@ export interface UserApiCreateUsersWithListInputRequest {
 export interface UserApiDeleteUserRequest {
     /**
      * The name that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApideleteUser
      */
@@ -422,6 +438,7 @@ export interface UserApiDeleteUserRequest {
 export interface UserApiGetUserByNameRequest {
     /**
      * The name that needs to be fetched. Use user1 for testing.
+     * Defaults to: undefined
      * @type string
      * @memberof UserApigetUserByName
      */
@@ -431,12 +448,14 @@ export interface UserApiGetUserByNameRequest {
 export interface UserApiLoginUserRequest {
     /**
      * The user name for login
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
     username: string
     /**
      * The password for login in clear text
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
@@ -449,6 +468,7 @@ export interface UserApiLogoutUserRequest {
 export interface UserApiUpdateUserRequest {
     /**
      * name that need to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiupdateUser
      */

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
@@ -62,7 +62,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
@@ -87,7 +87,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
         return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -229,8 +229,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
@@ -255,8 +255,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
         return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -266,8 +266,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
@@ -292,8 +292,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
         return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/PromiseAPI.ts
@@ -45,7 +45,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
@@ -56,7 +56,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
         const result = this.api.deletePet(petId, apiKey, _options);
@@ -147,8 +147,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
@@ -159,8 +159,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
@@ -171,8 +171,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
@@ -183,8 +183,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse> {
         const result = this.api.uploadFile(petId, additionalMetadata, file, _options);

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObjectParamAPI.ts
@@ -23,12 +23,14 @@ export interface PetApiAddPetRequest {
 export interface PetApiDeletePetRequest {
     /**
      * Pet id to delete
+     * Defaults to: undefined
      * @type number
      * @memberof PetApideletePet
      */
     petId: number
     /**
      * 
+     * Defaults to: undefined
      * @type string
      * @memberof PetApideletePet
      */
@@ -38,6 +40,7 @@ export interface PetApiDeletePetRequest {
 export interface PetApiFindPetsByStatusRequest {
     /**
      * Status values that need to be considered for filter
+     * Defaults to: undefined
      * @type Array&lt;&#39;available&#39; | &#39;pending&#39; | &#39;sold&#39;&gt;
      * @memberof PetApifindPetsByStatus
      */
@@ -47,6 +50,7 @@ export interface PetApiFindPetsByStatusRequest {
 export interface PetApiFindPetsByTagsRequest {
     /**
      * Tags to filter by
+     * Defaults to: undefined
      * @type Array&lt;string&gt;
      * @memberof PetApifindPetsByTags
      */
@@ -56,6 +60,7 @@ export interface PetApiFindPetsByTagsRequest {
 export interface PetApiGetPetByIdRequest {
     /**
      * ID of pet to return
+     * Defaults to: undefined
      * @type number
      * @memberof PetApigetPetById
      */
@@ -74,18 +79,21 @@ export interface PetApiUpdatePetRequest {
 export interface PetApiUpdatePetWithFormRequest {
     /**
      * ID of pet that needs to be updated
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiupdatePetWithForm
      */
     petId: number
     /**
      * Updated name of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
     name?: string
     /**
      * Updated status of the pet
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiupdatePetWithForm
      */
@@ -95,18 +103,21 @@ export interface PetApiUpdatePetWithFormRequest {
 export interface PetApiUploadFileRequest {
     /**
      * ID of pet to update
+     * Defaults to: undefined
      * @type number
      * @memberof PetApiuploadFile
      */
     petId: number
     /**
      * Additional data to pass to server
+     * Defaults to: undefined
      * @type string
      * @memberof PetApiuploadFile
      */
     additionalMetadata?: string
     /**
      * file to upload
+     * Defaults to: undefined
      * @type HttpFile
      * @memberof PetApiuploadFile
      */
@@ -272,6 +283,7 @@ import { StoreApiRequestFactory, StoreApiResponseProcessor} from "../apis/StoreA
 export interface StoreApiDeleteOrderRequest {
     /**
      * ID of the order that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof StoreApideleteOrder
      */
@@ -284,6 +296,9 @@ export interface StoreApiGetInventoryRequest {
 export interface StoreApiGetOrderByIdRequest {
     /**
      * ID of pet that needs to be fetched
+     * Minimum: 1
+     * Maximum: 5
+     * Defaults to: undefined
      * @type number
      * @memberof StoreApigetOrderById
      */
@@ -413,6 +428,7 @@ export interface UserApiCreateUsersWithListInputRequest {
 export interface UserApiDeleteUserRequest {
     /**
      * The name that needs to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApideleteUser
      */
@@ -422,6 +438,7 @@ export interface UserApiDeleteUserRequest {
 export interface UserApiGetUserByNameRequest {
     /**
      * The name that needs to be fetched. Use user1 for testing.
+     * Defaults to: undefined
      * @type string
      * @memberof UserApigetUserByName
      */
@@ -431,12 +448,14 @@ export interface UserApiGetUserByNameRequest {
 export interface UserApiLoginUserRequest {
     /**
      * The user name for login
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
     username: string
     /**
      * The password for login in clear text
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiloginUser
      */
@@ -449,6 +468,7 @@ export interface UserApiLogoutUserRequest {
 export interface UserApiUpdateUserRequest {
     /**
      * name that need to be deleted
+     * Defaults to: undefined
      * @type string
      * @memberof UserApiupdateUser
      */

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObservableAPI.ts
@@ -62,7 +62,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
@@ -87,7 +87,7 @@ export class ObservablePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
         return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -229,8 +229,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
@@ -255,8 +255,8 @@ export class ObservablePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
         return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
@@ -266,8 +266,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
@@ -292,8 +292,8 @@ export class ObservablePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
         return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/PromiseAPI.ts
@@ -45,7 +45,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
@@ -56,7 +56,7 @@ export class PromisePetApi {
      * 
      * Deletes a pet
      * @param petId Pet id to delete
-     * @param apiKey 
+     * @param [apiKey]
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
         const result = this.api.deletePet(petId, apiKey, _options);
@@ -147,8 +147,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
@@ -159,8 +159,8 @@ export class PromisePetApi {
      * 
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param [name] Updated name of the pet
+     * @param [status] Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
@@ -171,8 +171,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
@@ -183,8 +183,8 @@ export class PromisePetApi {
      * 
      * uploads an image
      * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param [additionalMetadata] Additional data to pass to server
+     * @param [file] file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse> {
         const result = this.api.uploadFile(petId, additionalMetadata, file, _options);


### PR DESCRIPTION
This adds the properties
* `minimum`
* `maximum`
* `default`

to the generated API docs.

I deliberately did not use the [`@default <value>`](https://jsdoc.app/tags-default) tag as that describes an assigned value, which is not how the generated code currently works. Defaults are outlined by the API spec but not enforced or provided on client side.

I also noticed that there is no validation in any of the typescript clients - `typescript-fetch` has a validation map that can be generated optionally, but that's it. Is that a deliberate design decision as minima/maxima can change on the server side, so we don't want to enforce them client side?


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)
