### PR TITLE
Added new option methodNamingConvention to abstract php class

### DIFF
--- a/docs/generators/php-dt.md
+++ b/docs/generators/php-dt.md
@@ -31,6 +31,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |licenseName|The name of the license| |null|
+|methodNamingConvention|naming convention of class method name, e.g. PascalCase.| |PascalCase|
 |modelPackage|package for generated models| |null|
 |modern|use modern language features (generated code will require PHP 8.1)| |false|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|

--- a/docs/generators/php-flight.md
+++ b/docs/generators/php-flight.md
@@ -32,6 +32,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |licenseName|The name of the license| |null|
+|methodNamingConvention|naming convention of class method name, e.g. PascalCase.| |PascalCase|
 |modelPackage|package for generated models| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/docs/generators/php-laravel.md
+++ b/docs/generators/php-laravel.md
@@ -31,6 +31,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |licenseName|The name of the license| |null|
+|methodNamingConvention|naming convention of class method name, e.g. PascalCase.| |PascalCase|
 |modelPackage|package for generated models| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/docs/generators/php-lumen.md
+++ b/docs/generators/php-lumen.md
@@ -31,6 +31,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |licenseName|The name of the license| |null|
+|methodNamingConvention|naming convention of class method name, e.g. PascalCase.| |PascalCase|
 |modelPackage|package for generated models| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/docs/generators/php-mezzio-ph.md
+++ b/docs/generators/php-mezzio-ph.md
@@ -31,6 +31,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |licenseName|The name of the license| |null|
+|methodNamingConvention|naming convention of class method name, e.g. PascalCase.| |PascalCase|
 |modelPackage|package for generated models| |null|
 |modern|use modern language features (generated code will require PHP 8.0)| |false|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|

--- a/docs/generators/php-nextgen.md
+++ b/docs/generators/php-nextgen.md
@@ -32,6 +32,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |licenseName|The name of the license| |null|
+|methodNamingConvention|naming convention of class method name, e.g. PascalCase.| |PascalCase|
 |modelPackage|package for generated models| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/docs/generators/php-slim4.md
+++ b/docs/generators/php-slim4.md
@@ -31,6 +31,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |licenseName|The name of the license| |null|
+|methodNamingConvention|naming convention of class method name, e.g. PascalCase.| |PascalCase|
 |modelPackage|package for generated models| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/docs/generators/php-symfony.md
+++ b/docs/generators/php-symfony.md
@@ -36,6 +36,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |licenseName|The name of the license| |null|
+|methodNamingConvention|naming convention of class method name, e.g. PascalCase.| |PascalCase|
 |modelPackage|package for generated models| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |phpLegacySupport|Should the generated code be compatible with PHP 5.x?| |true|

--- a/docs/generators/php.md
+++ b/docs/generators/php.md
@@ -33,6 +33,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |library|HTTP library template (sub-template) to use|<dl><dt>**guzzle**</dt><dd>Guzzle</dd><dt>**psr-18**</dt><dd>psr/http-client-implementation, also known as PSR-18. (beta support)</dd></dl>|guzzle|
 |licenseName|The name of the license| |null|
+|methodNamingConvention|naming convention of class method name, e.g. PascalCase.| |PascalCase|
 |modelPackage|package for generated models| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -47,6 +47,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     private final Logger LOGGER = LoggerFactory.getLogger(AbstractPhpCodegen.class);
 
     public static final String VARIABLE_NAMING_CONVENTION = "variableNamingConvention";
+    public static final String METHOD_NAMING_CONVENTION = "methodNamingConvention";
     public static final String PACKAGE_NAME = "packageName";
     public static final String SRC_BASE_PATH = "srcBasePath";
     @Getter @Setter
@@ -64,6 +65,8 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     protected String apiDirName = "Api";
     protected String modelDirName = "Model";
     protected String variableNamingConvention = "snake_case";
+    @Getter @Setter
+    protected String methodNamingConvention = "PascalCase";
     protected String apiDocPath = docsBasePath + "/" + apiDirName;
     protected String modelDocPath = docsBasePath + "/" + modelDirName;
     protected String interfaceNamePrefix = "", interfaceNameSuffix = "Interface";
@@ -150,6 +153,8 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));
         cliOptions.add(new CliOption(VARIABLE_NAMING_CONVENTION, "naming convention of variable name, e.g. camelCase.")
                 .defaultValue("snake_case"));
+        cliOptions.add(new CliOption(METHOD_NAMING_CONVENTION, "naming convention of class method name, e.g. PascalCase.")
+                .defaultValue("PascalCase"));
         cliOptions.add(new CliOption(CodegenConstants.INVOKER_PACKAGE, "The main namespace to use for all classes. e.g. Yay\\Pets"));
         cliOptions.add(new CliOption(PACKAGE_NAME, "The main package name for classes. e.g. GeneratedPetstore"));
         cliOptions.add(new CliOption(SRC_BASE_PATH, "The directory to serve as source root."));
@@ -243,6 +248,10 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
         if (additionalProperties.containsKey(VARIABLE_NAMING_CONVENTION)) {
             this.setParameterNamingConvention((String) additionalProperties.get(VARIABLE_NAMING_CONVENTION));
+        }
+
+        if (additionalProperties.containsKey(METHOD_NAMING_CONVENTION)) {
+            this.setMethodNamingConvention((String) additionalProperties.get(METHOD_NAMING_CONVENTION));
         }
 
         if (additionalProperties.containsKey(CodegenConstants.GIT_USER_ID)) {
@@ -427,8 +436,11 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         this.variableNamingConvention = variableNamingConvention;
     }
 
-    @Override
-    public String toVarName(String name) {
+    /**
+     * Abstracted method to get non convention var name because convention is handled
+     * different for toVarName and getter and setter
+     */
+    private String toNonConventionVarName(String name) {
         // obtain the name from nameMapping directly if provided
         if (nameMapping.containsKey(name)) {
             return nameMapping.get(name);
@@ -440,6 +452,19 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
         // sanitize name
         name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
+
+        // parameter name starting with number won't compile
+        // need to escape it by appending _ at the beginning
+        if (name.matches("^\\d.*")) {
+            name = "_" + name;
+        }
+
+        return name;
+    }
+
+    @Override
+    public String toVarName(String name) {
+        name = toNonConventionVarName(name);
 
         if ("camelCase".equals(variableNamingConvention)) {
             // return the name in camelCase style
@@ -453,10 +478,25 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             name = underscore(name);
         }
 
-        // parameter name starting with number won't compile
-        // need to escape it by appending _ at the beginning
-        if (name.matches("^\\d.*")) {
-            name = "_" + name;
+        return name;
+    }
+
+    @Override
+    public String getterAndSetterCapitalize(String name) {
+        name = toNonConventionVarName(name);
+
+        if ("snake_case".equals(methodNamingConvention)) {
+            // return the name in underscore style and prepend with _ to get method separation (e.g. get_phone_number)
+            // PhoneNumber => phone_number
+            name = "_" + underscore(name);
+        } else if ("camelCase".equals(methodNamingConvention)) {
+            // return the name in camelCase style
+            // phone_number => phoneNumber
+            name = camelize(name, LOWERCASE_FIRST_LETTER);
+        } else {
+            // return the name in PascalCase style
+            // phone_number => PhoneNumber
+            name = camelize(name);
         }
 
         return name;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/lumen/PhpLumenServerOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/lumen/PhpLumenServerOptionsTest.java
@@ -42,6 +42,7 @@ public class PhpLumenServerOptionsTest extends AbstractOptionsTest {
     protected void verifyOptions() {
         verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(PhpLumenServerOptionsProvider.SORT_PARAMS_VALUE));
         verify(clientCodegen).setParameterNamingConvention(PhpLumenServerOptionsProvider.VARIABLE_NAMING_CONVENTION_VALUE);
+        verify(clientCodegen).setMethodNamingConvention(PhpLumenServerOptionsProvider.METHOD_NAMING_CONVENTION_VALUE);
         verify(clientCodegen).setModelPackage(PhpLumenServerOptionsProvider.MODEL_PACKAGE_VALUE);
         verify(clientCodegen).setApiPackage(PhpLumenServerOptionsProvider.API_PACKAGE_VALUE);
         verify(clientCodegen).setInvokerPackage(PhpLumenServerOptionsProvider.INVOKER_PACKAGE_VALUE);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpClientOptionsProvider.java
@@ -30,6 +30,7 @@ public class PhpClientOptionsProvider implements OptionsProvider {
     public static final String SORT_MODEL_PROPERTIES_VALUE = "false";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String VARIABLE_NAMING_CONVENTION_VALUE = "snake_case";
+    public static final String METHOD_NAMING_CONVENTION_VALUE = "PascalCase";
     public static final String INVOKER_PACKAGE_VALUE = "OpenAPITools\\Client\\Php";
     public static final String PACKAGE_NAME_VALUE = "OpenAPIToolsClient-php";
     public static final String SRC_BASE_PATH_VALUE = "libPhp";
@@ -58,6 +59,7 @@ public class PhpClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.SORT_MODEL_PROPERTIES_BY_REQUIRED_FLAG, SORT_MODEL_PROPERTIES_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(PhpClientCodegen.VARIABLE_NAMING_CONVENTION, VARIABLE_NAMING_CONVENTION_VALUE)
+                .put(PhpClientCodegen.METHOD_NAMING_CONVENTION, METHOD_NAMING_CONVENTION_VALUE)
                 .put(CodegenConstants.INVOKER_PACKAGE, INVOKER_PACKAGE_VALUE)
                 .put(PhpClientCodegen.PACKAGE_NAME, PACKAGE_NAME_VALUE)
                 .put(PhpClientCodegen.SRC_BASE_PATH, SRC_BASE_PATH_VALUE)

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpLumenServerOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpLumenServerOptionsProvider.java
@@ -20,6 +20,7 @@ package org.openapitools.codegen.options;
 import com.google.common.collect.ImmutableMap;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.languages.AbstractPhpCodegen;
+import org.openapitools.codegen.languages.PhpClientCodegen;
 
 import java.util.Map;
 
@@ -30,6 +31,7 @@ public class PhpLumenServerOptionsProvider implements OptionsProvider {
     public static final String SORT_MODEL_PROPERTIES_VALUE = "false";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String VARIABLE_NAMING_CONVENTION_VALUE = "snake_case";
+    public static final String METHOD_NAMING_CONVENTION_VALUE = "PascalCase";
     public static final String INVOKER_PACKAGE_VALUE = "lumen";
     public static final String PACKAGE_NAME_VALUE = "php";
     public static final String SRC_BASE_PATH_VALUE = "libPhp";
@@ -53,6 +55,7 @@ public class PhpLumenServerOptionsProvider implements OptionsProvider {
         ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(AbstractPhpCodegen.VARIABLE_NAMING_CONVENTION, VARIABLE_NAMING_CONVENTION_VALUE)
+                .put(AbstractPhpCodegen.METHOD_NAMING_CONVENTION, METHOD_NAMING_CONVENTION_VALUE)
                 .put(AbstractPhpCodegen.PACKAGE_NAME, PACKAGE_NAME_VALUE)
                 .put(AbstractPhpCodegen.SRC_BASE_PATH, SRC_BASE_PATH_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlim4ServerOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlim4ServerOptionsProvider.java
@@ -28,6 +28,7 @@ public class PhpSlim4ServerOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String VARIABLE_NAMING_CONVENTION_VALUE = "camelCase";
+    public static final String METHOD_NAMING_CONVENTION_VALUE = "PascalCase";
     public static final String INVOKER_PACKAGE_VALUE = "OpenAPIServer";
     public static final String PACKAGE_NAME_VALUE = "";
     public static final String SRC_BASE_PATH_VALUE = "src";
@@ -55,6 +56,7 @@ public class PhpSlim4ServerOptionsProvider implements OptionsProvider {
         ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(AbstractPhpCodegen.VARIABLE_NAMING_CONVENTION, VARIABLE_NAMING_CONVENTION_VALUE)
+                .put(AbstractPhpCodegen.METHOD_NAMING_CONVENTION, METHOD_NAMING_CONVENTION_VALUE)
                 .put(AbstractPhpCodegen.PACKAGE_NAME, PACKAGE_NAME_VALUE)
                 .put(AbstractPhpCodegen.SRC_BASE_PATH, SRC_BASE_PATH_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientOptionsTest.java
@@ -44,6 +44,7 @@ public class PhpClientOptionsTest extends AbstractOptionsTest {
         verify(clientCodegen).setApiPackage(PhpClientOptionsProvider.API_PACKAGE_VALUE);
         verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(PhpClientOptionsProvider.SORT_PARAMS_VALUE));
         verify(clientCodegen).setParameterNamingConvention(PhpClientOptionsProvider.VARIABLE_NAMING_CONVENTION_VALUE);
+        verify(clientCodegen).setMethodNamingConvention(PhpClientOptionsProvider.METHOD_NAMING_CONVENTION_VALUE);
         verify(clientCodegen).setInvokerPackage(PhpClientOptionsProvider.INVOKER_PACKAGE_VALUE);
         verify(clientCodegen).setPackageName(PhpClientOptionsProvider.PACKAGE_NAME_VALUE);
         verify(clientCodegen).setSrcBasePath(PhpClientOptionsProvider.SRC_BASE_PATH_VALUE);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR added new additionalProperty "methodNamingConvention" to handle special cases with mutiple properties like "test" and "_test" which will end in the same getter and setter "getTest". (e.g. [Rocket.chat](https://raw.githubusercontent.com/RocketChat/Rocket.Chat-Open-API/refs/heads/main/messaging.yaml) GetApiV1ImList200ResponseImsInner.php)
By setting methodNamingConvenetion to snake_case the method names will be snake_case like "get__test" and "get_test" which is not the php default but solves the problem and makes the generated classes useable without a duplication error.
Also if there are two properties in openapi.yaml like "o_auth_test" and "oauth_test" it will end in a duplicate getter like "getOAuthTest" and "getOauthTest". (e.g. [Keycloak](https://www.keycloak.org/docs-api/latest/rest-api/openapi.yaml) RealmRepresentation.php)

This will add a solution for #1633

Technical Commitee PHP:
@jebentier, @dkarlovi, @mandrean, @jfastnacht, [@ybelenko](https://github.com/ybelenko), @renepardon

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
