### PR TITLE
Fix Rust generation for versions without minor or patch parts

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -422,9 +422,12 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
                 content = content.trim().replace("v", "");
                 content = content.replace("V", "");
 
-                // convert 5.2 to 5.2.0 for example
                 String[] contents = content.split("[.]");
-                if (contents.length == 2) {
+                if (contents.length == 1) {
+                    // convert 5 to 5.0.0 for example
+                    content += ".0.0";
+                } else if (contents.length == 2) {
+                    // convert 5.2 to 5.2.0 for example
                     content += ".0";
                 }
 


### PR DESCRIPTION
This fixes generation of a Rust library for OpenAPI specifications where `info.version` was a single-digit number. This happened to for [this](https://github.com/motis-project/motis/blob/db005f2e55812b8231e2e2dbac4d3abf711a8610/openapi.yaml#L10) specification. The fix for this issue is similar to the one in !17440.

The error of Rust generates for this is:

```
error: unexpected end of input while parsing major version number
 --> Cargo.toml:3:11
  |
3 | version = "1"
  |           ^^^
  |
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md). (I know I am supposed to open an issue discussing this change before actually opening the PR, but I think this change is simple enough to not require much discussion in an issue).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10)