### PR TITLE
python-pydantic-v1: Keep trailing commas for enum validation tuples

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-fastapi/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/model_generic.mustache
@@ -69,11 +69,11 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         {{/required}}
         {{#isArray}}
         for i in value:
-            if i not in ({{#allowableValues}}{{#enumVars}}{{{value}}}, {{/enumVars}}{{/allowableValues}}):
+            if i not in ({{#allowableValues}}{{#enumVars}}{{{value}}},{{^-last}} {{/-last}}{{/enumVars}}{{/allowableValues}}):
                 raise ValueError("each list item must be one of ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
         {{/isArray}}
         {{^isArray}}
-        if value not in ({{#allowableValues}}{{#enumVars}}{{{value}}}, {{/enumVars}}{{/allowableValues}}):
+        if value not in ({{#allowableValues}}{{#enumVars}}{{{value}}},{{^-last}} {{/-last}}{{/enumVars}}{{/allowableValues}}):
             raise ValueError("must be one of enum values ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
         {{/isArray}}
         return value

--- a/modules/openapi-generator/src/main/resources/python-fastapi/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/model_generic.mustache
@@ -69,11 +69,11 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         {{/required}}
         {{#isArray}}
         for i in value:
-            if i not in ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}):
+            if i not in ({{#allowableValues}}{{#enumVars}}{{{value}}}, {{/enumVars}}{{/allowableValues}}):
                 raise ValueError("each list item must be one of ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
         {{/isArray}}
         {{^isArray}}
-        if value not in ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}):
+        if value not in ({{#allowableValues}}{{#enumVars}}{{{value}}}, {{/enumVars}}{{/allowableValues}}):
             raise ValueError("must be one of enum values ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
         {{/isArray}}
         return value

--- a/modules/openapi-generator/src/main/resources/python-pydantic-v1/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python-pydantic-v1/model_generic.mustache
@@ -74,11 +74,11 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         {{/required}}
         {{#isArray}}
         for i in value:
-            if i not in ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}):
+            if i not in ({{#allowableValues}}{{#enumVars}}{{{value}}}, {{/enumVars}}{{/allowableValues}}):
                 raise ValueError("each list item must be one of ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
         {{/isArray}}
         {{^isArray}}
-        if value not in ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}):
+        if value not in ({{#allowableValues}}{{#enumVars}}{{{value}}}, {{/enumVars}}{{/allowableValues}}):
             raise ValueError("must be one of enum values ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
         {{/isArray}}
         return value

--- a/modules/openapi-generator/src/main/resources/python-pydantic-v1/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python-pydantic-v1/model_generic.mustache
@@ -74,11 +74,11 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         {{/required}}
         {{#isArray}}
         for i in value:
-            if i not in ({{#allowableValues}}{{#enumVars}}{{{value}}}, {{/enumVars}}{{/allowableValues}}):
+            if i not in ({{#allowableValues}}{{#enumVars}}{{{value}}},{{^-last}} {{/-last}}{{/enumVars}}{{/allowableValues}}):
                 raise ValueError("each list item must be one of ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
         {{/isArray}}
         {{^isArray}}
-        if value not in ({{#allowableValues}}{{#enumVars}}{{{value}}}, {{/enumVars}}{{/allowableValues}}):
+        if value not in ({{#allowableValues}}{{#enumVars}}{{{value}}},{{^-last}} {{/-last}}{{/enumVars}}{{/allowableValues}}):
             raise ValueError("must be one of enum values ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
         {{/isArray}}
         return value

--- a/modules/openapi-generator/src/test/resources/3_0/python/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/python/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -2124,6 +2124,15 @@ components:
             - FOOVar
             - BarVar
             - bazVar
+        enum_string_single_member:
+          type: string
+          enum:
+            - 'abc'
+        enum_integer_single_member:
+          type: integer
+          format: int32
+          enum:
+            - 100
         outerEnum:
           $ref: '#/components/schemas/OuterEnum'
         outerEnumInteger:

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/default_value.py
@@ -44,7 +44,7 @@ class DefaultValue(BaseModel):
             return value
 
         for i in value:
-            if i not in ('success', 'failure', 'unclassified'):
+            if i not in ('success', 'failure', 'unclassified',):
                 raise ValueError("each list item must be one of ('success', 'failure', 'unclassified')")
         return value
 

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/pet.py
@@ -42,7 +42,7 @@ class Pet(BaseModel):
         if value is None:
             return value
 
-        if value not in ('available', 'pending', 'sold'):
+        if value not in ('available', 'pending', 'sold',):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return value
 

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/query.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/query.py
@@ -37,7 +37,7 @@ class Query(BaseModel):
             return value
 
         for i in value:
-            if i not in ('SUCCESS', 'FAILURE', 'SKIPPED'):
+            if i not in ('SUCCESS', 'FAILURE', 'SKIPPED',):
                 raise ValueError("each list item must be one of ('SUCCESS', 'FAILURE', 'SKIPPED')")
         return value
 

--- a/samples/openapi3/client/petstore/python-aiohttp/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/python-aiohttp/docs/EnumTest.md
@@ -12,6 +12,8 @@ Name | Type | Description | Notes
 **enum_number** | **float** |  | [optional] 
 **enum_number_vendor_ext** | **int** |  | [optional] 
 **enum_string_vendor_ext** | **str** |  | [optional] 
+**enum_string_single_member** | **str** |  | [optional] 
+**enum_integer_single_member** | **int** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
 **outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to OuterEnumDefaultValue.PLACED]

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
@@ -37,11 +37,13 @@ class EnumTest(BaseModel):
     enum_number: Optional[float] = None
     enum_number_vendor_ext: Optional[StrictInt] = None
     enum_string_vendor_ext: Optional[StrictStr] = None
+    enum_string_single_member: Optional[StrictStr] = None
+    enum_integer_single_member: Optional[StrictInt] = None
     outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
     outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
     outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=OuterEnumDefaultValue.PLACED, alias="outerEnumDefaultValue")
     outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=OuterEnumIntegerDefaultValue.NUMBER_0, alias="outerEnumIntegerDefaultValue")
-    __properties: ClassVar[List[str]] = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_number_vendor_ext", "enum_string_vendor_ext", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
+    __properties: ClassVar[List[str]] = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_number_vendor_ext", "enum_string_vendor_ext", "enum_string_single_member", "enum_integer_single_member", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
 
     @field_validator('enum_string')
     def enum_string_validate_enum(cls, value):
@@ -110,6 +112,26 @@ class EnumTest(BaseModel):
             raise ValueError("must be one of enum values ('FOO', 'Bar', 'baz')")
         return value
 
+    @field_validator('enum_string_single_member')
+    def enum_string_single_member_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set(['abc']):
+            raise ValueError("must be one of enum values ('abc')")
+        return value
+
+    @field_validator('enum_integer_single_member')
+    def enum_integer_single_member_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set([100]):
+            raise ValueError("must be one of enum values (100)")
+        return value
+
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,
@@ -173,6 +195,8 @@ class EnumTest(BaseModel):
             "enum_number": obj.get("enum_number"),
             "enum_number_vendor_ext": obj.get("enum_number_vendor_ext"),
             "enum_string_vendor_ext": obj.get("enum_string_vendor_ext"),
+            "enum_string_single_member": obj.get("enum_string_single_member"),
+            "enum_integer_single_member": obj.get("enum_integer_single_member"),
             "outerEnum": obj.get("outerEnum"),
             "outerEnumInteger": obj.get("outerEnumInteger"),
             "outerEnumDefaultValue": obj.get("outerEnumDefaultValue") if obj.get("outerEnumDefaultValue") is not None else OuterEnumDefaultValue.PLACED,

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/EnumTest.md
@@ -11,6 +11,8 @@ Name | Type | Description | Notes
 **enum_number** | **float** |  | [optional] 
 **enum_number_vendor_ext** | **int** |  | [optional] 
 **enum_string_vendor_ext** | **str** |  | [optional] 
+**enum_string_single_member** | **str** |  | [optional] 
+**enum_integer_single_member** | **int** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
 **outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/bathing.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/bathing.py
@@ -33,14 +33,14 @@ class Bathing(BaseModel):
     @validator('task_name')
     def task_name_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('cleaning_deep'):
+        if value not in ('cleaning_deep',):
             raise ValueError("must be one of enum values ('cleaning_deep')")
         return value
 
     @validator('function_name')
     def function_name_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('care_nourish'):
+        if value not in ('care_nourish',):
             raise ValueError("must be one of enum values ('care_nourish')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_arrays.py
@@ -35,7 +35,7 @@ class EnumArrays(BaseModel):
         if value is None:
             return value
 
-        if value not in ('>=', '$'):
+        if value not in ('>=', '$',):
             raise ValueError("must be one of enum values ('>=', '$')")
         return value
 
@@ -46,7 +46,7 @@ class EnumArrays(BaseModel):
             return value
 
         for i in value:
-            if i not in ('fish', 'crab'):
+            if i not in ('fish', 'crab',):
                 raise ValueError("each list item must be one of ('fish', 'crab')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_test.py
@@ -36,11 +36,13 @@ class EnumTest(BaseModel):
     enum_number: Optional[float] = None
     enum_number_vendor_ext: Optional[StrictInt] = None
     enum_string_vendor_ext: Optional[StrictStr] = None
+    enum_string_single_member: Optional[StrictStr] = None
+    enum_integer_single_member: Optional[StrictInt] = None
     outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
     outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
     outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, alias="outerEnumDefaultValue")
     outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, alias="outerEnumIntegerDefaultValue")
-    __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_number_vendor_ext", "enum_string_vendor_ext", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
+    __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_number_vendor_ext", "enum_string_vendor_ext", "enum_string_single_member", "enum_integer_single_member", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
 
     @validator('enum_string')
     def enum_string_validate_enum(cls, value):
@@ -48,14 +50,14 @@ class EnumTest(BaseModel):
         if value is None:
             return value
 
-        if value not in ('UPPER', 'lower', ''):
+        if value not in ('UPPER', 'lower', '',):
             raise ValueError("must be one of enum values ('UPPER', 'lower', '')")
         return value
 
     @validator('enum_string_required')
     def enum_string_required_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('UPPER', 'lower', ''):
+        if value not in ('UPPER', 'lower', '',):
             raise ValueError("must be one of enum values ('UPPER', 'lower', '')")
         return value
 
@@ -65,7 +67,7 @@ class EnumTest(BaseModel):
         if value is None:
             return value
 
-        if value not in (1, 5, 14):
+        if value not in (1, 5, 14,):
             raise ValueError("must be one of enum values (1, 5, 14)")
         return value
 
@@ -75,7 +77,7 @@ class EnumTest(BaseModel):
         if value is None:
             return value
 
-        if value not in (1, -1):
+        if value not in (1, -1,):
             raise ValueError("must be one of enum values (1, -1)")
         return value
 
@@ -85,7 +87,7 @@ class EnumTest(BaseModel):
         if value is None:
             return value
 
-        if value not in (1.1, -1.2):
+        if value not in (1.1, -1.2,):
             raise ValueError("must be one of enum values (1.1, -1.2)")
         return value
 
@@ -95,7 +97,7 @@ class EnumTest(BaseModel):
         if value is None:
             return value
 
-        if value not in (42, 18, 56):
+        if value not in (42, 18, 56,):
             raise ValueError("must be one of enum values (42, 18, 56)")
         return value
 
@@ -105,8 +107,28 @@ class EnumTest(BaseModel):
         if value is None:
             return value
 
-        if value not in ('FOO', 'Bar', 'baz'):
+        if value not in ('FOO', 'Bar', 'baz',):
             raise ValueError("must be one of enum values ('FOO', 'Bar', 'baz')")
+        return value
+
+    @validator('enum_string_single_member')
+    def enum_string_single_member_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in ('abc',):
+            raise ValueError("must be one of enum values ('abc')")
+        return value
+
+    @validator('enum_integer_single_member')
+    def enum_integer_single_member_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in (100,):
+            raise ValueError("must be one of enum values (100)")
         return value
 
     class Config:
@@ -157,6 +179,8 @@ class EnumTest(BaseModel):
             "enum_number": obj.get("enum_number"),
             "enum_number_vendor_ext": obj.get("enum_number_vendor_ext"),
             "enum_string_vendor_ext": obj.get("enum_string_vendor_ext"),
+            "enum_string_single_member": obj.get("enum_string_single_member"),
+            "enum_integer_single_member": obj.get("enum_integer_single_member"),
             "outer_enum": obj.get("outerEnum"),
             "outer_enum_integer": obj.get("outerEnumInteger"),
             "outer_enum_default_value": obj.get("outerEnumDefaultValue"),

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/feeding.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/feeding.py
@@ -33,14 +33,14 @@ class Feeding(BaseModel):
     @validator('task_name')
     def task_name_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('cleaning'):
+        if value not in ('cleaning',):
             raise ValueError("must be one of enum values ('cleaning')")
         return value
 
     @validator('function_name')
     def function_name_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('care_nourish'):
+        if value not in ('care_nourish',):
             raise ValueError("must be one of enum values ('care_nourish')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_test.py
@@ -37,7 +37,7 @@ class MapTest(BaseModel):
         if value is None:
             return value
 
-        if value not in ('UPPER', 'lower'):
+        if value not in ('UPPER', 'lower',):
             raise ValueError("must be one of enum values ('UPPER', 'lower')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/order.py
@@ -39,7 +39,7 @@ class Order(BaseModel):
         if value is None:
             return value
 
-        if value not in ('placed', 'approved', 'delivered'):
+        if value not in ('placed', 'approved', 'delivered',):
             raise ValueError("must be one of enum values ('placed', 'approved', 'delivered')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/pet.py
@@ -41,7 +41,7 @@ class Pet(BaseModel):
         if value is None:
             return value
 
-        if value not in ('available', 'pending', 'sold'):
+        if value not in ('available', 'pending', 'sold',):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/poop_cleaning.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/poop_cleaning.py
@@ -33,14 +33,14 @@ class PoopCleaning(BaseModel):
     @validator('task_name')
     def task_name_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('cleaning'):
+        if value not in ('cleaning',):
             raise ValueError("must be one of enum values ('cleaning')")
         return value
 
     @validator('function_name')
     def function_name_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('care'):
+        if value not in ('care',):
             raise ValueError("must be one of enum values ('care')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_name.py
@@ -37,7 +37,7 @@ class SpecialName(BaseModel):
         if value is None:
             return value
 
-        if value not in ('available', 'pending', 'sold'):
+        if value not in ('available', 'pending', 'sold',):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/test_model_with_enum_default.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/test_model_with_enum_default.py
@@ -40,7 +40,7 @@ class TestModelWithEnumDefault(BaseModel):
         if value is None:
             return value
 
-        if value not in ('A', 'B', 'C'):
+        if value not in ('A', 'B', 'C',):
             raise ValueError("must be one of enum values ('A', 'B', 'C')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/docs/EnumTest.md
@@ -11,6 +11,8 @@ Name | Type | Description | Notes
 **enum_number** | **float** |  | [optional] 
 **enum_number_vendor_ext** | **int** |  | [optional] 
 **enum_string_vendor_ext** | **str** |  | [optional] 
+**enum_string_single_member** | **str** |  | [optional] 
+**enum_integer_single_member** | **int** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
 **outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/bathing.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/bathing.py
@@ -34,14 +34,14 @@ class Bathing(BaseModel):
     @validator('task_name')
     def task_name_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('cleaning_deep'):
+        if value not in ('cleaning_deep',):
             raise ValueError("must be one of enum values ('cleaning_deep')")
         return value
 
     @validator('function_name')
     def function_name_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('care_nourish'):
+        if value not in ('care_nourish',):
             raise ValueError("must be one of enum values ('care_nourish')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_arrays.py
@@ -36,7 +36,7 @@ class EnumArrays(BaseModel):
         if value is None:
             return value
 
-        if value not in ('>=', '$'):
+        if value not in ('>=', '$',):
             raise ValueError("must be one of enum values ('>=', '$')")
         return value
 
@@ -47,7 +47,7 @@ class EnumArrays(BaseModel):
             return value
 
         for i in value:
-            if i not in ('fish', 'crab'):
+            if i not in ('fish', 'crab',):
                 raise ValueError("each list item must be one of ('fish', 'crab')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_test.py
@@ -36,12 +36,14 @@ class EnumTest(BaseModel):
     enum_number: Optional[StrictFloat] = None
     enum_number_vendor_ext: Optional[StrictInt] = None
     enum_string_vendor_ext: Optional[StrictStr] = None
+    enum_string_single_member: Optional[StrictStr] = None
+    enum_integer_single_member: Optional[StrictInt] = None
     outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
     outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
     outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, alias="outerEnumDefaultValue")
     outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, alias="outerEnumIntegerDefaultValue")
     additional_properties: Dict[str, Any] = {}
-    __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_number_vendor_ext", "enum_string_vendor_ext", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
+    __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_number_vendor_ext", "enum_string_vendor_ext", "enum_string_single_member", "enum_integer_single_member", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
 
     @validator('enum_string')
     def enum_string_validate_enum(cls, value):
@@ -49,14 +51,14 @@ class EnumTest(BaseModel):
         if value is None:
             return value
 
-        if value not in ('UPPER', 'lower', ''):
+        if value not in ('UPPER', 'lower', '',):
             raise ValueError("must be one of enum values ('UPPER', 'lower', '')")
         return value
 
     @validator('enum_string_required')
     def enum_string_required_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('UPPER', 'lower', ''):
+        if value not in ('UPPER', 'lower', '',):
             raise ValueError("must be one of enum values ('UPPER', 'lower', '')")
         return value
 
@@ -66,7 +68,7 @@ class EnumTest(BaseModel):
         if value is None:
             return value
 
-        if value not in (1, 5, 14):
+        if value not in (1, 5, 14,):
             raise ValueError("must be one of enum values (1, 5, 14)")
         return value
 
@@ -76,7 +78,7 @@ class EnumTest(BaseModel):
         if value is None:
             return value
 
-        if value not in (1, -1):
+        if value not in (1, -1,):
             raise ValueError("must be one of enum values (1, -1)")
         return value
 
@@ -86,7 +88,7 @@ class EnumTest(BaseModel):
         if value is None:
             return value
 
-        if value not in (1.1, -1.2):
+        if value not in (1.1, -1.2,):
             raise ValueError("must be one of enum values (1.1, -1.2)")
         return value
 
@@ -96,7 +98,7 @@ class EnumTest(BaseModel):
         if value is None:
             return value
 
-        if value not in (42, 18, 56):
+        if value not in (42, 18, 56,):
             raise ValueError("must be one of enum values (42, 18, 56)")
         return value
 
@@ -106,8 +108,28 @@ class EnumTest(BaseModel):
         if value is None:
             return value
 
-        if value not in ('FOO', 'Bar', 'baz'):
+        if value not in ('FOO', 'Bar', 'baz',):
             raise ValueError("must be one of enum values ('FOO', 'Bar', 'baz')")
+        return value
+
+    @validator('enum_string_single_member')
+    def enum_string_single_member_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in ('abc',):
+            raise ValueError("must be one of enum values ('abc')")
+        return value
+
+    @validator('enum_integer_single_member')
+    def enum_integer_single_member_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in (100,):
+            raise ValueError("must be one of enum values (100)")
         return value
 
     class Config:
@@ -164,6 +186,8 @@ class EnumTest(BaseModel):
             "enum_number": obj.get("enum_number"),
             "enum_number_vendor_ext": obj.get("enum_number_vendor_ext"),
             "enum_string_vendor_ext": obj.get("enum_string_vendor_ext"),
+            "enum_string_single_member": obj.get("enum_string_single_member"),
+            "enum_integer_single_member": obj.get("enum_integer_single_member"),
             "outer_enum": obj.get("outerEnum"),
             "outer_enum_integer": obj.get("outerEnumInteger"),
             "outer_enum_default_value": obj.get("outerEnumDefaultValue"),

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/feeding.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/feeding.py
@@ -34,14 +34,14 @@ class Feeding(BaseModel):
     @validator('task_name')
     def task_name_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('cleaning'):
+        if value not in ('cleaning',):
             raise ValueError("must be one of enum values ('cleaning')")
         return value
 
     @validator('function_name')
     def function_name_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('care_nourish'):
+        if value not in ('care_nourish',):
             raise ValueError("must be one of enum values ('care_nourish')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_test.py
@@ -38,7 +38,7 @@ class MapTest(BaseModel):
         if value is None:
             return value
 
-        if value not in ('UPPER', 'lower'):
+        if value not in ('UPPER', 'lower',):
             raise ValueError("must be one of enum values ('UPPER', 'lower')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/order.py
@@ -40,7 +40,7 @@ class Order(BaseModel):
         if value is None:
             return value
 
-        if value not in ('placed', 'approved', 'delivered'):
+        if value not in ('placed', 'approved', 'delivered',):
             raise ValueError("must be one of enum values ('placed', 'approved', 'delivered')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/pet.py
@@ -42,7 +42,7 @@ class Pet(BaseModel):
         if value is None:
             return value
 
-        if value not in ('available', 'pending', 'sold'):
+        if value not in ('available', 'pending', 'sold',):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/poop_cleaning.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/poop_cleaning.py
@@ -34,14 +34,14 @@ class PoopCleaning(BaseModel):
     @validator('task_name')
     def task_name_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('cleaning'):
+        if value not in ('cleaning',):
             raise ValueError("must be one of enum values ('cleaning')")
         return value
 
     @validator('function_name')
     def function_name_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('care'):
+        if value not in ('care',):
             raise ValueError("must be one of enum values ('care')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_name.py
@@ -38,7 +38,7 @@ class SpecialName(BaseModel):
         if value is None:
             return value
 
-        if value not in ('available', 'pending', 'sold'):
+        if value not in ('available', 'pending', 'sold',):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/test_model_with_enum_default.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/test_model_with_enum_default.py
@@ -41,7 +41,7 @@ class TestModelWithEnumDefault(BaseModel):
         if value is None:
             return value
 
-        if value not in ('A', 'B', 'C'):
+        if value not in ('A', 'B', 'C',):
             raise ValueError("must be one of enum values ('A', 'B', 'C')")
         return value
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_model.py
@@ -378,7 +378,7 @@ class ModelTests(unittest.TestCase):
         self.assertEqual(d5.__fields_set__, {'value', 'str_value'})
         self.assertEqual(d5.to_json(), '{"value": 1, "str_value": null}')
 
-    def test_enum_string_single_member(self):
+    def test_enum_single_members(self):
         enum_test = petstore_api.EnumTest(
             enum_string_required="lower",
             enum_string_single_member="abc",

--- a/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_model.py
@@ -378,6 +378,28 @@ class ModelTests(unittest.TestCase):
         self.assertEqual(d5.__fields_set__, {'value', 'str_value'})
         self.assertEqual(d5.to_json(), '{"value": 1, "str_value": null}')
 
+    def test_enum_string_single_member(self):
+        enum_test = petstore_api.EnumTest(
+            enum_string_required="lower",
+            enum_string_single_member="abc",
+            enum_integer_single_member=100,
+        )
+        self.assertEqual(enum_test.enum_string_single_member, "abc")
+        self.assertEqual(enum_test.enum_integer_single_member, 100)
+        with self.assertRaises(ValueError) as e:
+            enum_test = petstore_api.EnumTest(
+                enum_string_required="lower",
+                enum_string_single_member="ab",
+            )
+            self.assertTrue("must be one of enum values ('abc')" in str(e))
+
+        with self.assertRaises(ValueError) as e:
+            enum_test = petstore_api.EnumTest(
+                enum_string_required="lower",
+                enum_integer_single_member=10,
+            )
+            self.assertTrue("must be one of enum values (100)" in str(e))
+    
     def test_valdiator(self):
         # test regular expression
         a = petstore_api.FormatTest(number=123.45, byte=bytes("string", 'utf-8'), date="2013-09-17", password="testing09876")
@@ -413,7 +435,6 @@ class ModelTests(unittest.TestCase):
         pet_ap3 = petstore_api.Pet.from_dict(pet_ap.to_dict())
         pet_ap4 = petstore_api.Pet.from_dict(pet_ap.to_dict())
         self.assertNotEqual(id(pet_ap3), id(pet_ap4))
-
 
     def test_additional_properties(self):
         pet_ap = petstore_api.Pet(name="test name", photo_urls=["string"])

--- a/samples/openapi3/client/petstore/python/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/python/docs/EnumTest.md
@@ -12,6 +12,8 @@ Name | Type | Description | Notes
 **enum_number** | **float** |  | [optional] 
 **enum_number_vendor_ext** | **int** |  | [optional] 
 **enum_string_vendor_ext** | **str** |  | [optional] 
+**enum_string_single_member** | **str** |  | [optional] 
+**enum_integer_single_member** | **int** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
 **outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to OuterEnumDefaultValue.PLACED]

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
@@ -37,12 +37,14 @@ class EnumTest(BaseModel):
     enum_number: Optional[StrictFloat] = None
     enum_number_vendor_ext: Optional[StrictInt] = None
     enum_string_vendor_ext: Optional[StrictStr] = None
+    enum_string_single_member: Optional[StrictStr] = None
+    enum_integer_single_member: Optional[StrictInt] = None
     outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
     outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
     outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=OuterEnumDefaultValue.PLACED, alias="outerEnumDefaultValue")
     outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=OuterEnumIntegerDefaultValue.NUMBER_0, alias="outerEnumIntegerDefaultValue")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_number_vendor_ext", "enum_string_vendor_ext", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
+    __properties: ClassVar[List[str]] = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_number_vendor_ext", "enum_string_vendor_ext", "enum_string_single_member", "enum_integer_single_member", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
 
     @field_validator('enum_string')
     def enum_string_validate_enum(cls, value):
@@ -109,6 +111,26 @@ class EnumTest(BaseModel):
 
         if value not in set(['FOO', 'Bar', 'baz']):
             raise ValueError("must be one of enum values ('FOO', 'Bar', 'baz')")
+        return value
+
+    @field_validator('enum_string_single_member')
+    def enum_string_single_member_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set(['abc']):
+            raise ValueError("must be one of enum values ('abc')")
+        return value
+
+    @field_validator('enum_integer_single_member')
+    def enum_integer_single_member_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set([100]):
+            raise ValueError("must be one of enum values (100)")
         return value
 
     model_config = ConfigDict(
@@ -181,6 +203,8 @@ class EnumTest(BaseModel):
             "enum_number": obj.get("enum_number"),
             "enum_number_vendor_ext": obj.get("enum_number_vendor_ext"),
             "enum_string_vendor_ext": obj.get("enum_string_vendor_ext"),
+            "enum_string_single_member": obj.get("enum_string_single_member"),
+            "enum_integer_single_member": obj.get("enum_integer_single_member"),
             "outerEnum": obj.get("outerEnum"),
             "outerEnumInteger": obj.get("outerEnumInteger"),
             "outerEnumDefaultValue": obj.get("outerEnumDefaultValue") if obj.get("outerEnumDefaultValue") is not None else OuterEnumDefaultValue.PLACED,

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/order.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/order.py
@@ -46,7 +46,7 @@ class Order(BaseModel):
         if value is None:
             return value
 
-        if value not in ('placed', 'approved', 'delivered'):
+        if value not in ('placed', 'approved', 'delivered',):
             raise ValueError("must be one of enum values ('placed', 'approved', 'delivered')")
         return value
 

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/pet.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/pet.py
@@ -47,7 +47,7 @@ class Pet(BaseModel):
         if value is None:
             return value
 
-        if value not in ('available', 'pending', 'sold'):
+        if value not in ('available', 'pending', 'sold',):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return value
 


### PR DESCRIPTION
It can happen that sometimes a enum just has a single member

This can result in a pydantic validator that can be incorrect 
E.g.

```
class TestClass(BaseModel):
    type: StrictStr = Field(...)  # Say this can only take a single value like "test" 

    @validator('type')
    def type_validate_enum(cls, value):
        if value not in ("test"):
            raise ValueError(...)
```

If I do some substring of "test", e.g. `TestClass(type="tes")`  this validation will not fail

Then trailing `,` in this case is required

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


