### PR TITLE
[BUG][KOTLIN] Sanitize names of the adapter variables in anyOf and oneOf model template to avoid compilation errors

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/anyof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/anyof_class.mustache
@@ -83,7 +83,7 @@ import java.io.IOException
             {{#anyOf}}
             {{^isArray}}
             {{^vendorExtensions.x-duplicated-data-type}}
-            val adapter{{{dataType}}} = gson.getDelegateAdapter(this, TypeToken.get({{{dataType}}}::class.java))
+            val adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}} = gson.getDelegateAdapter(this, TypeToken.get({{{dataType}}}::class.java))
             {{/vendorExtensions.x-duplicated-data-type}}
             {{/isArray}}
             {{#isArray}}
@@ -122,7 +122,7 @@ import java.io.IOException
                         return
                     {{/isPrimitiveType}}
                     {{^isPrimitiveType}}
-                        val element = adapter{{{dataType}}}.toJsonTree(value.actualInstance as {{{dataType}}}?)
+                        val element = adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}.toJsonTree(value.actualInstance as {{{dataType}}}?)
                         elementAdapter.write(out, element)
                         return
                     {{/isPrimitiveType}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/anyof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/anyof_class.mustache
@@ -185,7 +185,7 @@ import java.io.IOException
                         for(element in jsonElement.getAsJsonArray()) {
                         {{#items}}
                         {{#isNumber}}
-                            require(jsonElement.getAsJsonPrimitive().isNumber) {
+                            require(element.getAsJsonPrimitive().isNumber) {
                                 String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString())
                             }
                         {{/isNumber}}
@@ -236,6 +236,101 @@ import java.io.IOException
                     throw IOException(String.format("Failed deserialization for {{classname}}: no schema match result. Detailed failure message for anyOf schemas: %s. JSON: %s", errorMessages, jsonElement.toString()))
                 }
             }.nullSafe() as TypeAdapter<T>
+        }
+    }
+
+    companion object {
+        /**
+        * Validates the JSON Element and throws an exception if issues found
+        *
+        * @param jsonElement JSON Element
+        * @throws IOException if the JSON Element is invalid with respect to {{classname}}
+        */
+        @Throws(IOException::class)
+        fun validateJsonElement(jsonElement: JsonElement?) {
+            requireNotNull(jsonElement) {
+                "Provided json element must not be null"
+            }
+            var match = 0
+            val errorMessages = ArrayList<String>()
+            {{#composedSchemas}}
+            {{#anyOf}}
+            {{^vendorExtensions.x-duplicated-data-type}}
+            {{^hasVars}}
+            // validate the json string with {{{dataType}}}
+            try {
+                // validate the JSON object to see if any exception is thrown
+            {{^isArray}}
+            {{#isNumber}}
+                require(jsonElement.getAsJsonPrimitive().isNumber()) {
+                    String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString())
+                }
+            {{/isNumber}}
+            {{^isNumber}}
+            {{#isPrimitiveType}}
+                require(jsonElement.getAsJsonPrimitive().is{{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}}()) {
+                    String.format("Expected json element to be of type {{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}} in the JSON string but got `%s`", jsonElement.toString())
+                }
+            {{/isPrimitiveType}}
+            {{/isNumber}}
+            {{^isNumber}}
+            {{^isPrimitiveType}}
+                {{{dataType}}}.validateJsonElement(jsonElement)
+            {{/isPrimitiveType}}
+            {{/isNumber}}
+            {{/isArray}}
+            {{#isArray}}
+                require(jsonElement.isJsonArray) {
+                    String.format("Expected json element to be a array type in the JSON string but got `%s`", jsonElement.toString())
+                }
+
+                // validate array items
+                for(element in jsonElement.getAsJsonArray()) {
+                {{#items}}
+                {{#isNumber}}
+                    require(element.getAsJsonPrimitive().isNumber) {
+                        String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString())
+                    }
+                {{/isNumber}}
+                {{^isNumber}}
+                {{#isPrimitiveType}}
+                    require(element.getAsJsonPrimitive().is{{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}}) {
+                        String.format("Expected array items to be of type {{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}} in the JSON string but got `%s`", jsonElement.toString())
+                    }
+                {{/isPrimitiveType}}
+                {{/isNumber}}
+                {{^isNumber}}
+                {{^isPrimitiveType}}
+                    {{{dataType}}}.validateJsonElement(element)
+                {{/isPrimitiveType}}
+                {{/isNumber}}
+                {{/items}}
+                }
+            {{/isArray}}
+                match++
+            } catch (e: Exception) {
+                // Validation failed, continue
+                errorMessages.add(String.format("Validation for {{{dataType}}} failed with `%s`.", e.message))
+            }
+            {{/hasVars}}
+            {{#hasVars}}
+            // validate json string for {{{.}}}
+            try {
+                // validate the JSON object to see if any exception is thrown
+                {{.}}.validateJsonElement(jsonElement)
+                match++
+            } catch (e: Exception) {
+                // validation failed, continue
+                errorMessages.add(String.format("Validation for {{{.}}} failed with `%s`.", e.message))
+            }
+            {{/hasVars}}
+            {{/vendorExtensions.x-duplicated-data-type}}
+            {{/anyOf}}
+            {{/composedSchemas}}
+
+            if (match != 1) {
+                throw IOException(String.format("Failed validation for {{classname}}: %d classes match result, expected 1. Detailed failure message for oneOf schemas: %s. JSON: %s", match, errorMessages, jsonElement.toString()))
+            }
         }
     }
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
@@ -179,7 +179,7 @@ import java.io.IOException
                         for(element in jsonElement.getAsJsonArray()) {
                         {{#items}}
                         {{#isNumber}}
-                            require(jsonElement.getAsJsonPrimitive().isNumber) {
+                            require(element.getAsJsonPrimitive().isNumber) {
                                 String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString())
                             }
                         {{/isNumber}}
@@ -234,6 +234,101 @@ import java.io.IOException
                     throw IOException(String.format("Failed deserialization for {{classname}}: %d classes match result, expected 1. Detailed failure message for oneOf schemas: %s. JSON: %s", match, errorMessages, jsonElement.toString()))
                 }
             }.nullSafe() as TypeAdapter<T>
+        }
+    }
+
+    companion object {
+        /**
+        * Validates the JSON Element and throws an exception if issues found
+        *
+        * @param jsonElement JSON Element
+        * @throws IOException if the JSON Element is invalid with respect to {{classname}}
+        */
+        @Throws(IOException::class)
+        fun validateJsonElement(jsonElement: JsonElement?) {
+            requireNotNull(jsonElement) {
+                "Provided json element must not be null"
+            }
+            var match = 0
+            val errorMessages = ArrayList<String>()
+            {{#composedSchemas}}
+            {{#oneOf}}
+            {{^vendorExtensions.x-duplicated-data-type}}
+            {{^hasVars}}
+            // validate the json string with {{{dataType}}}
+            try {
+                // validate the JSON object to see if any exception is thrown
+            {{^isArray}}
+            {{#isNumber}}
+                require(jsonElement.getAsJsonPrimitive().isNumber()) {
+                    String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString())
+                }
+            {{/isNumber}}
+            {{^isNumber}}
+            {{#isPrimitiveType}}
+                require(jsonElement.getAsJsonPrimitive().is{{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}}()) {
+                    String.format("Expected json element to be of type {{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}} in the JSON string but got `%s`", jsonElement.toString())
+                }
+            {{/isPrimitiveType}}
+            {{/isNumber}}
+            {{^isNumber}}
+            {{^isPrimitiveType}}
+                {{{dataType}}}.validateJsonElement(jsonElement)
+            {{/isPrimitiveType}}
+            {{/isNumber}}
+            {{/isArray}}
+            {{#isArray}}
+                require(jsonElement.isJsonArray) {
+                    String.format("Expected json element to be a array type in the JSON string but got `%s`", jsonElement.toString())
+                }
+
+                // validate array items
+                for(element in jsonElement.getAsJsonArray()) {
+                {{#items}}
+                {{#isNumber}}
+                    require(jsonElement.getAsJsonPrimitive().isNumber) {
+                        String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString())
+                    }
+                {{/isNumber}}
+                {{^isNumber}}
+                {{#isPrimitiveType}}
+                    require(element.getAsJsonPrimitive().is{{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}}) {
+                        String.format("Expected array items to be of type {{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}} in the JSON string but got `%s`", jsonElement.toString())
+                    }
+                {{/isPrimitiveType}}
+                {{/isNumber}}
+                {{^isNumber}}
+                {{^isPrimitiveType}}
+                    {{{dataType}}}.validateJsonElement(element)
+                {{/isPrimitiveType}}
+                {{/isNumber}}
+                {{/items}}
+                }
+            {{/isArray}}
+                match++
+            } catch (e: Exception) {
+                // Validation failed, continue
+                errorMessages.add(String.format("Validation for {{{dataType}}} failed with `%s`.", e.message))
+            }
+            {{/hasVars}}
+            {{#hasVars}}
+            // validate json string for {{{.}}}
+            try {
+                // validate the JSON object to see if any exception is thrown
+                {{.}}.validateJsonElement(jsonElement)
+                match++
+            } catch (e: Exception) {
+                // validation failed, continue
+                errorMessages.add(String.format("Validation for {{{.}}} failed with `%s`.", e.message))
+            }
+            {{/hasVars}}
+            {{/vendorExtensions.x-duplicated-data-type}}
+            {{/oneOf}}
+            {{/composedSchemas}}
+
+            if (match != 1) {
+                throw IOException(String.format("Failed validation for {{classname}}: %d classes match result, expected 1. Detailed failure message for oneOf schemas: %s. JSON: %s", match, errorMessages, jsonElement.toString()))
+            }
         }
     }
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
@@ -83,7 +83,7 @@ import java.io.IOException
             {{#oneOf}}
             {{^isArray}}
             {{^vendorExtensions.x-duplicated-data-type}}
-            val adapter{{{dataType}}} = gson.getDelegateAdapter(this, TypeToken.get({{{dataType}}}::class.java))
+            val adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}} = gson.getDelegateAdapter(this, TypeToken.get({{{dataType}}}::class.java))
             {{/vendorExtensions.x-duplicated-data-type}}
             {{/isArray}}
             {{#isArray}}
@@ -122,7 +122,7 @@ import java.io.IOException
                         return
                     {{/isPrimitiveType}}
                     {{^isPrimitiveType}}
-                        val element = adapter{{{dataType}}}.toJsonTree(value.actualInstance as {{{dataType}}}?)
+                        val element = adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}.toJsonTree(value.actualInstance as {{{dataType}}}?)
                         elementAdapter.write(out, element)
                         return
                     {{/isPrimitiveType}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/ClientLibrary.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/ClientLibrary.java
@@ -1,0 +1,29 @@
+package org.openapitools.codegen.kotlin;
+
+import lombok.Getter;
+import org.jetbrains.kotlin.com.intellij.openapi.util.text.Strings;
+
+@Getter
+enum ClientLibrary {
+    JVM_KTOR("main/kotlin"),
+    JVM_OKHTTP4("main/kotlin"),
+    JVM_SPRING_WEBCLIENT("main/kotlin"),
+    JVM_SPRING_RESTCLIENT("main/kotlin"),
+    JVM_RETROFIT2("main/kotlin"),
+    MULTIPLATFORM("commonMain/kotlin"),
+    JVM_VOLLEY("gson", "main/java"),
+    JVM_VERTX("main/kotlin");
+    private final String serializationLibrary;
+    private final String libraryName;
+    private final String sourceRoot;
+
+    ClientLibrary(String serializationLibrary, String sourceRoot) {
+        this.serializationLibrary = serializationLibrary;
+        this.sourceRoot = sourceRoot;
+        this.libraryName = Strings.toLowerCase(this.name()).replace("_", "-");
+    }
+
+    ClientLibrary(String sourceRoot) {
+        this("jackson", sourceRoot);
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenApiTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenApiTest.java
@@ -22,7 +22,7 @@ import static org.openapitools.codegen.TestUtils.assertFileContains;
 
 public class KotlinClientCodegenApiTest {
 
-    @DataProvider(name = "pathResponses")
+    @DataProvider(name = "clientLibraries")
     public Object[][] pathResponses() {
         return new Object[][]{
                 {ClientLibrary.JVM_KTOR},
@@ -36,7 +36,7 @@ public class KotlinClientCodegenApiTest {
         };
     }
 
-    @Test(dataProvider = "pathResponses")
+    @Test(dataProvider = "clientLibraries")
     void testPathVariableIsNotEscaped_19930(ClientLibrary library) throws IOException {
 
         OpenAPI openAPI = new OpenAPIParser()
@@ -75,30 +75,5 @@ public class KotlinClientCodegenApiTest {
         codegen.additionalProperties().put(KotlinClientCodegen.USE_SPRING_BOOT3, "true");
         codegen.additionalProperties().put(KotlinClientCodegen.DATE_LIBRARY, "kotlinx-datetime");
         return codegen;
-    }
-
-    @Getter
-    private enum ClientLibrary {
-        JVM_KTOR("main/kotlin"),
-        JVM_OKHTTP4("main/kotlin"),
-        JVM_SPRING_WEBCLIENT("main/kotlin"),
-        JVM_SPRING_RESTCLIENT("main/kotlin"),
-        JVM_RETROFIT2("main/kotlin"),
-        MULTIPLATFORM("commonMain/kotlin"),
-        JVM_VOLLEY("gson", "main/java"),
-        JVM_VERTX("main/kotlin");
-        private final String serializationLibrary;
-        private final String libraryName;
-        private final String sourceRoot;
-
-        ClientLibrary(String serializationLibrary, String sourceRoot) {
-            this.serializationLibrary = serializationLibrary;
-            this.sourceRoot = sourceRoot;
-            this.libraryName = Strings.toLowerCase(this.name()).replace("_", "-");
-        }
-
-        ClientLibrary(String sourceRoot) {
-            this("jackson", sourceRoot);
-        }
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_19942.json
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_19942.json
@@ -1,0 +1,72 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "xxxxx",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://xxxxx"
+    },
+    {
+      "url": "http://localhost:3000"
+    }
+  ],
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOneOf",
+        "tags": [
+          "testOneOf"
+        ],
+        "summary": "fetches oneOf id",
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObjectWithComplexOneOf"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas": {
+      "ObjectWithComplexOneOf" : {
+        "type": "object",
+        "properties": {
+          "id": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        }
+      },
+      "ObjectWithComplexAnyOf" : {
+        "type": "object",
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiAnyOfUserOrPet.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiAnyOfUserOrPet.kt
@@ -111,4 +111,43 @@ data class ApiAnyOfUserOrPet(var actualInstance: Any? = null) {
             }.nullSafe() as TypeAdapter<T>
         }
     }
+
+    companion object {
+        /**
+        * Validates the JSON Element and throws an exception if issues found
+        *
+        * @param jsonElement JSON Element
+        * @throws IOException if the JSON Element is invalid with respect to ApiAnyOfUserOrPet
+        */
+        @Throws(IOException::class)
+        fun validateJsonElement(jsonElement: JsonElement?) {
+            requireNotNull(jsonElement) {
+                "Provided json element must not be null"
+            }
+            var match = 0
+            val errorMessages = ArrayList<String>()
+            // validate the json string with ApiUser
+            try {
+                // validate the JSON object to see if any exception is thrown
+                ApiUser.validateJsonElement(jsonElement)
+                match++
+            } catch (e: Exception) {
+                // Validation failed, continue
+                errorMessages.add(String.format("Validation for ApiUser failed with `%s`.", e.message))
+            }
+            // validate the json string with ApiPet
+            try {
+                // validate the JSON object to see if any exception is thrown
+                ApiPet.validateJsonElement(jsonElement)
+                match++
+            } catch (e: Exception) {
+                // Validation failed, continue
+                errorMessages.add(String.format("Validation for ApiPet failed with `%s`.", e.message))
+            }
+
+            if (match != 1) {
+                throw IOException(String.format("Failed validation for ApiAnyOfUserOrPet: %d classes match result, expected 1. Detailed failure message for oneOf schemas: %s. JSON: %s", match, errorMessages, jsonElement.toString()))
+            }
+        }
+    }
 }

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiAnyOfUserOrPetOrArrayString.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiAnyOfUserOrPetOrArrayString.kt
@@ -144,4 +144,61 @@ data class ApiAnyOfUserOrPetOrArrayString(var actualInstance: Any? = null) {
             }.nullSafe() as TypeAdapter<T>
         }
     }
+
+    companion object {
+        /**
+        * Validates the JSON Element and throws an exception if issues found
+        *
+        * @param jsonElement JSON Element
+        * @throws IOException if the JSON Element is invalid with respect to ApiAnyOfUserOrPetOrArrayString
+        */
+        @Throws(IOException::class)
+        fun validateJsonElement(jsonElement: JsonElement?) {
+            requireNotNull(jsonElement) {
+                "Provided json element must not be null"
+            }
+            var match = 0
+            val errorMessages = ArrayList<String>()
+            // validate the json string with ApiUser
+            try {
+                // validate the JSON object to see if any exception is thrown
+                ApiUser.validateJsonElement(jsonElement)
+                match++
+            } catch (e: Exception) {
+                // Validation failed, continue
+                errorMessages.add(String.format("Validation for ApiUser failed with `%s`.", e.message))
+            }
+            // validate the json string with ApiPet
+            try {
+                // validate the JSON object to see if any exception is thrown
+                ApiPet.validateJsonElement(jsonElement)
+                match++
+            } catch (e: Exception) {
+                // Validation failed, continue
+                errorMessages.add(String.format("Validation for ApiPet failed with `%s`.", e.message))
+            }
+            // validate the json string with kotlin.collections.List<kotlin.String>
+            try {
+                // validate the JSON object to see if any exception is thrown
+                require(jsonElement.isJsonArray) {
+                    String.format("Expected json element to be a array type in the JSON string but got `%s`", jsonElement.toString())
+                }
+
+                // validate array items
+                for(element in jsonElement.getAsJsonArray()) {
+                    require(element.getAsJsonPrimitive().isString) {
+                        String.format("Expected array items to be of type String in the JSON string but got `%s`", jsonElement.toString())
+                    }
+                }
+                match++
+            } catch (e: Exception) {
+                // Validation failed, continue
+                errorMessages.add(String.format("Validation for kotlin.collections.List<kotlin.String> failed with `%s`.", e.message))
+            }
+
+            if (match != 1) {
+                throw IOException(String.format("Failed validation for ApiAnyOfUserOrPetOrArrayString: %d classes match result, expected 1. Detailed failure message for oneOf schemas: %s. JSON: %s", match, errorMessages, jsonElement.toString()))
+            }
+        }
+    }
 }

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiUserOrPet.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiUserOrPet.kt
@@ -115,4 +115,43 @@ data class ApiUserOrPet(var actualInstance: Any? = null) {
             }.nullSafe() as TypeAdapter<T>
         }
     }
+
+    companion object {
+        /**
+        * Validates the JSON Element and throws an exception if issues found
+        *
+        * @param jsonElement JSON Element
+        * @throws IOException if the JSON Element is invalid with respect to ApiUserOrPet
+        */
+        @Throws(IOException::class)
+        fun validateJsonElement(jsonElement: JsonElement?) {
+            requireNotNull(jsonElement) {
+                "Provided json element must not be null"
+            }
+            var match = 0
+            val errorMessages = ArrayList<String>()
+            // validate the json string with ApiUser
+            try {
+                // validate the JSON object to see if any exception is thrown
+                ApiUser.validateJsonElement(jsonElement)
+                match++
+            } catch (e: Exception) {
+                // Validation failed, continue
+                errorMessages.add(String.format("Validation for ApiUser failed with `%s`.", e.message))
+            }
+            // validate the json string with ApiPet
+            try {
+                // validate the JSON object to see if any exception is thrown
+                ApiPet.validateJsonElement(jsonElement)
+                match++
+            } catch (e: Exception) {
+                // Validation failed, continue
+                errorMessages.add(String.format("Validation for ApiPet failed with `%s`.", e.message))
+            }
+
+            if (match != 1) {
+                throw IOException(String.format("Failed validation for ApiUserOrPet: %d classes match result, expected 1. Detailed failure message for oneOf schemas: %s. JSON: %s", match, errorMessages, jsonElement.toString()))
+            }
+        }
+    }
 }

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiUserOrPetOrArrayString.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiUserOrPetOrArrayString.kt
@@ -147,4 +147,61 @@ data class ApiUserOrPetOrArrayString(var actualInstance: Any? = null) {
             }.nullSafe() as TypeAdapter<T>
         }
     }
+
+    companion object {
+        /**
+        * Validates the JSON Element and throws an exception if issues found
+        *
+        * @param jsonElement JSON Element
+        * @throws IOException if the JSON Element is invalid with respect to ApiUserOrPetOrArrayString
+        */
+        @Throws(IOException::class)
+        fun validateJsonElement(jsonElement: JsonElement?) {
+            requireNotNull(jsonElement) {
+                "Provided json element must not be null"
+            }
+            var match = 0
+            val errorMessages = ArrayList<String>()
+            // validate the json string with ApiUser
+            try {
+                // validate the JSON object to see if any exception is thrown
+                ApiUser.validateJsonElement(jsonElement)
+                match++
+            } catch (e: Exception) {
+                // Validation failed, continue
+                errorMessages.add(String.format("Validation for ApiUser failed with `%s`.", e.message))
+            }
+            // validate the json string with ApiPet
+            try {
+                // validate the JSON object to see if any exception is thrown
+                ApiPet.validateJsonElement(jsonElement)
+                match++
+            } catch (e: Exception) {
+                // Validation failed, continue
+                errorMessages.add(String.format("Validation for ApiPet failed with `%s`.", e.message))
+            }
+            // validate the json string with kotlin.collections.List<kotlin.String>
+            try {
+                // validate the JSON object to see if any exception is thrown
+                require(jsonElement.isJsonArray) {
+                    String.format("Expected json element to be a array type in the JSON string but got `%s`", jsonElement.toString())
+                }
+
+                // validate array items
+                for(element in jsonElement.getAsJsonArray()) {
+                    require(element.getAsJsonPrimitive().isString) {
+                        String.format("Expected array items to be of type String in the JSON string but got `%s`", jsonElement.toString())
+                    }
+                }
+                match++
+            } catch (e: Exception) {
+                // Validation failed, continue
+                errorMessages.add(String.format("Validation for kotlin.collections.List<kotlin.String> failed with `%s`.", e.message))
+            }
+
+            if (match != 1) {
+                throw IOException(String.format("Failed validation for ApiUserOrPetOrArrayString: %d classes match result, expected 1. Detailed failure message for oneOf schemas: %s. JSON: %s", match, errorMessages, jsonElement.toString()))
+            }
+        }
+    }
 }


### PR DESCRIPTION
Pr introduces sanitizing of the adapter... names in the oneOf and anyOf model templates in order to avoid incorrect names being generated. 
The root cause of this issue comes from the fact that Kotlin generator uses canonical names for type mappings and thus {{dataType}} variable is a canonical name with dots. It is then used for variable names generation.
Sanitizing of the names will be enough to fix #19942 but the type mappings problem should also be addressed imo. 
It seems that other generators (i.e. java) are not having this issue.

During the preparation of this fix, I also realized that `validateJsonElement` methods are also missing in oneOf and anyOf classes, which would also cause the compilation errors. I fixed this issue as well in the scope of this pr.

Technical Kotlin Committee:
@dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier @e5l

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
