### PR TITLE
[swift6] alamofire interceptor

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/APIs.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/APIs.mustache
@@ -31,6 +31,7 @@ import Alamofire{{/useAlamofire}}
     ///
     /// If a HTTP status code is outside of this range the response will be interpreted as failed.
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var successfulStatusCodeRange: Range<Int>{{#useAlamofire}}
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var interceptor: RequestInterceptor?
     /// ResponseSerializer that will be used by the generator for `Data` responses
     ///
     /// If unchanged, Alamofires default `DataResponseSerializer` will be used. 
@@ -52,6 +53,7 @@ import Alamofire{{/useAlamofire}}
         apiResponseQueue: DispatchQueue = .main,
         codableHelper: CodableHelper = CodableHelper(),
         successfulStatusCodeRange: Range<Int> = 200..<300{{#useAlamofire}},
+        interceptor: RequestInterceptor? = nil,
         dataResponseSerializer: AnyResponseSerializer<Data> = AnyResponseSerializer(DataResponseSerializer()),
         stringResponseSerializer: AnyResponseSerializer<String> = AnyResponseSerializer(StringResponseSerializer()){{/useAlamofire}}{{/useVapor}}
     ) {
@@ -66,6 +68,7 @@ import Alamofire{{/useAlamofire}}
         self.apiResponseQueue = apiResponseQueue
         self.codableHelper = codableHelper
         self.successfulStatusCodeRange = successfulStatusCodeRange{{#useAlamofire}}
+        self.interceptor = interceptor
         self.dataResponseSerializer = dataResponseSerializer
         self.stringResponseSerializer = stringResponseSerializer{{/useAlamofire}}{{/useVapor}}
     }

--- a/modules/openapi-generator/src/main/resources/swift6/libraries/alamofire/AlamofireImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/libraries/alamofire/AlamofireImplementations.mustache
@@ -36,11 +36,11 @@ fileprivate class AlamofireRequestBuilderConfiguration: @unchecked Sendable {
      May be overridden by a subclass if you want to control the session
      configuration.
      */
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func createAlamofireSession(interceptor: RequestInterceptor? = nil) -> Alamofire.Session {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func createAlamofireSession() -> Alamofire.Session {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = buildHeaders()
         return Alamofire.Session(configuration: configuration,
-                                 interceptor: interceptor)
+                                 interceptor: openAPIClient.interceptor)
     }
 
     /**

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -22,6 +22,7 @@ open class OpenAPIClient: @unchecked Sendable {
     ///
     /// If a HTTP status code is outside of this range the response will be interpreted as failed.
     public var successfulStatusCodeRange: Range<Int>
+    public var interceptor: RequestInterceptor?
     /// ResponseSerializer that will be used by the generator for `Data` responses
     ///
     /// If unchanged, Alamofires default `DataResponseSerializer` will be used. 
@@ -39,6 +40,7 @@ open class OpenAPIClient: @unchecked Sendable {
         apiResponseQueue: DispatchQueue = .main,
         codableHelper: CodableHelper = CodableHelper(),
         successfulStatusCodeRange: Range<Int> = 200..<300,
+        interceptor: RequestInterceptor? = nil,
         dataResponseSerializer: AnyResponseSerializer<Data> = AnyResponseSerializer(DataResponseSerializer()),
         stringResponseSerializer: AnyResponseSerializer<String> = AnyResponseSerializer(StringResponseSerializer())
     ) {
@@ -49,6 +51,7 @@ open class OpenAPIClient: @unchecked Sendable {
         self.apiResponseQueue = apiResponseQueue
         self.codableHelper = codableHelper
         self.successfulStatusCodeRange = successfulStatusCodeRange
+        self.interceptor = interceptor
         self.dataResponseSerializer = dataResponseSerializer
         self.stringResponseSerializer = stringResponseSerializer
     }

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/AlamofireImplementations.swift
@@ -36,11 +36,11 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
      May be overridden by a subclass if you want to control the session
      configuration.
      */
-    open func createAlamofireSession(interceptor: RequestInterceptor? = nil) -> Alamofire.Session {
+    open func createAlamofireSession() -> Alamofire.Session {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = buildHeaders()
         return Alamofire.Session(configuration: configuration,
-                                 interceptor: interceptor)
+                                 interceptor: openAPIClient.interceptor)
     }
 
     /**

--- a/samples/client/petstore/swift6/alamofireLibrary/SwaggerClientTests/SwaggerClient.xcodeproj/project.pbxproj
+++ b/samples/client/petstore/swift6/alamofireLibrary/SwaggerClientTests/SwaggerClient.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		6D4EFBB51C693BE200B96B06 /* PetAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4EFBB41C693BE200B96B06 /* PetAPITests.swift */; };
 		6D4EFBB71C693BED00B96B06 /* StoreAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4EFBB61C693BED00B96B06 /* StoreAPITests.swift */; };
 		6D4EFBB91C693BFC00B96B06 /* UserAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4EFBB81C693BFC00B96B06 /* UserAPITests.swift */; };
-		A5465873259E306E00C3929B /* BearerDecodableRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5465872259E306E00C3929B /* BearerDecodableRequestBuilder.swift */; };
+		A5465873259E306E00C3929B /* BearerTokenHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5465872259E306E00C3929B /* BearerTokenHandler.swift */; };
 		A5782C6D2664F91D00CAA106 /* PetstoreClient in Frameworks */ = {isa = PBXBuildFile; productRef = A5782C6C2664F91D00CAA106 /* PetstoreClient */; };
 		A5EA12542419387200E30FC3 /* FileUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EA12522419387100E30FC3 /* FileUtils.swift */; };
 		A5EA12552419387200E30FC3 /* UIImage+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EA12532419387100E30FC3 /* UIImage+Extras.swift */; };
@@ -46,7 +46,7 @@
 		6D4EFBB41C693BE200B96B06 /* PetAPITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PetAPITests.swift; sourceTree = "<group>"; };
 		6D4EFBB61C693BED00B96B06 /* StoreAPITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreAPITests.swift; sourceTree = "<group>"; };
 		6D4EFBB81C693BFC00B96B06 /* UserAPITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAPITests.swift; sourceTree = "<group>"; };
-		A5465872259E306E00C3929B /* BearerDecodableRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BearerDecodableRequestBuilder.swift; sourceTree = "<group>"; };
+		A5465872259E306E00C3929B /* BearerTokenHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BearerTokenHandler.swift; sourceTree = "<group>"; };
 		A5EA12522419387100E30FC3 /* FileUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileUtils.swift; sourceTree = "<group>"; };
 		A5EA12532419387100E30FC3 /* UIImage+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Extras.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -101,7 +101,7 @@
 			children = (
 				6D4EFB941C692C6300B96B06 /* AppDelegate.swift */,
 				6D4EFB961C692C6300B96B06 /* ViewController.swift */,
-				A5465872259E306E00C3929B /* BearerDecodableRequestBuilder.swift */,
+				A5465872259E306E00C3929B /* BearerTokenHandler.swift */,
 				6D4EFB981C692C6300B96B06 /* Main.storyboard */,
 				6D4EFB9B1C692C6300B96B06 /* Assets.xcassets */,
 				6D4EFB9D1C692C6300B96B06 /* LaunchScreen.storyboard */,
@@ -231,7 +231,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6D4EFB971C692C6300B96B06 /* ViewController.swift in Sources */,
-				A5465873259E306E00C3929B /* BearerDecodableRequestBuilder.swift in Sources */,
+				A5465873259E306E00C3929B /* BearerTokenHandler.swift in Sources */,
 				6D4EFB951C692C6300B96B06 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/samples/client/petstore/swift6/alamofireLibrary/SwaggerClientTests/SwaggerClient/AppDelegate.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/SwaggerClientTests/SwaggerClient/AppDelegate.swift
@@ -16,9 +16,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        
-        // Customize requestBuilderFactory
-        OpenAPIClient.shared.requestBuilderFactory = BearerRequestBuilderFactory()
+                
+        OpenAPIClient.shared.interceptor = BearerTokenHandler()
         
         return true
     }

--- a/samples/client/petstore/swift6/alamofireLibrary/SwaggerClientTests/SwaggerClient/BearerTokenHandler.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/SwaggerClientTests/SwaggerClient/BearerTokenHandler.swift
@@ -1,5 +1,5 @@
 //
-//  BearerDecodableRequestBuilder.swift
+//  BearerTokenHandler.swift
 //  SwaggerClient
 //
 //  Created by Bruno Coelho on 31/12/2020.
@@ -9,44 +9,6 @@
 import Foundation
 import Alamofire
 import PetstoreClient
-
-class BearerRequestBuilderFactory: RequestBuilderFactory {
-    func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
-        BearerRequestBuilder<T>.self
-    }
-    
-    func getBuilder<T: Decodable>() -> RequestBuilder<T>.Type {
-        BearerDecodableRequestBuilder<T>.self
-    }
-}
-
-class BearerRequestBuilder<T>: AlamofireRequestBuilder<T>, @unchecked Sendable {
-    override func createAlamofireSession(interceptor: RequestInterceptor? = nil) -> Session {
-        if self.requiresAuthentication {
-
-            let bearerTokenHandler = BearerTokenHandler()
-            let alamofireSession = super.createAlamofireSession(interceptor: bearerTokenHandler)
-
-            return alamofireSession
-        } else {
-            return super.createAlamofireSession(interceptor: nil)
-        }      
-    }
-}
-
-class BearerDecodableRequestBuilder<T: Decodable>: AlamofireDecodableRequestBuilder<T>, @unchecked Sendable {
-    override func createAlamofireSession(interceptor: RequestInterceptor? = nil) -> Session {
-        if self.requiresAuthentication {
-
-            let bearerTokenHandler = BearerTokenHandler()
-            let alamofireSession = super.createAlamofireSession(interceptor: bearerTokenHandler)
-
-            return alamofireSession
-        } else {
-            return super.createAlamofireSession(interceptor: nil)
-        }  
-    }
-}
 
 class BearerTokenHandler: RequestInterceptor, @unchecked Sendable {
     private var bearerToken: String? = nil

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -22,6 +22,7 @@ open class OpenAPIClient: @unchecked Sendable {
     ///
     /// If a HTTP status code is outside of this range the response will be interpreted as failed.
     public var successfulStatusCodeRange: Range<Int>
+    public var interceptor: RequestInterceptor?
     /// ResponseSerializer that will be used by the generator for `Data` responses
     ///
     /// If unchanged, Alamofires default `DataResponseSerializer` will be used. 
@@ -39,6 +40,7 @@ open class OpenAPIClient: @unchecked Sendable {
         apiResponseQueue: DispatchQueue = .main,
         codableHelper: CodableHelper = CodableHelper(),
         successfulStatusCodeRange: Range<Int> = 200..<300,
+        interceptor: RequestInterceptor? = nil,
         dataResponseSerializer: AnyResponseSerializer<Data> = AnyResponseSerializer(DataResponseSerializer()),
         stringResponseSerializer: AnyResponseSerializer<String> = AnyResponseSerializer(StringResponseSerializer())
     ) {
@@ -49,6 +51,7 @@ open class OpenAPIClient: @unchecked Sendable {
         self.apiResponseQueue = apiResponseQueue
         self.codableHelper = codableHelper
         self.successfulStatusCodeRange = successfulStatusCodeRange
+        self.interceptor = interceptor
         self.dataResponseSerializer = dataResponseSerializer
         self.stringResponseSerializer = stringResponseSerializer
     }

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/AlamofireImplementations.swift
@@ -36,11 +36,11 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
      May be overridden by a subclass if you want to control the session
      configuration.
      */
-    open func createAlamofireSession(interceptor: RequestInterceptor? = nil) -> Alamofire.Session {
+    open func createAlamofireSession() -> Alamofire.Session {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = buildHeaders()
         return Alamofire.Session(configuration: configuration,
-                                 interceptor: interceptor)
+                                 interceptor: openAPIClient.interceptor)
     }
 
     /**


### PR DESCRIPTION
With this change, in swift6, while using alamofire, it's possible to intercept the request without make any subclass of the open api generated code.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)