### PR TITLE
Erlang server validation bugfixes and capability extensions

### DIFF
--- a/modules/openapi-generator/src/main/resources/erlang-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/api.mustache
@@ -50,6 +50,7 @@ accept_callback(Class, OperationID, Req, Context) ->
 
 -type rule() ::
     {type, binary} |
+    {type, byte} |
     {type, integer} |
     {type, float} |
     {type, boolean} |
@@ -137,7 +138,7 @@ for the `OperationID` operation.
             {type, integer},{{/isLong}}{{#isFloat}}
             {type, float},{{/isFloat}}{{#isDouble}}
             {type, float},{{/isDouble}}{{#isByteArray}}
-            {type, binary},{{/isByteArray}}{{#isBinary}}
+            {type, byte},{{/isByteArray}}{{#isBinary}}
             {type, binary},{{/isBinary}}{{#isBoolean}}
             {type, boolean},{{/isBoolean}}{{#isDate}}
             {type, date},{{/isDate}}{{#isDateTime}}
@@ -216,6 +217,11 @@ validate({type, float}, Value, _ReqParamName, _) when is_float(Value) ->
     ok;
 validate({type, binary}, Value, _ReqParamName, _) when is_binary(Value) ->
     ok;
+validate(Rule = {type, byte}, Value, ReqParamName, _) when is_binary(Value) ->
+    try base64:decode(Value) of
+        Decoded -> {ok, Decoded}
+    catch error:_Error -> validation_error(Rule, ReqParamName, Value)
+    end;
 validate({max, Max}, Value, _, _) when Value =< Max ->
     ok;
 validate({min, Min}, Value, _, _) when Min =< Value ->

--- a/modules/openapi-generator/src/main/resources/erlang-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/api.mustache
@@ -46,7 +46,7 @@ accept_callback(Class, OperationID, Req, Context) ->
 
 -export_type([operation_id/0]).
 
--dialyzer({nowarn_function, [to_binary/1, validate_response_body/4]}).
+-dialyzer({nowarn_function, [validate_response_body/4]}).
 
 -type rule() ::
     {type, binary} |
@@ -203,25 +203,20 @@ validate_response_body(_, ReturnBaseType, Body, ValidatorState) ->
     ok | {ok, term()}.
 validate(required, undefined, ReqParamName, _) ->
     validation_error(required, ReqParamName, undefined);
-validate(required, _Value, _ReqParamName, _) ->
+validate(required, _Value, _, _) ->
     ok;
-validate(not_required, _Value, _ReqParamName, _) ->
+validate(not_required, _Value, _, _) ->
     ok;
-validate(_, undefined, _ReqParamName, _) ->
+validate(_, undefined, _, _) ->
     ok;
-validate({type, boolean}, Value, _ReqParamName, _) when is_boolean(Value) ->
-    {ok, Value};
-validate({type, integer}, Value, _ReqParamName, _) when is_integer(Value) ->
+validate({type, boolean}, Value, _, _) when is_boolean(Value) ->
     ok;
-validate({type, float}, Value, _ReqParamName, _) when is_float(Value) ->
+validate({type, integer}, Value, _, _) when is_integer(Value) ->
     ok;
-validate({type, binary}, Value, _ReqParamName, _) when is_binary(Value) ->
+validate({type, float}, Value, _, _) when is_float(Value) ->
     ok;
-validate(Rule = {type, byte}, Value, ReqParamName, _) when is_binary(Value) ->
-    try base64:decode(Value) of
-        Decoded -> {ok, Decoded}
-    catch error:_Error -> validation_error(Rule, ReqParamName, Value)
-    end;
+validate({type, binary}, Value, _, _) when is_binary(Value) ->
+    ok;
 validate({max, Max}, Value, _, _) when Value =< Max ->
     ok;
 validate({min, Min}, Value, _, _) when Min =< Value ->
@@ -234,24 +229,27 @@ validate({max_length, MaxLength}, Value, _, _) when is_binary(Value), byte_size(
     ok;
 validate({min_length, MinLength}, Value, _, _) when is_binary(Value), MinLength =< byte_size(Value) ->
     ok;
-validate(Rule = {type, binary}, Value, ReqParamName, _) ->
-    validation_error(Rule, ReqParamName, Value);
-validate(Rule = {type, boolean}, Value, ReqParamName, _) ->
-    case binary_to_lower(Value) of
+validate(Rule = {type, byte}, Value, ReqParamName, _) when is_binary(Value) ->
+    try base64:decode(Value) of
+        Decoded -> {ok, Decoded}
+    catch error:_Error -> validation_error(Rule, ReqParamName, Value)
+    end;
+validate(Rule = {type, boolean}, Value, ReqParamName, _) when is_binary(Value) ->
+    case to_binary(string:lowercase(Value)) of
         <<"true">> -> {ok, true};
         <<"false">> -> {ok, false};
         _ -> validation_error(Rule, ReqParamName, Value)
     end;
-validate(Rule = {type, integer}, Value, ReqParamName, _) ->
+validate(Rule = {type, integer}, Value, ReqParamName, _) when is_binary(Value) ->
     try
-        {ok, to_int(Value)}
+        {ok, binary_to_integer(Value)}
     catch
         error:badarg ->
             validation_error(Rule, ReqParamName, Value)
     end;
-validate(Rule = {type, float}, Value, ReqParamName, _) ->
+validate(Rule = {type, float}, Value, ReqParamName, _) when is_binary(Value) ->
     try
-        {ok, to_float(Value)}
+        {ok, binary_to_float(Value)}
     catch
         error:badarg ->
             validation_error(Rule, ReqParamName, Value)
@@ -284,7 +282,7 @@ validate(Rule = {pattern, Pattern}, Value, ReqParamName, _) ->
         _ -> validation_error(Rule, ReqParamName, Value)
     end;
 validate(Rule = schema, Value, ReqParamName, ValidatorState) ->
-    Definition = iolist_to_binary(["#/components/schemas/", atom_to_binary(ReqParamName)]),
+    Definition = iolist_to_binary(["#/components/schemas/", atom_to_binary(ReqParamName, utf8)]),
     try
         _ = validate_with_schema(Value, Definition, ValidatorState),
         ok
@@ -304,9 +302,8 @@ validate(Rule = schema, Value, ReqParamName, ValidatorState) ->
             },
             validation_error(Rule, ReqParamName, Value, Info)
     end;
-validate(Rule, _Value, ReqParamName, _) ->
-    ?LOG_INFO(#{what => "Cannot validate rule", name => ReqParamName, rule => Rule}),
-    error({unknown_validation_rule, Rule}).
+validate(Rule, Value, ReqParamName, _) ->
+    validation_error(Rule, ReqParamName, Value).
 
 -spec validation_error(rule(), request_param(), term()) -> no_return().
 validation_error(ViolatedRule, Name, Value) ->
@@ -333,7 +330,7 @@ get_value(qs_val, Name, Req) ->
     {Value, Req};
 get_value(header, Name, Req) ->
     Headers = cowboy_req:headers(Req),
-    Value =  maps:get(to_header(Name), Headers, undefined),
+    Value = maps:get(to_header(Name), Headers, undefined),
     {Value, Req};
 get_value(binding, Name, Req) ->
     Value = cowboy_req:binding(Name, Req),
@@ -386,31 +383,13 @@ prepare_param(Rules, ReqParamName, Value, ValidatorState) ->
             {error, Reason}
     end.
 
--spec to_binary(iodata() | atom() | number()) -> binary().
+-spec to_binary(iodata()) -> binary().
 to_binary(V) when is_binary(V)  -> V;
-to_binary(V) when is_list(V)    -> iolist_to_binary(V);
-to_binary(V) when is_atom(V)    -> atom_to_binary(V, utf8);
-to_binary(V) when is_integer(V) -> integer_to_binary(V);
-to_binary(V) when is_float(V)   -> float_to_binary(V).
-
--spec to_float(binary() | list()) -> integer().
-to_float(Data) when is_binary(Data) ->
-    binary_to_float(Data);
-to_float(Data) when is_list(Data) ->
-    list_to_float(Data).
-
--spec to_int(binary() | list()) -> integer().
-to_int(Data) when is_binary(Data) ->
-    binary_to_integer(Data);
-to_int(Data) when is_list(Data) ->
-    list_to_integer(Data).
+to_binary(V) when is_list(V)    -> iolist_to_binary(V).
 
 -spec to_header(request_param()) -> binary().
 to_header(Name) ->
     to_binary(string:lowercase(atom_to_binary(Name, utf8))).
-
-binary_to_lower(V) when is_binary(V) ->
-    string:lowercase(V).
 
 -spec to_qs(request_param()) -> binary().
 to_qs(Name) ->

--- a/modules/openapi-generator/src/main/resources/erlang-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/api.mustache
@@ -262,9 +262,9 @@ validate(Rule = {type, date}, Value, ReqParamName, _) ->
         false -> validation_error(Rule, ReqParamName, Value)
     end;
 validate(Rule = {type, datetime}, Value, ReqParamName, _) ->
-    case is_binary(Value) of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
+    try calendar:rfc3339_to_system_time(binary_to_list(Value)) of
+        _ -> ok
+    catch error:_Error -> validation_error(Rule, ReqParamName, Value)
     end;
 validate(Rule = {enum, Values}, Value, ReqParamName, _) ->
     try

--- a/modules/openapi-generator/src/main/resources/erlang-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/api.mustache
@@ -143,10 +143,10 @@ for the `OperationID` operation.
             {type, date},{{/isDate}}{{#isDateTime}}
             {type, datetime},{{/isDateTime}}{{#isEnum}}
             {enum, [{{#allowableValues}}{{#values}}'{{.}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}] },{{/isEnum}}{{#maximum}}
-            {max, {{maximum}}},{{/maximum}}{{#exclusiveMaximum}}
-            {exclusive_max, {{exclusiveMaximum}}},{{/exclusiveMaximum}}{{#minimum}}
-            {min, {{minimum}}},{{/minimum}}{{#exclusiveMinimum}}
-            {exclusive_min, {{exclusiveMinimum}}},{{/exclusiveMinimum}}{{#maxLength}}
+            {max, {{maximum}}},{{#exclusiveMaximum}}
+            {exclusive_max, {{maximum}}},{{/exclusiveMaximum}}{{/maximum}}{{#minimum}}
+            {min, {{minimum}}},{{#exclusiveMinimum}}
+            {exclusive_min, {{minimum}}},{{/exclusiveMinimum}}{{/minimum}}{{#maxLength}}
             {max_length, {{maxLength}}},{{/maxLength}}{{#minLength}}
             {min_length, {{minLength}}},{{/minLength}}{{#pattern}}
             {pattern, "{{{pattern}}}"},{{/pattern}}{{#isBodyParam}}
@@ -216,6 +216,18 @@ validate({type, float}, Value, _ReqParamName, _) when is_float(Value) ->
     ok;
 validate({type, binary}, Value, _ReqParamName, _) when is_binary(Value) ->
     ok;
+validate({max, Max}, Value, _, _) when Value =< Max ->
+    ok;
+validate({min, Min}, Value, _, _) when Min =< Value ->
+    ok;
+validate({exclusive_max, Max}, Value, _, _) when Value < Max ->
+    ok;
+validate({exclusive_min, Min}, Value, _, _) when Min < Value ->
+    ok;
+validate({max_length, MaxLength}, Value, _, _) when is_binary(Value), byte_size(Value) =< MaxLength ->
+    ok;
+validate({min_length, MinLength}, Value, _, _) when is_binary(Value), MinLength =< byte_size(Value) ->
+    ok;
 validate(Rule = {type, binary}, Value, ReqParamName, _) ->
     validation_error(Rule, ReqParamName, Value);
 validate(Rule = {type, boolean}, Value, ReqParamName, _) ->
@@ -258,36 +270,6 @@ validate(Rule = {enum, Values}, Value, ReqParamName, _) ->
     catch
         error:badarg ->
             validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {max, Max}, Value, ReqParamName, _) ->
-    case Value =< Max of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {exclusive_max, ExclusiveMax}, Value, ReqParamName, _) ->
-    case Value > ExclusiveMax of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {min, Min}, Value, ReqParamName, _) ->
-    case Value >= Min of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {exclusive_min, ExclusiveMin}, Value, ReqParamName, _) ->
-    case Value =< ExclusiveMin of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {max_length, MaxLength}, Value, ReqParamName, _) ->
-    case size(Value) =< MaxLength of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {min_length, MinLength}, Value, ReqParamName, _) ->
-    case size(Value) >= MinLength of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
     end;
 validate(Rule = {pattern, Pattern}, Value, ReqParamName, _) ->
     {ok, MP} = re:compile(Pattern),

--- a/samples/server/echo_api/erlang-server/src/openapi_api.erl
+++ b/samples/server/echo_api/erlang-server/src/openapi_api.erl
@@ -46,10 +46,11 @@ accept_callback(Class, OperationID, Req, Context) ->
 
 -export_type([operation_id/0]).
 
--dialyzer({nowarn_function, [to_binary/1, validate_response_body/4]}).
+-dialyzer({nowarn_function, [validate_response_body/4]}).
 
 -type rule() ::
     {type, binary} |
+    {type, byte} |
     {type, integer} |
     {type, float} |
     {type, boolean} |
@@ -681,38 +682,53 @@ validate_response_body(_, ReturnBaseType, Body, ValidatorState) ->
     ok | {ok, term()}.
 validate(required, undefined, ReqParamName, _) ->
     validation_error(required, ReqParamName, undefined);
-validate(required, _Value, _ReqParamName, _) ->
+validate(required, _Value, _, _) ->
     ok;
-validate(not_required, _Value, _ReqParamName, _) ->
+validate(not_required, _Value, _, _) ->
     ok;
-validate(_, undefined, _ReqParamName, _) ->
+validate(_, undefined, _, _) ->
     ok;
-validate({type, boolean}, Value, _ReqParamName, _) when is_boolean(Value) ->
-    {ok, Value};
-validate({type, integer}, Value, _ReqParamName, _) when is_integer(Value) ->
+validate({type, boolean}, Value, _, _) when is_boolean(Value) ->
     ok;
-validate({type, float}, Value, _ReqParamName, _) when is_float(Value) ->
+validate({type, integer}, Value, _, _) when is_integer(Value) ->
     ok;
-validate({type, binary}, Value, _ReqParamName, _) when is_binary(Value) ->
+validate({type, float}, Value, _, _) when is_float(Value) ->
     ok;
-validate(Rule = {type, binary}, Value, ReqParamName, _) ->
-    validation_error(Rule, ReqParamName, Value);
-validate(Rule = {type, boolean}, Value, ReqParamName, _) ->
-    case binary_to_lower(Value) of
+validate({type, binary}, Value, _, _) when is_binary(Value) ->
+    ok;
+validate({max, Max}, Value, _, _) when Value =< Max ->
+    ok;
+validate({min, Min}, Value, _, _) when Min =< Value ->
+    ok;
+validate({exclusive_max, Max}, Value, _, _) when Value < Max ->
+    ok;
+validate({exclusive_min, Min}, Value, _, _) when Min < Value ->
+    ok;
+validate({max_length, MaxLength}, Value, _, _) when is_binary(Value), byte_size(Value) =< MaxLength ->
+    ok;
+validate({min_length, MinLength}, Value, _, _) when is_binary(Value), MinLength =< byte_size(Value) ->
+    ok;
+validate(Rule = {type, byte}, Value, ReqParamName, _) when is_binary(Value) ->
+    try base64:decode(Value) of
+        Decoded -> {ok, Decoded}
+    catch error:_Error -> validation_error(Rule, ReqParamName, Value)
+    end;
+validate(Rule = {type, boolean}, Value, ReqParamName, _) when is_binary(Value) ->
+    case to_binary(string:lowercase(Value)) of
         <<"true">> -> {ok, true};
         <<"false">> -> {ok, false};
         _ -> validation_error(Rule, ReqParamName, Value)
     end;
-validate(Rule = {type, integer}, Value, ReqParamName, _) ->
+validate(Rule = {type, integer}, Value, ReqParamName, _) when is_binary(Value) ->
     try
-        {ok, to_int(Value)}
+        {ok, binary_to_integer(Value)}
     catch
         error:badarg ->
             validation_error(Rule, ReqParamName, Value)
     end;
-validate(Rule = {type, float}, Value, ReqParamName, _) ->
+validate(Rule = {type, float}, Value, ReqParamName, _) when is_binary(Value) ->
     try
-        {ok, to_float(Value)}
+        {ok, binary_to_float(Value)}
     catch
         error:badarg ->
             validation_error(Rule, ReqParamName, Value)
@@ -723,9 +739,9 @@ validate(Rule = {type, date}, Value, ReqParamName, _) ->
         false -> validation_error(Rule, ReqParamName, Value)
     end;
 validate(Rule = {type, datetime}, Value, ReqParamName, _) ->
-    case is_binary(Value) of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
+    try calendar:rfc3339_to_system_time(binary_to_list(Value)) of
+        _ -> ok
+    catch error:_Error -> validation_error(Rule, ReqParamName, Value)
     end;
 validate(Rule = {enum, Values}, Value, ReqParamName, _) ->
     try
@@ -738,36 +754,6 @@ validate(Rule = {enum, Values}, Value, ReqParamName, _) ->
         error:badarg ->
             validation_error(Rule, ReqParamName, Value)
     end;
-validate(Rule = {max, Max}, Value, ReqParamName, _) ->
-    case Value =< Max of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {exclusive_max, ExclusiveMax}, Value, ReqParamName, _) ->
-    case Value > ExclusiveMax of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {min, Min}, Value, ReqParamName, _) ->
-    case Value >= Min of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {exclusive_min, ExclusiveMin}, Value, ReqParamName, _) ->
-    case Value =< ExclusiveMin of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {max_length, MaxLength}, Value, ReqParamName, _) ->
-    case size(Value) =< MaxLength of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {min_length, MinLength}, Value, ReqParamName, _) ->
-    case size(Value) >= MinLength of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
 validate(Rule = {pattern, Pattern}, Value, ReqParamName, _) ->
     {ok, MP} = re:compile(Pattern),
     case re:run(Value, MP) of
@@ -775,7 +761,7 @@ validate(Rule = {pattern, Pattern}, Value, ReqParamName, _) ->
         _ -> validation_error(Rule, ReqParamName, Value)
     end;
 validate(Rule = schema, Value, ReqParamName, ValidatorState) ->
-    Definition = iolist_to_binary(["#/components/schemas/", atom_to_binary(ReqParamName)]),
+    Definition = iolist_to_binary(["#/components/schemas/", atom_to_binary(ReqParamName, utf8)]),
     try
         _ = validate_with_schema(Value, Definition, ValidatorState),
         ok
@@ -795,9 +781,8 @@ validate(Rule = schema, Value, ReqParamName, ValidatorState) ->
             },
             validation_error(Rule, ReqParamName, Value, Info)
     end;
-validate(Rule, _Value, ReqParamName, _) ->
-    ?LOG_INFO(#{what => "Cannot validate rule", name => ReqParamName, rule => Rule}),
-    error({unknown_validation_rule, Rule}).
+validate(Rule, Value, ReqParamName, _) ->
+    validation_error(Rule, ReqParamName, Value).
 
 -spec validation_error(rule(), request_param(), term()) -> no_return().
 validation_error(ViolatedRule, Name, Value) ->
@@ -824,7 +809,7 @@ get_value(qs_val, Name, Req) ->
     {Value, Req};
 get_value(header, Name, Req) ->
     Headers = cowboy_req:headers(Req),
-    Value =  maps:get(to_header(Name), Headers, undefined),
+    Value = maps:get(to_header(Name), Headers, undefined),
     {Value, Req};
 get_value(binding, Name, Req) ->
     Value = cowboy_req:binding(Name, Req),
@@ -877,31 +862,13 @@ prepare_param(Rules, ReqParamName, Value, ValidatorState) ->
             {error, Reason}
     end.
 
--spec to_binary(iodata() | atom() | number()) -> binary().
+-spec to_binary(iodata()) -> binary().
 to_binary(V) when is_binary(V)  -> V;
-to_binary(V) when is_list(V)    -> iolist_to_binary(V);
-to_binary(V) when is_atom(V)    -> atom_to_binary(V, utf8);
-to_binary(V) when is_integer(V) -> integer_to_binary(V);
-to_binary(V) when is_float(V)   -> float_to_binary(V).
-
--spec to_float(binary() | list()) -> integer().
-to_float(Data) when is_binary(Data) ->
-    binary_to_float(Data);
-to_float(Data) when is_list(Data) ->
-    list_to_float(Data).
-
--spec to_int(binary() | list()) -> integer().
-to_int(Data) when is_binary(Data) ->
-    binary_to_integer(Data);
-to_int(Data) when is_list(Data) ->
-    list_to_integer(Data).
+to_binary(V) when is_list(V)    -> iolist_to_binary(V).
 
 -spec to_header(request_param()) -> binary().
 to_header(Name) ->
     to_binary(string:lowercase(atom_to_binary(Name, utf8))).
-
-binary_to_lower(V) when is_binary(V) ->
-    string:lowercase(V).
 
 -spec to_qs(request_param()) -> binary().
 to_qs(Name) ->

--- a/samples/server/petstore/erlang-server/src/openapi_api.erl
+++ b/samples/server/petstore/erlang-server/src/openapi_api.erl
@@ -46,10 +46,11 @@ accept_callback(Class, OperationID, Req, Context) ->
 
 -export_type([operation_id/0]).
 
--dialyzer({nowarn_function, [to_binary/1, validate_response_body/4]}).
+-dialyzer({nowarn_function, [validate_response_body/4]}).
 
 -type rule() ::
     {type, binary} |
+    {type, byte} |
     {type, integer} |
     {type, float} |
     {type, boolean} |
@@ -528,38 +529,53 @@ validate_response_body(_, ReturnBaseType, Body, ValidatorState) ->
     ok | {ok, term()}.
 validate(required, undefined, ReqParamName, _) ->
     validation_error(required, ReqParamName, undefined);
-validate(required, _Value, _ReqParamName, _) ->
+validate(required, _Value, _, _) ->
     ok;
-validate(not_required, _Value, _ReqParamName, _) ->
+validate(not_required, _Value, _, _) ->
     ok;
-validate(_, undefined, _ReqParamName, _) ->
+validate(_, undefined, _, _) ->
     ok;
-validate({type, boolean}, Value, _ReqParamName, _) when is_boolean(Value) ->
-    {ok, Value};
-validate({type, integer}, Value, _ReqParamName, _) when is_integer(Value) ->
+validate({type, boolean}, Value, _, _) when is_boolean(Value) ->
     ok;
-validate({type, float}, Value, _ReqParamName, _) when is_float(Value) ->
+validate({type, integer}, Value, _, _) when is_integer(Value) ->
     ok;
-validate({type, binary}, Value, _ReqParamName, _) when is_binary(Value) ->
+validate({type, float}, Value, _, _) when is_float(Value) ->
     ok;
-validate(Rule = {type, binary}, Value, ReqParamName, _) ->
-    validation_error(Rule, ReqParamName, Value);
-validate(Rule = {type, boolean}, Value, ReqParamName, _) ->
-    case binary_to_lower(Value) of
+validate({type, binary}, Value, _, _) when is_binary(Value) ->
+    ok;
+validate({max, Max}, Value, _, _) when Value =< Max ->
+    ok;
+validate({min, Min}, Value, _, _) when Min =< Value ->
+    ok;
+validate({exclusive_max, Max}, Value, _, _) when Value < Max ->
+    ok;
+validate({exclusive_min, Min}, Value, _, _) when Min < Value ->
+    ok;
+validate({max_length, MaxLength}, Value, _, _) when is_binary(Value), byte_size(Value) =< MaxLength ->
+    ok;
+validate({min_length, MinLength}, Value, _, _) when is_binary(Value), MinLength =< byte_size(Value) ->
+    ok;
+validate(Rule = {type, byte}, Value, ReqParamName, _) when is_binary(Value) ->
+    try base64:decode(Value) of
+        Decoded -> {ok, Decoded}
+    catch error:_Error -> validation_error(Rule, ReqParamName, Value)
+    end;
+validate(Rule = {type, boolean}, Value, ReqParamName, _) when is_binary(Value) ->
+    case to_binary(string:lowercase(Value)) of
         <<"true">> -> {ok, true};
         <<"false">> -> {ok, false};
         _ -> validation_error(Rule, ReqParamName, Value)
     end;
-validate(Rule = {type, integer}, Value, ReqParamName, _) ->
+validate(Rule = {type, integer}, Value, ReqParamName, _) when is_binary(Value) ->
     try
-        {ok, to_int(Value)}
+        {ok, binary_to_integer(Value)}
     catch
         error:badarg ->
             validation_error(Rule, ReqParamName, Value)
     end;
-validate(Rule = {type, float}, Value, ReqParamName, _) ->
+validate(Rule = {type, float}, Value, ReqParamName, _) when is_binary(Value) ->
     try
-        {ok, to_float(Value)}
+        {ok, binary_to_float(Value)}
     catch
         error:badarg ->
             validation_error(Rule, ReqParamName, Value)
@@ -570,9 +586,9 @@ validate(Rule = {type, date}, Value, ReqParamName, _) ->
         false -> validation_error(Rule, ReqParamName, Value)
     end;
 validate(Rule = {type, datetime}, Value, ReqParamName, _) ->
-    case is_binary(Value) of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
+    try calendar:rfc3339_to_system_time(binary_to_list(Value)) of
+        _ -> ok
+    catch error:_Error -> validation_error(Rule, ReqParamName, Value)
     end;
 validate(Rule = {enum, Values}, Value, ReqParamName, _) ->
     try
@@ -585,36 +601,6 @@ validate(Rule = {enum, Values}, Value, ReqParamName, _) ->
         error:badarg ->
             validation_error(Rule, ReqParamName, Value)
     end;
-validate(Rule = {max, Max}, Value, ReqParamName, _) ->
-    case Value =< Max of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {exclusive_max, ExclusiveMax}, Value, ReqParamName, _) ->
-    case Value > ExclusiveMax of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {min, Min}, Value, ReqParamName, _) ->
-    case Value >= Min of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {exclusive_min, ExclusiveMin}, Value, ReqParamName, _) ->
-    case Value =< ExclusiveMin of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {max_length, MaxLength}, Value, ReqParamName, _) ->
-    case size(Value) =< MaxLength of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
-validate(Rule = {min_length, MinLength}, Value, ReqParamName, _) ->
-    case size(Value) >= MinLength of
-        true -> ok;
-        false -> validation_error(Rule, ReqParamName, Value)
-    end;
 validate(Rule = {pattern, Pattern}, Value, ReqParamName, _) ->
     {ok, MP} = re:compile(Pattern),
     case re:run(Value, MP) of
@@ -622,7 +608,7 @@ validate(Rule = {pattern, Pattern}, Value, ReqParamName, _) ->
         _ -> validation_error(Rule, ReqParamName, Value)
     end;
 validate(Rule = schema, Value, ReqParamName, ValidatorState) ->
-    Definition = iolist_to_binary(["#/components/schemas/", atom_to_binary(ReqParamName)]),
+    Definition = iolist_to_binary(["#/components/schemas/", atom_to_binary(ReqParamName, utf8)]),
     try
         _ = validate_with_schema(Value, Definition, ValidatorState),
         ok
@@ -642,9 +628,8 @@ validate(Rule = schema, Value, ReqParamName, ValidatorState) ->
             },
             validation_error(Rule, ReqParamName, Value, Info)
     end;
-validate(Rule, _Value, ReqParamName, _) ->
-    ?LOG_INFO(#{what => "Cannot validate rule", name => ReqParamName, rule => Rule}),
-    error({unknown_validation_rule, Rule}).
+validate(Rule, Value, ReqParamName, _) ->
+    validation_error(Rule, ReqParamName, Value).
 
 -spec validation_error(rule(), request_param(), term()) -> no_return().
 validation_error(ViolatedRule, Name, Value) ->
@@ -671,7 +656,7 @@ get_value(qs_val, Name, Req) ->
     {Value, Req};
 get_value(header, Name, Req) ->
     Headers = cowboy_req:headers(Req),
-    Value =  maps:get(to_header(Name), Headers, undefined),
+    Value = maps:get(to_header(Name), Headers, undefined),
     {Value, Req};
 get_value(binding, Name, Req) ->
     Value = cowboy_req:binding(Name, Req),
@@ -724,31 +709,13 @@ prepare_param(Rules, ReqParamName, Value, ValidatorState) ->
             {error, Reason}
     end.
 
--spec to_binary(iodata() | atom() | number()) -> binary().
+-spec to_binary(iodata()) -> binary().
 to_binary(V) when is_binary(V)  -> V;
-to_binary(V) when is_list(V)    -> iolist_to_binary(V);
-to_binary(V) when is_atom(V)    -> atom_to_binary(V, utf8);
-to_binary(V) when is_integer(V) -> integer_to_binary(V);
-to_binary(V) when is_float(V)   -> float_to_binary(V).
-
--spec to_float(binary() | list()) -> integer().
-to_float(Data) when is_binary(Data) ->
-    binary_to_float(Data);
-to_float(Data) when is_list(Data) ->
-    list_to_float(Data).
-
--spec to_int(binary() | list()) -> integer().
-to_int(Data) when is_binary(Data) ->
-    binary_to_integer(Data);
-to_int(Data) when is_list(Data) ->
-    list_to_integer(Data).
+to_binary(V) when is_list(V)    -> iolist_to_binary(V).
 
 -spec to_header(request_param()) -> binary().
 to_header(Name) ->
     to_binary(string:lowercase(atom_to_binary(Name, utf8))).
-
-binary_to_lower(V) when is_binary(V) ->
-    string:lowercase(V).
 
 -spec to_qs(request_param()) -> binary().
 to_qs(Name) ->


### PR DESCRIPTION
Three things:
- First of all, fix a bug where `exclusiveMinimum` and `exclusiveMaximum` were considered integers, when they are in fact booleans.
- Add support for validating that strings of format `byte` are indeed `base64` encoded and return them parsed.
- Likewise for strings of format `date-time`.

Other changes are related to general performance optimisations and code quality.

Question, @wing328, I'm not sure to understand how documentation for the capabilities of the generators work, and I'm afraid they might be falling behind with all the recent changes, can you share with me some directions on this? I'd work on that on a follow-up PR though, just to keep this one focused.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
  - That's myself :)