### PR TITLE
docs: stop regeneration on error

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,9 +7,9 @@
 - [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
 - [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
   ```
-  ./mvnw clean package 
-  ./bin/generate-samples.sh ./bin/configs/*.yaml
-  ./bin/utils/export_docs_generators.sh
+  ./mvnw clean package || exit
+  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
+  ./bin/utils/export_docs_generators.sh || exit
   ``` 
   (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
   Commit all changed files. 


### PR DESCRIPTION
This change makes sure that the process exits and shows a non-zero exit code if any of the regeneration commands fail.

Compare:
```sh
(
echo 1
ehco 2
echo 3
)
echo "exit code: " $?
1
ehco: command not found
3
exit code: 0
vs:

```sh
(
echo 1 || exit
ehco 2 || exit
echo 3 || exit
)
echo "exit code: " $?
1
ehco: command not found
exit code: 127
```

I ran into this when the generation had an issue and was silently erroring, leaving the samples unregenerated. I only found out when the tests on CI failed.


<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
