### PR TITLE
[swift6] oneOf-default-case

### DIFF
--- a/docs/generators/swift6.md
+++ b/docs/generators/swift6.md
@@ -34,6 +34,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |mapFileBinaryToData|[WARNING] This option will be removed and enabled by default in the future once we've enhanced the code to work with `Data` in all the different situations. Map File and Binary to Data (default: false)| |false|
 |nonPublicApi|Generates code with reduced access modifiers; allows embedding elsewhere without exposing non-public API calls to consumers.(default: false)| |null|
 |objcCompatible|Add additional properties and methods for Objective-C compatibility (default: false)| |null|
+|oneOfUnknownDefaultCase|Add unknownDefault case to oneOf enum (default: false)| |false|
 |podAuthors|Authors used for Podspec| |null|
 |podDescription|Description used for Podspec| |null|
 |podDocumentationURL|Documentation URL used for Podspec| |null|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
@@ -67,6 +67,7 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
     public static final String LENIENT_TYPE_CAST = "lenientTypeCast";
     public static final String USE_SPM_FILE_STRUCTURE = "useSPMFileStructure";
     public static final String SWIFT_PACKAGE_PATH = "swiftPackagePath";
+    public static final String ONE_OF_UNKNOWN_DEFAULT_CASE = "oneOfUnknownDefaultCase";
     public static final String USE_CLASSES = "useClasses";
     public static final String USE_BACKTICK_ESCAPES = "useBacktickEscapes";
     public static final String GENERATE_MODEL_ADDITIONAL_PROPERTIES = "generateModelAdditionalProperties";
@@ -103,6 +104,8 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
     protected boolean useSPMFileStructure = false;
     @Setter
     protected String swiftPackagePath = "Classes" + File.separator + "OpenAPIs";
+    @Setter
+    protected boolean oneOfUnknownDefaultCase = false;
     @Setter
     protected boolean useClasses = false;
     @Setter
@@ -321,6 +324,9 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
         cliOptions.add(new CliOption(GENERATE_MODEL_ADDITIONAL_PROPERTIES,
                 "Generate model additional properties (default: true)")
                 .defaultValue(Boolean.TRUE.toString()));
+        cliOptions.add(new CliOption(ONE_OF_UNKNOWN_DEFAULT_CASE,
+                "Add unknownDefault case to oneOf enum (default: false)")
+                .defaultValue(Boolean.FALSE.toString()));
 
         cliOptions.add(new CliOption(CodegenConstants.API_NAME_PREFIX, CodegenConstants.API_NAME_PREFIX_DESC));
         cliOptions.add(new CliOption(USE_SPM_FILE_STRUCTURE, "Use SPM file structure"
@@ -572,6 +578,11 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
         } else {
             typeMapping.put("date", "Date");
         }
+
+        if (additionalProperties.containsKey(ONE_OF_UNKNOWN_DEFAULT_CASE)) {
+            setOneOfUnknownDefaultCase(convertPropertyToBooleanAndWriteBack(ONE_OF_UNKNOWN_DEFAULT_CASE));
+        }
+        additionalProperties.put(ONE_OF_UNKNOWN_DEFAULT_CASE, oneOfUnknownDefaultCase);
 
         if (additionalProperties.containsKey(USE_CLASSES)) {
             setUseClasses(convertPropertyToBooleanAndWriteBack(USE_CLASSES));

--- a/modules/openapi-generator/src/main/resources/swift6/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/modelOneOf.mustache
@@ -2,6 +2,9 @@
     {{#oneOf}}
     case type{{.}}({{.}})
     {{/oneOf}}
+    {{#oneOfUnknownDefaultCase}}
+    case unknownDefaultOpenApi
+    {{/oneOfUnknownDefaultCase}}
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
@@ -10,6 +13,10 @@
         case .type{{.}}(let value):
             try container.encode(value)
         {{/oneOf}}
+        {{#oneOfUnknownDefaultCase}}
+        case unknownDefaultOpenApi(let type):
+            try container.encodeNil()
+        {{/oneOfUnknownDefaultCase}}
         }
     }
 
@@ -25,7 +32,12 @@
             self = .type{{.}}(value)
         {{/oneOf}}
         } else {
+            {{#oneOfUnknownDefaultCase}}
+            self = .unknownDefaultOpenApi
+            {{/oneOfUnknownDefaultCase}}
+            {{^oneOfUnknownDefaultCase}}
             throw DecodingError.typeMismatch(Self.Type.self, .init(codingPath: decoder.codingPath, debugDescription: "Unable to decode instance of {{classname}}"))
+            {{/oneOfUnknownDefaultCase}}
         }
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/Swift6ClientCodegenOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/Swift6ClientCodegenOptionsProvider.java
@@ -104,6 +104,7 @@ public class Swift6ClientCodegenOptionsProvider implements OptionsProvider {
                 .put(Swift6ClientCodegen.MAP_FILE_BINARY_TO_DATA, "false")
                 .put(Swift6ClientCodegen.USE_CUSTOM_DATE_WITHOUT_TIME, "false")
                 .put(Swift6ClientCodegen.VALIDATABLE, "true")
+                .put(Swift6ClientCodegen.ONE_OF_UNKNOWN_DEFAULT_CASE, "false")
                 .put(Swift6ClientCodegen.USE_CLASSES, "false")
                 .put(Swift6ClientCodegen.API_STATIC_METHOD, 
                         API_STATIC_METHOD_VALUE)


### PR DESCRIPTION
This PR brings the changes of those two PR to swift 6.
https://github.com/OpenAPITools/openapi-generator/pull/19094
https://github.com/OpenAPITools/openapi-generator/pull/19753

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)