### PR TITLE
[elixir] Update dialyzer spec

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/request_builder.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/request_builder.ex.mustache
@@ -160,10 +160,11 @@ defmodule {{moduleName}}.RequestBuilder do
 
   ### Returns
 
-  - `{:ok, struct}` or `{:ok, Tesla.Env.t()}` on success
+  - `{:ok, struct}`, {:ok, [struct]} or `{:ok, Tesla.Env.t()}` on success
   - `{:error, term}` on failure
   """
-  @spec evaluate_response(Tesla.Env.result(), response_mapping) :: {:ok, struct()} | Tesla.Env.result()
+  @spec evaluate_response(Tesla.Env.result(), response_mapping) ::
+          {:ok, struct() | [struct()] | Tesla.Env.t()} | {:error, Tesla.Env.t() | any()}
   def evaluate_response({:ok, %Tesla.Env{} = env}, mapping) do
     resolve_mapping(env, mapping, nil)
   end

--- a/samples/client/petstore/elixir/lib/openapi_petstore/request_builder.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/request_builder.ex
@@ -162,10 +162,11 @@ defmodule OpenapiPetstore.RequestBuilder do
 
   ### Returns
 
-  - `{:ok, struct}` or `{:ok, Tesla.Env.t()}` on success
+  - `{:ok, struct}`, {:ok, [struct]} or `{:ok, Tesla.Env.t()}` on success
   - `{:error, term}` on failure
   """
-  @spec evaluate_response(Tesla.Env.result(), response_mapping) :: {:ok, struct()} | Tesla.Env.result()
+  @spec evaluate_response(Tesla.Env.result(), response_mapping) ::
+          {:ok, struct() | [struct()] | Tesla.Env.t()} | {:error, Tesla.Env.t() | any()}
   def evaluate_response({:ok, %Tesla.Env{} = env}, mapping) do
     resolve_mapping(env, mapping, nil)
   end


### PR DESCRIPTION
The spec for `RequestBuilder.evaluate_response/2` does not allow for lists of structs to be returned. This is incorrect as `Deserializer.to_struct/2` can return a list of structs that gets passed up through to the generated api functions.

This PR updates the `RequestBuilder.evaluate_response/2` spec to correctly reflect the behavior of the function return values.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@mrmstn 