### PR TITLE
Fix missing serverConf variable

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
@@ -23,9 +23,6 @@ void {{classname}}::initializeServerConfigs() {
     //Default server
     QList<{{prefix}}ServerConfiguration> defaultConf = QList<{{prefix}}ServerConfiguration>();
     //varying endpoint server
-    {{#servers}}
-    QList<{{prefix}}ServerConfiguration> serverConf = QList<{{prefix}}ServerConfiguration>();
-    {{/servers}}
 {{#vendorExtensions.x-cpp-global-server-list}}
     defaultConf.append({{prefix}}ServerConfiguration(
     QUrl("{{{url}}}"),
@@ -42,15 +39,18 @@ void {{classname}}::initializeServerConfigs() {
     _serverIndices.insert("{{nickname}}", 0);
     {{/servers}}
     {{#servers}}
-    serverConf.append({{prefix}}ServerConfiguration(
-    QUrl("{{{url}}}"),
-    "{{{description}}}{{^description}}No description provided{{/description}}",
-    {{#variables}}{{#-first}}QMap<QString, {{prefix}}ServerVariable>{ {{/-first}}
-    {"{{{name}}}", {{prefix}}ServerVariable("{{{description}}}{{^description}}No description provided{{/description}}","{{{defaultValue}}}",
-    QSet<QString>{ {{#enumValues}}{"{{{.}}}"}{{#-last}} })}, {{/-last}}{{^-last}},{{/-last}}{{/enumValues}}{{^enumValues}}{"{{defaultValue}}"} })},{{/enumValues}}{{#-last}} }));{{/-last}}
-    {{/variables}}{{^variables}}QMap<QString, {{prefix}}ServerVariable>()));{{/variables}}
-    {{#-last}}_serverConfigs.insert("{{nickname}}", serverConf);
-    _serverIndices.insert("{{nickname}}", 0);{{/-last}}
+    {
+        QList<{{prefix}}ServerConfiguration> serverConf = QList<{{prefix}}ServerConfiguration>();
+        serverConf.append({{prefix}}ServerConfiguration(
+        QUrl("{{{url}}}"),
+        "{{{description}}}{{^description}}No description provided{{/description}}",
+        {{#variables}}{{#-first}}QMap<QString, {{prefix}}ServerVariable>{ {{/-first}}
+        {"{{{name}}}", {{prefix}}ServerVariable("{{{description}}}{{^description}}No description provided{{/description}}","{{{defaultValue}}}",
+        QSet<QString>{ {{#enumValues}}{"{{{.}}}"}{{#-last}} })}, {{/-last}}{{^-last}},{{/-last}}{{/enumValues}}{{^enumValues}}{"{{defaultValue}}"} })},{{/enumValues}}{{#-last}} }));{{/-last}}
+        {{/variables}}{{^variables}}QMap<QString, {{prefix}}ServerVariable>()));{{/variables}}
+        {{#-last}}_serverConfigs.insert("{{nickname}}", serverConf);
+        _serverIndices.insert("{{nickname}}", 0);{{/-last}}
+    }
 {{/servers}}
 {{/operation}}
 {{/operations}}


### PR DESCRIPTION
Previously, if an operation had a 'servers' block, the template would emit code requiring a `serverConf` local variable. Unfortunately, the template would not emit this variable, because it was looking for a `servers` variable in the wrong context.

This change makes the template emit an anonymous block containing a unique server configuration for each operation.

I did not test this change beyond a simple code inspection, there are other problems with the code generator which prevent it from running on my API definition.

To reproduce the original issue, install QT build dependencies, then:

* go to https://lichess.org/api, click the "Download" link, save `openapi.json` somewhere
* `java -jar target/openapi-generator-cli.jar  generate -i /path/to/openapi.json -o /tmp/Lichess -g cpp-qt-client`
* `cd /tmp/Lichess/client`
* `mkdir build && cd build`
* `cmake ..`
* `make`

