### PR TITLE
[Python] Restore required dev dependency + Adjust generated Github workflow

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/github-workflow.mustache
+++ b/modules/openapi-generator/src/main/resources/python/github-workflow.mustache
@@ -25,15 +25,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
-      - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          pip install -r requirements.txt
+          pip install -r test-requirements.txt
       - name: Test with pytest
         run: |
-          pytest
+          pytest --cov={{packageName}}

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -29,11 +29,12 @@ pydantic = ">= 2"
 typing-extensions = ">= 4.7.1"
 
 [tool.poetry.dev-dependencies]
-pytest = ">=7.2.1"
-tox = ">=3.9.0"
-flake8 = ">=4.0.0"
-types-python-dateutil = ">=2.8.19.14"
-mypy = ">=1.5"
+pytest = ">= 7.2.1"
+pytest-cov = ">= 2.8.1"
+tox = ">= 3.9.0"
+flake8 = ">= 4.0.0"
+types-python-dateutil = ">= 2.8.19.14"
+mypy = ">= 1.5"
 
 
 [build-system]

--- a/modules/openapi-generator/src/main/resources/python/test-requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/test-requirements.mustache
@@ -1,4 +1,5 @@
 pytest >= 7.2.1
+pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0
 types-python-dateutil >= 2.8.19.14

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/.github/workflows/python.yml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/.github/workflows/python.yml
@@ -24,15 +24,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
-      - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          pip install -r requirements.txt
+          pip install -r test-requirements.txt
       - name: Test with pytest
         run: |
-          pytest
+          pytest --cov={{packageName}}

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
@@ -18,11 +18,12 @@ pydantic = ">= 2"
 typing-extensions = ">= 4.7.1"
 
 [tool.poetry.dev-dependencies]
-pytest = ">=7.2.1"
-tox = ">=3.9.0"
-flake8 = ">=4.0.0"
-types-python-dateutil = ">=2.8.19.14"
-mypy = ">=1.5"
+pytest = ">= 7.2.1"
+pytest-cov = ">= 2.8.1"
+tox = ">= 3.9.0"
+flake8 = ">= 4.0.0"
+types-python-dateutil = ">= 2.8.19.14"
+mypy = ">= 1.5"
 
 
 [build-system]

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/test-requirements.txt
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/test-requirements.txt
@@ -1,4 +1,5 @@
 pytest >= 7.2.1
+pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0
 types-python-dateutil >= 2.8.19.14

--- a/samples/client/echo_api/python/.github/workflows/python.yml
+++ b/samples/client/echo_api/python/.github/workflows/python.yml
@@ -24,15 +24,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
-      - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          pip install -r requirements.txt
+          pip install -r test-requirements.txt
       - name: Test with pytest
         run: |
-          pytest
+          pytest --cov={{packageName}}

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -18,11 +18,12 @@ pydantic = ">= 2"
 typing-extensions = ">= 4.7.1"
 
 [tool.poetry.dev-dependencies]
-pytest = ">=7.2.1"
-tox = ">=3.9.0"
-flake8 = ">=4.0.0"
-types-python-dateutil = ">=2.8.19.14"
-mypy = ">=1.5"
+pytest = ">= 7.2.1"
+pytest-cov = ">= 2.8.1"
+tox = ">= 3.9.0"
+flake8 = ">= 4.0.0"
+types-python-dateutil = ">= 2.8.19.14"
+mypy = ">= 1.5"
 
 
 [build-system]

--- a/samples/client/echo_api/python/test-requirements.txt
+++ b/samples/client/echo_api/python/test-requirements.txt
@@ -1,4 +1,5 @@
 pytest >= 7.2.1
+pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0
 types-python-dateutil >= 2.8.19.14

--- a/samples/openapi3/client/petstore/python-aiohttp/.github/workflows/python.yml
+++ b/samples/openapi3/client/petstore/python-aiohttp/.github/workflows/python.yml
@@ -24,15 +24,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
-      - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          pip install -r requirements.txt
+          pip install -r test-requirements.txt
       - name: Test with pytest
         run: |
-          pytest
+          pytest --cov={{packageName}}

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -22,11 +22,12 @@ pydantic = ">= 2"
 typing-extensions = ">= 4.7.1"
 
 [tool.poetry.dev-dependencies]
-pytest = ">=7.2.1"
-tox = ">=3.9.0"
-flake8 = ">=4.0.0"
-types-python-dateutil = ">=2.8.19.14"
-mypy = ">=1.5"
+pytest = ">= 7.2.1"
+pytest-cov = ">= 2.8.1"
+tox = ">= 3.9.0"
+flake8 = ">= 4.0.0"
+types-python-dateutil = ">= 2.8.19.14"
+mypy = ">= 1.5"
 
 
 [build-system]

--- a/samples/openapi3/client/petstore/python-aiohttp/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/test-requirements.txt
@@ -1,4 +1,5 @@
 pytest >= 7.2.1
+pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0
 types-python-dateutil >= 2.8.19.14

--- a/samples/openapi3/client/petstore/python/.github/workflows/python.yml
+++ b/samples/openapi3/client/petstore/python/.github/workflows/python.yml
@@ -24,15 +24,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
-      - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          pip install -r requirements.txt
+          pip install -r test-requirements.txt
       - name: Test with pytest
         run: |
-          pytest
+          pytest --cov={{packageName}}

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -20,11 +20,12 @@ pydantic = ">= 2"
 typing-extensions = ">= 4.7.1"
 
 [tool.poetry.dev-dependencies]
-pytest = ">=7.2.1"
-tox = ">=3.9.0"
-flake8 = ">=4.0.0"
-types-python-dateutil = ">=2.8.19.14"
-mypy = ">=1.5"
+pytest = ">= 7.2.1"
+pytest-cov = ">= 2.8.1"
+tox = ">= 3.9.0"
+flake8 = ">= 4.0.0"
+types-python-dateutil = ">= 2.8.19.14"
+mypy = ">= 1.5"
 
 
 [build-system]

--- a/samples/openapi3/client/petstore/python/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python/test-requirements.txt
@@ -1,4 +1,5 @@
 pytest >= 7.2.1
+pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0
 types-python-dateutil >= 2.8.19.14


### PR DESCRIPTION
Restores the python client dev dependency `pytest-cov` which is required in the generated workflows.

Fixes https://github.com/OpenAPITools/openapi-generator/pull/19694#issuecomment-2391646845.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
