### PR TITLE
fix(typescript): missing `override` directives

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/api/baseapi.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/baseapi.mustache
@@ -37,7 +37,7 @@ export class BaseAPIRequestFactory {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public api: string, public method: string, public field: string) {
         super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }

--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -317,9 +317,9 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
 
 export class HttpInfo<T> extends ResponseContext {
     public constructor(
-        public httpStatusCode: number,
-        public headers: Headers,
-        public body: ResponseBody,
+        httpStatusCode: number,
+        headers: Headers,
+        body: ResponseBody,
         public data: T,
     ) {
         super(httpStatusCode, headers, body);


### PR DESCRIPTION
In Deno v2 a generator which used to work with v1.x errors with:

```
error: TS4114 [ERROR]: This member must have an 'override' modifier because it overrides a member in the base class 'Error'.
    name: "RequiredError" = "RequiredError";
    ~~~~
    at file:///Users/joscha/dev/affinity-node/src/v2/generated/apis/baseapi.ts:33:5

TS4115 [ERROR]: This parameter property must have an 'override' modifier because it overrides a member in base class 'ResponseContext'.
        public httpStatusCode: number,
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    at file:///Users/joscha/dev/affinity-node/src/v2/generated/http/http.ts:237:9

TS4115 [ERROR]: This parameter property must have an 'override' modifier because it overrides a member in base class 'ResponseContext'.
        public headers: Headers,
        ~~~~~~~~~~~~~~~~~~~~~~~
    at file:///Users/joscha/dev/affinity-node/src/v2/generated/http/http.ts:238:9

TS4115 [ERROR]: This parameter property must have an 'override' modifier because it overrides a member in base class 'ResponseContext'.
        public body: ResponseBody,
        ~~~~~~~~~~~~~~~~~~~~~~~~~
    at file:///Users/joscha/dev/affinity-node/src/v2/generated/http/http.ts:239:9

Found 4 errors.
```

due to `noImplicitOverride` (Ensure overriding members in derived classes are marked with an override modifier) being enabled by default.

The first one is due to: https://github.com/microsoft/TypeScript/blob/b8e4ed8aeb0b228f544c5736908c31f136a9f7e3/src/lib/es5.d.ts#L1057-L1061

The other three in `http.ts` are simple, as all three properties are already public on the superclass and thus don't need to be exported again: https://github.com/OpenAPITools/openapi-generator/blob/38dac13c261d26a72be78bba89ee4a681843e7b0/modules/openapi-generator/src/main/resources/typescript/http/http.mustache#L228-L230

There is currently no fixture in the repository capturing these changes. It might be worth adding a change to a sample, so these changes will show up as diff in the future, @macjohnny WDYT?

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)
