### PR TITLE
[swift6] simplify authentication

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/libraries/urlsession/URLSessionImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/libraries/urlsession/URLSessionImplementations.mustache
@@ -52,8 +52,6 @@ extension URLSessionDataTask: URLSessionDataTaskProtocol {}
     }
 }
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} typealias {{projectName}}APIChallengeHandler = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
-
 fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     private init() {
         defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
@@ -67,19 +65,11 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     // Store the URLSession to retain its reference
     let defaultURLSession: URLSession
 
-    // Store current taskDidReceiveChallenge for every URLSessionTask
-    var challengeHandlerStore = SynchronizedDictionary<Int, {{projectName}}APIChallengeHandler>()
-
     // Store current URLCredential for every URLSessionTask
     var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
-
-    /**
-     May be assigned if you want to control the authentication challenges.
-     */
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var taskDidReceiveChallenge: {{projectName}}APIChallengeHandler?
 
     required {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool, openAPIClient: OpenAPIClient = OpenAPIClient.shared) {
         super.init(method: method, URLString: URLString, parameters: parameters, headers: headers, requiresAuthentication: requiresAuthentication, openAPIClient: openAPIClient)
@@ -187,7 +177,6 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
 
                     self.onProgressReady?(dataTask.progress)
 
-                    URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[dataTask.taskIdentifier] = self.taskDidReceiveChallenge
                     URLSessionRequestBuilderConfiguration.shared.credentialStore[dataTask.taskIdentifier] = self.credential
 
                     self.requestTask.set(task: dataTask)
@@ -211,7 +200,6 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
 
     private func cleanupRequest() {
         if let task = requestTask.get() {
-            URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] = nil
             URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] = nil
         }
     }
@@ -408,17 +396,13 @@ fileprivate final class SessionDelegate: NSObject, URLSessionTaskDelegate {
 
         var credential: URLCredential?
 
-        if let taskDidReceiveChallenge = URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] {
-            (disposition, credential) = taskDidReceiveChallenge(session, task, challenge)
+        if challenge.previousFailureCount > 0 {
+            disposition = .rejectProtectionSpace
         } else {
-            if challenge.previousFailureCount > 0 {
-                disposition = .rejectProtectionSpace
-            } else {
-                credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
+            credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
 
-                if credential != nil {
-                    disposition = .useCredential
-                }
+            if credential != nil {
+                disposition = .useCredential
             }
         }
 

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
@@ -52,8 +52,6 @@ public class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
-public typealias PetstoreClientAPIChallengeHandler = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
-
 fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     private init() {
         defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
@@ -67,19 +65,11 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     // Store the URLSession to retain its reference
     let defaultURLSession: URLSession
 
-    // Store current taskDidReceiveChallenge for every URLSessionTask
-    var challengeHandlerStore = SynchronizedDictionary<Int, PetstoreClientAPIChallengeHandler>()
-
     // Store current URLCredential for every URLSessionTask
     var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
-
-    /**
-     May be assigned if you want to control the authentication challenges.
-     */
-    public var taskDidReceiveChallenge: PetstoreClientAPIChallengeHandler?
 
     required public init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool, openAPIClient: OpenAPIClient = OpenAPIClient.shared) {
         super.init(method: method, URLString: URLString, parameters: parameters, headers: headers, requiresAuthentication: requiresAuthentication, openAPIClient: openAPIClient)
@@ -187,7 +177,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
                     self.onProgressReady?(dataTask.progress)
 
-                    URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[dataTask.taskIdentifier] = self.taskDidReceiveChallenge
                     URLSessionRequestBuilderConfiguration.shared.credentialStore[dataTask.taskIdentifier] = self.credential
 
                     self.requestTask.set(task: dataTask)
@@ -211,7 +200,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
     private func cleanupRequest() {
         if let task = requestTask.get() {
-            URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] = nil
             URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] = nil
         }
     }
@@ -408,17 +396,13 @@ fileprivate final class SessionDelegate: NSObject, URLSessionTaskDelegate {
 
         var credential: URLCredential?
 
-        if let taskDidReceiveChallenge = URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] {
-            (disposition, credential) = taskDidReceiveChallenge(session, task, challenge)
+        if challenge.previousFailureCount > 0 {
+            disposition = .rejectProtectionSpace
         } else {
-            if challenge.previousFailureCount > 0 {
-                disposition = .rejectProtectionSpace
-            } else {
-                credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
+            credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
 
-                if credential != nil {
-                    disposition = .useCredential
-                }
+            if credential != nil {
+                disposition = .useCredential
             }
         }
 

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -52,8 +52,6 @@ public class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
-public typealias PetstoreClientAPIChallengeHandler = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
-
 fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     private init() {
         defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
@@ -67,19 +65,11 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     // Store the URLSession to retain its reference
     let defaultURLSession: URLSession
 
-    // Store current taskDidReceiveChallenge for every URLSessionTask
-    var challengeHandlerStore = SynchronizedDictionary<Int, PetstoreClientAPIChallengeHandler>()
-
     // Store current URLCredential for every URLSessionTask
     var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
-
-    /**
-     May be assigned if you want to control the authentication challenges.
-     */
-    public var taskDidReceiveChallenge: PetstoreClientAPIChallengeHandler?
 
     required public init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool, openAPIClient: OpenAPIClient = OpenAPIClient.shared) {
         super.init(method: method, URLString: URLString, parameters: parameters, headers: headers, requiresAuthentication: requiresAuthentication, openAPIClient: openAPIClient)
@@ -187,7 +177,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
                     self.onProgressReady?(dataTask.progress)
 
-                    URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[dataTask.taskIdentifier] = self.taskDidReceiveChallenge
                     URLSessionRequestBuilderConfiguration.shared.credentialStore[dataTask.taskIdentifier] = self.credential
 
                     self.requestTask.set(task: dataTask)
@@ -211,7 +200,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
     private func cleanupRequest() {
         if let task = requestTask.get() {
-            URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] = nil
             URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] = nil
         }
     }
@@ -408,17 +396,13 @@ fileprivate final class SessionDelegate: NSObject, URLSessionTaskDelegate {
 
         var credential: URLCredential?
 
-        if let taskDidReceiveChallenge = URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] {
-            (disposition, credential) = taskDidReceiveChallenge(session, task, challenge)
+        if challenge.previousFailureCount > 0 {
+            disposition = .rejectProtectionSpace
         } else {
-            if challenge.previousFailureCount > 0 {
-                disposition = .rejectProtectionSpace
-            } else {
-                credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
+            credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
 
-                if credential != nil {
-                    disposition = .useCredential
-                }
+            if credential != nil {
+                disposition = .useCredential
             }
         }
 

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/URLSessionImplementations.swift
@@ -52,8 +52,6 @@ public class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
-public typealias PetstoreClientAPIChallengeHandler = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
-
 fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     private init() {
         defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
@@ -67,19 +65,11 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     // Store the URLSession to retain its reference
     let defaultURLSession: URLSession
 
-    // Store current taskDidReceiveChallenge for every URLSessionTask
-    var challengeHandlerStore = SynchronizedDictionary<Int, PetstoreClientAPIChallengeHandler>()
-
     // Store current URLCredential for every URLSessionTask
     var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
-
-    /**
-     May be assigned if you want to control the authentication challenges.
-     */
-    public var taskDidReceiveChallenge: PetstoreClientAPIChallengeHandler?
 
     required public init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool, openAPIClient: OpenAPIClient = OpenAPIClient.shared) {
         super.init(method: method, URLString: URLString, parameters: parameters, headers: headers, requiresAuthentication: requiresAuthentication, openAPIClient: openAPIClient)
@@ -187,7 +177,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
                     self.onProgressReady?(dataTask.progress)
 
-                    URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[dataTask.taskIdentifier] = self.taskDidReceiveChallenge
                     URLSessionRequestBuilderConfiguration.shared.credentialStore[dataTask.taskIdentifier] = self.credential
 
                     self.requestTask.set(task: dataTask)
@@ -211,7 +200,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
     private func cleanupRequest() {
         if let task = requestTask.get() {
-            URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] = nil
             URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] = nil
         }
     }
@@ -408,17 +396,13 @@ fileprivate final class SessionDelegate: NSObject, URLSessionTaskDelegate {
 
         var credential: URLCredential?
 
-        if let taskDidReceiveChallenge = URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] {
-            (disposition, credential) = taskDidReceiveChallenge(session, task, challenge)
+        if challenge.previousFailureCount > 0 {
+            disposition = .rejectProtectionSpace
         } else {
-            if challenge.previousFailureCount > 0 {
-                disposition = .rejectProtectionSpace
-            } else {
-                credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
+            credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
 
-                if credential != nil {
-                    disposition = .useCredential
-                }
+            if credential != nil {
+                disposition = .useCredential
             }
         }
 

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
@@ -52,8 +52,6 @@ public class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
-public typealias PetstoreClientAPIChallengeHandler = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
-
 fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     private init() {
         defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
@@ -67,19 +65,11 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     // Store the URLSession to retain its reference
     let defaultURLSession: URLSession
 
-    // Store current taskDidReceiveChallenge for every URLSessionTask
-    var challengeHandlerStore = SynchronizedDictionary<Int, PetstoreClientAPIChallengeHandler>()
-
     // Store current URLCredential for every URLSessionTask
     var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
-
-    /**
-     May be assigned if you want to control the authentication challenges.
-     */
-    public var taskDidReceiveChallenge: PetstoreClientAPIChallengeHandler?
 
     required public init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool, openAPIClient: OpenAPIClient = OpenAPIClient.shared) {
         super.init(method: method, URLString: URLString, parameters: parameters, headers: headers, requiresAuthentication: requiresAuthentication, openAPIClient: openAPIClient)
@@ -187,7 +177,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
                     self.onProgressReady?(dataTask.progress)
 
-                    URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[dataTask.taskIdentifier] = self.taskDidReceiveChallenge
                     URLSessionRequestBuilderConfiguration.shared.credentialStore[dataTask.taskIdentifier] = self.credential
 
                     self.requestTask.set(task: dataTask)
@@ -211,7 +200,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
     private func cleanupRequest() {
         if let task = requestTask.get() {
-            URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] = nil
             URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] = nil
         }
     }
@@ -408,17 +396,13 @@ fileprivate final class SessionDelegate: NSObject, URLSessionTaskDelegate {
 
         var credential: URLCredential?
 
-        if let taskDidReceiveChallenge = URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] {
-            (disposition, credential) = taskDidReceiveChallenge(session, task, challenge)
+        if challenge.previousFailureCount > 0 {
+            disposition = .rejectProtectionSpace
         } else {
-            if challenge.previousFailureCount > 0 {
-                disposition = .rejectProtectionSpace
-            } else {
-                credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
+            credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
 
-                if credential != nil {
-                    disposition = .useCredential
-                }
+            if credential != nil {
+                disposition = .useCredential
             }
         }
 

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
@@ -52,8 +52,6 @@ public class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
-public typealias PetstoreClientAPIChallengeHandler = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
-
 fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     private init() {
         defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
@@ -67,19 +65,11 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     // Store the URLSession to retain its reference
     let defaultURLSession: URLSession
 
-    // Store current taskDidReceiveChallenge for every URLSessionTask
-    var challengeHandlerStore = SynchronizedDictionary<Int, PetstoreClientAPIChallengeHandler>()
-
     // Store current URLCredential for every URLSessionTask
     var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
-
-    /**
-     May be assigned if you want to control the authentication challenges.
-     */
-    public var taskDidReceiveChallenge: PetstoreClientAPIChallengeHandler?
 
     required public init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool, openAPIClient: OpenAPIClient = OpenAPIClient.shared) {
         super.init(method: method, URLString: URLString, parameters: parameters, headers: headers, requiresAuthentication: requiresAuthentication, openAPIClient: openAPIClient)
@@ -187,7 +177,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
                     self.onProgressReady?(dataTask.progress)
 
-                    URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[dataTask.taskIdentifier] = self.taskDidReceiveChallenge
                     URLSessionRequestBuilderConfiguration.shared.credentialStore[dataTask.taskIdentifier] = self.credential
 
                     self.requestTask.set(task: dataTask)
@@ -211,7 +200,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
     private func cleanupRequest() {
         if let task = requestTask.get() {
-            URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] = nil
             URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] = nil
         }
     }
@@ -408,17 +396,13 @@ fileprivate final class SessionDelegate: NSObject, URLSessionTaskDelegate {
 
         var credential: URLCredential?
 
-        if let taskDidReceiveChallenge = URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] {
-            (disposition, credential) = taskDidReceiveChallenge(session, task, challenge)
+        if challenge.previousFailureCount > 0 {
+            disposition = .rejectProtectionSpace
         } else {
-            if challenge.previousFailureCount > 0 {
-                disposition = .rejectProtectionSpace
-            } else {
-                credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
+            credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
 
-                if credential != nil {
-                    disposition = .useCredential
-                }
+            if credential != nil {
+                disposition = .useCredential
             }
         }
 

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -52,8 +52,6 @@ public class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
-public typealias PetstoreClientAPIChallengeHandler = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
-
 fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     private init() {
         defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
@@ -67,19 +65,11 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     // Store the URLSession to retain its reference
     let defaultURLSession: URLSession
 
-    // Store current taskDidReceiveChallenge for every URLSessionTask
-    var challengeHandlerStore = SynchronizedDictionary<Int, PetstoreClientAPIChallengeHandler>()
-
     // Store current URLCredential for every URLSessionTask
     var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
-
-    /**
-     May be assigned if you want to control the authentication challenges.
-     */
-    public var taskDidReceiveChallenge: PetstoreClientAPIChallengeHandler?
 
     required public init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool, openAPIClient: OpenAPIClient = OpenAPIClient.shared) {
         super.init(method: method, URLString: URLString, parameters: parameters, headers: headers, requiresAuthentication: requiresAuthentication, openAPIClient: openAPIClient)
@@ -187,7 +177,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
                     self.onProgressReady?(dataTask.progress)
 
-                    URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[dataTask.taskIdentifier] = self.taskDidReceiveChallenge
                     URLSessionRequestBuilderConfiguration.shared.credentialStore[dataTask.taskIdentifier] = self.credential
 
                     self.requestTask.set(task: dataTask)
@@ -211,7 +200,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
     private func cleanupRequest() {
         if let task = requestTask.get() {
-            URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] = nil
             URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] = nil
         }
     }
@@ -408,17 +396,13 @@ fileprivate final class SessionDelegate: NSObject, URLSessionTaskDelegate {
 
         var credential: URLCredential?
 
-        if let taskDidReceiveChallenge = URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] {
-            (disposition, credential) = taskDidReceiveChallenge(session, task, challenge)
+        if challenge.previousFailureCount > 0 {
+            disposition = .rejectProtectionSpace
         } else {
-            if challenge.previousFailureCount > 0 {
-                disposition = .rejectProtectionSpace
-            } else {
-                credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
+            credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
 
-                if credential != nil {
-                    disposition = .useCredential
-                }
+            if credential != nil {
+                disposition = .useCredential
             }
         }
 

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -52,8 +52,6 @@ public class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
-public typealias PetstoreClientAPIChallengeHandler = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
-
 fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     private init() {
         defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
@@ -67,19 +65,11 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     // Store the URLSession to retain its reference
     let defaultURLSession: URLSession
 
-    // Store current taskDidReceiveChallenge for every URLSessionTask
-    var challengeHandlerStore = SynchronizedDictionary<Int, PetstoreClientAPIChallengeHandler>()
-
     // Store current URLCredential for every URLSessionTask
     var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
-
-    /**
-     May be assigned if you want to control the authentication challenges.
-     */
-    public var taskDidReceiveChallenge: PetstoreClientAPIChallengeHandler?
 
     required public init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool, openAPIClient: OpenAPIClient = OpenAPIClient.shared) {
         super.init(method: method, URLString: URLString, parameters: parameters, headers: headers, requiresAuthentication: requiresAuthentication, openAPIClient: openAPIClient)
@@ -187,7 +177,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
                     self.onProgressReady?(dataTask.progress)
 
-                    URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[dataTask.taskIdentifier] = self.taskDidReceiveChallenge
                     URLSessionRequestBuilderConfiguration.shared.credentialStore[dataTask.taskIdentifier] = self.credential
 
                     self.requestTask.set(task: dataTask)
@@ -211,7 +200,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
     private func cleanupRequest() {
         if let task = requestTask.get() {
-            URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] = nil
             URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] = nil
         }
     }
@@ -408,17 +396,13 @@ fileprivate final class SessionDelegate: NSObject, URLSessionTaskDelegate {
 
         var credential: URLCredential?
 
-        if let taskDidReceiveChallenge = URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] {
-            (disposition, credential) = taskDidReceiveChallenge(session, task, challenge)
+        if challenge.previousFailureCount > 0 {
+            disposition = .rejectProtectionSpace
         } else {
-            if challenge.previousFailureCount > 0 {
-                disposition = .rejectProtectionSpace
-            } else {
-                credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
+            credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
 
-                if credential != nil {
-                    disposition = .useCredential
-                }
+            if credential != nil {
+                disposition = .useCredential
             }
         }
 

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -52,8 +52,6 @@ public class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
-public typealias PetstoreClientAPIChallengeHandler = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
-
 fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     private init() {
         defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
@@ -67,19 +65,11 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     // Store the URLSession to retain its reference
     let defaultURLSession: URLSession
 
-    // Store current taskDidReceiveChallenge for every URLSessionTask
-    var challengeHandlerStore = SynchronizedDictionary<Int, PetstoreClientAPIChallengeHandler>()
-
     // Store current URLCredential for every URLSessionTask
     var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
-
-    /**
-     May be assigned if you want to control the authentication challenges.
-     */
-    public var taskDidReceiveChallenge: PetstoreClientAPIChallengeHandler?
 
     required public init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool, openAPIClient: OpenAPIClient = OpenAPIClient.shared) {
         super.init(method: method, URLString: URLString, parameters: parameters, headers: headers, requiresAuthentication: requiresAuthentication, openAPIClient: openAPIClient)
@@ -187,7 +177,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
                     self.onProgressReady?(dataTask.progress)
 
-                    URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[dataTask.taskIdentifier] = self.taskDidReceiveChallenge
                     URLSessionRequestBuilderConfiguration.shared.credentialStore[dataTask.taskIdentifier] = self.credential
 
                     self.requestTask.set(task: dataTask)
@@ -211,7 +200,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
     private func cleanupRequest() {
         if let task = requestTask.get() {
-            URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] = nil
             URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] = nil
         }
     }
@@ -408,17 +396,13 @@ fileprivate final class SessionDelegate: NSObject, URLSessionTaskDelegate {
 
         var credential: URLCredential?
 
-        if let taskDidReceiveChallenge = URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] {
-            (disposition, credential) = taskDidReceiveChallenge(session, task, challenge)
+        if challenge.previousFailureCount > 0 {
+            disposition = .rejectProtectionSpace
         } else {
-            if challenge.previousFailureCount > 0 {
-                disposition = .rejectProtectionSpace
-            } else {
-                credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
+            credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
 
-                if credential != nil {
-                    disposition = .useCredential
-                }
+            if credential != nil {
+                disposition = .useCredential
             }
         }
 

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
@@ -52,8 +52,6 @@ public class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
-public typealias PetstoreClientAPIChallengeHandler = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
-
 fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     private init() {
         defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
@@ -67,19 +65,11 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     // Store the URLSession to retain its reference
     let defaultURLSession: URLSession
 
-    // Store current taskDidReceiveChallenge for every URLSessionTask
-    var challengeHandlerStore = SynchronizedDictionary<Int, PetstoreClientAPIChallengeHandler>()
-
     // Store current URLCredential for every URLSessionTask
     var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
-
-    /**
-     May be assigned if you want to control the authentication challenges.
-     */
-    public var taskDidReceiveChallenge: PetstoreClientAPIChallengeHandler?
 
     required public init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool, openAPIClient: OpenAPIClient = OpenAPIClient.shared) {
         super.init(method: method, URLString: URLString, parameters: parameters, headers: headers, requiresAuthentication: requiresAuthentication, openAPIClient: openAPIClient)
@@ -187,7 +177,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
                     self.onProgressReady?(dataTask.progress)
 
-                    URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[dataTask.taskIdentifier] = self.taskDidReceiveChallenge
                     URLSessionRequestBuilderConfiguration.shared.credentialStore[dataTask.taskIdentifier] = self.credential
 
                     self.requestTask.set(task: dataTask)
@@ -211,7 +200,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
     private func cleanupRequest() {
         if let task = requestTask.get() {
-            URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] = nil
             URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] = nil
         }
     }
@@ -408,17 +396,13 @@ fileprivate final class SessionDelegate: NSObject, URLSessionTaskDelegate {
 
         var credential: URLCredential?
 
-        if let taskDidReceiveChallenge = URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] {
-            (disposition, credential) = taskDidReceiveChallenge(session, task, challenge)
+        if challenge.previousFailureCount > 0 {
+            disposition = .rejectProtectionSpace
         } else {
-            if challenge.previousFailureCount > 0 {
-                disposition = .rejectProtectionSpace
-            } else {
-                credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
+            credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
 
-                if credential != nil {
-                    disposition = .useCredential
-                }
+            if credential != nil {
+                disposition = .useCredential
             }
         }
 

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -52,8 +52,6 @@ public class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
-public typealias PetstoreClientAPIChallengeHandler = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
-
 fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     private init() {
         defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
@@ -67,19 +65,11 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     // Store the URLSession to retain its reference
     let defaultURLSession: URLSession
 
-    // Store current taskDidReceiveChallenge for every URLSessionTask
-    var challengeHandlerStore = SynchronizedDictionary<Int, PetstoreClientAPIChallengeHandler>()
-
     // Store current URLCredential for every URLSessionTask
     var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
-
-    /**
-     May be assigned if you want to control the authentication challenges.
-     */
-    public var taskDidReceiveChallenge: PetstoreClientAPIChallengeHandler?
 
     required public init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool, openAPIClient: OpenAPIClient = OpenAPIClient.shared) {
         super.init(method: method, URLString: URLString, parameters: parameters, headers: headers, requiresAuthentication: requiresAuthentication, openAPIClient: openAPIClient)
@@ -187,7 +177,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
                     self.onProgressReady?(dataTask.progress)
 
-                    URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[dataTask.taskIdentifier] = self.taskDidReceiveChallenge
                     URLSessionRequestBuilderConfiguration.shared.credentialStore[dataTask.taskIdentifier] = self.credential
 
                     self.requestTask.set(task: dataTask)
@@ -211,7 +200,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 
     private func cleanupRequest() {
         if let task = requestTask.get() {
-            URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] = nil
             URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] = nil
         }
     }
@@ -408,17 +396,13 @@ fileprivate final class SessionDelegate: NSObject, URLSessionTaskDelegate {
 
         var credential: URLCredential?
 
-        if let taskDidReceiveChallenge = URLSessionRequestBuilderConfiguration.shared.challengeHandlerStore[task.taskIdentifier] {
-            (disposition, credential) = taskDidReceiveChallenge(session, task, challenge)
+        if challenge.previousFailureCount > 0 {
+            disposition = .rejectProtectionSpace
         } else {
-            if challenge.previousFailureCount > 0 {
-                disposition = .rejectProtectionSpace
-            } else {
-                credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
+            credential = URLSessionRequestBuilderConfiguration.shared.credentialStore[task.taskIdentifier] ?? session.configuration.urlCredentialStorage?.defaultCredential(for: challenge.protectionSpace)
 
-                if credential != nil {
-                    disposition = .useCredential
-                }
+            if credential != nil {
+                disposition = .useCredential
             }
         }
 


### PR DESCRIPTION
This PR simplifies the authentication process in the swift generator.
When I introduced the URLSession integration, I made it over configurable, and a bit complex.
This is a step into making it simpler.
Also I suspect that no one is using this advanced configuration.
In the future, if someone need this, we can make this available again and simpler to use.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)