### PR TITLE
Fix anyOf/oneOf normalization for 3.1 spec

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -600,7 +600,9 @@ public class ModelUtils {
         Schema<?> items = schema.getItems();
         if (items == null) {
             if (schema instanceof JsonSchema) { // 3.1 spec
-                // do nothing as the schema may contain prefixItems only
+                // set the items to a new schema (any type)
+                items = new Schema<>();
+                schema.setItems(items);
             } else { // 3.0 spec, default to string
                 LOGGER.error("Undefined array inner type for `{}`. Default to String.", schema.getName());
                 items = new StringSchema().description("TODO default missing array inner type to string");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -605,6 +605,16 @@ public class OpenAPINormalizerTest {
         assertNotEquals(((Schema) schema7.getProperties().get("with_prefixitems")).getPrefixItems(), null);
         assertEquals(((Schema) schema7.getProperties().get("without_items")).getItems(), null);
 
+        Schema schema9 = openAPI.getComponents().getSchemas().get("AnyOfArrayWithPrefixItems");
+        assertEquals(((Schema) schema9.getAnyOf().get(0)).getItems(), null);
+        assertNotEquals(((Schema) schema9.getAnyOf().get(0)).getPrefixItems(), null);
+        assertEquals(((Schema) schema9.getAnyOf().get(1)).getItems(), null);
+
+        Schema schema11 = openAPI.getComponents().getSchemas().get("OneOfArrayWithPrefixItems");
+        assertEquals(((Schema) schema11.getOneOf().get(0)).getItems(), null);
+        assertNotEquals(((Schema) schema11.getOneOf().get(0)).getPrefixItems(), null);
+        assertEquals(((Schema) schema11.getOneOf().get(1)).getItems(), null);
+
         Map<String, String> inputRules = Map.of("NORMALIZE_31SPEC", "true");
         OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, inputRules);
         openAPINormalizer.normalize();
@@ -632,6 +642,16 @@ public class OpenAPINormalizerTest {
         assertNotEquals(((Schema) schema8.getProperties().get("with_prefixitems")).getItems(), null);
         assertEquals(((Schema) schema8.getProperties().get("with_prefixitems")).getPrefixItems(), null);
         assertNotEquals(((Schema) schema8.getProperties().get("without_items")).getItems(), null);
+
+        Schema schema10 = openAPI.getComponents().getSchemas().get("AnyOfArrayWithPrefixItems");
+        assertNotEquals(((Schema) schema10.getAnyOf().get(0)).getItems(), null);
+        assertEquals(((Schema) schema10.getAnyOf().get(0)).getPrefixItems(), null);
+        assertNotEquals(((Schema) schema10.getAnyOf().get(1)).getItems(), null);
+
+        Schema schema12 = openAPI.getComponents().getSchemas().get("OneOfArrayWithPrefixItems");
+        assertNotEquals(((Schema) schema12.getOneOf().get(0)).getItems(), null);
+        assertEquals(((Schema) schema12.getOneOf().get(0)).getPrefixItems(), null);
+        assertNotEquals(((Schema) schema12.getOneOf().get(1)).getItems(), null);
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -461,4 +461,12 @@ public class ModelUtilsTest {
         Assert.assertEquals(deepCopy, schema);
         Assert.assertNotSame(deepCopy, schema);
     }
+
+    @Test
+    public void testGetSchemaItemsWith31Spec() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/issue_18291.yaml");
+        Schema arrayWithPrefixItems = ModelUtils.getSchema(openAPI, "ArrayWithPrefixItems");
+        Assert.assertNotNull(ModelUtils.getSchemaItems((Schema) arrayWithPrefixItems.getProperties().get("with_prefixitems")));
+        Assert.assertNotNull(ModelUtils.getSchemaItems((Schema) arrayWithPrefixItems.getProperties().get("without_items")));
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_1/issue_18291.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_18291.yaml
@@ -47,3 +47,23 @@ components:
           minItems: 2
         without_items:
           type: array
+    AnyOfArrayWithPrefixItems:
+      anyOf:
+        - type: array
+          prefixItems:
+            - type: number
+              title: Longitude
+            - type: number
+              title: Latitude
+          maxItems: 2
+          minItems: 2
+        - type: array
+    OneOfArrayWithPrefixItems:
+      oneOf:
+        - type: array
+          prefixItems:
+            - type: integer
+            - type: integer
+          maxItems: 3
+          minItems: 3
+        - type: array

--- a/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
@@ -815,6 +815,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/myObject'
                 nullable: true
+                type: array
           description: ""
       tags:
       - fake
@@ -1185,6 +1186,7 @@ components:
       - type: string
       - items:
           type: string
+        type: array
   securitySchemes:
     petstore_auth:
       flows:


### PR DESCRIPTION
- fix normalization for anyOf, oneOf sub schemas (not being updated before this fix)
- better handling of 3.1 spec in getSchemaItems (model utils class)
- add tests

fyi @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
