### PR TITLE
Refactor copy lambda

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -33,6 +33,8 @@ import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
 import org.openapitools.codegen.templating.mustache.*;
+import org.openapitools.codegen.templating.mustache.CopyLambda.CopyContent;
+import org.openapitools.codegen.templating.mustache.CopyLambda.WhiteSpaceStrategy;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -427,7 +429,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
 
     @Override
     protected ImmutableMap.Builder<String, Lambda> addMustacheLambdas() {
-        CopyLambda copyLambda = new CopyLambda();
+        final CopyContent copyContent = new CopyContent();
 
         return super.addMustacheLambdas()
                 .put("camelcase_sanitize_param", new CamelCaseAndSanitizeLambda().generator(this).escapeAsParamName(true))
@@ -443,12 +445,13 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
                 .put("first", new FirstLambda("  "))
                 .put("firstDot", new FirstLambda("\\."))
                 .put("indent1", new IndentedLambda(4, " ", false, true))
+                .put("indentAll1", new IndentedLambda(4, " ", true, true))
                 .put("indent3", new IndentedLambda(12, " ", false, true))
                 .put("indent4", new IndentedLambda(16, " ", false, true))
-                .put("copy", copyLambda)
-                .put("paste", new PasteLambda(copyLambda, true, true, true, false))
-                .put("pasteOnce", new PasteLambda(copyLambda, true, true, true, true))
-                .put("pasteLine", new PasteLambda(copyLambda, true, true, false, false))
+                .put("copy", new CopyLambda(copyContent, WhiteSpaceStrategy.None, WhiteSpaceStrategy.None))
+                .put("copyText", new CopyLambda(copyContent, WhiteSpaceStrategy.Strip, WhiteSpaceStrategy.StripLineBreakIfPresent))
+                .put("paste", new PasteLambda(copyContent, false))
+                .put("pasteOnce", new PasteLambda(copyContent, true))
                 .put("uniqueLines", new UniqueLambda("\n", false))
                 .put("unique", new UniqueLambda("\n", true))
                 .put("camel_case", new CamelCaseLambda())

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/PasteLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/PasteLambda.java
@@ -19,6 +19,8 @@ package org.openapitools.codegen.templating.mustache;
 import java.io.IOException;
 import java.io.Writer;
 
+import org.openapitools.codegen.templating.mustache.CopyLambda.CopyContent;
+
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template.Fragment;
 
@@ -27,7 +29,7 @@ import com.samskivert.mustache.Template.Fragment;
  *
  * Register:
  * <pre>
- * additionalProperties.put("paste", new PasteLambda(copyLambda, true, true, true, false));
+ * additionalProperties.put("paste", new PasteLambda(copyContent, false));
  * </pre>
  *
  * Use:
@@ -36,41 +38,26 @@ import com.samskivert.mustache.Template.Fragment;
  * </pre>
  */
 public class PasteLambda implements Mustache.Lambda {
-    private final CopyLambda copyLambda;
-    private final Boolean stripLeading;
-    private final Boolean stripTrailing;
-    private final Boolean endWithLineBreak;
+    private final CopyContent copyContent;
     private final Boolean clear;
 
-    public PasteLambda(CopyLambda copyLambda, Boolean stripLeading, Boolean stripTrailing, Boolean endWithLineBreak, boolean clear) {
-        this.copyLambda = copyLambda;
-        this.stripLeading = stripLeading;
-        this.stripTrailing = stripTrailing;
-        this.endWithLineBreak = endWithLineBreak;
+    public PasteLambda(CopyContent copyContent, boolean clear) {
+        this.copyContent = copyContent;
         this.clear = clear;
     }
 
     @Override
     public void execute(Fragment fragment, Writer writer) throws IOException {
-        String content = this.copyLambda.savedContent;
+        String content = this.copyContent.content;
 
         if (content == null) {
             return;
         }
 
-        if (this.stripTrailing){
-            content = content.stripTrailing();
-        }
-        if (this.stripLeading) {
-            content = content.stripLeading();
-        }
-        if (this.endWithLineBreak && !content.endsWith("\n")){
-            content = content + "\n";
-        }
-        writer.write(content);
-
         if (this.clear) {
-            this.copyLambda.savedContent = null;
+            this.copyContent.content = null;
         }
+
+        writer.write(content);
     }
 }

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
@@ -342,12 +342,12 @@
         public override void Write(Utf8JsonWriter writer, {{classname}} {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}, JsonSerializerOptions jsonSerializerOptions)
         {
             {{#lambda.trimLineBreaks}}
-            {{#lambda.copy}}
+            {{#lambda.copyText}}
             {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}
-            {{/lambda.copy}}
+            {{/lambda.copyText}}
             {{#discriminator}}
             {{#children}}
-            if ({{#lambda.pasteLine}}{{/lambda.pasteLine}} is {{classname}} {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}){
+            if ({{#lambda.paste}}{{/lambda.paste}} is {{classname}} {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}){
                 JsonSerializer.Serialize<{{{name}}}>(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}, jsonSerializerOptions);
                 return;
             }
@@ -449,9 +449,9 @@
             {{^isMap}}
             {{^isEnum}}
             {{^isUuid}}
-            {{#lambda.copy}}
+            {{#lambda.copyText}}
             writer.WriteString("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}});
-            {{/lambda.copy}}
+            {{/lambda.copyText}}
             {{#lambda.indent3}}
             {{>WriteProperty}}
             {{/lambda.indent3}}
@@ -460,44 +460,44 @@
             {{/isMap}}
             {{/isString}}
             {{#isBoolean}}
-            {{#lambda.copy}}
+            {{#lambda.copyText}}
             writer.WriteBoolean("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{^required}}Option.Value{{#vendorExtensions.x-is-value-type}}{{nrt!}}.Value{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}{{#isNullable}}.Value{{/isNullable}}{{/required}});
-            {{/lambda.copy}}
+            {{/lambda.copyText}}
             {{#lambda.indent3}}
             {{>WriteProperty}}
             {{/lambda.indent3}}
             {{/isBoolean}}
             {{^isEnum}}
             {{#isNumeric}}
-            {{#lambda.copy}}
+            {{#lambda.copyText}}
             writer.WriteNumber("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{^required}}Option.Value{{#vendorExtensions.x-is-value-type}}{{nrt!}}.Value{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}{{#isNullable}}.Value{{/isNullable}}{{/required}});
-            {{/lambda.copy}}
+            {{/lambda.copyText}}
             {{#lambda.indent3}}
             {{>WriteProperty}}
             {{/lambda.indent3}}
             {{/isNumeric}}
             {{/isEnum}}
             {{#isDate}}
-            {{#lambda.copy}}
+            {{#lambda.copyText}}
             writer.WriteString("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{^required}}Option.Value{{#vendorExtensions.x-is-value-type}}{{nrt!}}.Value{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}{{#isNullable}}.Value{{/isNullable}}{{/required}}.ToString({{name}}Format));
-            {{/lambda.copy}}
+            {{/lambda.copyText}}
             {{#lambda.indent3}}
             {{>WriteProperty}}
             {{/lambda.indent3}}
             {{/isDate}}
             {{#isDateTime}}
-            {{#lambda.copy}}
+            {{#lambda.copyText}}
             writer.WriteString("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{^required}}Option.Value{{#vendorExtensions.x-is-value-type}}{{nrt!}}.Value{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}{{#isNullable}}.Value{{/isNullable}}{{/required}}.ToString({{name}}Format));
-            {{/lambda.copy}}
+            {{/lambda.copyText}}
             {{#lambda.indent3}}
             {{>WriteProperty}}
             {{/lambda.indent3}}
             {{/isDateTime}}
             {{#isEnum}}
             {{#isNumeric}}
-            {{#lambda.copy}}
+            {{#lambda.copyText}}
             writer.WriteNumber("{{baseName}}", {{#isInnerEnum}}{{classname}}.{{/isInnerEnum}}{{{datatypeWithEnum}}}ToJsonValue({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{^required}}Option.Value{{#vendorExtensions.x-is-value-type}}{{nrt!}}.Value{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}{{#isNullable}}.Value{{/isNullable}}{{/required}}));
-            {{/lambda.copy}}
+            {{/lambda.copyText}}
             {{#lambda.indent3}}
             {{>WriteProperty}}
             {{/lambda.indent3}}
@@ -519,9 +519,9 @@
             {{/isNullable}}
             {{/isInnerEnum}}
             {{^isInnerEnum}}
-            {{#lambda.copy}}
+            {{#lambda.copyText}}
             {{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}
-            {{/lambda.copy}}
+            {{/lambda.copyText}}
             {{#required}}
             {{#isNullable}}
             if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}} == null)
@@ -533,7 +533,7 @@
                 {{#enumVars}}
                 {{#-first}}
                 {{#isString}}
-                if ({{#lambda.pasteLine}}{{/lambda.pasteLine}}RawValue != null){{! we cant use name here because enumVar also has a name property, so use the paste lambda instead }}
+                if ({{#lambda.paste}}{{/lambda.paste}}RawValue != null){{! we cant use name here because enumVar also has a name property, so use the paste lambda instead }}
                     writer.WriteString("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{nameInPascalCase}}{{/lambda.camelcase_sanitize_param}}RawValue);
                 else
                     writer.WriteNull("{{baseName}}");
@@ -552,10 +552,10 @@
             {{#enumVars}}
             {{#-first}}
             {{^isNumeric}}
-            writer.WriteString("{{baseName}}", {{#lambda.pasteLine}}{{/lambda.pasteLine}}RawValue);
+            writer.WriteString("{{baseName}}", {{#lambda.paste}}{{/lambda.paste}}RawValue);
             {{/isNumeric}}
             {{#isNumeric}}
-            writer.WriteNumber("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{#lambda.pasteLine}}{{/lambda.pasteLine}}{{/lambda.camelcase_sanitize_param}}RawValue);
+            writer.WriteNumber("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{#lambda.paste}}{{/lambda.paste}}{{/lambda.camelcase_sanitize_param}}RawValue);
             {{/isNumeric}}
             {{/-first}}
             {{/enumVars}}
@@ -568,16 +568,16 @@
                 {{#isNullable}}
                 if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}Option{{nrt!}}.Value != null)
                 {
-                    var {{#lambda.pasteLine}}{{/lambda.pasteLine}}RawValue = {{{datatypeWithEnum}}}ValueConverter.ToJsonValue({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}Option.Value{{nrt!}}.Value);
-                    writer.{{#lambda.first}}{{#allowableValues}}{{#enumVars}}{{^isNumeric}}WriteString  {{/isNumeric}}{{#isNumeric}}WriteNumber  {{/isNumeric}}{{/enumVars}}{{/allowableValues}}{{/lambda.first}}("{{baseName}}", {{#lambda.pasteLine}}{{/lambda.pasteLine}}RawValue);
+                    var {{#lambda.paste}}{{/lambda.paste}}RawValue = {{{datatypeWithEnum}}}ValueConverter.ToJsonValue({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}Option.Value{{nrt!}}.Value);
+                    writer.{{#lambda.first}}{{#allowableValues}}{{#enumVars}}{{^isNumeric}}WriteString  {{/isNumeric}}{{#isNumeric}}WriteNumber  {{/isNumeric}}{{/enumVars}}{{/allowableValues}}{{/lambda.first}}("{{baseName}}", {{#lambda.paste}}{{/lambda.paste}}RawValue);
                 }
                 else
                     writer.WriteNull("{{baseName}}");
                 {{/isNullable}}
                 {{^isNullable}}
             {
-                var {{#lambda.pasteLine}}{{/lambda.pasteLine}}RawValue = {{{datatypeWithEnum}}}ValueConverter.ToJsonValue({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{nrt!}}.Value);
-                writer.{{#lambda.first}}{{#allowableValues}}{{#enumVars}}{{^isNumeric}}WriteString  {{/isNumeric}}{{#isNumeric}}WriteNumber  {{/isNumeric}}{{/enumVars}}{{/allowableValues}}{{/lambda.first}}("{{baseName}}", {{#lambda.pasteLine}}{{/lambda.pasteLine}}RawValue);
+                var {{#lambda.paste}}{{/lambda.paste}}RawValue = {{{datatypeWithEnum}}}ValueConverter.ToJsonValue({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{nrt!}}.Value);
+                writer.{{#lambda.first}}{{#allowableValues}}{{#enumVars}}{{^isNumeric}}WriteString  {{/isNumeric}}{{#isNumeric}}WriteNumber  {{/isNumeric}}{{/enumVars}}{{/allowableValues}}{{/lambda.first}}("{{baseName}}", {{#lambda.paste}}{{/lambda.paste}}RawValue);
             }
                 {{/isNullable}}
             {{/required}}
@@ -586,9 +586,9 @@
             {{/isMap}}
             {{/isEnum}}
             {{#isUuid}}
-            {{#lambda.copy}}
+            {{#lambda.copyText}}
             writer.WriteString("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{^required}}Option.Value{{#vendorExtensions.x-is-value-type}}{{nrt!}}.Value{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}{{#isNullable}}.Value{{/isNullable}}{{/required}});
-            {{/lambda.copy}}
+            {{/lambda.copyText}}
             {{#lambda.indent3}}
             {{>WriteProperty}}
             {{/lambda.indent3}}

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/RateLimitProvider`1.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/RateLimitProvider`1.mustache
@@ -53,11 +53,15 @@ namespace {{packageName}}.{{clientPackage}}
             }
             else
             {
-                {{#lambda.indent1}}{{#lambda.pasteLine}}{{/lambda.pasteLine}}{{/lambda.indent1}}
+                {{#lambda.indentAll1}}
+                {{#lambda.paste}}
+                {{/lambda.paste}}
+                {{/lambda.indentAll1}}
             }
             {{/hasApiKeyMethods}}
             {{^hasApiKeyMethods}}
-            {{#lambda.pasteLine}}{{/lambda.pasteLine}}
+            {{#lambda.paste}}
+            {{/lambda.paste}}
             {{/hasApiKeyMethods}}
 
             foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/ValidateRegex.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/ValidateRegex.mustache
@@ -1,7 +1,7 @@
 // {{{name}}} ({{{dataType}}}) pattern
 Regex regex{{{name}}} = new Regex(@"{{{vendorExtensions.x-regex}}}"{{#vendorExtensions.x-modifiers}}{{#-first}}, {{/-first}}RegexOptions.{{{.}}}{{^-last}} | {{/-last}}{{/vendorExtensions.x-modifiers}});
 {{#lambda.copy}}this.{{{name}}}{{#useGenericHost}}{{^required}}Option.Value{{/required}}{{/useGenericHost}} != null && {{/lambda.copy}}
-if ({{#lambda.first}}{{^required}}{{#lambda.pasteLine}}{{/lambda.pasteLine}}  {{/required}}{{#isNullable}}{{#lambda.pasteLine}}{{/lambda.pasteLine}}{{/isNullable}}{{/lambda.first}}!regex{{{name}}}.Match(this.{{{name}}}{{#useGenericHost}}{{^required}}Option.Value{{/required}}{{/useGenericHost}}{{#isUuid}}.ToString(){{#lambda.first}}{{^required}}{{nrt!}}  {{/required}}{{#isNullable}}!  {{/isNullable}}{{/lambda.first}}{{/isUuid}}).Success)
+if ({{#lambda.first}}{{^required}}{{#lambda.paste}}{{/lambda.paste}}  {{/required}}{{#isNullable}}{{#lambda.paste}}{{/lambda.paste}}{{/isNullable}}{{/lambda.first}}!regex{{{name}}}.Match(this.{{{name}}}{{#useGenericHost}}{{^required}}Option.Value{{/required}}{{/useGenericHost}}{{#isUuid}}.ToString(){{#lambda.first}}{{^required}}{{nrt!}}  {{/required}}{{#isNullable}}!  {{/isNullable}}{{/lambda.first}}{{/isUuid}}).Success)
 {
     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for {{{name}}}, must match a pattern of " + regex{{{name}}}, new [] { "{{{name}}}" });
 }

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/WritePropertyHelper.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/WritePropertyHelper.mustache
@@ -1,9 +1,10 @@
 {{#isNullable}}
 if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{^required}}Option.Value{{/required}} != null)
-    {{#lambda.pasteLine}}{{/lambda.pasteLine}}
+    {{#lambda.paste}}{{/lambda.paste}}
 else
     writer.WriteNull("{{baseName}}");
 {{/isNullable}}
 {{^isNullable}}
-{{#lambda.pasteLine}}{{/lambda.pasteLine}}
+{{#lambda.paste}}
+{{/lambda.paste}}
 {{/isNullable}}

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
@@ -345,15 +345,17 @@
                 {{/readOnlyVars}}
                 {{#readOnlyVars}}
                 {{#lambda.copy}}
-
                 if ({{name}} != null)
                     hashCode = (hashCode * 59) + {{name}}.GetHashCode();
+
                 {{/lambda.copy}}
                 {{#isNullable}}
-                {{#lambda.pasteOnce}}{{/lambda.pasteOnce}}
+                {{#lambda.pasteOnce}}
+                {{/lambda.pasteOnce}}
                 {{/isNullable}}
                 {{^required}}
-                {{#lambda.pasteOnce}}{{/lambda.pasteOnce}}
+                {{#lambda.pasteOnce}}
+                {{/lambda.pasteOnce}}
                 {{/required}}
                 {{/readOnlyVars}}
                 {{#isAdditionalPropertiesTrue}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -752,8 +752,8 @@ public class DefaultCodegenTest {
             });
 
             assertFalse(call1.get());
-            assertTrue(call2.get());
-            assertTrue(call3.get());
+            // assertTrue(call2.get()); these asserts do not work on Windows
+            // assertTrue(call3.get());
         } finally {
             executor.shutdown();
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -752,8 +752,8 @@ public class DefaultCodegenTest {
             });
 
             assertFalse(call1.get());
-            // assertTrue(call2.get()); these asserts do not work on Windows
-            // assertTrue(call3.get());
+            assertTrue(call2.get());
+            assertTrue(call3.get());
         } finally {
             executor.shutdown();
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/CopyPasteLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/CopyPasteLambdaTest.java
@@ -1,0 +1,71 @@
+package org.openapitools.codegen.templating.mustache;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.openapitools.codegen.CodegenConfig;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.openapitools.codegen.templating.mustache.CopyLambda.CopyContent;
+import org.openapitools.codegen.templating.mustache.CopyLambda.WhiteSpaceStrategy;
+
+public class CopyPasteLambdaTest extends LambdaTest {
+
+    @Mock
+    CodegenConfig generator;
+
+    @BeforeMethod
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void camelCaseTest() {
+        final CopyContent copyContent = new CopyContent();
+        Map<String, Object> ctx = context("copy", new CopyLambda(copyContent, WhiteSpaceStrategy.None, WhiteSpaceStrategy.None));
+        ctx.put("paste", new PasteLambda(copyContent, false));
+        test("foo", "{{#copy}}foo{{/copy}}{{#paste}}{{/paste}}", ctx);
+
+        // the first line break does not count
+        // it results in the tag being the only element on the line, so the line does not get printed
+        test("\nfoo\n", "{{#copy}}\n\nfoo\n{{/copy}}{{#paste}}{{/paste}}", ctx);
+    }
+
+    @Test
+    public void camelCaseTestAppend() {
+        final CopyContent copyContent = new CopyContent();
+        Map<String, Object> ctx = context("copy", new CopyLambda(copyContent, WhiteSpaceStrategy.AppendLineBreakIfMissing, WhiteSpaceStrategy.AppendLineBreakIfMissing));
+        ctx.put("paste", new PasteLambda(copyContent, false));
+        test("\nfoo\n", "{{#copy}}foo{{/copy}}{{#paste}}{{/paste}}", ctx);
+        test("\nfoo\n", "{{#copy}}\n\nfoo\n{{/copy}}{{#paste}}{{/paste}}", ctx);
+    }
+
+    @Test
+    public void camelCaseTestStripLineBreakIfPresent() {
+        final CopyContent copyContent = new CopyContent();
+        Map<String, Object> ctx = context("copy", new CopyLambda(copyContent, WhiteSpaceStrategy.StripLineBreakIfPresent, WhiteSpaceStrategy.StripLineBreakIfPresent));
+        ctx.put("paste", new PasteLambda(copyContent, false));
+        test("foo", "{{#copy}}foo{{/copy}}{{#paste}}{{/paste}}", ctx);
+        test("foo", "{{#copy}}\nfoo\n{{/copy}}{{#paste}}{{/paste}}", ctx);
+        test("    \nfoo\n    ", "{{#copy}}\n\n    \nfoo\n    {{/copy}}{{#paste}}{{/paste}}", ctx);
+        test("    foo    ", "{{#copy}}\n\n    foo    \n{{/copy}}{{#paste}}{{/paste}}", ctx);
+    }
+
+    @Test
+    public void camelCaseTestStrip() {
+        final CopyContent copyContent = new CopyContent();
+        Map<String, Object> ctx = context("copy", new CopyLambda(copyContent, WhiteSpaceStrategy.Strip, WhiteSpaceStrategy.Strip));
+        ctx.put("paste", new PasteLambda(copyContent, false));
+        test("foo", "{{#copy}}foo{{/copy}}{{#paste}}{{/paste}}", ctx);
+        test("foo", "{{#copy}}\n\nfoo\n{{/copy}}{{#paste}}{{/paste}}", ctx);
+        test("foo", "{{#copy}}    \nfoo\n    {{/copy}}{{#paste}}{{/paste}}", ctx);
+        test("foo", "{{#copy}}\n\n    foo    \n{{/copy}}{{#paste}}{{/paste}}", ctx);
+    }
+}


### PR DESCRIPTION
The copy lambda had a hard coded command that mutated the cached value. That was giving me an issue in another PR I'm working on. I removed that, and I also moved the white space handling from paste to copy. The reason for that change is that the way we handle white space will depend on how the copy is written. For example, these two will produce different results. Therefore, we should handle the white space correctly in the copy lambda where it occurs, not later in the paste.

```
{{#lambda.copy}}foo{{/lambda.copy}}

{{#lambda.copy}}
foo
{{/lambda.copy}}
```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
