### PR TITLE
[#19947] add parameter 'useURLSearchParams' to use JS build-in UrlSearchParams, instead of deprecated npm lib 'querystring'

### DIFF
--- a/docs/generators/javascript.md
+++ b/docs/generators/javascript.md
@@ -43,6 +43,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sourceFolder|source folder for generated code| |src|
 |useInheritance|use JavaScript prototype chains &amp; delegation for inheritance| |true|
 |usePromises|use Promises as return values from the client API, instead of superagent callbacks| |false|
+|useURLSearchParams|use JS build-in UrlSearchParams, instead of deprecated npm lib 'querystring'| |false|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
@@ -57,6 +57,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     public static final String EMIT_JS_DOC = "emitJSDoc";
     public static final String USE_ES6 = "useES6";
     public static final String NPM_REPOSITORY = "npmRepository";
+    public static final String USE_URL_SEARCH_PARAMS = "useURLSearchParams";
 
     public static final String LIBRARY_JAVASCRIPT = "javascript";
     public static final String LIBRARY_APOLLO = "apollo";
@@ -80,6 +81,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     protected boolean useES6 = true; // default is ES6
     @Setter protected String npmRepository = null;
     @Getter private String modelPropertyNaming = "camelCase";
+    @Setter protected boolean useURLSearchParams = false;
 
     public JavascriptClientCodegen() {
         super();
@@ -190,6 +192,10 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
                 .defaultValue(Boolean.TRUE.toString()));
         cliOptions.add(new CliOption(CodegenConstants.MODEL_PROPERTY_NAMING, CodegenConstants.MODEL_PROPERTY_NAMING_DESC).defaultValue("camelCase"));
         cliOptions.add(new CliOption(NPM_REPOSITORY, "Use this property to set an url your private npmRepo in the package.json"));
+        cliOptions.add(new CliOption(USE_URL_SEARCH_PARAMS,
+                "use JS build-in UrlSearchParams, instead of deprecated npm lib 'querystring'")
+                .defaultValue(Boolean.FALSE.toString())
+        );
 
         supportedLibraries.put(LIBRARY_JAVASCRIPT, "JavaScript client library");
         supportedLibraries.put(LIBRARY_APOLLO, "Apollo REST DataSource");
@@ -267,6 +273,9 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         if (additionalProperties.containsKey(NPM_REPOSITORY)) {
             setNpmRepository(((String) additionalProperties.get(NPM_REPOSITORY)));
         }
+        if (additionalProperties.containsKey(USE_URL_SEARCH_PARAMS)) {
+            setUseURLSearchParams(convertPropertyToBooleanAndWriteBack(USE_URL_SEARCH_PARAMS));
+        }
         if (additionalProperties.containsKey(CodegenConstants.LIBRARY)) {
             setLibrary((String) additionalProperties.get(CodegenConstants.LIBRARY));
         }
@@ -334,6 +343,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         additionalProperties.put(EMIT_JS_DOC, emitJSDoc);
         additionalProperties.put(USE_ES6, useES6);
         additionalProperties.put(NPM_REPOSITORY, npmRepository);
+        additionalProperties.put(USE_URL_SEARCH_PARAMS, useURLSearchParams);
 
         // make api and model doc path available in mustache template
         additionalProperties.put("apiDocPath", apiDocPath);

--- a/modules/openapi-generator/src/main/resources/Javascript/libraries/javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/libraries/javascript/ApiClient.mustache
@@ -1,7 +1,10 @@
 {{>licenseInfo}}
 
 import superagent from "superagent";
+{{^useURLSearchParams}}
 import querystring from "querystring";
+{{! see https://www.npmjs.com/package/querystring && https://github.com/Gozala/querystring }}
+{{/useURLSearchParams}}
 
 {{#emitJSDoc}}/**
 * @module {{#invokerPackage}}{{.}}/{{/invokerPackage}}ApiClient
@@ -455,7 +458,15 @@ class ApiClient {
         }
 
         if (contentType === 'application/x-www-form-urlencoded') {
-            request.send(querystring.stringify(this.normalizeParams(formParams)));
+            {{^useURLSearchParams}}
+            let queryString = querystring.stringify(this.normalizeParams(formParams));
+            {{/useURLSearchParams}}
+            {{#useURLSearchParams}}
+            let normalizedParams = this.normalizeParams(formParams)
+            let urlSearchParams =  new URLSearchParams(normalizedParams);
+            let queryString = urlSearchParams.toString();
+            {{/useURLSearchParams}}
+            request.send(queryString);
         } else if (contentType == 'multipart/form-data') {
             var _formParams = this.normalizeParams(formParams);
             for (var key in _formParams) {


### PR DESCRIPTION
Fixes #19947 

- Added a new parameter 'useURLSearchParams' to the JavaScript Client Codegen
- If set to true, the deprecated npm ['querystring'](https://www.npmjs.com/package/querystring) is not generated anymore in the javascript code. Instead we use [UrlSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams), which is a built-in function of javascript.
- If set to false, the old behavior is still generated.
- Default value is 'false'

Additional tests:
- manual testing with openapi-generator-cli additional properties and configuration file

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@CodeNinjai @frol @cliffano
