### PR TITLE
feat: update jdk to 21 in docker

### DIFF
--- a/.hub.cli.dockerfile
+++ b/.hub.cli.dockerfile
@@ -3,7 +3,7 @@
 ##
 ## You can build _just_ this part with:
 ##     docker --target builder -t container-name:builder -f .hub.cli.dockerfile .
-FROM maven:3-eclipse-temurin-17 as builder
+FROM maven:3-eclipse-temurin-21 as builder
 
 ENV GEN_DIR /opt/openapi-generator
 WORKDIR ${GEN_DIR}
@@ -15,7 +15,7 @@ RUN mvn -B -am -pl "modules/openapi-generator-cli" package
 ## The final (release) image
 ## The resulting container here only needs the target jar
 ## and ca-certificates (to be able to query HTTPS hosted specs)
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 
 ENV GEN_DIR /opt/openapi-generator
 

--- a/.hub.online.dockerfile
+++ b/.hub.online.dockerfile
@@ -3,7 +3,7 @@
 ##
 ## You can build _just_ this part with:
 ##     docker --target builder -t container-name:builder -f .hub.online.dockerfile .
-FROM maven:3-eclipse-temurin-17 as builder
+FROM maven:3-eclipse-temurin-21 as builder
 
 ENV GEN_DIR /opt/openapi-generator
 WORKDIR ${GEN_DIR}
@@ -14,7 +14,7 @@ RUN mvn -B -am -pl "modules/openapi-generator-online" package
 
 ## The final (release) image
 ## The resulting container here only needs the target jar
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 
 ENV GEN_DIR /opt/openapi-generator
 ENV TARGET_DIR /generator

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-eclipse-temurin-17
+FROM maven:3-eclipse-temurin-21
 
 ENV GEN_DIR /opt/openapi-generator
 WORKDIR ${GEN_DIR}

--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -21,4 +21,4 @@ docker run --rm -it \
         -v "${PWD}/CI/run-in-docker-settings.xml:/var/maven/.m2/settings.xml" \
         -v "${maven_cache_repo}:/var/maven/.m2/repository" \
         --entrypoint /gen/docker-entrypoint.sh \
-        maven:3-eclipse-temurin-17 "$@"
+        maven:3-eclipse-temurin-21 "$@"


### PR DESCRIPTION
The Docker setup currently used JDK 17 which is kinda outdated, so I updated the Docker files to use JDK 21 LTS.