### PR TITLE
Codegen: Java Client: The default value of a enum should be an enum value and not a string.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -6668,10 +6668,12 @@ public class DefaultCodegen implements CodegenConfig {
         // handle default value for enum, e.g. available => StatusEnum.AVAILABLE
         if (var.defaultValue != null) {
             final String enumDefaultValue = getEnumDefaultValue(var.defaultValue, dataType);
+            // The enum value may be represented with quotes. so, remove \" from this string.
+            final String enumDefaultUnescapedValue = enumDefaultValue.replace("\\\"", "");
 
             String enumName = null;
             for (Map<String, Object> enumVar : enumVars) {
-                if (enumDefaultValue.equals(enumVar.get("value"))) {
+                if (enumDefaultValue.equals(enumVar.get("value")) || enumDefaultUnescapedValue.equals(enumVar.get("value))) {
                     enumName = (String) enumVar.get("name");
                     break;
                 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2389,6 +2389,22 @@ public class JavaClientCodegenTest {
         JavaFileAssert.assertThat(apiFile).fileContains(expectedInnerEnumLines);
     }
 
+    @Test public void testEnumDefaultIsRepresentedAsEnumAndNotString() {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("java")
+                .setLibrary(JavaClientCodegen.RESTTEMPLATE)
+                .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
+                .setInputSpec("src/test/resources/3_0/java/enum_with_default.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        validateJavaSourceFiles(files);
+        TestUtils.assertFileContains(output.resolve("src/main/java/xyz/abcdef/api/CharacterRequest.java"), "private Planet planet = Planet.EARTH;");
+        
+    }
+
     @Test public void testQueryParamsExploded_whenQueryParamIsNull() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()

--- a/modules/openapi-generator/src/test/resources/3_0/java/enum_with_default.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/java/enum_with_default.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: API description in Markdown.
+  version: 1.0.0
+paths:
+  /characters:
+    post:
+      summary: Create a character in some planet.
+      description: Every character has a planet.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CharacterRequest'
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  description: ID of the created character.
+                  example: '123'
+                  type: string
+components:
+  schemas:
+    CharacterRequest:
+      type: object
+      properties:
+        planet:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/Planet'
+          default: Earth
+        name:
+          description: Character name.
+          type: string
+          default: Raj
+    Planet:
+      type: string
+      enum:
+        - Earth
+        - Pegasi
+        - Mercury


### PR DESCRIPTION
WHAT: Java Client
WHEN: Enum value is present in an object and a default is specified in the object and not in the enum.

If the spec contains a enum field and a default is specified, the java client generated does not compile.

There is an extremely well defined bug in https://github.com/OpenAPITools/openapi-generator/issues/15144

Currently, the default value of an enum is represented as a string.

`private JoinCriteria criteria = "AT_LEAST";`

Clearly, the generated code does not compile, since it the value should be an enum and not a string.
Instead, it should produce the enum when it is initialized.

`private JoinCriteria criteria = JoinCriteria.AT_LEAST;`

This can be solved in a lot of different ways. This bug was fixed in an earlier version, but then got reintroduced, when the enum string was "escaped".

To avoid this, two things are necessary.
1. Add a test that verifies this behavior, This protects against this happening again.
2. We can check for both the escaped version and an unescaped version. While this is not clean, it is extremely unlikely, a enum value has quotes.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
