### PR TITLE
[java] Fix generation of POJOs with sets of enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -395,7 +395,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     {{#uniqueItems}}
     if ({{getter}}() != null) {
       int i = 0;
-      for ({{{items.dataType}}} _item : {{getter}}()) {
+      for ({{{items.datatypeWithEnum}}} _item : {{getter}}()) {
         try {
           joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
               "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/apachehttpclient/ApacheHttpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/apachehttpclient/ApacheHttpClientCodegenTest.java
@@ -90,4 +90,28 @@ public class ApacheHttpClientCodegenTest {
             "localVarQueryParams.addAll(apiClient.parameterToPairs(\"multi\", \"values\", queryObject.getValues()))"
         );
     }
+
+    @Test
+    void testApacheHttpClientQueryParamHandlingUniqueItemsStringEnum() throws IOException {
+        // Arrange
+        var output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        var configurator = new CodegenConfigurator()
+                .setGeneratorName("java")
+                .setLibrary(JavaClientCodegen.APACHE)
+                .setInputSpec("src/test/resources/3_0/unique-items-string-enum.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+
+        // Act
+        var files = generator.opts(clientOptInput).generate();
+
+        // Assert
+        TestUtils.assertFileContains(Paths.get(output + "/src/main/java/org/openapitools/client/model/GetUsersRequestV1.java"),
+                "for (RolesEnum _item : getRoles()) {"
+        );
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/unique-items-string-enum.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/unique-items-string-enum.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.1
+info:
+  title: Sample API to test generation of schemas with uniqueItems arrays of enums
+  description: API description in Markdown.
+  version: 1.0.0
+servers: []
+paths: {}
+components:
+  schemas:
+    GetUsersRequestV1:
+      type: object
+      properties:
+        roles:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+            enum:
+              - ROLE1
+              - ROLE2


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes #19957

See the mentioned issue for more details on issue reproduction/validation. I changed the pojo.mustache file to use {{datatypeWithEnum}} instead of {{dataType}} and added a test.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
