### PR TITLE
[kotlin-spring] fix Api Interface for kotlin-spring with spring-cloud library

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
@@ -52,7 +52,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlin.collections.List
 import kotlin.collections.Map
 
+{{^useFeignClient}}
 @RestController
+{{/useFeignClient}}
 {{#useBeanValidation}}
 @Validated
 {{/useBeanValidation}}

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -29,7 +29,6 @@ import javax.validation.Valid
 import kotlin.collections.List
 import kotlin.collections.Map
 
-@RestController
 @Validated
 interface PetApi {
 

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/api/StoreApi.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/api/StoreApi.kt
@@ -28,7 +28,6 @@ import javax.validation.Valid
 import kotlin.collections.List
 import kotlin.collections.Map
 
-@RestController
 @Validated
 interface StoreApi {
 

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/api/UserApi.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/api/UserApi.kt
@@ -28,7 +28,6 @@ import javax.validation.Valid
 import kotlin.collections.List
 import kotlin.collections.Map
 
-@RestController
 @Validated
 interface UserApi {
 


### PR DESCRIPTION
The @RestController annotation is not suitable if the spring-cloud library with the feign client is used.

See discussion at https://github.com/OpenAPITools/openapi-generator/issues/19156#issuecomment-2414193210 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jimschubert, @dr4ke616, @karismann, @Zomzog, @andrewemery, @4brunu, @yutaka0m, @stefankoppier