### PR TITLE
[PHP] By default should use static Configuration class instance

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -82,7 +82,7 @@ use {{invokerPackage}}\ObjectSerializer;
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -82,7 +82,7 @@ use {{invokerPackage}}\ObjectSerializer;
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
@@ -93,7 +93,7 @@ class AuthApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
@@ -117,7 +117,7 @@ class BodyApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
@@ -96,7 +96,7 @@ class FormApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
@@ -90,7 +90,7 @@ class HeaderApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
@@ -90,7 +90,7 @@ class PathApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -117,7 +117,7 @@ class QueryApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
@@ -93,7 +93,7 @@ class AuthApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
@@ -117,7 +117,7 @@ class BodyApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
@@ -96,7 +96,7 @@ class FormApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
@@ -90,7 +90,7 @@ class HeaderApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
@@ -90,7 +90,7 @@ class PathApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -117,7 +117,7 @@ class QueryApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
@@ -89,7 +89,7 @@ class AnotherFakeApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
@@ -89,7 +89,7 @@ class DefaultApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -156,7 +156,7 @@ class FakeApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }
@@ -4570,7 +4570,7 @@ class FakeApi
         if ($number < 32.1) {
             throw new InvalidArgumentException('invalid value for "$number" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 32.1.');
         }
-        
+
         // verify the required parameter 'double' is set
         if ($double === null || (is_array($double) && count($double) === 0)) {
             throw new InvalidArgumentException(
@@ -4583,7 +4583,7 @@ class FakeApi
         if ($double < 67.8) {
             throw new InvalidArgumentException('invalid value for "$double" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 67.8.');
         }
-        
+
         // verify the required parameter 'pattern_without_delimiter' is set
         if ($pattern_without_delimiter === null || (is_array($pattern_without_delimiter) && count($pattern_without_delimiter) === 0)) {
             throw new InvalidArgumentException(
@@ -4593,7 +4593,7 @@ class FakeApi
         if (!preg_match("/^[A-Z].*/", $pattern_without_delimiter)) {
             throw new InvalidArgumentException("invalid value for \"pattern_without_delimiter\" when calling FakeApi.testEndpointParameters, must conform to the pattern /^[A-Z].*/.");
         }
-        
+
         // verify the required parameter 'byte' is set
         if ($byte === null || (is_array($byte) && count($byte) === 0)) {
             throw new InvalidArgumentException(
@@ -4607,23 +4607,23 @@ class FakeApi
         if ($integer !== null && $integer < 10) {
             throw new InvalidArgumentException('invalid value for "$integer" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 10.');
         }
-        
+
         if ($int32 !== null && $int32 > 200) {
             throw new InvalidArgumentException('invalid value for "$int32" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 200.');
         }
         if ($int32 !== null && $int32 < 20) {
             throw new InvalidArgumentException('invalid value for "$int32" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 20.');
         }
-        
+
 
         if ($float !== null && $float > 987.6) {
             throw new InvalidArgumentException('invalid value for "$float" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 987.6.');
         }
-        
+
         if ($string !== null && !preg_match("/[a-z]/i", $string)) {
             throw new InvalidArgumentException("invalid value for \"string\" when calling FakeApi.testEndpointParameters, must conform to the pattern /[a-z]/i.");
         }
-        
+
 
 
 
@@ -4633,7 +4633,7 @@ class FakeApi
         if ($password !== null && strlen($password) < 10) {
             throw new InvalidArgumentException('invalid length for "$password" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 10.');
         }
-        
+
 
 
         $resourcePath = '/fake';
@@ -5353,7 +5353,7 @@ class FakeApi
         $boolean_group = array_key_exists('boolean_group', $associative_array) ? $associative_array['boolean_group'] : null;
         $int64_group = array_key_exists('int64_group', $associative_array) ? $associative_array['int64_group'] : null;
         $contentType = $associative_array['contentType'] ?? self::contentTypes['testGroupParameters'][0];
-        
+
         // verify the required parameter 'required_string_group' is set
         if ($required_string_group === null || (is_array($required_string_group) && count($required_string_group) === 0)) {
             throw new InvalidArgumentException(

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
@@ -89,7 +89,7 @@ class FakeClassnameTags123Api
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -115,7 +115,7 @@ class PetApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }
@@ -1390,7 +1390,7 @@ class PetApi
                 'Missing the required parameter $tags when calling findPetsByTags'
             );
         }
-        
+
 
         $resourcePath = '/pet/findByTags';
         $formParams = [];

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -98,7 +98,7 @@ class StoreApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }
@@ -931,7 +931,7 @@ class StoreApi
         if ($order_id < 1) {
             throw new InvalidArgumentException('invalid value for "$order_id" when calling StoreApi.getOrderById, must be bigger than or equal to 1.');
         }
-        
+
 
         $resourcePath = '/store/order/{order_id}';
         $formParams = [];

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -110,7 +110,7 @@ class UserApi
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -89,7 +89,7 @@ class AnotherFakeApi
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
@@ -89,7 +89,7 @@ class DefaultApi
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -156,7 +156,7 @@ class FakeApi
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }
@@ -4564,7 +4564,7 @@ class FakeApi
         if ($number < 32.1) {
             throw new \InvalidArgumentException('invalid value for "$number" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 32.1.');
         }
-        
+
         // verify the required parameter 'double' is set
         if ($double === null || (is_array($double) && count($double) === 0)) {
             throw new \InvalidArgumentException(
@@ -4577,7 +4577,7 @@ class FakeApi
         if ($double < 67.8) {
             throw new \InvalidArgumentException('invalid value for "$double" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 67.8.');
         }
-        
+
         // verify the required parameter 'pattern_without_delimiter' is set
         if ($pattern_without_delimiter === null || (is_array($pattern_without_delimiter) && count($pattern_without_delimiter) === 0)) {
             throw new \InvalidArgumentException(
@@ -4587,7 +4587,7 @@ class FakeApi
         if (!preg_match("/^[A-Z].*/", $pattern_without_delimiter)) {
             throw new \InvalidArgumentException("invalid value for \"pattern_without_delimiter\" when calling FakeApi.testEndpointParameters, must conform to the pattern /^[A-Z].*/.");
         }
-        
+
         // verify the required parameter 'byte' is set
         if ($byte === null || (is_array($byte) && count($byte) === 0)) {
             throw new \InvalidArgumentException(
@@ -4601,23 +4601,23 @@ class FakeApi
         if ($integer !== null && $integer < 10) {
             throw new \InvalidArgumentException('invalid value for "$integer" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 10.');
         }
-        
+
         if ($int32 !== null && $int32 > 200) {
             throw new \InvalidArgumentException('invalid value for "$int32" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 200.');
         }
         if ($int32 !== null && $int32 < 20) {
             throw new \InvalidArgumentException('invalid value for "$int32" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 20.');
         }
-        
+
 
         if ($float !== null && $float > 987.6) {
             throw new \InvalidArgumentException('invalid value for "$float" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 987.6.');
         }
-        
+
         if ($string !== null && !preg_match("/[a-z]/i", $string)) {
             throw new \InvalidArgumentException("invalid value for \"string\" when calling FakeApi.testEndpointParameters, must conform to the pattern /[a-z]/i.");
         }
-        
+
 
 
 
@@ -4627,7 +4627,7 @@ class FakeApi
         if ($password !== null && strlen($password) < 10) {
             throw new \InvalidArgumentException('invalid length for "$password" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 10.');
         }
-        
+
 
 
         $resourcePath = '/fake';
@@ -5280,7 +5280,7 @@ class FakeApi
         $boolean_group = array_key_exists('boolean_group', $associative_array) ? $associative_array['boolean_group'] : null;
         $int64_group = array_key_exists('int64_group', $associative_array) ? $associative_array['int64_group'] : null;
         $contentType = $associative_array['contentType'] ?? self::contentTypes['testGroupParameters'][0];
-        
+
         // verify the required parameter 'required_string_group' is set
         if ($required_string_group === null || (is_array($required_string_group) && count($required_string_group) === 0)) {
             throw new \InvalidArgumentException(

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -89,7 +89,7 @@ class FakeClassnameTags123Api
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -115,7 +115,7 @@ class PetApi
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }
@@ -1315,7 +1315,7 @@ class PetApi
                 'Missing the required parameter $tags when calling findPetsByTags'
             );
         }
-        
+
 
         $resourcePath = '/pet/findByTags';
         $formParams = [];

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -98,7 +98,7 @@ class StoreApi
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }
@@ -891,7 +891,7 @@ class StoreApi
         if ($order_id < 1) {
             throw new \InvalidArgumentException('invalid value for "$order_id" when calling StoreApi.getOrderById, must be bigger than or equal to 1.');
         }
-        
+
 
         $resourcePath = '/store/order/{order_id}';
         $formParams = [];

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -110,7 +110,7 @@ class UserApi
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
-        $this->config = $config ?: new Configuration();
+        $this->config = $config ?: Configuration::getDefaultConfiguration();
         $this->headerSelector = $selector ?: new HeaderSelector();
         $this->hostIndex = $hostIndex;
     }


### PR DESCRIPTION
For **PHP**.

By default should use static Configuration class instance, otherwise new instance is created every time you make an API call.

Before this PR every time you create new API object and do not pass Configuration object as 2nd argument to API class constructor it creates new Configuration instance. This is wrong, because Configuration class is meant to be Singleton - so `Configuration::getDefaultConfiguration()` should be used instead.


Please review: @jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon 
