### PR TITLE
[swift6] make async await the default response library

### DIFF
--- a/bin/configs/swift6-alamofireLibrary.yaml
+++ b/bin/configs/swift6-alamofireLibrary.yaml
@@ -6,6 +6,7 @@ templateDir: modules/openapi-generator/src/main/resources/swift6
 generateAliasAsModel: true
 useCustomDateWithoutTime: true
 additionalProperties:
+  responseAs: ObjcBlock
   podAuthors: ""
   podSummary: PetstoreClient
   projectName: PetstoreClient

--- a/bin/configs/swift6-api-non-static-method.yaml
+++ b/bin/configs/swift6-api-non-static-method.yaml
@@ -4,7 +4,7 @@ library: alamofire
 inputSpec: modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml
 templateDir: modules/openapi-generator/src/main/resources/swift6
 additionalProperties:
-  responseAs: AsyncAwait,Combine,Result,PromiseKit,RxSwift
+  responseAs: AsyncAwait,Combine,Result,PromiseKit,RxSwift,ObjcBlock
   apiStaticMethod: false
   podAuthors: ""
   podSummary: PetstoreClient

--- a/bin/configs/swift6-objcCompatible.yaml
+++ b/bin/configs/swift6-objcCompatible.yaml
@@ -4,6 +4,7 @@ inputSpec: modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-
 templateDir: modules/openapi-generator/src/main/resources/swift6
 generateAliasAsModel: true
 additionalProperties:
+  responseAs: ObjcBlock
   podAuthors: ""
   podSummary: PetstoreClient
   objcCompatible: true

--- a/bin/configs/swift6-oneOf.yaml
+++ b/bin/configs/swift6-oneOf.yaml
@@ -4,6 +4,7 @@ inputSpec: modules/openapi-generator/src/test/resources/3_0/oneOf.yaml
 templateDir: modules/openapi-generator/src/main/resources/swift6
 generateAliasAsModel: true
 additionalProperties:
+  responseAs: ObjcBlock
   useSPMFileStructure: false
   podAuthors: ""
   podSummary: PetstoreClient

--- a/bin/configs/swift6-urlsessionLibrary.yaml
+++ b/bin/configs/swift6-urlsessionLibrary.yaml
@@ -5,6 +5,7 @@ inputSpec: modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-
 templateDir: modules/openapi-generator/src/main/resources/swift6
 generateAliasAsModel: true
 additionalProperties:
+  responseAs: ObjcBlock
   podAuthors: ""
   podSummary: PetstoreClient
   projectName: PetstoreClient

--- a/docs/generators/swift6.md
+++ b/docs/generators/swift6.md
@@ -47,7 +47,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |projectName|Project name in Xcode| |null|
 |readonlyProperties|Make properties readonly (default: false)| |null|
-|responseAs|Optionally use libraries to manage response.  Currently PromiseKit, RxSwift, Result, Combine, AsyncAwait are available.| |null|
+|responseAs|Optionally use libraries to manage response.  Currently AsyncAwait, Combine, Result, RxSwift, ObjcBlock, PromiseKit are available.| |null|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |swiftPackagePath|Set a custom source path instead of Sources/{{projectName}}.| |null|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
@@ -86,9 +86,7 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
     protected static final String RESPONSE_LIBRARY_COMBINE = "Combine";
     protected static final String RESPONSE_LIBRARY_ASYNC_AWAIT = "AsyncAwait";
     protected static final String RESPONSE_LIBRARY_OBJC_BLOCK = "ObjcBlock";
-    protected static final String[] RESPONSE_LIBRARIES = { RESPONSE_LIBRARY_PROMISE_KIT, RESPONSE_LIBRARY_RX_SWIFT,
-            RESPONSE_LIBRARY_RESULT, RESPONSE_LIBRARY_COMBINE, RESPONSE_LIBRARY_ASYNC_AWAIT, 
-            RESPONSE_LIBRARY_OBJC_BLOCK };
+    protected static final String[] RESPONSE_LIBRARIES = { RESPONSE_LIBRARY_ASYNC_AWAIT, RESPONSE_LIBRARY_COMBINE, RESPONSE_LIBRARY_RESULT, RESPONSE_LIBRARY_RX_SWIFT, RESPONSE_LIBRARY_OBJC_BLOCK, RESPONSE_LIBRARY_PROMISE_KIT };
     @Setter
     protected String projectName = "OpenAPIClient";
     @Setter

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
@@ -85,8 +85,10 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
     protected static final String RESPONSE_LIBRARY_RESULT = "Result";
     protected static final String RESPONSE_LIBRARY_COMBINE = "Combine";
     protected static final String RESPONSE_LIBRARY_ASYNC_AWAIT = "AsyncAwait";
+    protected static final String RESPONSE_LIBRARY_OBJC_BLOCK = "ObjcBlock";
     protected static final String[] RESPONSE_LIBRARIES = { RESPONSE_LIBRARY_PROMISE_KIT, RESPONSE_LIBRARY_RX_SWIFT,
-            RESPONSE_LIBRARY_RESULT, RESPONSE_LIBRARY_COMBINE, RESPONSE_LIBRARY_ASYNC_AWAIT };
+            RESPONSE_LIBRARY_RESULT, RESPONSE_LIBRARY_COMBINE, RESPONSE_LIBRARY_ASYNC_AWAIT, 
+            RESPONSE_LIBRARY_OBJC_BLOCK };
     @Setter
     protected String projectName = "OpenAPIClient";
     @Setter
@@ -125,7 +127,7 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
     @Setter
     protected boolean combineDeferred = true;
     @Setter
-    protected String[] responseAs = new String[0];
+    protected String[] responseAs = { RESPONSE_LIBRARY_ASYNC_AWAIT };
     protected String sourceFolder = swiftPackagePath;
     protected HashSet objcReservedWords;
     protected String apiDocPath = "docs/";
@@ -502,6 +504,9 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
         }
         if (ArrayUtils.contains(responseAs, RESPONSE_LIBRARY_ASYNC_AWAIT)) {
             additionalProperties.put("useAsyncAwait", true);
+        }
+        if (ArrayUtils.contains(responseAs, RESPONSE_LIBRARY_OBJC_BLOCK)) {
+            additionalProperties.put("useObjcBlock", true);
         }
 
         // Setup readonlyProperties option, which declares properties so they can only

--- a/modules/openapi-generator/src/main/resources/swift6/Models.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/Models.mustache
@@ -127,7 +127,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }{{/useAlamofire}}
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} final class RequestTask{{#useAsyncAwait}}: @unchecked Sendable{{/useAsyncAwait}} {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()
 {{#useAlamofire}}
     private var request: Request?

--- a/modules/openapi-generator/src/main/resources/swift6/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/api.mustache
@@ -53,11 +53,7 @@ extension {{projectName}}API {
     {{/isEnum}}
     {{/allParams}}
 {{^useVapor}}
-{{^usePromiseKit}}
-{{^useRxSwift}}
-{{^useResult}}
-{{^useCombine}}
-{{^useAsyncAwait}}
+{{#useObjcBlock}}
 
     /**
      {{#summary}}
@@ -71,7 +67,7 @@ extension {{projectName}}API {
     @available(*, deprecated, message: "This operation is deprecated.")
     {{/isDeprecated}}
     @discardableResult
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} {{#apiStaticMethod}}class {{/apiStaticMethod}}func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#apiStaticMethod}}{{#hasParams}}, {{/hasParams}}openAPIClient: OpenAPIClient = OpenAPIClient.shared{{/apiStaticMethod}}, completion: @Sendable @escaping (_ data: {{{returnType}}}{{^returnType}}Void{{/returnType}}?, _ error: Error?) -> Void) -> RequestTask {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} {{#apiStaticMethod}}class {{/apiStaticMethod}}func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}, {{/allParams}}{{#apiStaticMethod}}openAPIClient: OpenAPIClient = OpenAPIClient.shared, {{/apiStaticMethod}}completion: @Sendable @escaping (_ data: {{{returnType}}}{{^returnType}}Void{{/returnType}}?, _ error: Error?) -> Void) -> RequestTask {
         return {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}{{#apiStaticMethod}}{{#hasParams}}, {{/hasParams}}openAPIClient: openAPIClient{{/apiStaticMethod}}).execute { result in
             switch result {
             {{#returnType}}
@@ -87,12 +83,7 @@ extension {{projectName}}API {
             }
         }
     }
-{{/useAsyncAwait}}
-{{/useCombine}}
-{{/useResult}}
-{{/useRxSwift}}
-{{/usePromiseKit}}
-{{/useVapor}}
+{{/useObjcBlock}}
 {{#usePromiseKit}}
 
     /**
@@ -257,6 +248,86 @@ extension {{projectName}}API {
         }
     }
 {{/useResult}}
+
+    /**
+     {{#summary}}
+     {{{.}}}
+     {{/summary}}
+     - {{httpMethod}} {{{path}}}{{#notes}}
+     - {{{.}}}{{/notes}}{{#subresourceOperation}}
+     - subresourceOperation: {{.}}{{/subresourceOperation}}{{#defaultResponse}}
+     - defaultResponse: {{.}}{{/defaultResponse}}
+     {{#authMethods}}
+     - {{#isBasicBasic}}BASIC{{/isBasicBasic}}{{#isBasicBearer}}Bearer Token{{/isBasicBearer}}{{#isOAuth}}OAuth{{/isOAuth}}{{#isApiKey}}API Key{{/isApiKey}}:
+       - type: {{type}}{{#keyParamName}} {{keyParamName}} {{#isKeyInQuery}}(QUERY){{/isKeyInQuery}}{{#isKeyInHeader}}(HEADER){{/isKeyInHeader}}{{/keyParamName}}
+       - name: {{name}}
+       {{/authMethods}}
+     {{#hasResponseHeaders}}
+     - responseHeaders: [{{#responseHeaders}}{{{baseName}}}({{{dataType}}}){{^-last}}, {{/-last}}{{/responseHeaders}}]
+     {{/hasResponseHeaders}}
+     {{#externalDocs}}
+     - externalDocs: {{.}}
+     {{/externalDocs}}
+     {{#allParams}}
+     - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     {{/allParams}}{{#apiStaticMethod}}
+     - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.{{/apiStaticMethod}}
+     - returns: RequestBuilder<{{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{description}}
+     */
+    {{#isDeprecated}}
+    @available(*, deprecated, message: "This operation is deprecated.")
+    {{/isDeprecated}}
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} {{#apiStaticMethod}}class {{/apiStaticMethod}}func {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#apiStaticMethod}}{{#hasParams}}, {{/hasParams}}openAPIClient: OpenAPIClient = OpenAPIClient.shared{{/apiStaticMethod}}) -> RequestBuilder<{{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+        {{^pathParams}}let{{/pathParams}}{{#pathParams}}{{#-first}}var{{/-first}}{{/pathParams}} localVariablePath = "{{{path}}}"{{#pathParams}}
+        let {{paramName}}PreEscape = "\({{#isEnum}}{{paramName}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}.rawValue{{/isContainer}}{{/isEnum}}{{^isEnum}}APIHelper.mapValueToPathItem({{paramName}}){{/isEnum}})"
+        let {{paramName}}PostEscape = {{paramName}}PreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        localVariablePath = localVariablePath.replacingOccurrences(of: "{{=<% %>=}}{<%baseName%>}<%={{ }}=%>", with: {{paramName}}PostEscape, options: .literal, range: nil){{/pathParams}}
+        let localVariableURLString = openAPIClient.basePath + localVariablePath
+        {{#bodyParam}}
+            {{#isBinary}}
+        let localVariableParameters = ["body": {{paramName}}]
+            {{/isBinary}}
+            {{^isBinary}}
+        let localVariableParameters = JSONEncodingHelper.encodingParameters(forEncodableObject: {{paramName}}, codableHelper: openAPIClient.codableHelper)
+            {{/isBinary}}
+        {{/bodyParam}}
+        {{^bodyParam}}
+            {{#hasFormParams}}
+        let localVariableFormParams: [String: Any?] = [
+                {{#formParams}}
+            {{> _param}},
+                {{/formParams}}
+        ]
+
+        let localVariableNonNullParameters = APIHelper.rejectNil(localVariableFormParams)
+        let localVariableParameters = APIHelper.convertBoolToString(localVariableNonNullParameters)
+            {{/hasFormParams}}
+            {{^hasFormParams}}
+        let localVariableParameters: [String: Any]? = nil
+            {{/hasFormParams}}
+{{/bodyParam}}{{#hasQueryParams}}
+        var localVariableUrlComponents = URLComponents(string: localVariableURLString)
+        localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([{{^queryParams}}:{{/queryParams}}
+            {{#queryParams}}
+            {{> _param}},
+            {{/queryParams}}
+        ]){{/hasQueryParams}}{{^hasQueryParams}}
+        let localVariableUrlComponents = URLComponents(string: localVariableURLString){{/hasQueryParams}}
+
+        let localVariableNillableHeaders: [String: Any?] = [{{^headerParams}}{{^hasFormParams}}{{^hasConsumes}}
+            :{{/hasConsumes}}{{/hasFormParams}}{{/headerParams}}{{#hasFormParams}}
+            "Content-Type": {{^consumes}}"multipart/form-data"{{/consumes}}{{#consumes.0}}"{{{mediaType}}}"{{/consumes.0}},{{/hasFormParams}}{{^hasFormParams}}{{#hasConsumes}}
+            "Content-Type": {{#consumes.0}}"{{{mediaType}}}"{{/consumes.0}},{{/hasConsumes}}{{/hasFormParams}}{{#headerParams}}
+            {{> _param}},{{/headerParams}}
+        ]
+
+        let localVariableHeaderParameters = APIHelper.rejectNilHeaders(localVariableNillableHeaders)
+
+        let localVariableRequestBuilder: RequestBuilder<{{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.Type = openAPIClient.requestBuilderFactory.{{#returnType}}getBuilder(){{/returnType}}{{^returnType}}getNonDecodableBuilder(){{/returnType}}
+
+        return localVariableRequestBuilder.init(method: "{{httpMethod}}", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: {{#hasAuthMethods}}true{{/hasAuthMethods}}{{^hasAuthMethods}}false{{/hasAuthMethods}}, openAPIClient: openAPIClient)
+    }
+{{/useVapor}}
 {{#useVapor}}
 
     /**
@@ -379,87 +450,6 @@ extension {{projectName}}API {
             {{/hasDefaultResponse}}
             }
         }
-    }
-{{/useVapor}}
-{{^useVapor}}
-
-    /**
-     {{#summary}}
-     {{{.}}}
-     {{/summary}}
-     - {{httpMethod}} {{{path}}}{{#notes}}
-     - {{{.}}}{{/notes}}{{#subresourceOperation}}
-     - subresourceOperation: {{.}}{{/subresourceOperation}}{{#defaultResponse}}
-     - defaultResponse: {{.}}{{/defaultResponse}}
-     {{#authMethods}}
-     - {{#isBasicBasic}}BASIC{{/isBasicBasic}}{{#isBasicBearer}}Bearer Token{{/isBasicBearer}}{{#isOAuth}}OAuth{{/isOAuth}}{{#isApiKey}}API Key{{/isApiKey}}:
-       - type: {{type}}{{#keyParamName}} {{keyParamName}} {{#isKeyInQuery}}(QUERY){{/isKeyInQuery}}{{#isKeyInHeader}}(HEADER){{/isKeyInHeader}}{{/keyParamName}}
-       - name: {{name}}
-       {{/authMethods}}
-     {{#hasResponseHeaders}}
-     - responseHeaders: [{{#responseHeaders}}{{{baseName}}}({{{dataType}}}){{^-last}}, {{/-last}}{{/responseHeaders}}]
-     {{/hasResponseHeaders}}
-     {{#externalDocs}}
-     - externalDocs: {{.}}
-     {{/externalDocs}}
-     {{#allParams}}
-     - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
-     {{/allParams}}{{#apiStaticMethod}}
-     - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.{{/apiStaticMethod}}
-     - returns: RequestBuilder<{{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{description}}
-     */
-    {{#isDeprecated}}
-    @available(*, deprecated, message: "This operation is deprecated.")
-    {{/isDeprecated}}
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} {{#apiStaticMethod}}class {{/apiStaticMethod}}func {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#apiStaticMethod}}{{#hasParams}}, {{/hasParams}}openAPIClient: OpenAPIClient = OpenAPIClient.shared{{/apiStaticMethod}}) -> RequestBuilder<{{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
-        {{^pathParams}}let{{/pathParams}}{{#pathParams}}{{#-first}}var{{/-first}}{{/pathParams}} localVariablePath = "{{{path}}}"{{#pathParams}}
-        let {{paramName}}PreEscape = "\({{#isEnum}}{{paramName}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}.rawValue{{/isContainer}}{{/isEnum}}{{^isEnum}}APIHelper.mapValueToPathItem({{paramName}}){{/isEnum}})"
-        let {{paramName}}PostEscape = {{paramName}}PreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
-        localVariablePath = localVariablePath.replacingOccurrences(of: "{{=<% %>=}}{<%baseName%>}<%={{ }}=%>", with: {{paramName}}PostEscape, options: .literal, range: nil){{/pathParams}}
-        let localVariableURLString = openAPIClient.basePath + localVariablePath
-        {{#bodyParam}}
-            {{#isBinary}}
-        let localVariableParameters = ["body": {{paramName}}]
-            {{/isBinary}}
-            {{^isBinary}}
-        let localVariableParameters = JSONEncodingHelper.encodingParameters(forEncodableObject: {{paramName}}, codableHelper: openAPIClient.codableHelper)
-            {{/isBinary}}
-        {{/bodyParam}}
-        {{^bodyParam}}
-            {{#hasFormParams}}
-        let localVariableFormParams: [String: Any?] = [
-                {{#formParams}}
-            {{> _param}},
-                {{/formParams}}
-        ]
-
-        let localVariableNonNullParameters = APIHelper.rejectNil(localVariableFormParams)
-        let localVariableParameters = APIHelper.convertBoolToString(localVariableNonNullParameters)
-            {{/hasFormParams}}
-            {{^hasFormParams}}
-        let localVariableParameters: [String: Any]? = nil
-            {{/hasFormParams}}
-{{/bodyParam}}{{#hasQueryParams}}
-        var localVariableUrlComponents = URLComponents(string: localVariableURLString)
-        localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([{{^queryParams}}:{{/queryParams}}
-            {{#queryParams}}
-            {{> _param}},
-            {{/queryParams}}
-        ]){{/hasQueryParams}}{{^hasQueryParams}}
-        let localVariableUrlComponents = URLComponents(string: localVariableURLString){{/hasQueryParams}}
-
-        let localVariableNillableHeaders: [String: Any?] = [{{^headerParams}}{{^hasFormParams}}{{^hasConsumes}}
-            :{{/hasConsumes}}{{/hasFormParams}}{{/headerParams}}{{#hasFormParams}}
-            "Content-Type": {{^consumes}}"multipart/form-data"{{/consumes}}{{#consumes.0}}"{{{mediaType}}}"{{/consumes.0}},{{/hasFormParams}}{{^hasFormParams}}{{#hasConsumes}}
-            "Content-Type": {{#consumes.0}}"{{{mediaType}}}"{{/consumes.0}},{{/hasConsumes}}{{/hasFormParams}}{{#headerParams}}
-            {{> _param}},{{/headerParams}}
-        ]
-
-        let localVariableHeaderParameters = APIHelper.rejectNilHeaders(localVariableNillableHeaders)
-
-        let localVariableRequestBuilder: RequestBuilder<{{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.Type = openAPIClient.requestBuilderFactory.{{#returnType}}getBuilder(){{/returnType}}{{^returnType}}getNonDecodableBuilder(){{/returnType}}
-
-        return localVariableRequestBuilder.init(method: "{{httpMethod}}", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: {{#hasAuthMethods}}true{{/hasAuthMethods}}{{^hasAuthMethods}}false{{/hasAuthMethods}}, openAPIClient: openAPIClient)
     }
 {{/useVapor}}
 {{/operation}}

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -127,7 +127,7 @@ public struct AnyResponseSerializer<T>: ResponseSerializer {
     }
 }
 
-public final class RequestTask {
+public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var request: Request?
 

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/AnotherFakeAPI.swift
@@ -22,6 +22,24 @@ open class AnotherFakeAPI {
      To test special tags
      
      - parameter body: (body) client model 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func call123testSpecialTags(body: Client, completion: @Sendable @escaping (_ data: Client?, _ error: Error?) -> Void) -> RequestTask {
+        return call123testSpecialTagsWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     To test special tags
+     
+     - parameter body: (body) client model 
      - returns: Promise<Client>
      */
     open func call123testSpecialTags(body: Client) -> Promise<Client> {

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/FakeAPI.swift
@@ -21,6 +21,23 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input boolean as post body (optional)
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func fakeOuterBooleanSerialize(body: Bool? = nil, completion: @Sendable @escaping (_ data: Bool?, _ error: Error?) -> Void) -> RequestTask {
+        return fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+
+     - parameter body: (body) Input boolean as post body (optional)
      - returns: Promise<Bool>
      */
     open func fakeOuterBooleanSerialize(body: Bool? = nil) -> Promise<Bool> {
@@ -139,6 +156,23 @@ open class FakeAPI {
         let localVariableRequestBuilder: RequestBuilder<Bool>.Type = openAPIClient.requestBuilderFactory.getBuilder()
 
         return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false, openAPIClient: openAPIClient)
+    }
+
+    /**
+
+     - parameter body: (body) Input composite as post body (optional)
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func fakeOuterCompositeSerialize(body: OuterComposite? = nil, completion: @Sendable @escaping (_ data: OuterComposite?, _ error: Error?) -> Void) -> RequestTask {
+        return fakeOuterCompositeSerializeWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**
@@ -267,6 +301,23 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input number as post body (optional)
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func fakeOuterNumberSerialize(body: Double? = nil, completion: @Sendable @escaping (_ data: Double?, _ error: Error?) -> Void) -> RequestTask {
+        return fakeOuterNumberSerializeWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+
+     - parameter body: (body) Input number as post body (optional)
      - returns: Promise<Double>
      */
     open func fakeOuterNumberSerialize(body: Double? = nil) -> Promise<Double> {
@@ -385,6 +436,23 @@ open class FakeAPI {
         let localVariableRequestBuilder: RequestBuilder<Double>.Type = openAPIClient.requestBuilderFactory.getBuilder()
 
         return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false, openAPIClient: openAPIClient)
+    }
+
+    /**
+
+     - parameter body: (body) Input string as post body (optional)
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func fakeOuterStringSerialize(body: String? = nil, completion: @Sendable @escaping (_ data: String?, _ error: Error?) -> Void) -> RequestTask {
+        return fakeOuterStringSerializeWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**
@@ -513,6 +581,23 @@ open class FakeAPI {
     /**
 
      - parameter body: (body)  
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func testBodyWithFileSchema(body: FileSchemaTestClass, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return testBodyWithFileSchemaWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+
+     - parameter body: (body)  
      - returns: Promise<Void>
      */
     open func testBodyWithFileSchema(body: FileSchemaTestClass) -> Promise<Void> {
@@ -631,6 +716,24 @@ open class FakeAPI {
         let localVariableRequestBuilder: RequestBuilder<Void>.Type = openAPIClient.requestBuilderFactory.getNonDecodableBuilder()
 
         return localVariableRequestBuilder.init(method: "PUT", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false, openAPIClient: openAPIClient)
+    }
+
+    /**
+
+     - parameter query: (query)  
+     - parameter body: (body)  
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func testBodyWithQueryParams(query: String, body: User, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return testBodyWithQueryParamsWithRequestBuilder(query: query, body: body).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**
@@ -768,6 +871,24 @@ open class FakeAPI {
      To test \"client\" model
      
      - parameter body: (body) client model 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func testClientModel(body: Client, completion: @Sendable @escaping (_ data: Client?, _ error: Error?) -> Void) -> RequestTask {
+        return testClientModelWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     To test \"client\" model
+     
+     - parameter body: (body) client model 
      - returns: Promise<Client>
      */
     open func testClientModel(body: Client) -> Promise<Client> {
@@ -891,6 +1012,37 @@ open class FakeAPI {
         let localVariableRequestBuilder: RequestBuilder<Client>.Type = openAPIClient.requestBuilderFactory.getBuilder()
 
         return localVariableRequestBuilder.init(method: "PATCH", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false, openAPIClient: openAPIClient)
+    }
+
+    /**
+     Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+     
+     - parameter number: (form) None 
+     - parameter double: (form) None 
+     - parameter patternWithoutDelimiter: (form) None 
+     - parameter byte: (form) None 
+     - parameter integer: (form) None (optional)
+     - parameter int32: (form) None (optional)
+     - parameter int64: (form) None (optional)
+     - parameter float: (form) None (optional)
+     - parameter string: (form) None (optional)
+     - parameter binary: (form) None (optional)
+     - parameter date: (form) None (optional)
+     - parameter dateTime: (form) None (optional)
+     - parameter password: (form) None (optional)
+     - parameter callback: (form) None (optional)
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**
@@ -1199,6 +1351,31 @@ open class FakeAPI {
      - parameter enumQueryDouble: (query) Query parameter enum test (double) (optional)
      - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional, default to .dollar)
      - parameter enumFormString: (form) Form parameter enum test (string) (optional, default to .efg)
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     To test enum parameters
+     
+     - parameter enumHeaderStringArray: (header) Header parameter enum test (string array) (optional)
+     - parameter enumHeaderString: (header) Header parameter enum test (string) (optional, default to .efg)
+     - parameter enumQueryStringArray: (query) Query parameter enum test (string array) (optional)
+     - parameter enumQueryString: (query) Query parameter enum test (string) (optional, default to .efg)
+     - parameter enumQueryInteger: (query) Query parameter enum test (double) (optional)
+     - parameter enumQueryDouble: (query) Query parameter enum test (double) (optional)
+     - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional, default to .dollar)
+     - parameter enumFormString: (form) Form parameter enum test (string) (optional, default to .efg)
      - returns: Promise<Void>
      */
     open func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil) -> Promise<Void> {
@@ -1382,6 +1559,29 @@ open class FakeAPI {
      - parameter stringGroup: (query) String in group parameters (optional)
      - parameter booleanGroup: (header) Boolean in group parameters (optional)
      - parameter int64Group: (query) Integer in group parameters (optional)
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     Fake endpoint to test group parameters (optional)
+     
+     - parameter requiredStringGroup: (query) Required String in group parameters 
+     - parameter requiredBooleanGroup: (header) Required Boolean in group parameters 
+     - parameter requiredInt64Group: (query) Required Integer in group parameters 
+     - parameter stringGroup: (query) String in group parameters (optional)
+     - parameter booleanGroup: (header) Boolean in group parameters (optional)
+     - parameter int64Group: (query) Integer in group parameters (optional)
      - returns: Promise<Void>
      */
     open func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil) -> Promise<Void> {
@@ -1543,6 +1743,24 @@ open class FakeAPI {
      test inline additionalProperties
      
      - parameter param: (body) request body 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func testInlineAdditionalProperties(param: [String: String], completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return testInlineAdditionalPropertiesWithRequestBuilder(param: param).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     test inline additionalProperties
+     
+     - parameter param: (body) request body 
      - returns: Promise<Void>
      */
     open func testInlineAdditionalProperties(param: [String: String]) -> Promise<Void> {
@@ -1665,6 +1883,25 @@ open class FakeAPI {
         let localVariableRequestBuilder: RequestBuilder<Void>.Type = openAPIClient.requestBuilderFactory.getNonDecodableBuilder()
 
         return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false, openAPIClient: openAPIClient)
+    }
+
+    /**
+     test json serialization of form data
+     
+     - parameter param: (form) field1 
+     - parameter param2: (form) field2 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func testJsonFormData(param: String, param2: String, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/FakeClassnameTags123API.swift
@@ -22,6 +22,24 @@ open class FakeClassnameTags123API {
      To test class name in snake case
      
      - parameter body: (body) client model 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func testClassname(body: Client, completion: @Sendable @escaping (_ data: Client?, _ error: Error?) -> Void) -> RequestTask {
+        return testClassnameWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     To test class name in snake case
+     
+     - parameter body: (body) client model 
      - returns: Promise<Client>
      */
     open func testClassname(body: Client) -> Promise<Client> {

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -22,6 +22,24 @@ open class PetAPI {
      Add a new pet to the store
      
      - parameter body: (body) Pet object that needs to be added to the store 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func addPet(body: Pet, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return addPetWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     Add a new pet to the store
+     
+     - parameter body: (body) Pet object that needs to be added to the store 
      - returns: Promise<Void>
      */
     open func addPet(body: Pet) -> Promise<Void> {
@@ -150,6 +168,25 @@ open class PetAPI {
         let localVariableRequestBuilder: RequestBuilder<Void>.Type = openAPIClient.requestBuilderFactory.getNonDecodableBuilder()
 
         return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: true, openAPIClient: openAPIClient)
+    }
+
+    /**
+     Deletes a pet
+     
+     - parameter petId: (path) Pet id to delete 
+     - parameter apiKey: (header)  (optional)
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func deletePet(petId: Int64, apiKey: String? = nil, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**
@@ -305,6 +342,24 @@ open class PetAPI {
      Finds Pets by status
      
      - parameter status: (query) Status values that need to be considered for filter 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func findPetsByStatus(status: [Status_findPetsByStatus], completion: @Sendable @escaping (_ data: [Pet]?, _ error: Error?) -> Void) -> RequestTask {
+        return findPetsByStatusWithRequestBuilder(status: status).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     Finds Pets by status
+     
+     - parameter status: (query) Status values that need to be considered for filter 
      - returns: Promise<[Pet]>
      */
     open func findPetsByStatus(status: [Status_findPetsByStatus]) -> Promise<[Pet]> {
@@ -434,6 +489,25 @@ open class PetAPI {
         let localVariableRequestBuilder: RequestBuilder<[Pet]>.Type = openAPIClient.requestBuilderFactory.getBuilder()
 
         return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: true, openAPIClient: openAPIClient)
+    }
+
+    /**
+     Finds Pets by tags
+     
+     - parameter tags: (query) Tags to filter by 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @available(*, deprecated, message: "This operation is deprecated.")
+    @discardableResult
+    open func findPetsByTags(tags: [String], completion: @Sendable @escaping (_ data: [Pet]?, _ error: Error?) -> Void) -> RequestTask {
+        return findPetsByTagsWithRequestBuilder(tags: tags).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**
@@ -581,6 +655,24 @@ open class PetAPI {
      Find pet by ID
      
      - parameter petId: (path) ID of pet to return 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func getPetById(petId: Int64, completion: @Sendable @escaping (_ data: Pet?, _ error: Error?) -> Void) -> RequestTask {
+        return getPetByIdWithRequestBuilder(petId: petId).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     Find pet by ID
+     
+     - parameter petId: (path) ID of pet to return 
      - returns: Promise<Pet>
      */
     open func getPetById(petId: Int64) -> Promise<Pet> {
@@ -716,6 +808,24 @@ open class PetAPI {
      Update an existing pet
      
      - parameter body: (body) Pet object that needs to be added to the store 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func updatePet(body: Pet, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return updatePetWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     Update an existing pet
+     
+     - parameter body: (body) Pet object that needs to be added to the store 
      - returns: Promise<Void>
      */
     open func updatePet(body: Pet) -> Promise<Void> {
@@ -841,6 +951,26 @@ open class PetAPI {
         let localVariableRequestBuilder: RequestBuilder<Void>.Type = openAPIClient.requestBuilderFactory.getNonDecodableBuilder()
 
         return localVariableRequestBuilder.init(method: "PUT", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: true, openAPIClient: openAPIClient)
+    }
+
+    /**
+     Updates a pet in the store with form data
+     
+     - parameter petId: (path) ID of pet that needs to be updated 
+     - parameter name: (form) Updated name of the pet (optional)
+     - parameter status: (form) Updated status of the pet (optional)
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**
@@ -1001,6 +1131,26 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
      - parameter file: (form) file to upload (optional)
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @Sendable @escaping (_ data: ApiResponse?, _ error: Error?) -> Void) -> RequestTask {
+        return uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     uploads an image
+     
+     - parameter petId: (path) ID of pet to update 
+     - parameter additionalMetadata: (form) Additional data to pass to server (optional)
+     - parameter file: (form) file to upload (optional)
      - returns: Promise<ApiResponse>
      */
     open func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> Promise<ApiResponse> {
@@ -1145,6 +1295,26 @@ open class PetAPI {
         let localVariableRequestBuilder: RequestBuilder<ApiResponse>.Type = openAPIClient.requestBuilderFactory.getBuilder()
 
         return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: true, openAPIClient: openAPIClient)
+    }
+
+    /**
+     uploads an image (required)
+     
+     - parameter petId: (path) ID of pet to update 
+     - parameter requiredFile: (form) file to upload 
+     - parameter additionalMetadata: (form) Additional data to pass to server (optional)
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, completion: @Sendable @escaping (_ data: ApiResponse?, _ error: Error?) -> Void) -> RequestTask {
+        return uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/StoreAPI.swift
@@ -22,6 +22,24 @@ open class StoreAPI {
      Delete purchase order by ID
      
      - parameter orderId: (path) ID of the order that needs to be deleted 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func deleteOrder(orderId: String, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return deleteOrderWithRequestBuilder(orderId: orderId).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     Delete purchase order by ID
+     
+     - parameter orderId: (path) ID of the order that needs to be deleted 
      - returns: Promise<Void>
      */
     open func deleteOrder(orderId: String) -> Promise<Void> {
@@ -148,6 +166,23 @@ open class StoreAPI {
         let localVariableRequestBuilder: RequestBuilder<Void>.Type = openAPIClient.requestBuilderFactory.getNonDecodableBuilder()
 
         return localVariableRequestBuilder.init(method: "DELETE", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false, openAPIClient: openAPIClient)
+    }
+
+    /**
+     Returns pet inventories by status
+     
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func getInventory(completion: @Sendable @escaping (_ data: [String: Int]?, _ error: Error?) -> Void) -> RequestTask {
+        return getInventoryWithRequestBuilder().execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**
@@ -280,6 +315,24 @@ open class StoreAPI {
      Find purchase order by ID
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func getOrderById(orderId: Int64, completion: @Sendable @escaping (_ data: Order?, _ error: Error?) -> Void) -> RequestTask {
+        return getOrderByIdWithRequestBuilder(orderId: orderId).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     Find purchase order by ID
+     
+     - parameter orderId: (path) ID of pet that needs to be fetched 
      - returns: Promise<Order>
      */
     open func getOrderById(orderId: Int64) -> Promise<Order> {
@@ -406,6 +459,24 @@ open class StoreAPI {
         let localVariableRequestBuilder: RequestBuilder<Order>.Type = openAPIClient.requestBuilderFactory.getBuilder()
 
         return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false, openAPIClient: openAPIClient)
+    }
+
+    /**
+     Place an order for a pet
+     
+     - parameter body: (body) order placed for purchasing the pet 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func placeOrder(body: Order, completion: @Sendable @escaping (_ data: Order?, _ error: Error?) -> Void) -> RequestTask {
+        return placeOrderWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/UserAPI.swift
@@ -22,6 +22,24 @@ open class UserAPI {
      Create user
      
      - parameter body: (body) Created user object 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func createUser(body: User, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return createUserWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     Create user
+     
+     - parameter body: (body) Created user object 
      - returns: Promise<Void>
      */
     open func createUser(body: User) -> Promise<Void> {
@@ -145,6 +163,24 @@ open class UserAPI {
         let localVariableRequestBuilder: RequestBuilder<Void>.Type = openAPIClient.requestBuilderFactory.getNonDecodableBuilder()
 
         return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false, openAPIClient: openAPIClient)
+    }
+
+    /**
+     Creates list of users with given input array
+     
+     - parameter body: (body) List of user object 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func createUsersWithArrayInput(body: [User], completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return createUsersWithArrayInputWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**
@@ -279,6 +315,24 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter body: (body) List of user object 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func createUsersWithListInput(body: [User], completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return createUsersWithListInputWithRequestBuilder(body: body).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     Creates list of users with given input array
+     
+     - parameter body: (body) List of user object 
      - returns: Promise<Void>
      */
     open func createUsersWithListInput(body: [User]) -> Promise<Void> {
@@ -401,6 +455,24 @@ open class UserAPI {
         let localVariableRequestBuilder: RequestBuilder<Void>.Type = openAPIClient.requestBuilderFactory.getNonDecodableBuilder()
 
         return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false, openAPIClient: openAPIClient)
+    }
+
+    /**
+     Delete user
+     
+     - parameter username: (path) The name that needs to be deleted 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func deleteUser(username: String, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return deleteUserWithRequestBuilder(username: username).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**
@@ -539,6 +611,24 @@ open class UserAPI {
      Get user by user name
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func getUserByName(username: String, completion: @Sendable @escaping (_ data: User?, _ error: Error?) -> Void) -> RequestTask {
+        return getUserByNameWithRequestBuilder(username: username).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     Get user by user name
+     
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
      - returns: Promise<User>
      */
     open func getUserByName(username: String) -> Promise<User> {
@@ -664,6 +754,25 @@ open class UserAPI {
         let localVariableRequestBuilder: RequestBuilder<User>.Type = openAPIClient.requestBuilderFactory.getBuilder()
 
         return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false, openAPIClient: openAPIClient)
+    }
+
+    /**
+     Logs user into the system
+     
+     - parameter username: (query) The user name for login 
+     - parameter password: (query) The password for login in clear text 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func loginUser(username: String, password: String, completion: @Sendable @escaping (_ data: String?, _ error: Error?) -> Void) -> RequestTask {
+        return loginUserWithRequestBuilder(username: username, password: password).execute { result in
+            switch result {
+            case let .success(response):
+                completion(response.body, nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**
@@ -808,6 +917,23 @@ open class UserAPI {
     /**
      Logs out current logged in user session
      
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func logoutUser(completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return logoutUserWithRequestBuilder().execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+     Logs out current logged in user session
+     
      - returns: Promise<Void>
      */
     open func logoutUser() -> Promise<Void> {
@@ -925,6 +1051,25 @@ open class UserAPI {
         let localVariableRequestBuilder: RequestBuilder<Void>.Type = openAPIClient.requestBuilderFactory.getNonDecodableBuilder()
 
         return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false, openAPIClient: openAPIClient)
+    }
+
+    /**
+     Updated user
+     
+     - parameter username: (path) name that need to be deleted 
+     - parameter body: (body) Updated user object 
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    @discardableResult
+    open func updateUser(username: String, body: User, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
+        return updateUserWithRequestBuilder(username: username, body: body).execute { result in
+            switch result {
+            case .success:
+                completion((), nil)
+            case let .failure(error):
+                completion(nil, error)
+            }
+        }
     }
 
     /**

--- a/samples/client/petstore/swift6/apiNonStaticMethod/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
@@ -31,24 +31,24 @@ class PetAPITests: XCTestCase {
         try await PetAPI().addPet(body: newPet)
     }
 
-    func test2GetPet() async throws {
-        let pet = try await PetAPI().getPetById(petId: 1000)
-        
-        XCTAssert(pet.id == 1000, "invalid id")
-        XCTAssert(pet.name == "Fluffy", "invalid name")
-        XCTAssert(pet.category!.id == 1234, "invalid category id")
-        XCTAssert(pet.category!.name == "eyeColor", "invalid category name")
-        
-        let tag1 = pet.tags![0]
-        XCTAssert(tag1.id == 1234, "invalid tag id")
-        XCTAssert(tag1.name == "New York", "invalid tag name")
-        
-        let tag2 = pet.tags![1]
-        XCTAssert(tag2.id == 124321, "invalid tag id")
-        XCTAssert(tag2.name == "Jose", "invalid tag name")
-        
-        XCTAssert(pet.photoUrls[0] == "https://petstore.com/sample/photo1.jpg")
-        XCTAssert(pet.photoUrls[1] == "https://petstore.com/sample/photo2.jpg")
+    func test2GetPet() {
+        let expectation = self.expectation(description: "testGetPet")
+
+        PetAPI().getPetById(petId: 1000) { (pet, error) in
+            guard error == nil else {
+                XCTFail("error retrieving pet")
+                return
+            }
+
+            if let pet = pet {
+                XCTAssert(pet.id == 1000, "invalid id")
+                XCTAssert(pet.name == "Fluffy", "invalid name")
+
+                expectation.fulfill()
+            }
+        }
+
+        self.waitForExpectations(timeout: testTimeout, handler: nil)
     }
 
     func test3UploadFile() async throws {

--- a/samples/client/petstore/swift6/apiNonStaticMethod/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
@@ -31,7 +31,7 @@ class PetAPITests: XCTestCase {
         try await PetAPI().addPet(body: newPet)
     }
 
-    func test2GetPet() {
+    @MainActor func test2GetPet() {
         let expectation = self.expectation(description: "testGetPet")
 
         PetAPI().getPetById(petId: 1000) { (pet, error) in
@@ -48,7 +48,7 @@ class PetAPITests: XCTestCase {
             }
         }
 
-        self.waitForExpectations(timeout: testTimeout, handler: nil)
+        self.waitForExpectations(timeout: 10.0, handler: nil)
     }
 
     func test3UploadFile() async throws {

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -110,7 +110,7 @@ open class Response<T> {
     }
 }
 
-public final class RequestTask {
+public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var task: URLSessionDataTaskProtocol?
 

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Models.swift
@@ -110,7 +110,7 @@ open class Response<T> {
     }
 }
 
-public final class RequestTask {
+public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var task: URLSessionDataTaskProtocol?
 

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/AnotherFakeAPI.swift
@@ -15,18 +15,11 @@ open class AnotherFakeAPI {
      - parameter uuidTest: (header) to test uuid example value 
      - parameter body: (body) client model 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Client
      */
-    @discardableResult
-    open class func call123testSpecialTags(uuidTest: UUID, body: Client, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Client?, _ error: Error?) -> Void) -> RequestTask {
-        return call123testSpecialTagsWithRequestBuilder(uuidTest: uuidTest, body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func call123testSpecialTags(uuidTest: UUID, body: Client, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> Client {
+        return try await call123testSpecialTagsWithRequestBuilder(uuidTest: uuidTest, body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/FakeAPI.swift
@@ -14,18 +14,11 @@ open class FakeAPI {
      
      - parameter xmlItem: (body) XmlItem Body 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func createXmlItem(xmlItem: XmlItem, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return createXmlItemWithRequestBuilder(xmlItem: xmlItem, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func createXmlItem(xmlItem: XmlItem, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await createXmlItemWithRequestBuilder(xmlItem: xmlItem, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -59,18 +52,11 @@ open class FakeAPI {
 
      - parameter body: (body) Input boolean as post body (optional)
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Bool
      */
-    @discardableResult
-    open class func fakeOuterBooleanSerialize(body: Bool? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Bool?, _ error: Error?) -> Void) -> RequestTask {
-        return fakeOuterBooleanSerializeWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func fakeOuterBooleanSerialize(body: Bool? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> Bool {
+        return try await fakeOuterBooleanSerializeWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -103,18 +89,11 @@ open class FakeAPI {
 
      - parameter body: (body) Input composite as post body (optional)
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: OuterComposite
      */
-    @discardableResult
-    open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: OuterComposite?, _ error: Error?) -> Void) -> RequestTask {
-        return fakeOuterCompositeSerializeWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> OuterComposite {
+        return try await fakeOuterCompositeSerializeWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -147,18 +126,11 @@ open class FakeAPI {
 
      - parameter body: (body) Input number as post body (optional)
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Double
      */
-    @discardableResult
-    open class func fakeOuterNumberSerialize(body: Double? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Double?, _ error: Error?) -> Void) -> RequestTask {
-        return fakeOuterNumberSerializeWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func fakeOuterNumberSerialize(body: Double? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> Double {
+        return try await fakeOuterNumberSerializeWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -191,18 +163,11 @@ open class FakeAPI {
 
      - parameter body: (body) Input string as post body (optional)
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: String
      */
-    @discardableResult
-    open class func fakeOuterStringSerialize(body: String? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: String?, _ error: Error?) -> Void) -> RequestTask {
-        return fakeOuterStringSerializeWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func fakeOuterStringSerialize(body: String? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> String {
+        return try await fakeOuterStringSerializeWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -235,18 +200,11 @@ open class FakeAPI {
 
      - parameter body: (body)  
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func testBodyWithFileSchema(body: FileSchemaTestClass, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return testBodyWithFileSchemaWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func testBodyWithFileSchema(body: FileSchemaTestClass, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await testBodyWithFileSchemaWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -280,18 +238,11 @@ open class FakeAPI {
      - parameter query: (query)  
      - parameter body: (body)  
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func testBodyWithQueryParams(query: String, body: User, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return testBodyWithQueryParamsWithRequestBuilder(query: query, body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func testBodyWithQueryParams(query: String, body: User, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await testBodyWithQueryParamsWithRequestBuilder(query: query, body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -328,18 +279,11 @@ open class FakeAPI {
      
      - parameter body: (body) client model 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Client
      */
-    @discardableResult
-    open class func testClientModel(body: Client, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Client?, _ error: Error?) -> Void) -> RequestTask {
-        return testClientModelWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func testClientModel(body: Client, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> Client {
+        return try await testClientModelWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -387,18 +331,11 @@ open class FakeAPI {
      - parameter password: (form) None (optional)
      - parameter callback: (form) None (optional)
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -541,18 +478,11 @@ open class FakeAPI {
      - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional, default to .dollar)
      - parameter enumFormString: (form) Form parameter enum test (string) (optional, default to .efg)
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -613,18 +543,11 @@ open class FakeAPI {
      - parameter booleanGroup: (header) Boolean in group parameters (optional)
      - parameter int64Group: (query) Integer in group parameters (optional)
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -671,18 +594,11 @@ open class FakeAPI {
      
      - parameter param: (body) request body 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func testInlineAdditionalProperties(param: [String: String], openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return testInlineAdditionalPropertiesWithRequestBuilder(param: param, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func testInlineAdditionalProperties(param: [String: String], openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await testInlineAdditionalPropertiesWithRequestBuilder(param: param, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -717,18 +633,11 @@ open class FakeAPI {
      - parameter param: (form) field1 
      - parameter param2: (form) field2 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func testJsonFormData(param: String, param2: String, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return testJsonFormDataWithRequestBuilder(param: param, param2: param2, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func testJsonFormData(param: String, param2: String, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await testJsonFormDataWithRequestBuilder(param: param, param2: param2, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -772,18 +681,11 @@ open class FakeAPI {
      - parameter url: (query)  
      - parameter context: (query)  
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func testQueryParameterCollectionFormat(pipe: [String], ioutil: [String], http: [String], url: [String], context: [String], openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return testQueryParameterCollectionFormatWithRequestBuilder(pipe: pipe, ioutil: ioutil, http: http, url: url, context: context, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func testQueryParameterCollectionFormat(pipe: [String], ioutil: [String], http: [String], url: [String], context: [String], openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await testQueryParameterCollectionFormatWithRequestBuilder(pipe: pipe, ioutil: ioutil, http: http, url: url, context: context, openAPIClient: openAPIClient).execute().body
     }
 
     /**

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/FakeClassnameTags123API.swift
@@ -14,18 +14,11 @@ open class FakeClassnameTags123API {
      
      - parameter body: (body) client model 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Client
      */
-    @discardableResult
-    open class func testClassname(body: Client, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Client?, _ error: Error?) -> Void) -> RequestTask {
-        return testClassnameWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func testClassname(body: Client, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> Client {
+        return try await testClassnameWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -14,18 +14,11 @@ open class PetAPI {
      
      - parameter body: (body) Pet object that needs to be added to the store 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func addPet(body: Pet, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return addPetWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func addPet(body: Pet, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await addPetWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -63,18 +56,11 @@ open class PetAPI {
      - parameter petId: (path) Pet id to delete 
      - parameter apiKey: (header)  (optional)
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func deletePet(petId: Int64, apiKey: String? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return deletePetWithRequestBuilder(petId: petId, apiKey: apiKey, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func deletePet(petId: Int64, apiKey: String? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await deletePetWithRequestBuilder(petId: petId, apiKey: apiKey, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -124,18 +110,11 @@ open class PetAPI {
      
      - parameter status: (query) Status values that need to be considered for filter 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: [Pet]
      */
-    @discardableResult
-    open class func findPetsByStatus(status: [Status_findPetsByStatus], openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: [Pet]?, _ error: Error?) -> Void) -> RequestTask {
-        return findPetsByStatusWithRequestBuilder(status: status, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func findPetsByStatus(status: [Status_findPetsByStatus], openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> [Pet] {
+        return try await findPetsByStatusWithRequestBuilder(status: status, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -176,19 +155,12 @@ open class PetAPI {
      
      - parameter tags: (query) Tags to filter by 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Set<Pet>
      */
     @available(*, deprecated, message: "This operation is deprecated.")
-    @discardableResult
-    open class func findPetsByTags(tags: Set<String>, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Set<Pet>?, _ error: Error?) -> Void) -> RequestTask {
-        return findPetsByTagsWithRequestBuilder(tags: tags, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func findPetsByTags(tags: Set<String>, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> Set<Pet> {
+        return try await findPetsByTagsWithRequestBuilder(tags: tags, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -230,18 +202,11 @@ open class PetAPI {
      
      - parameter petId: (path) ID of pet to return 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Pet
      */
-    @discardableResult
-    open class func getPetById(petId: Int64, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Pet?, _ error: Error?) -> Void) -> RequestTask {
-        return getPetByIdWithRequestBuilder(petId: petId, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func getPetById(petId: Int64, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> Pet {
+        return try await getPetByIdWithRequestBuilder(petId: petId, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -282,18 +247,11 @@ open class PetAPI {
      
      - parameter body: (body) Pet object that needs to be added to the store 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func updatePet(body: Pet, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return updatePetWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func updatePet(body: Pet, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await updatePetWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -332,18 +290,11 @@ open class PetAPI {
      - parameter name: (form) Updated name of the pet (optional)
      - parameter status: (form) Updated status of the pet (optional)
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -393,18 +344,11 @@ open class PetAPI {
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
      - parameter file: (form) file to upload (optional)
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: ApiResponse
      */
-    @discardableResult
-    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: ApiResponse?, _ error: Error?) -> Void) -> RequestTask {
-        return uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> ApiResponse {
+        return try await uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -454,18 +398,11 @@ open class PetAPI {
      - parameter requiredFile: (form) file to upload 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: ApiResponse
      */
-    @discardableResult
-    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: ApiResponse?, _ error: Error?) -> Void) -> RequestTask {
-        return uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> ApiResponse {
+        return try await uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata, openAPIClient: openAPIClient).execute().body
     }
 
     /**

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/StoreAPI.swift
@@ -14,18 +14,11 @@ open class StoreAPI {
      
      - parameter orderId: (path) ID of the order that needs to be deleted 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func deleteOrder(orderId: String, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return deleteOrderWithRequestBuilder(orderId: orderId, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func deleteOrder(orderId: String, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await deleteOrderWithRequestBuilder(orderId: orderId, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -62,18 +55,11 @@ open class StoreAPI {
      Returns pet inventories by status
      
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: [String: Int]
      */
-    @discardableResult
-    open class func getInventory(openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: [String: Int]?, _ error: Error?) -> Void) -> RequestTask {
-        return getInventoryWithRequestBuilder(openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func getInventory(openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> [String: Int] {
+        return try await getInventoryWithRequestBuilder(openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -110,18 +96,11 @@ open class StoreAPI {
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Order
      */
-    @discardableResult
-    open class func getOrderById(orderId: Int64, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Order?, _ error: Error?) -> Void) -> RequestTask {
-        return getOrderByIdWithRequestBuilder(orderId: orderId, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func getOrderById(orderId: Int64, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> Order {
+        return try await getOrderByIdWithRequestBuilder(orderId: orderId, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -159,18 +138,11 @@ open class StoreAPI {
      
      - parameter body: (body) order placed for purchasing the pet 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Order
      */
-    @discardableResult
-    open class func placeOrder(body: Order, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Order?, _ error: Error?) -> Void) -> RequestTask {
-        return placeOrderWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func placeOrder(body: Order, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> Order {
+        return try await placeOrderWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/UserAPI.swift
@@ -14,18 +14,11 @@ open class UserAPI {
      
      - parameter body: (body) Created user object 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func createUser(body: User, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return createUserWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func createUser(body: User, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await createUserWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -60,18 +53,11 @@ open class UserAPI {
      
      - parameter body: (body) List of user object 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func createUsersWithArrayInput(body: [User], openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return createUsersWithArrayInputWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func createUsersWithArrayInput(body: [User], openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await createUsersWithArrayInputWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -105,18 +91,11 @@ open class UserAPI {
      
      - parameter body: (body) List of user object 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func createUsersWithListInput(body: [User], openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return createUsersWithListInputWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func createUsersWithListInput(body: [User], openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await createUsersWithListInputWithRequestBuilder(body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -150,18 +129,11 @@ open class UserAPI {
      
      - parameter username: (path) The name that needs to be deleted 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func deleteUser(username: String, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return deleteUserWithRequestBuilder(username: username, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func deleteUser(username: String, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await deleteUserWithRequestBuilder(username: username, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -199,18 +171,11 @@ open class UserAPI {
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: User
      */
-    @discardableResult
-    open class func getUserByName(username: String, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: User?, _ error: Error?) -> Void) -> RequestTask {
-        return getUserByNameWithRequestBuilder(username: username, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func getUserByName(username: String, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> User {
+        return try await getUserByNameWithRequestBuilder(username: username, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -248,18 +213,11 @@ open class UserAPI {
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: String
      */
-    @discardableResult
-    open class func loginUser(username: String, password: String, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: String?, _ error: Error?) -> Void) -> RequestTask {
-        return loginUserWithRequestBuilder(username: username, password: password, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func loginUser(username: String, password: String, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> String {
+        return try await loginUserWithRequestBuilder(username: username, password: password, openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -298,18 +256,11 @@ open class UserAPI {
      Logs out current logged in user session
      
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func logoutUser(openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return logoutUserWithRequestBuilder(openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func logoutUser(openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await logoutUserWithRequestBuilder(openAPIClient: openAPIClient).execute().body
     }
 
     /**
@@ -343,18 +294,11 @@ open class UserAPI {
      - parameter username: (path) name that need to be deleted 
      - parameter body: (body) Updated user object 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Void
      */
-    @discardableResult
-    open class func updateUser(username: String, body: User, openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Void?, _ error: Error?) -> Void) -> RequestTask {
-        return updateUserWithRequestBuilder(username: username, body: body, openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case .success:
-                completion((), nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func updateUser(username: String, body: User, openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) {
+        return try await updateUserWithRequestBuilder(username: username, body: body, openAPIClient: openAPIClient).execute().body
     }
 
     /**

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -110,7 +110,7 @@ open class Response<T> {
     }
 }
 
-public final class RequestTask {
+public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var task: URLSessionDataTaskProtocol?
 

--- a/samples/client/petstore/swift6/default/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
+++ b/samples/client/petstore/swift6/default/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
@@ -10,10 +10,8 @@ import PetstoreClient
 import XCTest
 @testable import SwaggerClient
 
-@MainActor
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 class PetAPITests: XCTestCase {
-
-    let testTimeout = 10.0
 
     override func setUp() {
         super.setUp()
@@ -25,47 +23,32 @@ class PetAPITests: XCTestCase {
         super.tearDown()
     }
 
-    func test1CreatePet() {
-        let expectation = self.expectation(description: "testCreatePet")
+    func test1CreatePet() async throws {
         let category = Category(id: 1234, name: "eyeColor")
         let tags = [Tag(id: 1234, name: "New York"), Tag(id: 124321, name: "Jose")]
         let newPet = Pet(id: 1000, category: category, name: "Fluffy", photoUrls: ["https://petstore.com/sample/photo1.jpg", "https://petstore.com/sample/photo2.jpg"], tags: tags, status: .available)
 
-        PetAPI.addPet(body: newPet) { (_, error) in
-            guard error == nil else {
-                XCTFail("error creating pet")
-                return
-            }
-
-            expectation.fulfill()
-        }
-
-        self.waitForExpectations(timeout: testTimeout, handler: nil)
+        try await PetAPI.addPet(body: newPet)
     }
 
-    func test2GetPet() {
-        let expectation = self.expectation(description: "testGetPet")
-
-        PetAPI.getPetById(petId: 1000) { (pet, error) in
-            guard error == nil else {
-                XCTFail("error retrieving pet")
-                return
-            }
-
-            if let pet = pet {
-                XCTAssert(pet.id == 1000, "invalid id")
-                XCTAssert(pet.name == "Fluffy", "invalid name")
-
-                expectation.fulfill()
-            }
-        }
-
-        self.waitForExpectations(timeout: testTimeout, handler: nil)
+    func test2GetPet() async throws {
+        let pet = try await PetAPI.getPetById(petId: 1000)
+        
+        XCTAssert(pet.id == 1000, "invalid id")
+        XCTAssert(pet.name == "Fluffy", "invalid name")
+        XCTAssert(pet.category!.id == 1234, "invalid category id")
+        XCTAssert(pet.category!.name == "eyeColor", "invalid category name")
+        
+        let tag1 = pet.tags![0]
+        XCTAssert(tag1.id == 1234, "invalid tag id")
+        XCTAssert(tag1.name == "New York", "invalid tag name")
+        
+        let tag2 = pet.tags![1]
+        XCTAssert(tag2.id == 124321, "invalid tag id")
+        XCTAssert(tag2.name == "Jose", "invalid tag name")        
     }
 
-    func test3UploadFile() {
-        let expectation = self.expectation(description: "testUploadFile")
-
+    func test3UploadFile() async throws {
         let imageName = UUID().uuidString + ".png"
 
         guard
@@ -75,33 +58,31 @@ class PetAPITests: XCTestCase {
             fatalError()
         }
 
-        PetAPI.uploadFile(petId: 1000, additionalMetadata: "additionalMetadata", file: imageURL) { (_, error) in
-            guard error == nil else {
-                FileUtils.deleteFile(fileURL: imageURL)
-                XCTFail("error uploading file")
-                return
-            }
-
+        do {
+            let _ = try await PetAPI.uploadFile(petId: 1000, additionalMetadata: "additionalMetadata", file: imageURL)
+            
             FileUtils.deleteFile(fileURL: imageURL)
-            expectation.fulfill()
+        } catch {
+            FileUtils.deleteFile(fileURL: imageURL)
+            XCTFail("error uploading file")
         }
-
-        self.waitForExpectations(timeout: testTimeout, handler: nil)
     }
 
-    func test4DeletePet() {
-        let expectation = self.expectation(description: "testDeletePet")
-
-        PetAPI.deletePet(petId: 1000) { (_, error) in
-            guard error == nil else {
+    func test4DeletePet() async throws {
+        do {
+            try await PetAPI.deletePet(petId: 1000)
+        } catch let errorType {
+            // The server gives us no data back so alamofire parsing fails - at least
+            // verify that is the error we get here
+            // Error Domain=com.alamofire.error Code=-6006 "JSON could not be serialized. Input data was nil or zero
+            // length." UserInfo={NSLocalizedFailureReason=JSON could not be serialized. Input data was nil or zero
+            // length.}
+            let error = errorType as NSError
+            if error.code == -6006 {
+                // Everything ok!
+            } else {
                 XCTFail("error deleting pet")
-                return
             }
-
-            expectation.fulfill()
         }
-
-        self.waitForExpectations(timeout: testTimeout, handler: nil)
     }
-
 }

--- a/samples/client/petstore/swift6/default/SwaggerClientTests/SwaggerClientTests/UserAPITests.swift
+++ b/samples/client/petstore/swift6/default/SwaggerClientTests/SwaggerClientTests/UserAPITests.swift
@@ -7,13 +7,12 @@
 //
 
 import PetstoreClient
+import Combine
 import XCTest
 @testable import SwaggerClient
 
-@MainActor
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 class UserAPITests: XCTestCase {
-
-    let testTimeout = 10.0
 
     override func setUp() {
         super.setUp()
@@ -25,44 +24,39 @@ class UserAPITests: XCTestCase {
         super.tearDown()
     }
 
-    func testLogin() {
-        let expectation = self.expectation(description: "testLogin")
-
-        UserAPI.loginUser(username: "swiftTester", password: "swift") { (_, error) in
-            guard error == nil else {
-                XCTFail("error logging in")
-                return
+    func testLogin() async throws {
+        do {
+            let _ = try await UserAPI.loginUser(username: "swiftTester", password: "swift")
+        } catch let errorType {
+            // The server gives us no data back so alamofire parsing fails - at least
+            // verify that is the error we get here
+            // Error Domain=com.alamofire.error Code=-6006 "JSON could not be serialized. Input data was nil or zero
+            // length." UserInfo={NSLocalizedFailureReason=JSON could not be serialized. Input data was nil or zero
+            // length.}
+            let error = errorType as NSError
+            if error.code == -6006 {
+                // Everything ok!
+            } else {
+                XCTFail("error deleting order")
             }
-
-            expectation.fulfill()
         }
-
-        self.waitForExpectations(timeout: testTimeout, handler: nil)
     }
 
-    func testLogout() {
-        let expectation = self.expectation(description: "testLogout")
-
-        UserAPI.logoutUser { (_, error) in
-            guard error == nil else {
-                XCTFail("error logging out")
-                return
+    func testLogout() async throws {
+        do {
+            try await UserAPI.logoutUser()
+        } catch let errorType {
+            // The server gives us no data back so alamofire parsing fails - at least
+            // verify that is the error we get here
+            // Error Domain=com.alamofire.error Code=-6006 "JSON could not be serialized. Input data was nil or zero
+            // length." UserInfo={NSLocalizedFailureReason=JSON could not be serialized. Input data was nil or zero
+            // length.}
+            let error = errorType as NSError
+            if error.code == -6006 {
+                // Everything ok!
+            } else {
+                XCTFail("error deleting order")
             }
-
-            expectation.fulfill()
         }
-
-        self.waitForExpectations(timeout: testTimeout, handler: nil)
     }
-
-    func testPathParamsAreEscaped() {
-        // The path for this operation is /user/{userId}. In order to make a usable path,
-        // then we must make sure that {userId} is percent-escaped when it is substituted
-        // into the path. So we intentionally introduce a path with spaces.
-        let userRequestBuilder = UserAPI.getUserByNameWithRequestBuilder(username: "User Name With Spaces")
-        let urlContainsSpace = userRequestBuilder.URLString.contains(" ")
-
-        XCTAssert(!urlContainsSpace, "Expected URL to be escaped, but it was not.")
-    }
-
 }

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -110,7 +110,7 @@ open class Response<T> {
     }
 }
 
-public final class RequestTask {
+public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var task: URLSessionDataTaskProtocol?
 

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -110,7 +110,7 @@ open class Response<T> {
     }
 }
 
-public final class RequestTask {
+public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var task: URLSessionDataTaskProtocol?
 

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -110,7 +110,7 @@ open class Response<T> {
     }
 }
 
-public final class RequestTask {
+public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var task: URLSessionDataTaskProtocol?
 

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -110,7 +110,7 @@ internal class Response<T> {
     }
 }
 
-internal final class RequestTask {
+internal final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var task: URLSessionDataTaskProtocol?
 

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -110,7 +110,7 @@ open class Response<T> {
     }
 }
 
-public final class RequestTask {
+public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var task: URLSessionDataTaskProtocol?
 

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -110,7 +110,7 @@ open class Response<T> {
     }
 }
 
-public final class RequestTask {
+public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var task: URLSessionDataTaskProtocol?
 

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/APIs/DefaultAPI.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/APIs/DefaultAPI.swift
@@ -12,18 +12,11 @@ open class DefaultAPI {
     /**
 
      - parameter openAPIClient: The OpenAPIClient that contains the configuration for the http request.
-     - parameter completion: completion handler to receive the data and the error objects
+     - returns: Banana
      */
-    @discardableResult
-    open class func rootGet(openAPIClient: OpenAPIClient = OpenAPIClient.shared, completion: @Sendable @escaping (_ data: Banana?, _ error: Error?) -> Void) -> RequestTask {
-        return rootGetWithRequestBuilder(openAPIClient: openAPIClient).execute { result in
-            switch result {
-            case let .success(response):
-                completion(response.body, nil)
-            case let .failure(error):
-                completion(nil, error)
-            }
-        }
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    open class func rootGet(openAPIClient: OpenAPIClient = OpenAPIClient.shared) async throws(ErrorResponse) -> Banana {
+        return try await rootGetWithRequestBuilder(openAPIClient: openAPIClient).execute().body
     }
 
     /**

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -110,7 +110,7 @@ open class Response<T> {
     }
 }
 
-public final class RequestTask {
+public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var task: URLSessionDataTaskProtocol?
 


### PR DESCRIPTION
[swift6] make async await the default response library

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)