### PR TITLE
[swift6] Add Sendable conformance to request parameter enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/api.mustache
@@ -32,7 +32,7 @@ extension {{projectName}}API {
     /**
      * enum for parameter {{paramName}}
      */
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum {{enumName}}_{{operationId}}: {{^isContainer}}{{{dataType}}}{{/isContainer}}{{#isContainer}}String{{/isContainer}}, CaseIterable{{#useVapor}}, Content{{/useVapor}} {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum {{enumName}}_{{operationId}}: {{^isContainer}}{{{dataType}}}{{/isContainer}}{{#isContainer}}String{{/isContainer}}, Sendable, CaseIterable{{#useVapor}}, Content{{/useVapor}} {
         {{^enumUnknownDefaultCase}}
         {{#allowableValues}}
         {{#enumVars}}

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/APIs/FakeAPI.swift
@@ -411,7 +411,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderStringArray
      */
-    public enum EnumHeaderStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -419,7 +419,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderString
      */
-    public enum EnumHeaderString_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -428,7 +428,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryStringArray
      */
-    public enum EnumQueryStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -436,7 +436,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryString
      */
-    public enum EnumQueryString_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -445,7 +445,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryInteger
      */
-    public enum EnumQueryInteger_testEnumParameters: Int, CaseIterable {
+    public enum EnumQueryInteger_testEnumParameters: Int, Sendable, CaseIterable {
         case _1 = 1
         case number2 = -2
     }
@@ -453,7 +453,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryDouble
      */
-    public enum EnumQueryDouble_testEnumParameters: Double, CaseIterable {
+    public enum EnumQueryDouble_testEnumParameters: Double, Sendable, CaseIterable {
         case _11 = 1.1
         case number12 = -1.2
     }
@@ -461,7 +461,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormStringArray
      */
-    public enum EnumFormStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumFormStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -469,7 +469,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormString
      */
-    public enum EnumFormString_testEnumParameters: String, CaseIterable {
+    public enum EnumFormString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -114,7 +114,7 @@ open class PetAPI {
     /**
      * enum for parameter status
      */
-    public enum Status_findPetsByStatus: String, CaseIterable {
+    public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
         case available = "available"
         case pending = "pending"
         case sold = "sold"

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/FakeAPI.swift
@@ -1268,7 +1268,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderStringArray
      */
-    public enum EnumHeaderStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -1276,7 +1276,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderString
      */
-    public enum EnumHeaderString_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -1285,7 +1285,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryStringArray
      */
-    public enum EnumQueryStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -1293,7 +1293,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryString
      */
-    public enum EnumQueryString_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -1302,7 +1302,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryInteger
      */
-    public enum EnumQueryInteger_testEnumParameters: Int, CaseIterable {
+    public enum EnumQueryInteger_testEnumParameters: Int, Sendable, CaseIterable {
         case _1 = 1
         case number2 = -2
     }
@@ -1310,7 +1310,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryDouble
      */
-    public enum EnumQueryDouble_testEnumParameters: Double, CaseIterable {
+    public enum EnumQueryDouble_testEnumParameters: Double, Sendable, CaseIterable {
         case _11 = 1.1
         case number12 = -1.2
     }
@@ -1318,7 +1318,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormStringArray
      */
-    public enum EnumFormStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumFormStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -1326,7 +1326,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormString
      */
-    public enum EnumFormString_testEnumParameters: String, CaseIterable {
+    public enum EnumFormString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -330,7 +330,7 @@ open class PetAPI {
     /**
      * enum for parameter status
      */
-    public enum Status_findPetsByStatus: String, CaseIterable {
+    public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
         case available = "available"
         case pending = "pending"
         case sold = "sold"

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/APIs/FakeAPI.swift
@@ -355,7 +355,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderStringArray
      */
-    public enum EnumHeaderStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -363,7 +363,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderString
      */
-    public enum EnumHeaderString_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -372,7 +372,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryStringArray
      */
-    public enum EnumQueryStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -380,7 +380,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryString
      */
-    public enum EnumQueryString_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -389,7 +389,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryInteger
      */
-    public enum EnumQueryInteger_testEnumParameters: Int, CaseIterable {
+    public enum EnumQueryInteger_testEnumParameters: Int, Sendable, CaseIterable {
         case _1 = 1
         case number2 = -2
     }
@@ -397,7 +397,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryDouble
      */
-    public enum EnumQueryDouble_testEnumParameters: Double, CaseIterable {
+    public enum EnumQueryDouble_testEnumParameters: Double, Sendable, CaseIterable {
         case _11 = 1.1
         case number12 = -1.2
     }
@@ -405,7 +405,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormStringArray
      */
-    public enum EnumFormStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumFormStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -413,7 +413,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormString
      */
-    public enum EnumFormString_testEnumParameters: String, CaseIterable {
+    public enum EnumFormString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -100,7 +100,7 @@ open class PetAPI {
     /**
      * enum for parameter status
      */
-    public enum Status_findPetsByStatus: String, CaseIterable {
+    public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
         case available = "available"
         case pending = "pending"
         case sold = "sold"

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -518,7 +518,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderStringArray
      */
-    public enum EnumHeaderStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -526,7 +526,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderString
      */
-    public enum EnumHeaderString_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -535,7 +535,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryStringArray
      */
-    public enum EnumQueryStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -543,7 +543,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryString
      */
-    public enum EnumQueryString_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -552,7 +552,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryInteger
      */
-    public enum EnumQueryInteger_testEnumParameters: Int, CaseIterable {
+    public enum EnumQueryInteger_testEnumParameters: Int, Sendable, CaseIterable {
         case _1 = 1
         case number2 = -2
     }
@@ -560,7 +560,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryDouble
      */
-    public enum EnumQueryDouble_testEnumParameters: Double, CaseIterable {
+    public enum EnumQueryDouble_testEnumParameters: Double, Sendable, CaseIterable {
         case _11 = 1.1
         case number12 = -1.2
     }
@@ -568,7 +568,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormStringArray
      */
-    public enum EnumFormStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumFormStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -576,7 +576,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormString
      */
-    public enum EnumFormString_testEnumParameters: String, CaseIterable {
+    public enum EnumFormString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -143,7 +143,7 @@ open class PetAPI {
     /**
      * enum for parameter status
      */
-    public enum Status_findPetsByStatus: String, CaseIterable {
+    public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
         case available = "available"
         case pending = "pending"
         case sold = "sold"

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/FakeAPI.swift
@@ -502,7 +502,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderStringArray
      */
-    public enum EnumHeaderStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -510,7 +510,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderString
      */
-    public enum EnumHeaderString_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -519,7 +519,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryStringArray
      */
-    public enum EnumQueryStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -527,7 +527,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryString
      */
-    public enum EnumQueryString_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -536,7 +536,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryInteger
      */
-    public enum EnumQueryInteger_testEnumParameters: Int, CaseIterable {
+    public enum EnumQueryInteger_testEnumParameters: Int, Sendable, CaseIterable {
         case _1 = 1
         case number2 = -2
     }
@@ -544,7 +544,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryDouble
      */
-    public enum EnumQueryDouble_testEnumParameters: Double, CaseIterable {
+    public enum EnumQueryDouble_testEnumParameters: Double, Sendable, CaseIterable {
         case _11 = 1.1
         case number12 = -1.2
     }
@@ -552,7 +552,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormStringArray
      */
-    public enum EnumFormStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumFormStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -560,7 +560,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormString
      */
-    public enum EnumFormString_testEnumParameters: String, CaseIterable {
+    public enum EnumFormString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/PetAPI.swift
@@ -139,7 +139,7 @@ open class PetAPI {
     /**
      * enum for parameter status
      */
-    public enum Status_findPetsByStatus: String, CaseIterable {
+    public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
         case available = "available"
         case pending = "pending"
         case sold = "sold"

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/FakeAPI.swift
@@ -393,7 +393,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderStringArray
      */
-    public enum EnumHeaderStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -401,7 +401,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderString
      */
-    public enum EnumHeaderString_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -410,7 +410,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryStringArray
      */
-    public enum EnumQueryStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -418,7 +418,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryString
      */
-    public enum EnumQueryString_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -427,7 +427,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryInteger
      */
-    public enum EnumQueryInteger_testEnumParameters: Int, CaseIterable {
+    public enum EnumQueryInteger_testEnumParameters: Int, Sendable, CaseIterable {
         case _1 = 1
         case number2 = -2
     }
@@ -435,7 +435,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryDouble
      */
-    public enum EnumQueryDouble_testEnumParameters: Double, CaseIterable {
+    public enum EnumQueryDouble_testEnumParameters: Double, Sendable, CaseIterable {
         case _11 = 1.1
         case number12 = -1.2
     }
@@ -443,7 +443,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormStringArray
      */
-    public enum EnumFormStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumFormStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -451,7 +451,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormString
      */
-    public enum EnumFormString_testEnumParameters: String, CaseIterable {
+    public enum EnumFormString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -97,7 +97,7 @@ open class PetAPI {
     /**
      * enum for parameter status
      */
-    public enum Status_findPetsByStatus: String, CaseIterable {
+    public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
         case available = "available"
         case pending = "pending"
         case sold = "sold"

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/APIs/FakeAPI.swift
@@ -411,7 +411,7 @@ import Foundation
     /**
      * enum for parameter enumHeaderStringArray
      */
-    public enum EnumHeaderStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -419,7 +419,7 @@ import Foundation
     /**
      * enum for parameter enumHeaderString
      */
-    public enum EnumHeaderString_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -428,7 +428,7 @@ import Foundation
     /**
      * enum for parameter enumQueryStringArray
      */
-    public enum EnumQueryStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -436,7 +436,7 @@ import Foundation
     /**
      * enum for parameter enumQueryString
      */
-    public enum EnumQueryString_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -445,7 +445,7 @@ import Foundation
     /**
      * enum for parameter enumQueryInteger
      */
-    public enum EnumQueryInteger_testEnumParameters: Int, CaseIterable {
+    public enum EnumQueryInteger_testEnumParameters: Int, Sendable, CaseIterable {
         case _1 = 1
         case number2 = -2
     }
@@ -453,7 +453,7 @@ import Foundation
     /**
      * enum for parameter enumQueryDouble
      */
-    public enum EnumQueryDouble_testEnumParameters: Double, CaseIterable {
+    public enum EnumQueryDouble_testEnumParameters: Double, Sendable, CaseIterable {
         case _11 = 1.1
         case number12 = -1.2
     }
@@ -461,7 +461,7 @@ import Foundation
     /**
      * enum for parameter enumFormStringArray
      */
-    public enum EnumFormStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumFormStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -469,7 +469,7 @@ import Foundation
     /**
      * enum for parameter enumFormString
      */
-    public enum EnumFormString_testEnumParameters: String, CaseIterable {
+    public enum EnumFormString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -114,7 +114,7 @@ import Foundation
     /**
      * enum for parameter status
      */
-    public enum Status_findPetsByStatus: String, CaseIterable {
+    public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
         case available = "available"
         case pending = "pending"
         case sold = "sold"

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -420,7 +420,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderStringArray
      */
-    public enum EnumHeaderStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -428,7 +428,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderString
      */
-    public enum EnumHeaderString_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -437,7 +437,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryStringArray
      */
-    public enum EnumQueryStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -445,7 +445,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryString
      */
-    public enum EnumQueryString_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -454,7 +454,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryInteger
      */
-    public enum EnumQueryInteger_testEnumParameters: Int, CaseIterable {
+    public enum EnumQueryInteger_testEnumParameters: Int, Sendable, CaseIterable {
         case _1 = 1
         case number2 = -2
     }
@@ -462,7 +462,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryDouble
      */
-    public enum EnumQueryDouble_testEnumParameters: Double, CaseIterable {
+    public enum EnumQueryDouble_testEnumParameters: Double, Sendable, CaseIterable {
         case _11 = 1.1
         case number12 = -1.2
     }
@@ -470,7 +470,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormStringArray
      */
-    public enum EnumFormStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumFormStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -478,7 +478,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormString
      */
-    public enum EnumFormString_testEnumParameters: String, CaseIterable {
+    public enum EnumFormString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -117,7 +117,7 @@ open class PetAPI {
     /**
      * enum for parameter status
      */
-    public enum Status_findPetsByStatus: String, CaseIterable {
+    public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
         case available = "available"
         case pending = "pending"
         case sold = "sold"

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -411,7 +411,7 @@ internal class FakeAPI {
     /**
      * enum for parameter enumHeaderStringArray
      */
-    internal enum EnumHeaderStringArray_testEnumParameters: String, CaseIterable {
+    internal enum EnumHeaderStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -419,7 +419,7 @@ internal class FakeAPI {
     /**
      * enum for parameter enumHeaderString
      */
-    internal enum EnumHeaderString_testEnumParameters: String, CaseIterable {
+    internal enum EnumHeaderString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -428,7 +428,7 @@ internal class FakeAPI {
     /**
      * enum for parameter enumQueryStringArray
      */
-    internal enum EnumQueryStringArray_testEnumParameters: String, CaseIterable {
+    internal enum EnumQueryStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -436,7 +436,7 @@ internal class FakeAPI {
     /**
      * enum for parameter enumQueryString
      */
-    internal enum EnumQueryString_testEnumParameters: String, CaseIterable {
+    internal enum EnumQueryString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -445,7 +445,7 @@ internal class FakeAPI {
     /**
      * enum for parameter enumQueryInteger
      */
-    internal enum EnumQueryInteger_testEnumParameters: Int, CaseIterable {
+    internal enum EnumQueryInteger_testEnumParameters: Int, Sendable, CaseIterable {
         case _1 = 1
         case number2 = -2
     }
@@ -453,7 +453,7 @@ internal class FakeAPI {
     /**
      * enum for parameter enumQueryDouble
      */
-    internal enum EnumQueryDouble_testEnumParameters: Double, CaseIterable {
+    internal enum EnumQueryDouble_testEnumParameters: Double, Sendable, CaseIterable {
         case _11 = 1.1
         case number12 = -1.2
     }
@@ -461,7 +461,7 @@ internal class FakeAPI {
     /**
      * enum for parameter enumFormStringArray
      */
-    internal enum EnumFormStringArray_testEnumParameters: String, CaseIterable {
+    internal enum EnumFormStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -469,7 +469,7 @@ internal class FakeAPI {
     /**
      * enum for parameter enumFormString
      */
-    internal enum EnumFormString_testEnumParameters: String, CaseIterable {
+    internal enum EnumFormString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -114,7 +114,7 @@ internal class PetAPI {
     /**
      * enum for parameter status
      */
-    internal enum Status_findPetsByStatus: String, CaseIterable {
+    internal enum Status_findPetsByStatus: String, Sendable, CaseIterable {
         case available = "available"
         case pending = "pending"
         case sold = "sold"

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -460,7 +460,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderStringArray
      */
-    public enum EnumHeaderStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -468,7 +468,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderString
      */
-    public enum EnumHeaderString_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -477,7 +477,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryStringArray
      */
-    public enum EnumQueryStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -485,7 +485,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryString
      */
-    public enum EnumQueryString_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -494,7 +494,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryInteger
      */
-    public enum EnumQueryInteger_testEnumParameters: Int, CaseIterable {
+    public enum EnumQueryInteger_testEnumParameters: Int, Sendable, CaseIterable {
         case _1 = 1
         case number2 = -2
     }
@@ -502,7 +502,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryDouble
      */
-    public enum EnumQueryDouble_testEnumParameters: Double, CaseIterable {
+    public enum EnumQueryDouble_testEnumParameters: Double, Sendable, CaseIterable {
         case _11 = 1.1
         case number12 = -1.2
     }
@@ -510,7 +510,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormStringArray
      */
-    public enum EnumFormStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumFormStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -518,7 +518,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormString
      */
-    public enum EnumFormString_testEnumParameters: String, CaseIterable {
+    public enum EnumFormString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -127,7 +127,7 @@ open class PetAPI {
     /**
      * enum for parameter status
      */
-    public enum Status_findPetsByStatus: String, CaseIterable {
+    public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
         case available = "available"
         case pending = "pending"
         case sold = "sold"

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/APIs/FakeAPI.swift
@@ -414,7 +414,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderStringArray
      */
-    public enum EnumHeaderStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -422,7 +422,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderString
      */
-    public enum EnumHeaderString_testEnumParameters: String, CaseIterable {
+    public enum EnumHeaderString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -431,7 +431,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryStringArray
      */
-    public enum EnumQueryStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -439,7 +439,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryString
      */
-    public enum EnumQueryString_testEnumParameters: String, CaseIterable {
+    public enum EnumQueryString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -448,7 +448,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryInteger
      */
-    public enum EnumQueryInteger_testEnumParameters: Int, CaseIterable {
+    public enum EnumQueryInteger_testEnumParameters: Int, Sendable, CaseIterable {
         case _1 = 1
         case number2 = -2
     }
@@ -456,7 +456,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryDouble
      */
-    public enum EnumQueryDouble_testEnumParameters: Double, CaseIterable {
+    public enum EnumQueryDouble_testEnumParameters: Double, Sendable, CaseIterable {
         case _11 = 1.1
         case number12 = -1.2
     }
@@ -464,7 +464,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormStringArray
      */
-    public enum EnumFormStringArray_testEnumParameters: String, CaseIterable {
+    public enum EnumFormStringArray_testEnumParameters: String, Sendable, CaseIterable {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -472,7 +472,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormString
      */
-    public enum EnumFormString_testEnumParameters: String, CaseIterable {
+    public enum EnumFormString_testEnumParameters: String, Sendable, CaseIterable {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -117,7 +117,7 @@ open class PetAPI {
     /**
      * enum for parameter status
      */
-    public enum Status_findPetsByStatus: String, CaseIterable {
+    public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
         case available = "available"
         case pending = "pending"
         case sold = "sold"

--- a/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/APIs/FakeAPI.swift
@@ -499,7 +499,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderStringArray
      */
-    public enum EnumHeaderStringArray_testEnumParameters: String, CaseIterable, Content {
+    public enum EnumHeaderStringArray_testEnumParameters: String, Sendable, CaseIterable, Content {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -507,7 +507,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumHeaderString
      */
-    public enum EnumHeaderString_testEnumParameters: String, CaseIterable, Content {
+    public enum EnumHeaderString_testEnumParameters: String, Sendable, CaseIterable, Content {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -516,7 +516,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryStringArray
      */
-    public enum EnumQueryStringArray_testEnumParameters: String, CaseIterable, Content {
+    public enum EnumQueryStringArray_testEnumParameters: String, Sendable, CaseIterable, Content {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -524,7 +524,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryString
      */
-    public enum EnumQueryString_testEnumParameters: String, CaseIterable, Content {
+    public enum EnumQueryString_testEnumParameters: String, Sendable, CaseIterable, Content {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"
@@ -533,7 +533,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryInteger
      */
-    public enum EnumQueryInteger_testEnumParameters: Int, CaseIterable, Content {
+    public enum EnumQueryInteger_testEnumParameters: Int, Sendable, CaseIterable, Content {
         case _1 = 1
         case number2 = -2
     }
@@ -541,7 +541,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumQueryDouble
      */
-    public enum EnumQueryDouble_testEnumParameters: Double, CaseIterable, Content {
+    public enum EnumQueryDouble_testEnumParameters: Double, Sendable, CaseIterable, Content {
         case _11 = 1.1
         case number12 = -1.2
     }
@@ -549,7 +549,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormStringArray
      */
-    public enum EnumFormStringArray_testEnumParameters: String, CaseIterable, Content {
+    public enum EnumFormStringArray_testEnumParameters: String, Sendable, CaseIterable, Content {
         case greaterThan = ">"
         case dollar = "$"
     }
@@ -557,7 +557,7 @@ open class FakeAPI {
     /**
      * enum for parameter enumFormString
      */
-    public enum EnumFormString_testEnumParameters: String, CaseIterable, Content {
+    public enum EnumFormString_testEnumParameters: String, Sendable, CaseIterable, Content {
         case abc = "_abc"
         case efg = "-efg"
         case xyz = "(xyz)"

--- a/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -129,7 +129,7 @@ open class PetAPI {
     /**
      * enum for parameter status
      */
-    public enum Status_findPetsByStatus: String, CaseIterable, Content {
+    public enum Status_findPetsByStatus: String, Sendable, CaseIterable, Content {
         case available = "available"
         case pending = "pending"
         case sold = "sold"


### PR DESCRIPTION
Continuation of #20013. I missed a place where enums are generated which can always conform to `Sendable`.

@jgavris @ehyche @Edubits @jaz-ah @4brunu @dydus0x14

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
