### PR TITLE
fix(csharp): Fixed JsonConverter for discriminators only appearing on base classes

### DIFF
--- a/modules/openapi-generator/src/main/resources/aspnetcore/3.0/model.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/3.0/model.mustache
@@ -34,7 +34,9 @@ namespace {{modelPackage}}
     [DataContract]
     {{#discriminator}}
     {{#useNewtonsoft}}
+    {{#mappedModels.size}}
     [JsonConverter(typeof(JsonSubtypes), "{{{discriminatorName}}}")]
+    {{/mappedModels.size}}
     {{/useNewtonsoft}}
     {{#useSwashbuckle}}
     [SwaggerDiscriminator("{{{discriminatorName}}}")]

--- a/modules/openapi-generator/src/main/resources/csharp-functions/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-functions/modelGeneric.mustache
@@ -3,7 +3,9 @@
     /// </summary>
     [DataContract(Name = "{{{name}}}")]
     {{#discriminator}}
+    {{#mappedModels.size}}
     [JsonConverter(typeof(JsonSubtypes), "{{{discriminatorName}}}")]
+    {{/mappedModels.size}}
     {{#mappedModels}}
     [JsonSubtypes.KnownSubType(typeof({{{modelName}}}), "{{^vendorExtensions.x-discriminator-value}}{{{mappingName}}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{.}}}{{/vendorExtensions.x-discriminator-value}}")]
     {{/mappedModels}}

--- a/modules/openapi-generator/src/main/resources/csharp/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/modelGeneric.mustache
@@ -10,7 +10,9 @@
     [DataContract(Name = "{{{name}}}")]
     {{^useUnityWebRequest}}
     {{#discriminator}}
+    {{#mappedModels.size}}
     [JsonConverter(typeof(JsonSubtypes), "{{{discriminatorName}}}")]
+    {{/mappedModels.size}}
     {{#mappedModels}}
     [JsonSubtypes.KnownSubType(typeof({{{modelName}}}), "{{^vendorExtensions.x-discriminator-value}}{{{mappingName}}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{.}}}{{/vendorExtensions.x-discriminator-value}}")]
     {{/mappedModels}}

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -32,7 +32,6 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -32,7 +32,6 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -32,7 +32,6 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Cat.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Model/Dog.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Cat.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/Dog.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -31,7 +31,6 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This fixes the issue mentioned in https://github.com/OpenAPITools/openapi-generator/issues/17990.

The change was tested and applied using template overrides in the modelGeneric scenario. I updated all other references to this attribute as it should be causing the same issue.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
