### PR TITLE
[csharp] Address obsolete build warnings in ApiClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -455,7 +455,7 @@ namespace {{packageName}}.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                MaxTimeout = configuration.Timeout,
+                Timeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,

--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -455,7 +455,7 @@ namespace {{packageName}}.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = configuration.Timeout,
+                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,

--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -550,7 +550,7 @@ namespace {{packageName}}.Client
             }
         }
 
-        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
+        private async Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {

--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -550,11 +550,11 @@ namespace {{packageName}}.Client
             }
         }
 
-        private RestResponse<T> DeserializeRestResponseFromPolicy<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult)
+        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {
-                return client.Deserialize<T>(policyResult.Result);
+                return await client.Deserialize<T>(policyResult.Result, cancellationToken);
             }
             else
             {
@@ -587,7 +587,7 @@ namespace {{packageName}}.Client
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
+                    return DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult);
                 }
                 else
                 {
@@ -613,7 +613,7 @@ namespace {{packageName}}.Client
                 {
                     var policy = RetryConfiguration.AsyncRetryPolicy;
                     var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return await DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult, cancellationToken);
                 }
                 else
                 {

--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -455,7 +455,7 @@ namespace {{packageName}}.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
+                MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -455,7 +455,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                MaxTimeout = configuration.Timeout,
+                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,
@@ -533,11 +533,11 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private RestResponse<T> DeserializeRestResponseFromPolicy<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult)
+        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {
-                return client.Deserialize<T>(policyResult.Result);
+                return await client.Deserialize<T>(policyResult.Result, cancellationToken);
             }
             else
             {
@@ -570,7 +570,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
+                    return DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult);
                 }
                 else
                 {
@@ -594,7 +594,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.AsyncRetryPolicy;
                     var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return await DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult, cancellationToken);
                 }
                 else
                 {

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -533,7 +533,7 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
+        private async Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -455,7 +455,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
+                MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,

--- a/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -455,7 +455,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                MaxTimeout = configuration.Timeout,
+                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,
@@ -533,11 +533,11 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private RestResponse<T> DeserializeRestResponseFromPolicy<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult)
+        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {
-                return client.Deserialize<T>(policyResult.Result);
+                return await client.Deserialize<T>(policyResult.Result, cancellationToken);
             }
             else
             {
@@ -570,7 +570,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
+                    return DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult);
                 }
                 else
                 {
@@ -594,7 +594,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.AsyncRetryPolicy;
                     var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return await DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult, cancellationToken);
                 }
                 else
                 {

--- a/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -533,7 +533,7 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
+        private async Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {

--- a/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -455,7 +455,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
+                MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,

--- a/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -456,7 +456,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                MaxTimeout = configuration.Timeout,
+                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,
@@ -549,11 +549,11 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private RestResponse<T> DeserializeRestResponseFromPolicy<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult)
+        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {
-                return client.Deserialize<T>(policyResult.Result);
+                return await client.Deserialize<T>(policyResult.Result, cancellationToken);
             }
             else
             {
@@ -586,7 +586,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
+                    return DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult);
                 }
                 else
                 {
@@ -610,7 +610,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.AsyncRetryPolicy;
                     var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return await DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult, cancellationToken);
                 }
                 else
                 {

--- a/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -549,7 +549,7 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
+        private async Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {

--- a/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -456,7 +456,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
+                MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -456,7 +456,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                MaxTimeout = configuration.Timeout,
+                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,
@@ -549,11 +549,11 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private RestResponse<T> DeserializeRestResponseFromPolicy<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult)
+        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {
-                return client.Deserialize<T>(policyResult.Result);
+                return await client.Deserialize<T>(policyResult.Result, cancellationToken);
             }
             else
             {
@@ -586,7 +586,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
+                    return DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult);
                 }
                 else
                 {
@@ -610,7 +610,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.AsyncRetryPolicy;
                     var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return await DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult, cancellationToken);
                 }
                 else
                 {

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -549,7 +549,7 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
+        private async Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -456,7 +456,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
+                MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -456,7 +456,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                MaxTimeout = configuration.Timeout,
+                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,
@@ -549,11 +549,11 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private RestResponse<T> DeserializeRestResponseFromPolicy<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult)
+        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {
-                return client.Deserialize<T>(policyResult.Result);
+                return await client.Deserialize<T>(policyResult.Result, cancellationToken);
             }
             else
             {
@@ -586,7 +586,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
+                    return DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult);
                 }
                 else
                 {
@@ -610,7 +610,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.AsyncRetryPolicy;
                     var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return await DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult, cancellationToken);
                 }
                 else
                 {

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -549,7 +549,7 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
+        private async Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -456,7 +456,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
+                MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,

--- a/samples/client/petstore/csharp/restsharp/net6/ParameterMappings/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net6/ParameterMappings/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -532,7 +532,7 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
+        private async Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {

--- a/samples/client/petstore/csharp/restsharp/net6/ParameterMappings/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net6/ParameterMappings/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -454,7 +454,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
+                MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -548,7 +548,7 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
+        private async Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -455,7 +455,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
+                MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -455,7 +455,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                MaxTimeout = configuration.Timeout,
+                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,
@@ -548,11 +548,11 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private RestResponse<T> DeserializeRestResponseFromPolicy<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult)
+        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {
-                return client.Deserialize<T>(policyResult.Result);
+                return await client.Deserialize<T>(policyResult.Result, cancellationToken);
             }
             else
             {
@@ -585,7 +585,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
+                    return DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult);
                 }
                 else
                 {
@@ -609,7 +609,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.AsyncRetryPolicy;
                     var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return await DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult, cancellationToken);
                 }
                 else
                 {

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -548,7 +548,7 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
+        private async Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -455,7 +455,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
+                MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -455,7 +455,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                MaxTimeout = configuration.Timeout,
+                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,
@@ -548,11 +548,11 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private RestResponse<T> DeserializeRestResponseFromPolicy<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult)
+        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {
-                return client.Deserialize<T>(policyResult.Result);
+                return await client.Deserialize<T>(policyResult.Result, cancellationToken);
             }
             else
             {
@@ -585,7 +585,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
+                    return DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult);
                 }
                 else
                 {
@@ -609,7 +609,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.AsyncRetryPolicy;
                     var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return await DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult, cancellationToken);
                 }
                 else
                 {

--- a/samples/client/petstore/csharp/restsharp/net7/UseDateTimeForDate/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/UseDateTimeForDate/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -532,7 +532,7 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
+        private async Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {

--- a/samples/client/petstore/csharp/restsharp/net7/UseDateTimeForDate/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/UseDateTimeForDate/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -454,7 +454,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
+                MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -456,7 +456,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                MaxTimeout = configuration.Timeout,
+                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,
@@ -549,11 +549,11 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private RestResponse<T> DeserializeRestResponseFromPolicy<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult)
+        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {
-                return client.Deserialize<T>(policyResult.Result);
+                return await client.Deserialize<T>(policyResult.Result, cancellationToken);
             }
             else
             {
@@ -586,7 +586,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
+                    return DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult);
                 }
                 else
                 {
@@ -610,7 +610,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.AsyncRetryPolicy;
                     var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return await DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult, cancellationToken);
                 }
                 else
                 {

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -549,7 +549,7 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
+        private async Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -456,7 +456,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
+                MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -456,7 +456,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                MaxTimeout = configuration.Timeout,
+                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,
@@ -549,11 +549,11 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private RestResponse<T> DeserializeRestResponseFromPolicy<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult)
+        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {
-                return client.Deserialize<T>(policyResult.Result);
+                return await client.Deserialize<T>(policyResult.Result, cancellationToken);
             }
             else
             {
@@ -586,7 +586,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.RetryPolicy;
                     var policyResult = policy.ExecuteAndCapture(() => client.Execute(request));
-                    return Task.FromResult(DeserializeRestResponseFromPolicy<T>(client, request, policyResult));
+                    return DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult);
                 }
                 else
                 {
@@ -610,7 +610,7 @@ namespace Org.OpenAPITools.Client
                 {
                     var policy = RetryConfiguration.AsyncRetryPolicy;
                     var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(request, ct), cancellationToken).ConfigureAwait(false);
-                    return DeserializeRestResponseFromPolicy<T>(client, request, policyResult);
+                    return await DeserializeRestResponseFromPolicyAsync<T>(client, request, policyResult, cancellationToken);
                 }
                 else
                 {

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -549,7 +549,7 @@ namespace Org.OpenAPITools.Client
             }
         }
 
-        private asycn Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
+        private async Task<RestResponse<T>> DeserializeRestResponseFromPolicyAsync<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult, CancellationToken cancellationToken = default)
         {
             if (policyResult.Outcome == OutcomeType.Successful) 
             {

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -456,7 +456,7 @@ namespace Org.OpenAPITools.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = TimeSpan.FromMilliseconds(configuration.Timeout),
+                MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,


### PR DESCRIPTION
See issue #19525 

- Non-async overload of `Deserialize` is obsolete, RestSharp suggests using async overload of `Deserialize` instead.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
