### PR TITLE
[java] Fix javadoc in resttemplate OAuth class

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/auth/OAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/auth/OAuth.mustache
@@ -26,7 +26,7 @@ public class OAuth implements Authentication {
     /**
      * Sets the bearer access token used for Authorization.
      *
-     * @param bearerToken The bearer token to send in the Authorization header
+     * @param accessToken The bearer token to send in the Authorization header
      */
     public void setAccessToken(String accessToken) {
         setAccessToken(() -> accessToken);

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -37,7 +37,7 @@ public class OAuth implements Authentication {
     /**
      * Sets the bearer access token used for Authorization.
      *
-     * @param bearerToken The bearer token to send in the Authorization header
+     * @param accessToken The bearer token to send in the Authorization header
      */
     public void setAccessToken(String accessToken) {
         setAccessToken(() -> accessToken);

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -37,7 +37,7 @@ public class OAuth implements Authentication {
     /**
      * Sets the bearer access token used for Authorization.
      *
-     * @param bearerToken The bearer token to send in the Authorization header
+     * @param accessToken The bearer token to send in the Authorization header
      */
     public void setAccessToken(String accessToken) {
         setAccessToken(() -> accessToken);

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -37,7 +37,7 @@ public class OAuth implements Authentication {
     /**
      * Sets the bearer access token used for Authorization.
      *
-     * @param bearerToken The bearer token to send in the Authorization header
+     * @param accessToken The bearer token to send in the Authorization header
      */
     public void setAccessToken(String accessToken) {
         setAccessToken(() -> accessToken);

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -37,7 +37,7 @@ public class OAuth implements Authentication {
     /**
      * Sets the bearer access token used for Authorization.
      *
-     * @param bearerToken The bearer token to send in the Authorization header
+     * @param accessToken The bearer token to send in the Authorization header
      */
     public void setAccessToken(String accessToken) {
         setAccessToken(() -> accessToken);

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -37,7 +37,7 @@ public class OAuth implements Authentication {
     /**
      * Sets the bearer access token used for Authorization.
      *
-     * @param bearerToken The bearer token to send in the Authorization header
+     * @param accessToken The bearer token to send in the Authorization header
      */
     public void setAccessToken(String accessToken) {
         setAccessToken(() -> accessToken);


### PR DESCRIPTION
Fix javadoc issue (incorrect parameter name) in resttemplate OAuth class

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
