### PR TITLE
Fix path with unescaped value

### DIFF
--- a/modules/openapi-generator/src/main/resources/Ada/client-body.mustache
+++ b/modules/openapi-generator/src/main/resources/Ada/client-body.mustache
@@ -51,7 +51,7 @@ package body {{package}}.Clients is
       URI.Add_Param ("{{baseName}}", {{paramName}});{{/isLong}}{{#isContainer}}
       URI.Add_Param ("{{baseName}}", {{paramName}});{{/isContainer}}{{#isDateTime}}
       URI.Add_Param ("{{baseName}}", {{paramName}});{{/isDateTime}}{{/isQueryParam}}{{/queryParams}}
-      URI.Set_Path ("{{path}}");{{#pathParams}}
+      URI.Set_Path ("{{{path}}}");{{#pathParams}}
       URI.Set_Path_Param ("{{baseName}}", {{^isString}}{{#vendorExtensions.x-is-model-type}}{{package}}.Models{{/vendorExtensions.x-is-model-type}}{{^vendorExtensions.x-is-model-type}}{{openApiPackageName}}{{/vendorExtensions.x-is-model-type}}.To_String ({{/isString}}{{paramName}}{{^isString}}){{/isString}});{{/pathParams}}
       Client.Call ({{openApiPackageName}}.Clients.{{httpMethod}}, URI{{#hasBodyParam}}, Req{{/hasBodyParam}}{{#hasFormParams}}, Req{{/hasFormParams}}{{#returnType}}, Reply{{/returnType}});
       {{#returnProperty}}

--- a/modules/openapi-generator/src/main/resources/Ada/server-skeleton-body.mustache
+++ b/modules/openapi-generator/src/main/resources/Ada/server-skeleton-body.mustache
@@ -27,7 +27,7 @@ package body {{package}}.Skeletons is
          new {{openApiPackageName}}.Servers.Operation
             (Handler => {{operationId}},
              Method  => {{openApiPackageName}}.Servers.{{httpMethod}},
-             URI     => URI_Prefix & "{{path}}",
+             URI     => URI_Prefix & "{{{path}}}",
 {{#vendorExtensions.x-produces-media-index}}
              Mimes   => Media_List_{{vendorExtensions.x-produces-media-index}}'Access);
 {{/vendorExtensions.x-produces-media-index}}
@@ -259,7 +259,7 @@ package body {{package}}.Skeletons is
          new {{openApiPackageName}}.Servers.Operation
             (Handler => {{operationId}},
              Method  => {{openApiPackageName}}.Servers.{{httpMethod}},
-             URI     => URI_Prefix & "{{path}}",
+             URI     => URI_Prefix & "{{{path}}}",
 {{#vendorExtensions.x-produces-media-index}}
              Mimes   => Media_List_{{vendorExtensions.x-produces-media-index}}'Access);
 {{/vendorExtensions.x-produces-media-index}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -195,7 +195,7 @@ public class {{classname}} {
     {{#returnType}}
     GenericType<{{{returnType}}}> localVarReturnType = new GenericType<{{{returnType}}}>() {};
     {{/returnType}}
-    return apiClient.invokeAPI("{{classname}}.{{operationId}}", {{#hasPathParams}}localVarPath{{/hasPathParams}}{{^hasPathParams}}"{{path}}"{{/hasPathParams}}, "{{httpMethod}}", {{#queryParams}}{{#-first}}localVarQueryParams{{/-first}}{{/queryParams}}{{^queryParams}}new ArrayList<>(){{/queryParams}}, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}},
+    return apiClient.invokeAPI("{{classname}}.{{operationId}}", {{#hasPathParams}}localVarPath{{/hasPathParams}}{{^hasPathParams}}"{{{path}}}"{{/hasPathParams}}, "{{httpMethod}}", {{#queryParams}}{{#-first}}localVarQueryParams{{/-first}}{{/queryParams}}{{^queryParams}}new ArrayList<>(){{/queryParams}}, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}},
                                {{#headerParams}}{{#-first}}localVarHeaderParams{{/-first}}{{/headerParams}}{{^headerParams}}new LinkedHashMap<>(){{/headerParams}}, {{#cookieParams}}{{#-first}}localVarCookieParams{{/-first}}{{/cookieParams}}{{^cookieParams}}new LinkedHashMap<>(){{/cookieParams}}, {{#formParams}}{{#-first}}localVarFormParams{{/-first}}{{/formParams}}{{^formParams}}new LinkedHashMap<>(){{/formParams}}, localVarAccept, localVarContentType,
                                {{#hasAuthMethods}}localVarAuthNames{{/hasAuthMethods}}{{^hasAuthMethods}}null{{/hasAuthMethods}}, {{#returnType}}localVarReturnType{{/returnType}}{{^returnType}}null{{/returnType}}, {{#bodyParam}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/bodyParam}}{{^bodyParam}}false{{/bodyParam}});
   }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
@@ -195,7 +195,7 @@ public class {{classname}} {
     {{#returnType}}
     GenericType<{{{returnType}}}> localVarReturnType = new GenericType<{{{returnType}}}>() {};
     {{/returnType}}
-    return apiClient.invokeAPI("{{classname}}.{{operationId}}", {{#hasPathParams}}localVarPath{{/hasPathParams}}{{^hasPathParams}}"{{path}}"{{/hasPathParams}}, "{{httpMethod}}", {{#queryParams}}{{#-first}}localVarQueryParams{{/-first}}{{/queryParams}}{{^queryParams}}new ArrayList<>(){{/queryParams}}, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}},
+    return apiClient.invokeAPI("{{classname}}.{{operationId}}", {{#hasPathParams}}localVarPath{{/hasPathParams}}{{^hasPathParams}}"{{{path}}}"{{/hasPathParams}}, "{{httpMethod}}", {{#queryParams}}{{#-first}}localVarQueryParams{{/-first}}{{/queryParams}}{{^queryParams}}new ArrayList<>(){{/queryParams}}, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}},
                                {{#headerParams}}{{#-first}}localVarHeaderParams{{/-first}}{{/headerParams}}{{^headerParams}}new LinkedHashMap<>(){{/headerParams}}, {{#cookieParams}}{{#-first}}localVarCookieParams{{/-first}}{{/cookieParams}}{{^cookieParams}}new LinkedHashMap<>(){{/cookieParams}}, {{#formParams}}{{#-first}}localVarFormParams{{/-first}}{{/formParams}}{{^formParams}}new LinkedHashMap<>(){{/formParams}}, localVarAccept, localVarContentType,
                                {{#hasAuthMethods}}localVarAuthNames{{/hasAuthMethods}}{{^hasAuthMethods}}null{{/hasAuthMethods}}, {{#returnType}}localVarReturnType{{/returnType}}{{^returnType}}null{{/returnType}}, {{#bodyParam}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/bodyParam}}{{^bodyParam}}false{{/bodyParam}});
   }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
@@ -146,7 +146,7 @@ public class {{classname}} {
     public static class {{operationIdCamelCase}}Oper implements Oper {
 
         public static final Method REQ_METHOD = {{httpMethod}};
-        public static final String REQ_URI = "{{path}}";
+        public static final String REQ_URI = "{{{path}}}";
 
         private RequestSpecBuilder reqSpec;
         private ResponseSpecBuilder respSpec;
@@ -163,7 +163,7 @@ public class {{classname}} {
         }
 
         /**
-         * {{httpMethod}} {{path}}
+         * {{httpMethod}} {{{path}}}
          * @param handler handler
          * @param <T> type
          * @return type
@@ -175,7 +175,7 @@ public class {{classname}} {
         {{#returnType}}
 
         /**
-         * {{httpMethod}} {{path}}
+         * {{httpMethod}} {{{path}}}
          * @param handler handler
          * @return {{returnType}}
          */

--- a/modules/openapi-generator/src/main/resources/Javascript-Closure-Angular/es6/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript-Closure-Angular/es6/api.mustache
@@ -54,7 +54,7 @@ export default class {{classname}} {
   {{operationId}}() {
     return {
       method: '{{httpMethod}}',
-      url: this.basePath + '{{path}}'
+      url: this.basePath + '{{{path}}}'
       {{#pathParams}}
         .replace('{' + '{{baseName}}' + '}', ':{{paramName}}')
       {{/pathParams}}

--- a/modules/openapi-generator/src/main/resources/apache2/apache-config.mustache
+++ b/modules/openapi-generator/src/main/resources/apache2/apache-config.mustache
@@ -1,6 +1,6 @@
 {{#operations}}
 {{#operation}}
-<Location "{{basePathWithoutHost}}{{path}}">
+<Location "{{{basePathWithoutHost}}}{{{path}}}">
 	{{>authConf}}
 	<LimitExcept GET POST PUT DELETE>
 		Require valid-user

--- a/modules/openapi-generator/src/main/resources/apex/api.mustache
+++ b/modules/openapi-generator/src/main/resources/apex/api.mustache
@@ -74,7 +74,7 @@ public class {{classname}} {
     {{/formParams}}
 
         {{#returnType}}return ({{{.}}}) {{/returnType}}client.invoke(
-            '{{httpMethod}}', '{{path}}',{{#bodyParam}}
+            '{{httpMethod}}', '{{{path}}}',{{#bodyParam}}
             ({{{dataType}}}) params.get('{{paramName}}'){{/bodyParam}}{{^bodyParam}} ''{{/bodyParam}},
             query, form,
             new Map<String, Object>{{#hasPathParams}}{

--- a/modules/openapi-generator/src/main/resources/cpp-restbed-server/api-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-restbed-server/api-source.mustache
@@ -104,9 +104,9 @@ std::string convertMapResponse(const std::map<KEY_T, VAL_T>& map)
 
 namespace {{classname}}Resources {
 {{#operation}}
-{{vendorExtensions.x-codegen-resource-name}}Resource::{{vendorExtensions.x-codegen-resource-name}}Resource(const std::string& context /* = "{{contextPath}}" */)
+{{vendorExtensions.x-codegen-resource-name}}Resource::{{vendorExtensions.x-codegen-resource-name}}Resource(const std::string& context /* = "{{{contextPath}}}" */)
 {
-	this->set_path(context + "{{path}}");
+	this->set_path(context + "{{{path}}}");
 	this->set_method_handler("{{httpMethod}}",
 		std::bind(&{{vendorExtensions.x-codegen-resource-name}}Resource::handler_{{httpMethod}}_internal, this,
 			std::placeholders::_1));

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/api.mustache
@@ -380,7 +380,7 @@ namespace {{packageName}}.{{apiPackage}}
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress{{nrt!}}.Host;
                     uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
                     uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
-                    uriBuilderLocalVar.Path = ClientUtils.CONTEXT_PATH + "{{path}}";
+                    uriBuilderLocalVar.Path = ClientUtils.CONTEXT_PATH + "{{{path}}}";
                     {{/servers}}
                     {{#servers}}
                     {{#-first}}
@@ -621,7 +621,7 @@ namespace {{packageName}}.{{apiPackage}}
 
                         ILogger<{{operationId}}ApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<{{operationId}}ApiResponse>();
 
-                        {{operationId}}ApiResponse apiResponseLocalVar = new{{^net60OrLater}} {{operationId}}ApiResponse{{/net60OrLater}}(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "{{path}}", requestedAtLocalVar, _jsonSerializerOptions);
+                        {{operationId}}ApiResponse apiResponseLocalVar = new{{^net60OrLater}} {{operationId}}ApiResponse{{/net60OrLater}}(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "{{{path}}}", requestedAtLocalVar, _jsonSerializerOptions);
 
                         After{{operationId}}DefaultImplementation({{#lambda.joinWithComma}}apiResponseLocalVar  {{#allParams}}{{paramName}}  {{/allParams}}{{/lambda.joinWithComma}});
 
@@ -674,7 +674,7 @@ namespace {{packageName}}.{{apiPackage}}
             }
             catch(Exception e)
             {
-                OnError{{operationId}}DefaultImplementation({{#lambda.joinWithComma}}e  "{{path}}"  uriBuilderLocalVar.Path  {{#allParams}}{{paramName}}  {{/allParams}}{{/lambda.joinWithComma}});
+                OnError{{operationId}}DefaultImplementation({{#lambda.joinWithComma}}e  "{{{path}}}"  uriBuilderLocalVar.Path  {{#allParams}}{{paramName}}  {{/allParams}}{{/lambda.joinWithComma}});
                 Events.ExecuteOnError{{operationId}}(e);
                 throw;
             }

--- a/modules/openapi-generator/src/main/resources/erlang-server/handler.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/handler.mustache
@@ -2,7 +2,7 @@
 -moduledoc """
 Exposes the following operation IDs:
 {{#operations}}{{#operation}}
-- `{{httpMethod}}` to `{{path}}`, OperationId: `{{operationIdOriginal}}`:
+- `{{httpMethod}}` to `{{{path}}}`, OperationId: `{{{operationIdOriginal}}}`:
 {{summary}}.
 {{notes}}
 {{/operation}}{{/operations}}

--- a/modules/openapi-generator/src/main/resources/fsharp-functions-server/Handler.mustache
+++ b/modules/openapi-generator/src/main/resources/fsharp-functions-server/Handler.mustache
@@ -22,7 +22,7 @@ module {{classname}}Handlers =
     /// </summary>
    [<FunctionName("{{operationId}}")>]
     let {{operationId}}
-        ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "{{httpMethod}}", Route = "{{contextPath}}{{path}}")>]
+        ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "{{httpMethod}}", Route = "{{{contextPath}}}{{{path}}}")>]
         req:HttpRequest ) =
 
       {{#hasBodyParam}}

--- a/modules/openapi-generator/src/main/resources/fsharp-giraffe-server/Program.mustache
+++ b/modules/openapi-generator/src/main/resources/fsharp-giraffe-server/Program.mustache
@@ -54,7 +54,7 @@ module App =
       {{#apis}}
       {{#operations}}
       {{#operation}}
-      {{httpMethod}} >=> {{^hasPathParams}}route{{/hasPathParams}}{{#hasPathParams}}routeBind<{{operationId}}PathParams>{{/hasPathParams}} "{{contextPath}}{{path}}" {{^pathParams}}>=>{{/pathParams}} {{#pathParams}}(fun x -> {{/pathParams}}{{#authMethods}}{{#isOAuth}}requiresAuthentication authFailure{{/isOAuth}}{{#isApiKey}}challenge ApiKeyDefaults.AuthenticationScheme >=> requiresAuthentication authFailure{{/isApiKey}} >=> {{/authMethods}} {{classname}}Handler.{{operationId}}{{#pathParams}} x){{/pathParams}};
+      {{httpMethod}} >=> {{^hasPathParams}}route{{/hasPathParams}}{{#hasPathParams}}routeBind<{{operationId}}PathParams>{{/hasPathParams}} "{{contextPath}}{{{path}}}" {{^pathParams}}>=>{{/pathParams}} {{#pathParams}}(fun x -> {{/pathParams}}{{#authMethods}}{{#isOAuth}}requiresAuthentication authFailure{{/isOAuth}}{{#isApiKey}}challenge ApiKeyDefaults.AuthenticationScheme >=> requiresAuthentication authFailure{{/isApiKey}} >=> {{/authMethods}} {{classname}}Handler.{{operationId}}{{#pathParams}} x){{/pathParams}};
       {{/operation}}
       {{/operations}}
       {{/apis}}

--- a/modules/openapi-generator/src/main/resources/haskell-yesod/config/routes.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-yesod/config/routes.mustache
@@ -4,5 +4,5 @@
 -- /static StaticR Static appStatic
 
 {{#routes}}
-{{path}} {{resource}}{{#methods}} {{this}}{{/methods}}
+{{{path}}} {{resource}}{{#methods}} {{this}}{{/methods}}
 {{/routes}}

--- a/modules/openapi-generator/src/main/resources/java-camel-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/java-camel-server/api.mustache
@@ -46,7 +46,7 @@ public class {{classname}} extends RouteBuilder {
             .endSecurityDefinition(){{/-last}}{{/isApiKey}}{{#isBasic}}{{#isBasicBasic}}
                 .basicAuth("{{name}}"){{#-last}}.end(){{/-last}}{{/isBasicBasic}}{{#isBasicBearer}}
                 .bearerToken("{{name}}"{{#bearerFormat}}, "{{bearerFormat}}"{{/bearerFormat}}){{#-last}}.end(){{/-last}}{{/isBasicBearer}}{{/isBasic}}{{/authMethods}}{{/hasAuthMethods}}{{/camelSecurityDefinitions}}
-            .{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}("{{path}}")
+            .{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}("{{{path}}}")
                 .description("{{#summary}}{{{.}}}{{/summary}}")
                 .id("{{operationId}}Api"){{#vendorExtensions}}{{#camelRestBindingMode}}
                 .clientRequestValidation(false)

--- a/modules/openapi-generator/src/main/resources/java-camel-server/test.mustache
+++ b/modules/openapi-generator/src/main/resources/java-camel-server/test.mustache
@@ -25,7 +25,7 @@ public class {{classname}}Test {
     public void {{operationId}}TestJson() throws Exception {
         String contentType = "application/json";
         String accept = "application/json";
-        String url = API_URL + "{{path}}";
+        String url = API_URL + "{{{path}}}";
         HttpRequest httpRequest = Unirest.{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}(url);{{#hasConsumes}}
         httpRequest = httpRequest.header("Content-Type", contentType);{{/hasConsumes}}{{#hasProduces}}
         httpRequest = httpRequest.header("Accept", accept);{{/hasProduces}}{{#pathParams}}
@@ -45,7 +45,7 @@ public class {{classname}}Test {
     public void {{operationId}}TestXml() throws Exception {
         String contentType = "application/xml";
         String accept = "application/xml";
-        String url = API_URL + "{{path}}";
+        String url = API_URL + "{{{path}}}";
         HttpRequest httpRequest = Unirest.{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}(url);{{#hasConsumes}}
         httpRequest = httpRequest.header("Content-Type", contentType);{{/hasConsumes}}{{#hasProduces}}
         httpRequest = httpRequest.header("Accept", accept);{{/hasProduces}}{{#pathParams}}

--- a/modules/openapi-generator/src/main/resources/java-pkmst/cucumber/cucumberTest.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/cucumber/cucumberTest.mustache
@@ -9,7 +9,7 @@ import cucumber.api.junit.Cucumber;
 @ActiveProfiles("test")
 @CucumberOptions(format = { "pretty", "html:target/cucumber-html-report",
 {{#resourcePaths}}
- "json:./report/{{path}}-report-json/{{path}}.json",
+ "json:./report/{{{path}}}-report-json/{{{path}}}.json",
 {{/resourcePaths}} })
 public class {{serviceName}}Test {
 }

--- a/modules/openapi-generator/src/main/resources/java-pkmst/cucumber/executeReport.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/cucumber/executeReport.mustache
@@ -24,9 +24,9 @@ public class ExecuteReport {
     Configuration configuration = null;
     ReportBuilder reportBuilder = null;
     {{#resourcePaths}}
-    reportOutputDirectory = new File("./report/{{path}}-report-html/");
+    reportOutputDirectory = new File("./report/{{{path}}}-report-html/");
     jsonFiles = new ArrayList();
-    jsonFiles.add("./report/{{path}}-report-json/{{path}}.json");
+    jsonFiles.add("./report/{{{path}}}-report-json/{{{path}}}.json");
 
     configuration = new Configuration(reportOutputDirectory,projectName);
     // optionally only if you need

--- a/modules/openapi-generator/src/main/resources/java-pkmst/gatling/testapi.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/gatling/testapi.mustache
@@ -9,7 +9,7 @@ import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 
 
-class get{{path}} extends Simulation {
+class get{{{path}}} extends Simulation {
 
 
 	val app: ConfigurableApplicationContext = SpringApplication.run(classOf[{{basePackage}}.{{serviceName}}Application])

--- a/modules/openapi-generator/src/main/resources/java-pkmst/security/resourceServerConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/security/resourceServerConfiguration.mustache
@@ -32,9 +32,9 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
     {{#resourcePaths}}
         http.
         anonymous().disable()
-        .requestMatchers().antMatchers(HttpMethod.GET, "/{{path}}/**")
+        .requestMatchers().antMatchers(HttpMethod.GET, "/{{{path}}}/**")
         .and().authorizeRequests()
-        .antMatchers(HttpMethod.GET, "/{{path}}/**").access("hasRole('ADMIN')")
+        .antMatchers(HttpMethod.GET, "/{{{path}}}/**").access("hasRole('ADMIN')")
         .and().exceptionHandling().accessDeniedHandler(new OAuth2AccessDeniedHandler());
         {{/resourcePaths}}
     }

--- a/modules/openapi-generator/src/main/resources/jetbrains-http-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/jetbrains-http-client/api.mustache
@@ -5,7 +5,7 @@
 {{#vendorExtensions.requests}}
 ### {{#summary}}{{summary}}{{/summary}}
 ## {{name}}
-{{httpMethod}} {{basePath}}{{#lambda.doubleMustache}}{{path}}{{/lambda.doubleMustache}}{{>queryParams}}
+{{httpMethod}} {{basePath}}{{#lambda.doubleMustache}}{{{path}}}{{/lambda.doubleMustache}}{{>queryParams}}
 {{#consumes}}
 Content-Type: {{{mediaType}}}
 {{/consumes}}

--- a/modules/openapi-generator/src/main/resources/julia-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-client/api.mustache
@@ -46,7 +46,7 @@ function _oacinternal_{{operationId}}(_api::{{classname}}{{#allParams}}{{#requir
 
 {{/hasValidation}}
 {{/allParams}}
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "{{httpMethod}}", _returntypes_{{operationId}}_{{classname}}, "{{path}}", [{{#authMethods}}"{{name}}", {{/authMethods}}]{{#bodyParam}}, {{paramName}}{{/bodyParam}})
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "{{httpMethod}}", _returntypes_{{operationId}}_{{classname}}, "{{{path}}}", [{{#authMethods}}"{{name}}", {{/authMethods}}]{{#bodyParam}}, {{paramName}}{{/bodyParam}})
 {{#pathParams}}
     OpenAPI.Clients.set_param(_ctx.path, "{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{paramName}}{{#isListContainer}}; collection_format="{{collectionFormat}}"{{/isListContainer}})  # type {{dataType}}
 {{/pathParams}}

--- a/modules/openapi-generator/src/main/resources/julia-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/api.mustache
@@ -61,7 +61,7 @@ end
 
 function register{{classname}}(router::HTTP.Router, impl; path_prefix::String="", optional_middlewares...)
     {{#operation}}
-    HTTP.register!(router, "{{httpMethod}}", path_prefix * "{{path}}", OpenAPI.Servers.middleware(impl, {{operationId}}_read, {{operationId}}_validate, {{operationId}}_invoke; optional_middlewares...))
+    HTTP.register!(router, "{{httpMethod}}", path_prefix * "{{{path}}}", OpenAPI.Servers.middleware(impl, {{operationId}}_read, {{operationId}}_validate, {{operationId}}_invoke; optional_middlewares...))
     {{/operation}}
     return router
 end

--- a/modules/openapi-generator/src/main/resources/julia-server/server.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/server.mustache
@@ -10,7 +10,7 @@ The following server methods must be implemented:
 {{#operations}}
 {{#operation}}
 - **{{operationId}}**
-    - *invocation:* {{httpMethod}} {{path}}
+    - *invocation:* {{httpMethod}} {{{path}}}
     - *signature:* {{operationId}}(req::HTTP.Request{{#allParams}}{{#required}}, {{paramName}}::{{dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}}) -> {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}
 {{/operation}}
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/Main.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/Main.kt.mustache
@@ -23,7 +23,7 @@ fun main() {
                 {{#apis}}
                 {{#operations}}
                 {{#operation}}
-                {{#lowercase}}{{httpMethod}}{{/lowercase}}("{{path}}", {{classname}}::{{operationId}})
+                {{#lowercase}}{{httpMethod}}{{/lowercase}}("{{{path}}}", {{classname}}::{{operationId}})
                 {{/operation}}
                 {{/operations}}
 

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/Paths.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/Paths.kt.mustache
@@ -18,10 +18,10 @@ object Paths {
      {{#allParams}}* @param {{paramName}} {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
      {{/allParams}}*/
     {{#hasParams}}
-    @Serializable @Resource("{{path}}") class {{operationId}}({{#allParams}}val {{paramName}}: {{{dataType}}}{{^required}}? = null{{/required}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}})
+    @Serializable @Resource("{{{path}}}") class {{operationId}}({{#allParams}}val {{paramName}}: {{{dataType}}}{{^required}}? = null{{/required}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}})
     {{/hasParams}}
     {{^hasParams}}
-    @Serializable @Resource("{{path}}") class {{operationId}}
+    @Serializable @Resource("{{{path}}}") class {{operationId}}
     {{/hasParams}}
 
     {{/operation}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
@@ -83,7 +83,7 @@ class {{classname}}Controller({{#serviceInterface}}@Autowired(required = true) v
         value = [{{#responses}}ApiResponse(code = {{{code}}}, message = "{{{message}}}"{{#baseType}}, response = {{{.}}}::class{{/baseType}}{{#containerType}}, responseContainer = "{{{.}}}"{{/containerType}}){{^-last}},{{/-last}}{{/responses}}]){{/swagger1AnnotationLibrary}}
     @RequestMapping(
         method = [RequestMethod.{{httpMethod}}],
-        value = ["{{#lambdaEscapeInNormalString}}{{path}}{{/lambdaEscapeInNormalString}}"]{{#singleContentTypes}}{{#hasProduces}},
+        value = ["{{#lambdaEscapeInNormalString}}{{{path}}}{{/lambdaEscapeInNormalString}}"]{{#singleContentTypes}}{{#hasProduces}},
         produces = [{{#vendorExtensions.x-accepts}}"{{{.}}}"{{^-last}}, {{/-last}}{{/vendorExtensions.x-accepts}}]{{/hasProduces}}{{#hasConsumes}},
         consumes = "{{{vendorExtensions.x-content-type}}}"{{/hasConsumes}}{{/singleContentTypes}}{{^singleContentTypes}}{{#hasProduces}},
         produces = [{{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}}]{{/hasProduces}}{{#hasConsumes}},

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
@@ -96,7 +96,7 @@ interface {{classname}} {
         value = [{{#responses}}ApiResponse(code = {{{code}}}, message = "{{{message}}}"{{#baseType}}, response = {{{.}}}::class{{/baseType}}{{#containerType}}, responseContainer = "{{{.}}}"{{/containerType}}){{^-last}}, {{/-last}}{{/responses}}]){{/swagger1AnnotationLibrary}}
     @RequestMapping(
             method = [RequestMethod.{{httpMethod}}],
-            value = ["{{#lambdaEscapeInNormalString}}{{path}}{{/lambdaEscapeInNormalString}}"]{{#singleContentTypes}}{{#hasProduces}},
+            value = ["{{#lambdaEscapeInNormalString}}{{{path}}}{{/lambdaEscapeInNormalString}}"]{{#singleContentTypes}}{{#hasProduces}},
             produces = [{{#vendorExtensions.x-accepts}}"{{{.}}}"{{^-last}}, {{/-last}}{{/vendorExtensions.x-accepts}}]{{/hasProduces}}{{#hasConsumes}},
             consumes = "{{{vendorExtensions.x-content-type}}}"{{/hasConsumes}}{{/singleContentTypes}}{{^singleContentTypes}}{{#hasProduces}},
             produces = [{{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}}]{{/hasProduces}}{{#hasConsumes}},

--- a/modules/openapi-generator/src/main/resources/kotlin-wiremock/api-stub.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-wiremock/api-stub.mustache
@@ -33,7 +33,7 @@ open class {{classname}}Stubs(private val objectMapper: ObjectMapper) {
      * @return A [{{operationIdCamelCase}}StubBuilder] to configure the response, and the final [MappingBuilder].
      */
     fun {{operationId}}({{#pathParams}}{{paramName}}: StringValuePattern, {{/pathParams}}{{#queryParams}}{{paramName}}: StringValuePattern? = null, {{/queryParams}}configurer: MappingBuilder.() -> MappingBuilder = { this }): {{operationIdCamelCase}}StubBuilder =
-        {{operationIdCamelCase}}StubBuilder(objectMapper, {{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}(urlPathTemplate("{{path}}"))
+        {{operationIdCamelCase}}StubBuilder(objectMapper, {{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}(urlPathTemplate("{{{path}}}"))
             {{#pathParams}}
             .withPathParam("{{baseName}}", {{paramName}})
             {{/pathParams}}

--- a/modules/openapi-generator/src/main/resources/openapi-static/operation.mustache
+++ b/modules/openapi-generator/src/main/resources/openapi-static/operation.mustache
@@ -9,7 +9,7 @@
   <p>{{description}}</p>
   {{#notes}}<p>{{.}}</p>{{/notes}}
   <h3 class="section">URL</h3>
-  <code>{{basePath}}{{path}}</code>
+  <code>{{{basePath}}}{{{path}}}</code>
   <h3 class="section">HTTP Method</h3>
   <code>{{httpMethod}}</code>
   <h3 class="section">Response Type</h3>

--- a/modules/openapi-generator/src/main/resources/php-dt/ApiClient.php.mustache
+++ b/modules/openapi-generator/src/main/resources/php-dt/ApiClient.php.mustache
@@ -36,7 +36,7 @@ class ApiClient extends OAGAC\AbstractApiClient
 {{>api_arg_declaration
 }}    ): ResponseInterface
     {
-        $request = $this->createRequest('{{httpMethod}}', '{{path}}', {{#pathParams.0}}$this->getPathParameters($parameters){{/pathParams.0}}{{^pathParams.0}}[]{{/pathParams.0}}, {{#queryParams.0}}$this->getQueryParameters($parameters){{/queryParams.0}}{{^queryParams.0}}[]{{/queryParams.0}});
+        $request = $this->createRequest('{{httpMethod}}', '{{{path}}}', {{#pathParams.0}}$this->getPathParameters($parameters){{/pathParams.0}}{{^pathParams.0}}[]{{/pathParams.0}}, {{#queryParams.0}}$this->getQueryParameters($parameters){{/queryParams.0}}{{^queryParams.0}}[]{{/queryParams.0}});
 {{#headerParams.0}}
         $request = $this->addCustomHeaders($request, $parameters);
 {{/headerParams.0}}

--- a/modules/openapi-generator/src/main/resources/php-symfony/routing.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/routing.mustache
@@ -8,7 +8,7 @@
 # {{pathPrefix}}
 {{#operation}}
 {{bundleAlias}}_{{pathPrefix}}_{{operationIdLowerCase}}:
-    path:     {{path}}
+    path:     {{{path}}}
     methods:  [{{httpMethod}}]
     defaults:
         _controller: {{bundleAlias}}.controller.{{pathPrefix}}::{{operationId}}Action

--- a/modules/openapi-generator/src/main/resources/postman-collection/item.mustache
+++ b/modules/openapi-generator/src/main/resources/postman-collection/item.mustache
@@ -1,5 +1,5 @@
 {
-    "name": "{{path}}{{#isDeprecated}} (DEPRECATED){{/isDeprecated}}",
+    "name": "{{{path}}}{{#isDeprecated}} (DEPRECATED){{/isDeprecated}}",
                 "description": "{{{notes}}}",
                  "item": [
                         {{#vendorExtensions.postmanRequests}}
@@ -27,7 +27,7 @@
                                         }
                                     },
                                     "url": {
-                                        "raw": "{{=<% %>=}}{{baseUrl}}<%={{ }}=%>{{path}}",
+                                        "raw": "{{=<% %>=}}{{baseUrl}}<%={{ }}=%>{{{path}}}",
                                         "host": [
                                             "{{=<% %>=}}{{baseUrl}}<%={{ }}=%>"
                                         ],

--- a/modules/openapi-generator/src/main/resources/python-fastapi/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/api.mustache
@@ -38,7 +38,7 @@ for _, name, _ in pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + "."):
 {{#operations}}
 {{#operation}}
 @router.{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}(
-    "{{path}}",
+    "{{{path}}}",
     responses={
         {{#responses}}
         {{code}}: {{=<% %>=}}{<%#dataType%>"model": <%dataType%>, "description": "<%message%>"<%/dataType%><%^dataType%>"description": "<%message%>"<%/dataType%>}<%={{ }}=%>,

--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -461,7 +461,7 @@
 
       {{/bodyParams}}
       {{/hasBodyParam}}
-      local_var_url_path <- "{{path}}"
+      local_var_url_path <- "{{{path}}}"
       {{#hasPathParams}}
       {{#pathParams}}
       if (!missing(`{{paramName}}`)) {

--- a/modules/openapi-generator/src/main/resources/ruby-on-rails-server/routes.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-on-rails-server/routes.mustache
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 {{#apis}}
 {{#operations}}
 {{#operation}}
-  add_openapi_route '{{httpMethod}}', '{{basePathWithoutHost}}{{path}}', controller_name: '{{classVarName}}', action_name: {{#isRestfulIndex}}'index'{{/isRestfulIndex}}{{#isRestfulCreate}}'create'{{/isRestfulCreate}}{{#isRestfulUpdate}}'update'{{/isRestfulUpdate}}{{#isRestfulShow}}'show'{{/isRestfulShow}}{{#isRestfulDestroy}}'destroy'{{/isRestfulDestroy}}{{^isRestful}}'{{nickname}}'{{/isRestful}}
+  add_openapi_route '{{httpMethod}}', '{{{basePathWithoutHost}}}{{{path}}}', controller_name: '{{classVarName}}', action_name: {{#isRestfulIndex}}'index'{{/isRestfulIndex}}{{#isRestfulCreate}}'create'{{/isRestfulCreate}}{{#isRestfulUpdate}}'update'{{/isRestfulUpdate}}{{#isRestfulShow}}'show'{{/isRestfulShow}}{{#isRestfulDestroy}}'destroy'{{/isRestfulDestroy}}{{^isRestful}}'{{nickname}}'{{/isRestful}}
 {{/operation}}
 {{/operations}}
 {{/apis}}

--- a/modules/openapi-generator/src/main/resources/scala-lagom-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-lagom-server/api.mustache
@@ -18,7 +18,7 @@ trait {{classname}} extends Service {
     named("{{classname}}").withCalls(
 {{#operations}}
   {{#operation}}
-      restCall(Method.{{httpMethod}}, "{{path}}{{#queryParams.0}}?{{/queryParams.0}}{{#queryParams}}{{paramName}}{{^-last}}&{{/-last}}{{/queryParams}}", {{operationId}} _){{^-last}}, {{/-last}}
+      restCall(Method.{{httpMethod}}, "{{{path}}}{{#queryParams.0}}?{{/queryParams.0}}{{#queryParams}}{{paramName}}{{^-last}}&{{/-last}}{{/queryParams}}", {{operationId}} _){{^-last}}, {{/-last}}
   {{/operation}}
 {{/operations}}
     ).withAutoAcl(true)

--- a/modules/openapi-generator/src/main/resources/scala-play-server/app/apiController.scala.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-play-server/app/apiController.scala.mustache
@@ -19,7 +19,7 @@ import {{import}}
 class {{classname}}Controller @Inject()(cc: ControllerComponents, api: {{classname}}){{#supportAsync}}(implicit executionContext: ExecutionContext){{/supportAsync}} extends AbstractController(cc) {
   {{#operation}}
   /**
-    * {{httpMethod}} {{contextPath}}{{path}}{{#queryParams.0}}?{{/queryParams.0}}{{#queryParams}}{{paramName}}=[value]{{^-last}}&{{/-last}}{{/queryParams}}
+    * {{httpMethod}} {{contextPath}}{{{path}}}{{#queryParams.0}}?{{/queryParams.0}}{{#queryParams}}{{paramName}}=[value]{{^-last}}&{{/-last}}{{/queryParams}}
     {{#pathParams}}
     {{#description}}
     * @param {{paramName}} {{description}}

--- a/modules/openapi-generator/src/main/resources/scalaz/api.mustache
+++ b/modules/openapi-generator/src/main/resources/scalaz/api.mustache
@@ -35,7 +35,7 @@ object {{classname}} {
   def {{nickname}}(host: String{{#allParams}}{{#-first}}, {{/-first}}{{paramName}}: {{dataType}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/allParams}}){{#queryParams}}{{#-first}}(implicit {{/-first}}{{paramName}}Query: QueryParam[{{dataType}}]{{^-last}}, {{/-last}}{{#-last}}){{/-last}}{{/queryParams}}: {{>operationReturnType}}{{#returnType}}    implicit val returnTypeDecoder: EntityDecoder[{{returnType}}] = jsonOf[{{returnType}}]
 
 {{/returnType}}
-    val path = "{{path}}"{{#pathParams}}.replaceAll("\\{" + "{{baseName}}" + "\\}",escape({{paramName}}.toString)){{/pathParams}}
+    val path = "{{{path}}}"{{#pathParams}}.replaceAll("\\{" + "{{baseName}}" + "\\}",escape({{paramName}}.toString)){{/pathParams}}
 
     val httpMethod = Method.{{httpMethod}}
     val contentType = `Content-Type`(MediaType.`application/json`)
@@ -64,7 +64,7 @@ class HttpService{{classname}}(service: HttpService) {
   def {{nickname}}({{#allParams}}{{paramName}}: {{dataType}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/allParams}}){{#queryParams}}{{#-first}}(implicit {{/-first}}{{paramName}}Query: QueryParam[{{dataType}}]{{^-last}}, {{/-last}}{{#-last}}){{/-last}}{{/queryParams}}: {{>operationReturnType}}{{#returnType}}    implicit val returnTypeDecoder: EntityDecoder[{{returnType}}] = jsonOf[{{returnType}}]
 
 {{/returnType}}
-    val path = "{{path}}"{{#pathParams}}.replaceAll("\\{" + "{{baseName}}" + "\\}",escape({{paramName}}.toString)){{/pathParams}}
+    val path = "{{{path}}}"{{#pathParams}}.replaceAll("\\{" + "{{baseName}}" + "\\}",escape({{paramName}}.toString)){{/pathParams}}
 
     val httpMethod = Method.{{httpMethod}}
     val contentType = `Content-Type`(MediaType.`application/json`)

--- a/modules/openapi-generator/src/main/resources/swift-combine/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift-combine/api.mustache
@@ -102,7 +102,7 @@ open class {{classname}} {
                 guard let baseURL = self.transport.baseURL ?? self.baseURL else {
                     throw OpenAPITransportError.badURLError()
                 }
-                {{#pathParams}}{{#-last}}var{{/-last}}{{/pathParams}}{{^pathParams}}let{{/pathParams}} localVarPath = "{{path}}"
+                {{#pathParams}}{{#-last}}var{{/-last}}{{/pathParams}}{{^pathParams}}let{{/pathParams}} localVarPath = "{{{path}}}"
                 {{#pathParams}}
                 {{#required}}localVarPath = localVarPath.replacingOccurrences(of: "{{=<% %>=}}{<%baseName%>}<%={{ }}=%>", with: {{> toString}}){{/required}}{{^required}}if let {{paramName}} = {{paramName}} { localVarPath = localVarPath.replacingOccurrences(of: "{{=<% %>=}}{<%baseName%>}<%={{ }}=%>", with: {{> toString}}) } {{/required}}
                 {{/pathParams}}

--- a/modules/openapi-generator/src/main/resources/zapier/api.mustache
+++ b/modules/openapi-generator/src/main/resources/zapier/api.mustache
@@ -80,7 +80,7 @@ module.exports = {
                 {{/allParams}}
                 {{/isMultipart}}
                 const options = {
-                    url: utils.replacePathParameters('{{basePath}}{{path}}'),
+                    url: utils.replacePathParameters('{{{basePath}}}{{{path}}}'),
                     method: '{{httpMethod}}',
                     removeMissingValuesFrom: { params: true, body: true },
                     headers: {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
