### PR TITLE
feat cpp-qt-client: fix cast primitive to string

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
@@ -391,7 +391,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         }
         fullPath.append(paramString);
         {{/isPrimitiveType}}{{#isPrimitiveType}}
-        fullPath.append(QUrl::toPercentEncoding("{{baseName}}")).append(querySuffix).append(QUrl::toPercentEncoding({{paramName}}{{^required}}.stringValue(){{/required}}));
+        fullPath.append(QUrl::toPercentEncoding("{{baseName}}")).append(querySuffix).append(QUrl::toPercentEncoding(::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.stringValue(){{/required}})));
 {{/isPrimitiveType}}
 {{/collectionFormat}}
 {{#collectionFormat}}

--- a/samples/client/petstore/cpp-qt-addDownloadProgress/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt-addDownloadProgress/client/PFXUserApi.cpp
@@ -635,7 +635,7 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
         else
             fullPath.append("?");
 
-        fullPath.append(QUrl::toPercentEncoding("username")).append(querySuffix).append(QUrl::toPercentEncoding(username));
+        fullPath.append(QUrl::toPercentEncoding("username")).append(querySuffix).append(QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
     }
     
     {
@@ -650,7 +650,7 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
         else
             fullPath.append("?");
 
-        fullPath.append(QUrl::toPercentEncoding("password")).append(querySuffix).append(QUrl::toPercentEncoding(password));
+        fullPath.append(QUrl::toPercentEncoding("password")).append(querySuffix).append(QUrl::toPercentEncoding(::test_namespace::toStringValue(password)));
     }
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);

--- a/samples/client/petstore/cpp-qt/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXUserApi.cpp
@@ -635,7 +635,7 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
         else
             fullPath.append("?");
 
-        fullPath.append(QUrl::toPercentEncoding("username")).append(querySuffix).append(QUrl::toPercentEncoding(username));
+        fullPath.append(QUrl::toPercentEncoding("username")).append(querySuffix).append(QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
     }
     
     {
@@ -650,7 +650,7 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
         else
             fullPath.append("?");
 
-        fullPath.append(QUrl::toPercentEncoding("password")).append(querySuffix).append(QUrl::toPercentEncoding(password));
+        fullPath.append(QUrl::toPercentEncoding("password")).append(querySuffix).append(QUrl::toPercentEncoding(::test_namespace::toStringValue(password)));
     }
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);


### PR DESCRIPTION
QUrl::toPercentEncoding accepts only QString type, but we pass any primitive type to him
It's fix for [issue 20001](https://github.com/OpenAPITools/openapi-generator/issues/20001)

##### For validate the work
1. mark non string property as required in openapi file
2. generate client
3. try build it
4. build must pass without any error messages

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@ravinikam (2017/07) @stkrwork (2017/07) @etherealjoy (2018/02) @martindelille (2018/03) @muttleyxd (2019/08)
