### PR TITLE
python-pydantic-v1: Handle response chartset in exception.

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-pydantic-v1/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python-pydantic-v1/api_client.mustache
@@ -220,6 +220,12 @@ class ApiClient:
                                                      collection_formats)
             url += "?" + url_query
 
+        def extract_charset(content_type):
+            match = None
+            if content_type is not None:
+                match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
+            return match.group(1) if match else "utf-8"
+
         try:
             # perform request and return response
             response_data = {{#asyncio}}await {{/asyncio}}{{#tornado}}yield {{/tornado}}self.request(
@@ -231,7 +237,12 @@ class ApiClient:
                 _request_timeout=_request_timeout)
         except ApiException as e:
             if e.body:
-                e.body = e.body.decode('utf-8')
+                try:
+                    charset = extract_charset((e.headers or {}).get('content-type'))
+                    e.body = e.body.decode(charset)
+                except UnicodeDecodeError:
+                    # Keep original body if charset is not recognized.
+                    pass
             raise e
 
         self.last_response = response_data
@@ -247,12 +258,9 @@ class ApiClient:
           if response_type == "bytearray":
               response_data.data = response_data.data
           else:
-              match = None
               content_type = response_data.getheader('content-type')
-              if content_type is not None:
-                  match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
-              encoding = match.group(1) if match else "utf-8"
-              response_data.data = response_data.data.decode(encoding)
+              charset = extract_charset(content_type)
+              response_data.data = response_data.data.decode(charset)
 
           # deserialize response data
           if response_type == "bytearray":

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/api_client.py
@@ -207,6 +207,12 @@ class ApiClient:
                                                      collection_formats)
             url += "?" + url_query
 
+        def extract_charset(content_type):
+            match = None
+            if content_type is not None:
+                match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
+            return match.group(1) if match else "utf-8"
+
         try:
             # perform request and return response
             response_data = self.request(
@@ -218,7 +224,12 @@ class ApiClient:
                 _request_timeout=_request_timeout)
         except ApiException as e:
             if e.body:
-                e.body = e.body.decode('utf-8')
+                try:
+                    charset = extract_charset((e.headers or {}).get('content-type'))
+                    e.body = e.body.decode(charset)
+                except UnicodeDecodeError:
+                    # Keep original body if charset is not recognized.
+                    pass
             raise e
 
         self.last_response = response_data
@@ -234,12 +245,9 @@ class ApiClient:
           if response_type == "bytearray":
               response_data.data = response_data.data
           else:
-              match = None
               content_type = response_data.getheader('content-type')
-              if content_type is not None:
-                  match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
-              encoding = match.group(1) if match else "utf-8"
-              response_data.data = response_data.data.decode(encoding)
+              charset = extract_charset(content_type)
+              response_data.data = response_data.data.decode(charset)
 
           # deserialize response data
           if response_type == "bytearray":

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/api_client.py
@@ -187,6 +187,12 @@ class ApiClient:
                                                      collection_formats)
             url += "?" + url_query
 
+        def extract_charset(content_type):
+            match = None
+            if content_type is not None:
+                match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
+            return match.group(1) if match else "utf-8"
+
         try:
             # perform request and return response
             response_data = await self.request(
@@ -198,7 +204,12 @@ class ApiClient:
                 _request_timeout=_request_timeout)
         except ApiException as e:
             if e.body:
-                e.body = e.body.decode('utf-8')
+                try:
+                    charset = extract_charset((e.headers or {}).get('content-type'))
+                    e.body = e.body.decode(charset)
+                except UnicodeDecodeError:
+                    # Keep original body if charset is not recognized.
+                    pass
             raise e
 
         self.last_response = response_data
@@ -214,12 +225,9 @@ class ApiClient:
           if response_type == "bytearray":
               response_data.data = response_data.data
           else:
-              match = None
               content_type = response_data.getheader('content-type')
-              if content_type is not None:
-                  match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
-              encoding = match.group(1) if match else "utf-8"
-              response_data.data = response_data.data.decode(encoding)
+              charset = extract_charset(content_type)
+              response_data.data = response_data.data.decode(charset)
 
           # deserialize response data
           if response_type == "bytearray":

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/api_client.py
@@ -206,6 +206,12 @@ class ApiClient:
                                                      collection_formats)
             url += "?" + url_query
 
+        def extract_charset(content_type):
+            match = None
+            if content_type is not None:
+                match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
+            return match.group(1) if match else "utf-8"
+
         try:
             # perform request and return response
             response_data = self.request(
@@ -217,7 +223,12 @@ class ApiClient:
                 _request_timeout=_request_timeout)
         except ApiException as e:
             if e.body:
-                e.body = e.body.decode('utf-8')
+                try:
+                    charset = extract_charset((e.headers or {}).get('content-type'))
+                    e.body = e.body.decode(charset)
+                except UnicodeDecodeError:
+                    # Keep original body if charset is not recognized.
+                    pass
             raise e
 
         self.last_response = response_data
@@ -233,12 +244,9 @@ class ApiClient:
           if response_type == "bytearray":
               response_data.data = response_data.data
           else:
-              match = None
               content_type = response_data.getheader('content-type')
-              if content_type is not None:
-                  match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
-              encoding = match.group(1) if match else "utf-8"
-              response_data.data = response_data.data.decode(encoding)
+              charset = extract_charset(content_type)
+              response_data.data = response_data.data.decode(charset)
 
           # deserialize response data
           if response_type == "bytearray":


### PR DESCRIPTION
This PR fixes the issue https://github.com/OpenAPITools/openapi-generator/issues/19862.

Currently, the generated code for `python-pydantic-v1` tries to decode the response using `utf-8`. This fails when the response uses character sequence that is not `utf-8`, like so:
```
  File ".../.venv/lib/python3.11/site-packages/my_api/api_client.py", line 219, in __call_api
    e.body = e.body.decode('utf-8')
             ^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe7 in position 78: invalid continuation byte
```
This change tries to use charset from the response. It leaves content unchanged when decoding fails.  

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
