### PR TITLE
bug: Data class not generated if schema contains allOf

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2632,6 +2632,8 @@ public class DefaultCodegen implements CodegenConfig {
 
         // TODO revise the logic below to set discriminator, xml attributes
         if (supportsInheritance || supportsMixins) {
+            // FIXME Comment out the next line, and allVars will be used in the template to generate the missing fields.
+            // Why is m.allVars being reset in this case?
             m.allVars = new ArrayList<>();
             if (composed.getAllOf() != null) {
                 int modelImplCnt = 0; // only one inline object allowed in a ComposedModel

--- a/modules/openapi-generator/src/test/resources/3_1/issue_wip.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_wip.yaml
@@ -1,0 +1,51 @@
+openapi: 3.1.0
+info:
+  title: Title
+  description: Description
+  version: 1.0.0
+servers:
+  - url: /
+paths:
+  /v1/path:
+    get:
+      summary: A path
+      description: Stuff happens on this path
+      operationId: getStuffFromPath
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                title: AListOfThings
+                items:
+                  type: object
+                  allOf:
+                    - if:
+                        properties:
+                          aBooleanCheck:
+                            const: false
+                      then:
+                        required:
+                          - condition
+                    - if:
+                        properties:
+                          aBooleanCheck:
+                            const: true
+                      then:
+                        required:
+                          - purpose
+                  properties:
+                    aBooleanCheck:
+                      type: boolean
+                    condition:
+                      type: string
+                    purpose:
+                      type: array
+                      items:
+                        type: string
+                        enum:
+                          - FIRST
+                          - SECOND
+                          - THIRD

--- a/modules/openapi-generator/src/test/resources/3_1/issue_wip_working_without_all_of.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_wip_working_without_all_of.yaml
@@ -1,0 +1,36 @@
+openapi: 3.1.0
+info:
+  title: Title
+  description: Description
+  version: 1.0.0
+servers:
+  - url: /
+paths:
+  /v1/path:
+    get:
+      summary: A path
+      description: Stuff happens on this path
+      operationId: getStuffFromPath
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                title: AListOfThings
+                items:
+                  type: object
+                  properties:
+                    aBooleanCheck:
+                      type: boolean
+                    condition:
+                      type: string
+                    purpose:
+                      type: array
+                      items:
+                        type: string
+                        enum:
+                          - FIRST
+                          - SECOND
+                          - THIRD


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
**This is not a PR for a fix, this PR contains my findings while investigating the issue, as requested by @wing328 in #19755** 
<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
