### PR TITLE
[Typescript-Node] Mark deprecated endpoints

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
@@ -155,7 +155,7 @@ export class {{classname}} {
      {{/allParams}}
      {{#isDeprecated}}
      *
- * @deprecated
+     * @deprecated
      {{/isDeprecated}}
      */
     public async {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; {{#returnType}}body: {{{.}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {

--- a/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
@@ -153,6 +153,10 @@ export class {{classname}} {
      {{#allParams}}
      * @param {{paramName}} {{description}}
      {{/allParams}}
+     {{#isDeprecated}}
+     *
+	 * @deprecated
+     {{/isDeprecated}}
      */
     public async {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; {{#returnType}}body: {{{.}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {
         const localVarPath = this.basePath + '{{{path}}}'{{#pathParams}}

--- a/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
@@ -155,7 +155,7 @@ export class {{classname}} {
      {{/allParams}}
      {{#isDeprecated}}
      *
-	 * @deprecated
+ * @deprecated
      {{/isDeprecated}}
      */
     public async {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; {{#returnType}}body: {{{.}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -173,6 +173,18 @@ public class TestUtils {
         }
     }
 
+    public static void assertFileContains(Path path, String line, int lineNumber) {
+        try {
+            List<String> lines = Files.readAllLines(path);
+            assertNotNull(lines);
+
+            String target = lines.get(lineNumber - 1);
+            assertTrue(target.contains(line), "File does not contain line [" + line + "] at lineNumber [" + lineNumber + "]");
+        } catch (IOException e) {
+            fail("Unable to evaluate file " + path);
+        }
+    }
+
     public static String linearize(String target) {
         return target.replaceAll("\r?\n", "").replaceAll("\\s+", "\\s");
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -173,18 +173,6 @@ public class TestUtils {
         }
     }
 
-    public static void assertFileContains(Path path, String line, int lineNumber) {
-        try {
-            List<String> lines = Files.readAllLines(path);
-            assertNotNull(lines);
-
-            String target = lines.get(lineNumber - 1);
-            assertTrue(target.contains(line), "File does not contain line [" + line + "] at lineNumber [" + lineNumber + "]");
-        } catch (IOException e) {
-            fail("Unable to evaluate file " + path);
-        }
-    }
-
     public static String linearize(String target) {
         return target.replaceAll("\r?\n", "").replaceAll("\\s+", "\\s");
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
@@ -310,7 +310,7 @@ public class TypeScriptNodeClientCodegenTest {
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
         DefaultGenerator generator = new DefaultGenerator();
         List<File> files = generator.opts(clientOptInput).generate();
-        //files.forEach(File::deleteOnExit);
+        files.forEach(File::deleteOnExit);
 
         TestUtils.assertFileContains(Paths.get(output + "/api/defaultApi.ts"),
                 "* @deprecated", 118);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
@@ -296,6 +296,26 @@ public class TypeScriptNodeClientCodegenTest {
                 "* @deprecated");
     }
 
+    @Test
+    public void testDeprecatedOperation() throws IOException {
+
+        File output = Files.createTempDirectory("typescriptnodeclient_").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("typescript-node")
+                .setInputSpec("src/test/resources/3_0/typescript-node/SampleProject.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+        //files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileContains(Paths.get(output + "/api/defaultApi.ts"),
+                "* @deprecated", 118);
+    }
+
     private OperationsMap createPostProcessOperationsMapWithImportName(String importName) {
         OperationMap operations = new OperationMap();
         operations.setClassname("Pet");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
@@ -313,7 +313,7 @@ public class TypeScriptNodeClientCodegenTest {
         files.forEach(File::deleteOnExit);
 
         TestUtils.assertFileContains(Paths.get(output + "/api/defaultApi.ts"),
-                "* @deprecated", 118);
+                "* @deprecated");
     }
 
     private OperationsMap createPostProcessOperationsMapWithImportName(String importName) {

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-node/SampleProject.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-node/SampleProject.yaml
@@ -147,6 +147,7 @@ paths:
     patch:
       summary: Update User Information
       operationId: patch-users-userId
+      deprecated: true
       responses:
         '200':
           description: User Updated

--- a/samples/client/petstore/typescript-node/3_0/api/defaultApi.ts
+++ b/samples/client/petstore/typescript-node/3_0/api/defaultApi.ts
@@ -114,6 +114,8 @@ export class DefaultApi {
      * @param strCode Code as header
      * @param strCode2 Code as header2
      * @param patchUsersUserIdRequest Patch user properties to update.
+     *
+	 * @deprecated
      */
     public async patchUsersUserId (userId: number, strCode?: string, strCode2?: string, patchUsersUserIdRequest?: PatchUsersUserIdRequest, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: User;  }> {
         const localVarPath = this.basePath + '/users/{userId}'

--- a/samples/client/petstore/typescript-node/3_0/api/defaultApi.ts
+++ b/samples/client/petstore/typescript-node/3_0/api/defaultApi.ts
@@ -115,7 +115,7 @@ export class DefaultApi {
      * @param strCode2 Code as header2
      * @param patchUsersUserIdRequest Patch user properties to update.
      *
-	 * @deprecated
+     * @deprecated
      */
     public async patchUsersUserId (userId: number, strCode?: string, strCode2?: string, patchUsersUserIdRequest?: PatchUsersUserIdRequest, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: User;  }> {
         const localVarPath = this.basePath + '/users/{userId}'

--- a/samples/client/petstore/typescript-node/default/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/petApi.ts
@@ -304,6 +304,8 @@ export class PetApi {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
+     *
+	 * @deprecated
      */
     public async findPetsByTags (tags: Array<string>, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';

--- a/samples/client/petstore/typescript-node/default/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/petApi.ts
@@ -305,7 +305,7 @@ export class PetApi {
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
      *
-	 * @deprecated
+     * @deprecated
      */
     public async findPetsByTags (tags: Array<string>, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';

--- a/samples/client/petstore/typescript-node/npm/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/petApi.ts
@@ -304,6 +304,8 @@ export class PetApi {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
+     *
+	 * @deprecated
      */
     public async findPetsByTags (tags: Array<string>, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';

--- a/samples/client/petstore/typescript-node/npm/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/petApi.ts
@@ -305,7 +305,7 @@ export class PetApi {
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
      *
-	 * @deprecated
+     * @deprecated
      */
     public async findPetsByTags (tags: Array<string>, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';


### PR DESCRIPTION
Add @deprecated tag when processing deprecated operations in the OpenAPI file

@wing328 I have added a helper method (`assertFileContains(Path path, String line, int lineNumber)`) to verify a specific line (more effective than searching for the string in the file anywhere), let me know if this is ok or you see some drawbacks. Thanks.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)