### PR TITLE
[swift6] improve retry interceptor

### DIFF
--- a/docs/faq-generators.md
+++ b/docs/faq-generators.md
@@ -350,7 +350,14 @@ First you implement the `OpenAPIInterceptor` protocol.
 public class BearerOpenAPIInterceptor: OpenAPIInterceptor {
     public init() {}
     
-    public func intercept(urlRequest: URLRequest, urlSession: URLSessionProtocol, openAPIClient: OpenAPIClient, completion: @escaping (Result<URLRequest, any Error>) -> Void) {
+    public func intercept<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, completion: @escaping (Result<URLRequest, any Error>) -> Void) {
+
+        guard requestBuilder.requiresAuthentication else {
+            // no authentication required
+            completion(.success(urlRequest))
+            return
+        }
+
         refreshTokenIfDoesntExist { token in
             
             // Change the current url request
@@ -358,13 +365,13 @@ public class BearerOpenAPIInterceptor: OpenAPIInterceptor {
             newUrlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
             
             // Change the global headers
-            openAPIClient.customHeaders["Authorization"] = "Bearer \(token)"
+            requestBuilder.openAPIClient.customHeaders["Authorization"] = "Bearer \(token)"
             
             completion(.success(newUrlRequest))
         }
     }
     
-    public func retry(urlRequest: URLRequest, urlSession: URLSessionProtocol, openAPIClient: OpenAPIClient, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         // We will analyse the response to see if it's a 401, and if it's a 401, we will refresh the token and retry the request
         refreshTokenIfUnauthorizedRequestResponse(
             data: data,
@@ -375,7 +382,7 @@ public class BearerOpenAPIInterceptor: OpenAPIInterceptor {
             if wasTokenRefreshed, let newToken = newToken {
                 
                 // Change the global headers
-                openAPIClient.customHeaders["Authorization"] = "Bearer \(newToken)"
+                requestBuilder.openAPIClient.customHeaders["Authorization"] = "Bearer \(newToken)"
                 
                 completion(.retry)
             } else {
@@ -397,7 +404,7 @@ public class BearerOpenAPIInterceptor: OpenAPIInterceptor {
         }
     }
     
-    func refreshTokenIfUnauthorizedRequestResponse(data: Data?, response: URLResponse, error: Error, completionHandler: @escaping (Bool, String?) -> Void) {
+    func refreshTokenIfUnauthorizedRequestResponse(data: Data?, response: URLResponse?, error: Error, completionHandler: @escaping (Bool, String?) -> Void) {
         if let response = response as? HTTPURLResponse, response.statusCode == 401 {
             startRefreshingToken { token in
                 completionHandler(true, token)

--- a/modules/openapi-generator/src/main/resources/swift6/libraries/urlsession/URLSessionImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/libraries/urlsession/URLSessionImplementations.mustache
@@ -155,24 +155,48 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
                 switch result {
                 case .success(let modifiedRequest):
                     let dataTask = urlSession.dataTaskFromProtocol(with: modifiedRequest) { data, response, error in
-                    self.cleanupRequest()
-                        if let response, let error {
-                            self.openAPIClient.interceptor.retry(urlRequest: modifiedRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
-                                switch retry {
-                                case .retry:
-                                    self.execute(completion: completion)
+                        self.cleanupRequest()
 
-                                case .dontRetry:
-                                    self.openAPIClient.apiResponseQueue.async {
-                                        self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                                    }
-                                }
-                            }
-                        } else {
-                            self.openAPIClient.apiResponseQueue.async {
-                                self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                            }
+                        if let error = error {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -1,
+                                data: data,
+                                response: response,
+                                error: error,
+                                completion: completion
+                            )
+                            return
                         }
+
+                        guard let httpResponse = response as? HTTPURLResponse else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -2,
+                                data: data,
+                                response: response,
+                                error: DecodableRequestBuilderError.nilHTTPResponse,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        guard self.openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: httpResponse.statusCode,
+                                data: data,
+                                response: httpResponse,
+                                error: DecodableRequestBuilderError.unsuccessfulHTTPStatusCode,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        self.processRequestResponse(urlRequest: request, data: data, httpResponse: httpResponse, error: error, completion: completion)
                     }
 
                     self.onProgressReady?(dataTask.progress)
@@ -204,22 +228,21 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
         }
     }
 
-    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+    private func retryRequest(urlRequest: URLRequest, urlSession: URLSessionProtocol, statusCode: Int, data: Data?, response: URLResponse?, error: Error, completion: @Sendable @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+        self.openAPIClient.interceptor.retry(urlRequest: urlRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
+            switch retry {
+            case .retry:
+                self.execute(completion: completion)
 
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
+            case .dontRetry:
+                self.openAPIClient.apiResponseQueue.async {
+                    completion(.failure(ErrorResponse.error(statusCode, data, response, error)))
+                }
+            }
         }
+    }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is Void.Type:
@@ -297,22 +320,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
 }
 
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T>, @unchecked Sendable {
-    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
-        }
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is String.Type:
@@ -353,9 +361,9 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
                 completion(.success(Response(response: httpResponse, body: filePath as! T, bodyData: data)))
 
             } catch let requestParserError as DownloadException {
-                completion(.failure(ErrorResponse.error(400, data, response, requestParserError)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, requestParserError)))
             } catch {
-                completion(.failure(ErrorResponse.error(400, data, response, error)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, error)))
             }
 
         case is Void.Type:
@@ -372,7 +380,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
                 if let expressibleByNilLiteralType = T.self as? ExpressibleByNilLiteral.Type {
                     completion(.success(Response(response: httpResponse, body: expressibleByNilLiteralType.init(nilLiteral: ()) as! T, bodyData: data)))
                 } else {
-                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, response, DecodableRequestBuilderError.emptyDataResponse)))
+                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, httpResponse, DecodableRequestBuilderError.emptyDataResponse)))
                 }
                 return
             }
@@ -383,7 +391,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
             case let .success(decodableObj):
                 completion(.success(Response(response: httpResponse, body: decodableObj, bodyData: unwrappedData)))
             case let .failure(error):
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, response, error)))
+                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, httpResponse, error)))
             }
         }
     }
@@ -694,7 +702,7 @@ extension JSONDataEncoding: ParameterEncoding {}
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} protocol OpenAPIInterceptor {
     func intercept<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, completion: @escaping (Result<URLRequest, Error>) -> Void)
 
-    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
+    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
 }
 
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
@@ -704,7 +712,7 @@ extension JSONDataEncoding: ParameterEncoding {}
         completion(.success(urlRequest))
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         completion(.dontRetry)
     }
 }

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
@@ -155,24 +155,48 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
                 switch result {
                 case .success(let modifiedRequest):
                     let dataTask = urlSession.dataTaskFromProtocol(with: modifiedRequest) { data, response, error in
-                    self.cleanupRequest()
-                        if let response, let error {
-                            self.openAPIClient.interceptor.retry(urlRequest: modifiedRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
-                                switch retry {
-                                case .retry:
-                                    self.execute(completion: completion)
+                        self.cleanupRequest()
 
-                                case .dontRetry:
-                                    self.openAPIClient.apiResponseQueue.async {
-                                        self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                                    }
-                                }
-                            }
-                        } else {
-                            self.openAPIClient.apiResponseQueue.async {
-                                self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                            }
+                        if let error = error {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -1,
+                                data: data,
+                                response: response,
+                                error: error,
+                                completion: completion
+                            )
+                            return
                         }
+
+                        guard let httpResponse = response as? HTTPURLResponse else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -2,
+                                data: data,
+                                response: response,
+                                error: DecodableRequestBuilderError.nilHTTPResponse,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        guard self.openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: httpResponse.statusCode,
+                                data: data,
+                                response: httpResponse,
+                                error: DecodableRequestBuilderError.unsuccessfulHTTPStatusCode,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        self.processRequestResponse(urlRequest: request, data: data, httpResponse: httpResponse, error: error, completion: completion)
                     }
 
                     self.onProgressReady?(dataTask.progress)
@@ -204,22 +228,21 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
         }
     }
 
-    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+    private func retryRequest(urlRequest: URLRequest, urlSession: URLSessionProtocol, statusCode: Int, data: Data?, response: URLResponse?, error: Error, completion: @Sendable @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+        self.openAPIClient.interceptor.retry(urlRequest: urlRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
+            switch retry {
+            case .retry:
+                self.execute(completion: completion)
 
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
+            case .dontRetry:
+                self.openAPIClient.apiResponseQueue.async {
+                    completion(.failure(ErrorResponse.error(statusCode, data, response, error)))
+                }
+            }
         }
+    }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is Void.Type:
@@ -297,22 +320,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 }
 
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T>, @unchecked Sendable {
-    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
-        }
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is String.Type:
@@ -353,9 +361,9 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 completion(.success(Response(response: httpResponse, body: filePath as! T, bodyData: data)))
 
             } catch let requestParserError as DownloadException {
-                completion(.failure(ErrorResponse.error(400, data, response, requestParserError)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, requestParserError)))
             } catch {
-                completion(.failure(ErrorResponse.error(400, data, response, error)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, error)))
             }
 
         case is Void.Type:
@@ -372,7 +380,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 if let expressibleByNilLiteralType = T.self as? ExpressibleByNilLiteral.Type {
                     completion(.success(Response(response: httpResponse, body: expressibleByNilLiteralType.init(nilLiteral: ()) as! T, bodyData: data)))
                 } else {
-                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, response, DecodableRequestBuilderError.emptyDataResponse)))
+                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, httpResponse, DecodableRequestBuilderError.emptyDataResponse)))
                 }
                 return
             }
@@ -383,7 +391,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             case let .success(decodableObj):
                 completion(.success(Response(response: httpResponse, body: decodableObj, bodyData: unwrappedData)))
             case let .failure(error):
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, response, error)))
+                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, httpResponse, error)))
             }
         }
     }
@@ -694,7 +702,7 @@ public enum OpenAPIInterceptorRetry {
 public protocol OpenAPIInterceptor {
     func intercept<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, completion: @escaping (Result<URLRequest, Error>) -> Void)
 
-    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
+    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
 }
 
 public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
@@ -704,7 +712,7 @@ public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
         completion(.success(urlRequest))
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         completion(.dontRetry)
     }
 }

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -155,24 +155,48 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
                 switch result {
                 case .success(let modifiedRequest):
                     let dataTask = urlSession.dataTaskFromProtocol(with: modifiedRequest) { data, response, error in
-                    self.cleanupRequest()
-                        if let response, let error {
-                            self.openAPIClient.interceptor.retry(urlRequest: modifiedRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
-                                switch retry {
-                                case .retry:
-                                    self.execute(completion: completion)
+                        self.cleanupRequest()
 
-                                case .dontRetry:
-                                    self.openAPIClient.apiResponseQueue.async {
-                                        self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                                    }
-                                }
-                            }
-                        } else {
-                            self.openAPIClient.apiResponseQueue.async {
-                                self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                            }
+                        if let error = error {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -1,
+                                data: data,
+                                response: response,
+                                error: error,
+                                completion: completion
+                            )
+                            return
                         }
+
+                        guard let httpResponse = response as? HTTPURLResponse else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -2,
+                                data: data,
+                                response: response,
+                                error: DecodableRequestBuilderError.nilHTTPResponse,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        guard self.openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: httpResponse.statusCode,
+                                data: data,
+                                response: httpResponse,
+                                error: DecodableRequestBuilderError.unsuccessfulHTTPStatusCode,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        self.processRequestResponse(urlRequest: request, data: data, httpResponse: httpResponse, error: error, completion: completion)
                     }
 
                     self.onProgressReady?(dataTask.progress)
@@ -204,22 +228,21 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
         }
     }
 
-    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+    private func retryRequest(urlRequest: URLRequest, urlSession: URLSessionProtocol, statusCode: Int, data: Data?, response: URLResponse?, error: Error, completion: @Sendable @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+        self.openAPIClient.interceptor.retry(urlRequest: urlRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
+            switch retry {
+            case .retry:
+                self.execute(completion: completion)
 
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
+            case .dontRetry:
+                self.openAPIClient.apiResponseQueue.async {
+                    completion(.failure(ErrorResponse.error(statusCode, data, response, error)))
+                }
+            }
         }
+    }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is Void.Type:
@@ -297,22 +320,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 }
 
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T>, @unchecked Sendable {
-    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
-        }
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is String.Type:
@@ -353,9 +361,9 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 completion(.success(Response(response: httpResponse, body: filePath as! T, bodyData: data)))
 
             } catch let requestParserError as DownloadException {
-                completion(.failure(ErrorResponse.error(400, data, response, requestParserError)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, requestParserError)))
             } catch {
-                completion(.failure(ErrorResponse.error(400, data, response, error)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, error)))
             }
 
         case is Void.Type:
@@ -372,7 +380,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 if let expressibleByNilLiteralType = T.self as? ExpressibleByNilLiteral.Type {
                     completion(.success(Response(response: httpResponse, body: expressibleByNilLiteralType.init(nilLiteral: ()) as! T, bodyData: data)))
                 } else {
-                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, response, DecodableRequestBuilderError.emptyDataResponse)))
+                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, httpResponse, DecodableRequestBuilderError.emptyDataResponse)))
                 }
                 return
             }
@@ -383,7 +391,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             case let .success(decodableObj):
                 completion(.success(Response(response: httpResponse, body: decodableObj, bodyData: unwrappedData)))
             case let .failure(error):
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, response, error)))
+                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, httpResponse, error)))
             }
         }
     }
@@ -694,7 +702,7 @@ public enum OpenAPIInterceptorRetry {
 public protocol OpenAPIInterceptor {
     func intercept<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, completion: @escaping (Result<URLRequest, Error>) -> Void)
 
-    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
+    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
 }
 
 public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
@@ -704,7 +712,7 @@ public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
         completion(.success(urlRequest))
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         completion(.dontRetry)
     }
 }

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/URLSessionImplementations.swift
@@ -155,24 +155,48 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
                 switch result {
                 case .success(let modifiedRequest):
                     let dataTask = urlSession.dataTaskFromProtocol(with: modifiedRequest) { data, response, error in
-                    self.cleanupRequest()
-                        if let response, let error {
-                            self.openAPIClient.interceptor.retry(urlRequest: modifiedRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
-                                switch retry {
-                                case .retry:
-                                    self.execute(completion: completion)
+                        self.cleanupRequest()
 
-                                case .dontRetry:
-                                    self.openAPIClient.apiResponseQueue.async {
-                                        self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                                    }
-                                }
-                            }
-                        } else {
-                            self.openAPIClient.apiResponseQueue.async {
-                                self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                            }
+                        if let error = error {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -1,
+                                data: data,
+                                response: response,
+                                error: error,
+                                completion: completion
+                            )
+                            return
                         }
+
+                        guard let httpResponse = response as? HTTPURLResponse else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -2,
+                                data: data,
+                                response: response,
+                                error: DecodableRequestBuilderError.nilHTTPResponse,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        guard self.openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: httpResponse.statusCode,
+                                data: data,
+                                response: httpResponse,
+                                error: DecodableRequestBuilderError.unsuccessfulHTTPStatusCode,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        self.processRequestResponse(urlRequest: request, data: data, httpResponse: httpResponse, error: error, completion: completion)
                     }
 
                     self.onProgressReady?(dataTask.progress)
@@ -204,22 +228,21 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
         }
     }
 
-    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+    private func retryRequest(urlRequest: URLRequest, urlSession: URLSessionProtocol, statusCode: Int, data: Data?, response: URLResponse?, error: Error, completion: @Sendable @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+        self.openAPIClient.interceptor.retry(urlRequest: urlRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
+            switch retry {
+            case .retry:
+                self.execute(completion: completion)
 
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
+            case .dontRetry:
+                self.openAPIClient.apiResponseQueue.async {
+                    completion(.failure(ErrorResponse.error(statusCode, data, response, error)))
+                }
+            }
         }
+    }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is Void.Type:
@@ -297,22 +320,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 }
 
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T>, @unchecked Sendable {
-    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
-        }
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is String.Type:
@@ -353,9 +361,9 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 completion(.success(Response(response: httpResponse, body: filePath as! T, bodyData: data)))
 
             } catch let requestParserError as DownloadException {
-                completion(.failure(ErrorResponse.error(400, data, response, requestParserError)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, requestParserError)))
             } catch {
-                completion(.failure(ErrorResponse.error(400, data, response, error)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, error)))
             }
 
         case is Void.Type:
@@ -372,7 +380,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 if let expressibleByNilLiteralType = T.self as? ExpressibleByNilLiteral.Type {
                     completion(.success(Response(response: httpResponse, body: expressibleByNilLiteralType.init(nilLiteral: ()) as! T, bodyData: data)))
                 } else {
-                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, response, DecodableRequestBuilderError.emptyDataResponse)))
+                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, httpResponse, DecodableRequestBuilderError.emptyDataResponse)))
                 }
                 return
             }
@@ -383,7 +391,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             case let .success(decodableObj):
                 completion(.success(Response(response: httpResponse, body: decodableObj, bodyData: unwrappedData)))
             case let .failure(error):
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, response, error)))
+                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, httpResponse, error)))
             }
         }
     }
@@ -694,7 +702,7 @@ public enum OpenAPIInterceptorRetry {
 public protocol OpenAPIInterceptor {
     func intercept<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, completion: @escaping (Result<URLRequest, Error>) -> Void)
 
-    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
+    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
 }
 
 public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
@@ -704,7 +712,7 @@ public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
         completion(.success(urlRequest))
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         completion(.dontRetry)
     }
 }

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
@@ -155,24 +155,48 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
                 switch result {
                 case .success(let modifiedRequest):
                     let dataTask = urlSession.dataTaskFromProtocol(with: modifiedRequest) { data, response, error in
-                    self.cleanupRequest()
-                        if let response, let error {
-                            self.openAPIClient.interceptor.retry(urlRequest: modifiedRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
-                                switch retry {
-                                case .retry:
-                                    self.execute(completion: completion)
+                        self.cleanupRequest()
 
-                                case .dontRetry:
-                                    self.openAPIClient.apiResponseQueue.async {
-                                        self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                                    }
-                                }
-                            }
-                        } else {
-                            self.openAPIClient.apiResponseQueue.async {
-                                self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                            }
+                        if let error = error {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -1,
+                                data: data,
+                                response: response,
+                                error: error,
+                                completion: completion
+                            )
+                            return
                         }
+
+                        guard let httpResponse = response as? HTTPURLResponse else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -2,
+                                data: data,
+                                response: response,
+                                error: DecodableRequestBuilderError.nilHTTPResponse,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        guard self.openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: httpResponse.statusCode,
+                                data: data,
+                                response: httpResponse,
+                                error: DecodableRequestBuilderError.unsuccessfulHTTPStatusCode,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        self.processRequestResponse(urlRequest: request, data: data, httpResponse: httpResponse, error: error, completion: completion)
                     }
 
                     self.onProgressReady?(dataTask.progress)
@@ -204,22 +228,21 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
         }
     }
 
-    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+    private func retryRequest(urlRequest: URLRequest, urlSession: URLSessionProtocol, statusCode: Int, data: Data?, response: URLResponse?, error: Error, completion: @Sendable @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+        self.openAPIClient.interceptor.retry(urlRequest: urlRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
+            switch retry {
+            case .retry:
+                self.execute(completion: completion)
 
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
+            case .dontRetry:
+                self.openAPIClient.apiResponseQueue.async {
+                    completion(.failure(ErrorResponse.error(statusCode, data, response, error)))
+                }
+            }
         }
+    }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is Void.Type:
@@ -297,22 +320,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 }
 
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T>, @unchecked Sendable {
-    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
-        }
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is String.Type:
@@ -353,9 +361,9 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 completion(.success(Response(response: httpResponse, body: filePath as! T, bodyData: data)))
 
             } catch let requestParserError as DownloadException {
-                completion(.failure(ErrorResponse.error(400, data, response, requestParserError)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, requestParserError)))
             } catch {
-                completion(.failure(ErrorResponse.error(400, data, response, error)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, error)))
             }
 
         case is Void.Type:
@@ -372,7 +380,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 if let expressibleByNilLiteralType = T.self as? ExpressibleByNilLiteral.Type {
                     completion(.success(Response(response: httpResponse, body: expressibleByNilLiteralType.init(nilLiteral: ()) as! T, bodyData: data)))
                 } else {
-                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, response, DecodableRequestBuilderError.emptyDataResponse)))
+                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, httpResponse, DecodableRequestBuilderError.emptyDataResponse)))
                 }
                 return
             }
@@ -383,7 +391,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             case let .success(decodableObj):
                 completion(.success(Response(response: httpResponse, body: decodableObj, bodyData: unwrappedData)))
             case let .failure(error):
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, response, error)))
+                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, httpResponse, error)))
             }
         }
     }
@@ -694,7 +702,7 @@ public enum OpenAPIInterceptorRetry {
 public protocol OpenAPIInterceptor {
     func intercept<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, completion: @escaping (Result<URLRequest, Error>) -> Void)
 
-    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
+    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
 }
 
 public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
@@ -704,7 +712,7 @@ public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
         completion(.success(urlRequest))
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         completion(.dontRetry)
     }
 }

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
@@ -155,24 +155,48 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
                 switch result {
                 case .success(let modifiedRequest):
                     let dataTask = urlSession.dataTaskFromProtocol(with: modifiedRequest) { data, response, error in
-                    self.cleanupRequest()
-                        if let response, let error {
-                            self.openAPIClient.interceptor.retry(urlRequest: modifiedRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
-                                switch retry {
-                                case .retry:
-                                    self.execute(completion: completion)
+                        self.cleanupRequest()
 
-                                case .dontRetry:
-                                    self.openAPIClient.apiResponseQueue.async {
-                                        self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                                    }
-                                }
-                            }
-                        } else {
-                            self.openAPIClient.apiResponseQueue.async {
-                                self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                            }
+                        if let error = error {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -1,
+                                data: data,
+                                response: response,
+                                error: error,
+                                completion: completion
+                            )
+                            return
                         }
+
+                        guard let httpResponse = response as? HTTPURLResponse else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -2,
+                                data: data,
+                                response: response,
+                                error: DecodableRequestBuilderError.nilHTTPResponse,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        guard self.openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: httpResponse.statusCode,
+                                data: data,
+                                response: httpResponse,
+                                error: DecodableRequestBuilderError.unsuccessfulHTTPStatusCode,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        self.processRequestResponse(urlRequest: request, data: data, httpResponse: httpResponse, error: error, completion: completion)
                     }
 
                     self.onProgressReady?(dataTask.progress)
@@ -204,22 +228,21 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
         }
     }
 
-    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+    private func retryRequest(urlRequest: URLRequest, urlSession: URLSessionProtocol, statusCode: Int, data: Data?, response: URLResponse?, error: Error, completion: @Sendable @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+        self.openAPIClient.interceptor.retry(urlRequest: urlRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
+            switch retry {
+            case .retry:
+                self.execute(completion: completion)
 
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
+            case .dontRetry:
+                self.openAPIClient.apiResponseQueue.async {
+                    completion(.failure(ErrorResponse.error(statusCode, data, response, error)))
+                }
+            }
         }
+    }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is Void.Type:
@@ -297,22 +320,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 }
 
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T>, @unchecked Sendable {
-    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
-        }
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is String.Type:
@@ -353,9 +361,9 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 completion(.success(Response(response: httpResponse, body: filePath as! T, bodyData: data)))
 
             } catch let requestParserError as DownloadException {
-                completion(.failure(ErrorResponse.error(400, data, response, requestParserError)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, requestParserError)))
             } catch {
-                completion(.failure(ErrorResponse.error(400, data, response, error)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, error)))
             }
 
         case is Void.Type:
@@ -372,7 +380,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 if let expressibleByNilLiteralType = T.self as? ExpressibleByNilLiteral.Type {
                     completion(.success(Response(response: httpResponse, body: expressibleByNilLiteralType.init(nilLiteral: ()) as! T, bodyData: data)))
                 } else {
-                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, response, DecodableRequestBuilderError.emptyDataResponse)))
+                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, httpResponse, DecodableRequestBuilderError.emptyDataResponse)))
                 }
                 return
             }
@@ -383,7 +391,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             case let .success(decodableObj):
                 completion(.success(Response(response: httpResponse, body: decodableObj, bodyData: unwrappedData)))
             case let .failure(error):
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, response, error)))
+                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, httpResponse, error)))
             }
         }
     }
@@ -694,7 +702,7 @@ public enum OpenAPIInterceptorRetry {
 public protocol OpenAPIInterceptor {
     func intercept<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, completion: @escaping (Result<URLRequest, Error>) -> Void)
 
-    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
+    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
 }
 
 public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
@@ -704,7 +712,7 @@ public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
         completion(.success(urlRequest))
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         completion(.dontRetry)
     }
 }

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -155,24 +155,48 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
                 switch result {
                 case .success(let modifiedRequest):
                     let dataTask = urlSession.dataTaskFromProtocol(with: modifiedRequest) { data, response, error in
-                    self.cleanupRequest()
-                        if let response, let error {
-                            self.openAPIClient.interceptor.retry(urlRequest: modifiedRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
-                                switch retry {
-                                case .retry:
-                                    self.execute(completion: completion)
+                        self.cleanupRequest()
 
-                                case .dontRetry:
-                                    self.openAPIClient.apiResponseQueue.async {
-                                        self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                                    }
-                                }
-                            }
-                        } else {
-                            self.openAPIClient.apiResponseQueue.async {
-                                self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                            }
+                        if let error = error {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -1,
+                                data: data,
+                                response: response,
+                                error: error,
+                                completion: completion
+                            )
+                            return
                         }
+
+                        guard let httpResponse = response as? HTTPURLResponse else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -2,
+                                data: data,
+                                response: response,
+                                error: DecodableRequestBuilderError.nilHTTPResponse,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        guard self.openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: httpResponse.statusCode,
+                                data: data,
+                                response: httpResponse,
+                                error: DecodableRequestBuilderError.unsuccessfulHTTPStatusCode,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        self.processRequestResponse(urlRequest: request, data: data, httpResponse: httpResponse, error: error, completion: completion)
                     }
 
                     self.onProgressReady?(dataTask.progress)
@@ -204,22 +228,21 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
         }
     }
 
-    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+    private func retryRequest(urlRequest: URLRequest, urlSession: URLSessionProtocol, statusCode: Int, data: Data?, response: URLResponse?, error: Error, completion: @Sendable @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+        self.openAPIClient.interceptor.retry(urlRequest: urlRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
+            switch retry {
+            case .retry:
+                self.execute(completion: completion)
 
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
+            case .dontRetry:
+                self.openAPIClient.apiResponseQueue.async {
+                    completion(.failure(ErrorResponse.error(statusCode, data, response, error)))
+                }
+            }
         }
+    }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is Void.Type:
@@ -297,22 +320,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 }
 
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T>, @unchecked Sendable {
-    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
-        }
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is String.Type:
@@ -353,9 +361,9 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 completion(.success(Response(response: httpResponse, body: filePath as! T, bodyData: data)))
 
             } catch let requestParserError as DownloadException {
-                completion(.failure(ErrorResponse.error(400, data, response, requestParserError)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, requestParserError)))
             } catch {
-                completion(.failure(ErrorResponse.error(400, data, response, error)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, error)))
             }
 
         case is Void.Type:
@@ -372,7 +380,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 if let expressibleByNilLiteralType = T.self as? ExpressibleByNilLiteral.Type {
                     completion(.success(Response(response: httpResponse, body: expressibleByNilLiteralType.init(nilLiteral: ()) as! T, bodyData: data)))
                 } else {
-                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, response, DecodableRequestBuilderError.emptyDataResponse)))
+                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, httpResponse, DecodableRequestBuilderError.emptyDataResponse)))
                 }
                 return
             }
@@ -383,7 +391,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             case let .success(decodableObj):
                 completion(.success(Response(response: httpResponse, body: decodableObj, bodyData: unwrappedData)))
             case let .failure(error):
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, response, error)))
+                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, httpResponse, error)))
             }
         }
     }
@@ -694,7 +702,7 @@ public enum OpenAPIInterceptorRetry {
 public protocol OpenAPIInterceptor {
     func intercept<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, completion: @escaping (Result<URLRequest, Error>) -> Void)
 
-    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
+    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
 }
 
 public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
@@ -704,7 +712,7 @@ public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
         completion(.success(urlRequest))
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         completion(.dontRetry)
     }
 }

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -155,24 +155,48 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
                 switch result {
                 case .success(let modifiedRequest):
                     let dataTask = urlSession.dataTaskFromProtocol(with: modifiedRequest) { data, response, error in
-                    self.cleanupRequest()
-                        if let response, let error {
-                            self.openAPIClient.interceptor.retry(urlRequest: modifiedRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
-                                switch retry {
-                                case .retry:
-                                    self.execute(completion: completion)
+                        self.cleanupRequest()
 
-                                case .dontRetry:
-                                    self.openAPIClient.apiResponseQueue.async {
-                                        self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                                    }
-                                }
-                            }
-                        } else {
-                            self.openAPIClient.apiResponseQueue.async {
-                                self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                            }
+                        if let error = error {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -1,
+                                data: data,
+                                response: response,
+                                error: error,
+                                completion: completion
+                            )
+                            return
                         }
+
+                        guard let httpResponse = response as? HTTPURLResponse else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -2,
+                                data: data,
+                                response: response,
+                                error: DecodableRequestBuilderError.nilHTTPResponse,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        guard self.openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: httpResponse.statusCode,
+                                data: data,
+                                response: httpResponse,
+                                error: DecodableRequestBuilderError.unsuccessfulHTTPStatusCode,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        self.processRequestResponse(urlRequest: request, data: data, httpResponse: httpResponse, error: error, completion: completion)
                     }
 
                     self.onProgressReady?(dataTask.progress)
@@ -204,22 +228,21 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
         }
     }
 
-    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+    private func retryRequest(urlRequest: URLRequest, urlSession: URLSessionProtocol, statusCode: Int, data: Data?, response: URLResponse?, error: Error, completion: @Sendable @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+        self.openAPIClient.interceptor.retry(urlRequest: urlRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
+            switch retry {
+            case .retry:
+                self.execute(completion: completion)
 
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
+            case .dontRetry:
+                self.openAPIClient.apiResponseQueue.async {
+                    completion(.failure(ErrorResponse.error(statusCode, data, response, error)))
+                }
+            }
         }
+    }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is Void.Type:
@@ -297,22 +320,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 }
 
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T>, @unchecked Sendable {
-    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
-        }
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is String.Type:
@@ -353,9 +361,9 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 completion(.success(Response(response: httpResponse, body: filePath as! T, bodyData: data)))
 
             } catch let requestParserError as DownloadException {
-                completion(.failure(ErrorResponse.error(400, data, response, requestParserError)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, requestParserError)))
             } catch {
-                completion(.failure(ErrorResponse.error(400, data, response, error)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, error)))
             }
 
         case is Void.Type:
@@ -372,7 +380,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 if let expressibleByNilLiteralType = T.self as? ExpressibleByNilLiteral.Type {
                     completion(.success(Response(response: httpResponse, body: expressibleByNilLiteralType.init(nilLiteral: ()) as! T, bodyData: data)))
                 } else {
-                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, response, DecodableRequestBuilderError.emptyDataResponse)))
+                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, httpResponse, DecodableRequestBuilderError.emptyDataResponse)))
                 }
                 return
             }
@@ -383,7 +391,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             case let .success(decodableObj):
                 completion(.success(Response(response: httpResponse, body: decodableObj, bodyData: unwrappedData)))
             case let .failure(error):
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, response, error)))
+                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, httpResponse, error)))
             }
         }
     }
@@ -694,7 +702,7 @@ public enum OpenAPIInterceptorRetry {
 public protocol OpenAPIInterceptor {
     func intercept<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, completion: @escaping (Result<URLRequest, Error>) -> Void)
 
-    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
+    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
 }
 
 public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
@@ -704,7 +712,7 @@ public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
         completion(.success(urlRequest))
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         completion(.dontRetry)
     }
 }

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -155,24 +155,48 @@ internal class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendab
                 switch result {
                 case .success(let modifiedRequest):
                     let dataTask = urlSession.dataTaskFromProtocol(with: modifiedRequest) { data, response, error in
-                    self.cleanupRequest()
-                        if let response, let error {
-                            self.openAPIClient.interceptor.retry(urlRequest: modifiedRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
-                                switch retry {
-                                case .retry:
-                                    self.execute(completion: completion)
+                        self.cleanupRequest()
 
-                                case .dontRetry:
-                                    self.openAPIClient.apiResponseQueue.async {
-                                        self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                                    }
-                                }
-                            }
-                        } else {
-                            self.openAPIClient.apiResponseQueue.async {
-                                self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                            }
+                        if let error = error {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -1,
+                                data: data,
+                                response: response,
+                                error: error,
+                                completion: completion
+                            )
+                            return
                         }
+
+                        guard let httpResponse = response as? HTTPURLResponse else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -2,
+                                data: data,
+                                response: response,
+                                error: DecodableRequestBuilderError.nilHTTPResponse,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        guard self.openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: httpResponse.statusCode,
+                                data: data,
+                                response: httpResponse,
+                                error: DecodableRequestBuilderError.unsuccessfulHTTPStatusCode,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        self.processRequestResponse(urlRequest: request, data: data, httpResponse: httpResponse, error: error, completion: completion)
                     }
 
                     self.onProgressReady?(dataTask.progress)
@@ -204,22 +228,21 @@ internal class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendab
         }
     }
 
-    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+    private func retryRequest(urlRequest: URLRequest, urlSession: URLSessionProtocol, statusCode: Int, data: Data?, response: URLResponse?, error: Error, completion: @Sendable @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+        self.openAPIClient.interceptor.retry(urlRequest: urlRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
+            switch retry {
+            case .retry:
+                self.execute(completion: completion)
 
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
+            case .dontRetry:
+                self.openAPIClient.apiResponseQueue.async {
+                    completion(.failure(ErrorResponse.error(statusCode, data, response, error)))
+                }
+            }
         }
+    }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is Void.Type:
@@ -297,22 +320,7 @@ internal class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendab
 }
 
 internal class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T>, @unchecked Sendable {
-    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
-        }
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is String.Type:
@@ -353,9 +361,9 @@ internal class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionReques
                 completion(.success(Response(response: httpResponse, body: filePath as! T, bodyData: data)))
 
             } catch let requestParserError as DownloadException {
-                completion(.failure(ErrorResponse.error(400, data, response, requestParserError)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, requestParserError)))
             } catch {
-                completion(.failure(ErrorResponse.error(400, data, response, error)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, error)))
             }
 
         case is Void.Type:
@@ -372,7 +380,7 @@ internal class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionReques
                 if let expressibleByNilLiteralType = T.self as? ExpressibleByNilLiteral.Type {
                     completion(.success(Response(response: httpResponse, body: expressibleByNilLiteralType.init(nilLiteral: ()) as! T, bodyData: data)))
                 } else {
-                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, response, DecodableRequestBuilderError.emptyDataResponse)))
+                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, httpResponse, DecodableRequestBuilderError.emptyDataResponse)))
                 }
                 return
             }
@@ -383,7 +391,7 @@ internal class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionReques
             case let .success(decodableObj):
                 completion(.success(Response(response: httpResponse, body: decodableObj, bodyData: unwrappedData)))
             case let .failure(error):
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, response, error)))
+                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, httpResponse, error)))
             }
         }
     }
@@ -694,7 +702,7 @@ internal enum OpenAPIInterceptorRetry {
 internal protocol OpenAPIInterceptor {
     func intercept<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, completion: @escaping (Result<URLRequest, Error>) -> Void)
 
-    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
+    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
 }
 
 internal class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
@@ -704,7 +712,7 @@ internal class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
         completion(.success(urlRequest))
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         completion(.dontRetry)
     }
 }

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -155,24 +155,48 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
                 switch result {
                 case .success(let modifiedRequest):
                     let dataTask = urlSession.dataTaskFromProtocol(with: modifiedRequest) { data, response, error in
-                    self.cleanupRequest()
-                        if let response, let error {
-                            self.openAPIClient.interceptor.retry(urlRequest: modifiedRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
-                                switch retry {
-                                case .retry:
-                                    self.execute(completion: completion)
+                        self.cleanupRequest()
 
-                                case .dontRetry:
-                                    self.openAPIClient.apiResponseQueue.async {
-                                        self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                                    }
-                                }
-                            }
-                        } else {
-                            self.openAPIClient.apiResponseQueue.async {
-                                self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                            }
+                        if let error = error {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -1,
+                                data: data,
+                                response: response,
+                                error: error,
+                                completion: completion
+                            )
+                            return
                         }
+
+                        guard let httpResponse = response as? HTTPURLResponse else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -2,
+                                data: data,
+                                response: response,
+                                error: DecodableRequestBuilderError.nilHTTPResponse,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        guard self.openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: httpResponse.statusCode,
+                                data: data,
+                                response: httpResponse,
+                                error: DecodableRequestBuilderError.unsuccessfulHTTPStatusCode,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        self.processRequestResponse(urlRequest: request, data: data, httpResponse: httpResponse, error: error, completion: completion)
                     }
 
                     self.onProgressReady?(dataTask.progress)
@@ -204,22 +228,21 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
         }
     }
 
-    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+    private func retryRequest(urlRequest: URLRequest, urlSession: URLSessionProtocol, statusCode: Int, data: Data?, response: URLResponse?, error: Error, completion: @Sendable @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+        self.openAPIClient.interceptor.retry(urlRequest: urlRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
+            switch retry {
+            case .retry:
+                self.execute(completion: completion)
 
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
+            case .dontRetry:
+                self.openAPIClient.apiResponseQueue.async {
+                    completion(.failure(ErrorResponse.error(statusCode, data, response, error)))
+                }
+            }
         }
+    }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is Void.Type:
@@ -297,22 +320,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 }
 
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T>, @unchecked Sendable {
-    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
-        }
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is String.Type:
@@ -353,9 +361,9 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 completion(.success(Response(response: httpResponse, body: filePath as! T, bodyData: data)))
 
             } catch let requestParserError as DownloadException {
-                completion(.failure(ErrorResponse.error(400, data, response, requestParserError)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, requestParserError)))
             } catch {
-                completion(.failure(ErrorResponse.error(400, data, response, error)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, error)))
             }
 
         case is Void.Type:
@@ -372,7 +380,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 if let expressibleByNilLiteralType = T.self as? ExpressibleByNilLiteral.Type {
                     completion(.success(Response(response: httpResponse, body: expressibleByNilLiteralType.init(nilLiteral: ()) as! T, bodyData: data)))
                 } else {
-                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, response, DecodableRequestBuilderError.emptyDataResponse)))
+                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, httpResponse, DecodableRequestBuilderError.emptyDataResponse)))
                 }
                 return
             }
@@ -383,7 +391,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             case let .success(decodableObj):
                 completion(.success(Response(response: httpResponse, body: decodableObj, bodyData: unwrappedData)))
             case let .failure(error):
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, response, error)))
+                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, httpResponse, error)))
             }
         }
     }
@@ -694,7 +702,7 @@ public enum OpenAPIInterceptorRetry {
 public protocol OpenAPIInterceptor {
     func intercept<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, completion: @escaping (Result<URLRequest, Error>) -> Void)
 
-    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
+    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
 }
 
 public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
@@ -704,7 +712,7 @@ public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
         completion(.success(urlRequest))
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         completion(.dontRetry)
     }
 }

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
@@ -155,24 +155,48 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
                 switch result {
                 case .success(let modifiedRequest):
                     let dataTask = urlSession.dataTaskFromProtocol(with: modifiedRequest) { data, response, error in
-                    self.cleanupRequest()
-                        if let response, let error {
-                            self.openAPIClient.interceptor.retry(urlRequest: modifiedRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
-                                switch retry {
-                                case .retry:
-                                    self.execute(completion: completion)
+                        self.cleanupRequest()
 
-                                case .dontRetry:
-                                    self.openAPIClient.apiResponseQueue.async {
-                                        self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                                    }
-                                }
-                            }
-                        } else {
-                            self.openAPIClient.apiResponseQueue.async {
-                                self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                            }
+                        if let error = error {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -1,
+                                data: data,
+                                response: response,
+                                error: error,
+                                completion: completion
+                            )
+                            return
                         }
+
+                        guard let httpResponse = response as? HTTPURLResponse else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -2,
+                                data: data,
+                                response: response,
+                                error: DecodableRequestBuilderError.nilHTTPResponse,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        guard self.openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: httpResponse.statusCode,
+                                data: data,
+                                response: httpResponse,
+                                error: DecodableRequestBuilderError.unsuccessfulHTTPStatusCode,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        self.processRequestResponse(urlRequest: request, data: data, httpResponse: httpResponse, error: error, completion: completion)
                     }
 
                     self.onProgressReady?(dataTask.progress)
@@ -204,22 +228,21 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
         }
     }
 
-    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+    private func retryRequest(urlRequest: URLRequest, urlSession: URLSessionProtocol, statusCode: Int, data: Data?, response: URLResponse?, error: Error, completion: @Sendable @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+        self.openAPIClient.interceptor.retry(urlRequest: urlRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
+            switch retry {
+            case .retry:
+                self.execute(completion: completion)
 
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
+            case .dontRetry:
+                self.openAPIClient.apiResponseQueue.async {
+                    completion(.failure(ErrorResponse.error(statusCode, data, response, error)))
+                }
+            }
         }
+    }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is Void.Type:
@@ -297,22 +320,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 }
 
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T>, @unchecked Sendable {
-    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
-        }
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is String.Type:
@@ -353,9 +361,9 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 completion(.success(Response(response: httpResponse, body: filePath as! T, bodyData: data)))
 
             } catch let requestParserError as DownloadException {
-                completion(.failure(ErrorResponse.error(400, data, response, requestParserError)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, requestParserError)))
             } catch {
-                completion(.failure(ErrorResponse.error(400, data, response, error)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, error)))
             }
 
         case is Void.Type:
@@ -372,7 +380,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 if let expressibleByNilLiteralType = T.self as? ExpressibleByNilLiteral.Type {
                     completion(.success(Response(response: httpResponse, body: expressibleByNilLiteralType.init(nilLiteral: ()) as! T, bodyData: data)))
                 } else {
-                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, response, DecodableRequestBuilderError.emptyDataResponse)))
+                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, httpResponse, DecodableRequestBuilderError.emptyDataResponse)))
                 }
                 return
             }
@@ -383,7 +391,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             case let .success(decodableObj):
                 completion(.success(Response(response: httpResponse, body: decodableObj, bodyData: unwrappedData)))
             case let .failure(error):
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, response, error)))
+                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, httpResponse, error)))
             }
         }
     }
@@ -694,7 +702,7 @@ public enum OpenAPIInterceptorRetry {
 public protocol OpenAPIInterceptor {
     func intercept<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, completion: @escaping (Result<URLRequest, Error>) -> Void)
 
-    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
+    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
 }
 
 public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
@@ -704,7 +712,7 @@ public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
         completion(.success(urlRequest))
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         completion(.dontRetry)
     }
 }

--- a/samples/client/petstore/swift6/urlsessionLibrary/SwaggerClientTests/SwaggerClient/BearerTokenHandler.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/SwaggerClientTests/SwaggerClient/BearerTokenHandler.swift
@@ -33,7 +33,7 @@ public class BearerOpenAPIInterceptor: OpenAPIInterceptor {
         }
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: any URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: any Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         // We will analyse the response to see if it's a 401, and if it's a 401, we will refresh the token and retry the request
         refreshTokenIfUnauthorizedRequestResponse(
             data: data,

--- a/samples/client/petstore/swift6/urlsessionLibrary/SwaggerClientTests/SwaggerClient/BearerTokenHandler.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/SwaggerClientTests/SwaggerClient/BearerTokenHandler.swift
@@ -33,7 +33,7 @@ public class BearerOpenAPIInterceptor: OpenAPIInterceptor {
         }
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: any URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: any Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         // We will analyse the response to see if it's a 401, and if it's a 401, we will refresh the token and retry the request
         refreshTokenIfUnauthorizedRequestResponse(
             data: data,
@@ -66,7 +66,7 @@ public class BearerOpenAPIInterceptor: OpenAPIInterceptor {
         }
     }
     
-    func refreshTokenIfUnauthorizedRequestResponse(data: Data?, response: URLResponse, error: Error, completionHandler: @escaping (Bool, String?) -> Void) {
+    func refreshTokenIfUnauthorizedRequestResponse(data: Data?, response: URLResponse?, error: Error, completionHandler: @escaping (Bool, String?) -> Void) {
         if let response = response as? HTTPURLResponse, response.statusCode == 401 {
             startRefreshingToken { token in
                 completionHandler(true, token)

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -155,24 +155,48 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
                 switch result {
                 case .success(let modifiedRequest):
                     let dataTask = urlSession.dataTaskFromProtocol(with: modifiedRequest) { data, response, error in
-                    self.cleanupRequest()
-                        if let response, let error {
-                            self.openAPIClient.interceptor.retry(urlRequest: modifiedRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
-                                switch retry {
-                                case .retry:
-                                    self.execute(completion: completion)
+                        self.cleanupRequest()
 
-                                case .dontRetry:
-                                    self.openAPIClient.apiResponseQueue.async {
-                                        self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                                    }
-                                }
-                            }
-                        } else {
-                            self.openAPIClient.apiResponseQueue.async {
-                                self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                            }
+                        if let error = error {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -1,
+                                data: data,
+                                response: response,
+                                error: error,
+                                completion: completion
+                            )
+                            return
                         }
+
+                        guard let httpResponse = response as? HTTPURLResponse else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: -2,
+                                data: data,
+                                response: response,
+                                error: DecodableRequestBuilderError.nilHTTPResponse,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        guard self.openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
+                            self.retryRequest(
+                                urlRequest: modifiedRequest,
+                                urlSession: urlSession,
+                                statusCode: httpResponse.statusCode,
+                                data: data,
+                                response: httpResponse,
+                                error: DecodableRequestBuilderError.unsuccessfulHTTPStatusCode,
+                                completion: completion
+                            )
+                            return
+                        }
+
+                        self.processRequestResponse(urlRequest: request, data: data, httpResponse: httpResponse, error: error, completion: completion)
                     }
 
                     self.onProgressReady?(dataTask.progress)
@@ -204,22 +228,21 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
         }
     }
 
-    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+    private func retryRequest(urlRequest: URLRequest, urlSession: URLSessionProtocol, statusCode: Int, data: Data?, response: URLResponse?, error: Error, completion: @Sendable @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
+        self.openAPIClient.interceptor.retry(urlRequest: urlRequest, urlSession: urlSession, requestBuilder: self, data: data, response: response, error: error) { retry in
+            switch retry {
+            case .retry:
+                self.execute(completion: completion)
 
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
+            case .dontRetry:
+                self.openAPIClient.apiResponseQueue.async {
+                    completion(.failure(ErrorResponse.error(statusCode, data, response, error)))
+                }
+            }
         }
+    }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is Void.Type:
@@ -297,22 +320,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T>, @unchecked Sendable {
 }
 
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T>, @unchecked Sendable {
-    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(-1, data, response, error)))
-            return
-        }
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, data, response, DecodableRequestBuilderError.nilHTTPResponse)))
-            return
-        }
-
-        guard openAPIClient.successfulStatusCodeRange.contains(httpResponse.statusCode) else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, response, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
-            return
-        }
+    override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, httpResponse: HTTPURLResponse, error: Error?, completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) {
 
         switch T.self {
         case is String.Type:
@@ -353,9 +361,9 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 completion(.success(Response(response: httpResponse, body: filePath as! T, bodyData: data)))
 
             } catch let requestParserError as DownloadException {
-                completion(.failure(ErrorResponse.error(400, data, response, requestParserError)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, requestParserError)))
             } catch {
-                completion(.failure(ErrorResponse.error(400, data, response, error)))
+                completion(.failure(ErrorResponse.error(400, data, httpResponse, error)))
             }
 
         case is Void.Type:
@@ -372,7 +380,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
                 if let expressibleByNilLiteralType = T.self as? ExpressibleByNilLiteral.Type {
                     completion(.success(Response(response: httpResponse, body: expressibleByNilLiteralType.init(nilLiteral: ()) as! T, bodyData: data)))
                 } else {
-                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, response, DecodableRequestBuilderError.emptyDataResponse)))
+                    completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, httpResponse, DecodableRequestBuilderError.emptyDataResponse)))
                 }
                 return
             }
@@ -383,7 +391,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             case let .success(decodableObj):
                 completion(.success(Response(response: httpResponse, body: decodableObj, bodyData: unwrappedData)))
             case let .failure(error):
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, response, error)))
+                completion(.failure(ErrorResponse.error(httpResponse.statusCode, unwrappedData, httpResponse, error)))
             }
         }
     }
@@ -694,7 +702,7 @@ public enum OpenAPIInterceptorRetry {
 public protocol OpenAPIInterceptor {
     func intercept<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, completion: @escaping (Result<URLRequest, Error>) -> Void)
 
-    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
+    func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void)
 }
 
 public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
@@ -704,7 +712,7 @@ public class DefaultOpenAPIInterceptor: OpenAPIInterceptor {
         completion(.success(urlRequest))
     }
     
-    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
+    public func retry<T>(urlRequest: URLRequest, urlSession: URLSessionProtocol, requestBuilder: RequestBuilder<T>, data: Data?, response: URLResponse?, error: Error, completion: @escaping (OpenAPIInterceptorRetry) -> Void) {
         completion(.dontRetry)
     }
 }


### PR DESCRIPTION
Swift 6 improve retry interceptor to fix https://github.com/OpenAPITools/openapi-generator/issues/19939

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)