### PR TITLE
[typescript-fetch][Fix] `oneOf` models are generated without `...ToJSONTyped` functions but models referencing still try to import

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -108,11 +108,11 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     {{/hasVars}}
 }
 
-  export function {{classname}}ToJSON(json: any): {{classname}} {
-      return {{classname}}ToJSONTyped(json, false);
-  }
+export function {{classname}}ToJSON(json: any): {{classname}} {
+    return {{classname}}ToJSONTyped(json, false);
+}
 
-  export function {{classname}}ToJSONTyped(value?: {{#hasReadOnly}}Omit<{{classname}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{classname}}{{/hasReadOnly}} | null, ignoreDiscriminator: boolean = false): any {
+export function {{classname}}ToJSONTyped(value?: {{#hasReadOnly}}Omit<{{classname}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{classname}}{{/hasReadOnly}} | null, ignoreDiscriminator: boolean = false): any {
     {{#hasVars}}
     if (value == null) {
         return value;

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -41,7 +41,11 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
 {{/discriminator}}
 }
 
-export function {{classname}}ToJSON(value?: {{classname}} | null): any {
+export function {{classname}}ToJSON(json: any): any {
+    return {{classname}}ToJSONTyped(json, false);
+}
+
+export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
@@ -80,11 +80,11 @@ export function AbstractUserDtoFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-  export function AbstractUserDtoToJSON(json: any): AbstractUserDto {
-      return AbstractUserDtoToJSONTyped(json, false);
-  }
+export function AbstractUserDtoToJSON(json: any): AbstractUserDto {
+    return AbstractUserDtoToJSONTyped(json, false);
+}
 
-  export function AbstractUserDtoToJSONTyped(value?: AbstractUserDto | null, ignoreDiscriminator: boolean = false): any {
+export function AbstractUserDtoToJSONTyped(value?: AbstractUserDto | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/others/typescript-fetch/self-import-issue/models/BranchDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/BranchDto.ts
@@ -48,11 +48,11 @@ export function BranchDtoFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-  export function BranchDtoToJSON(json: any): BranchDto {
-      return BranchDtoToJSONTyped(json, false);
-  }
+export function BranchDtoToJSON(json: any): BranchDto {
+    return BranchDtoToJSONTyped(json, false);
+}
 
-  export function BranchDtoToJSONTyped(value?: BranchDto | null, ignoreDiscriminator: boolean = false): any {
+export function BranchDtoToJSONTyped(value?: BranchDto | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/others/typescript-fetch/self-import-issue/models/InternalAuthenticatedUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/InternalAuthenticatedUserDto.ts
@@ -51,11 +51,11 @@ export function InternalAuthenticatedUserDtoFromJSONTyped(json: any, ignoreDiscr
     return json;
 }
 
-  export function InternalAuthenticatedUserDtoToJSON(json: any): InternalAuthenticatedUserDto {
-      return InternalAuthenticatedUserDtoToJSONTyped(json, false);
-  }
+export function InternalAuthenticatedUserDtoToJSON(json: any): InternalAuthenticatedUserDto {
+    return InternalAuthenticatedUserDtoToJSONTyped(json, false);
+}
 
-  export function InternalAuthenticatedUserDtoToJSONTyped(value?: InternalAuthenticatedUserDto | null, ignoreDiscriminator: boolean = false): any {
+export function InternalAuthenticatedUserDtoToJSONTyped(value?: InternalAuthenticatedUserDto | null, ignoreDiscriminator: boolean = false): any {
     return value;
 }
 

--- a/samples/client/others/typescript-fetch/self-import-issue/models/RemoteAuthenticatedUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/RemoteAuthenticatedUserDto.ts
@@ -51,11 +51,11 @@ export function RemoteAuthenticatedUserDtoFromJSONTyped(json: any, ignoreDiscrim
     return json;
 }
 
-  export function RemoteAuthenticatedUserDtoToJSON(json: any): RemoteAuthenticatedUserDto {
-      return RemoteAuthenticatedUserDtoToJSONTyped(json, false);
-  }
+export function RemoteAuthenticatedUserDtoToJSON(json: any): RemoteAuthenticatedUserDto {
+    return RemoteAuthenticatedUserDtoToJSONTyped(json, false);
+}
 
-  export function RemoteAuthenticatedUserDtoToJSONTyped(value?: RemoteAuthenticatedUserDto | null, ignoreDiscriminator: boolean = false): any {
+export function RemoteAuthenticatedUserDtoToJSONTyped(value?: RemoteAuthenticatedUserDto | null, ignoreDiscriminator: boolean = false): any {
     return value;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
@@ -56,11 +56,11 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
     };
 }
 
-  export function ClubToJSON(json: any): Club {
-      return ClubToJSONTyped(json, false);
-  }
+export function ClubToJSON(json: any): Club {
+    return ClubToJSONTyped(json, false);
+}
 
-  export function ClubToJSONTyped(value?: Club | null, ignoreDiscriminator: boolean = false): any {
+export function ClubToJSONTyped(value?: Club | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
@@ -48,11 +48,11 @@ export function OwnerFromJSONTyped(json: any, ignoreDiscriminator: boolean): Own
     };
 }
 
-  export function OwnerToJSON(json: any): Owner {
-      return OwnerToJSONTyped(json, false);
-  }
+export function OwnerToJSON(json: any): Owner {
+    return OwnerToJSONTyped(json, false);
+}
 
-  export function OwnerToJSONTyped(value?: Owner | null, ignoreDiscriminator: boolean = false): any {
+export function OwnerToJSONTyped(value?: Owner | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
@@ -56,11 +56,11 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
     };
 }
 
-  export function ClubToJSON(json: any): Club {
-      return ClubToJSONTyped(json, false);
-  }
+export function ClubToJSON(json: any): Club {
+    return ClubToJSONTyped(json, false);
+}
 
-  export function ClubToJSONTyped(value?: Omit<Club, 'owner'> | null, ignoreDiscriminator: boolean = false): any {
+export function ClubToJSONTyped(value?: Omit<Club, 'owner'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
@@ -48,11 +48,11 @@ export function OwnerFromJSONTyped(json: any, ignoreDiscriminator: boolean): Own
     };
 }
 
-  export function OwnerToJSON(json: any): Owner {
-      return OwnerToJSONTyped(json, false);
-  }
+export function OwnerToJSON(json: any): Owner {
+    return OwnerToJSONTyped(json, false);
+}
 
-  export function OwnerToJSONTyped(value?: Owner | null, ignoreDiscriminator: boolean = false): any {
+export function OwnerToJSONTyped(value?: Owner | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
@@ -55,11 +55,11 @@ export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscrimi
     };
 }
 
-  export function AdditionalPropertiesClassToJSON(json: any): AdditionalPropertiesClass {
-      return AdditionalPropertiesClassToJSONTyped(json, false);
-  }
+export function AdditionalPropertiesClassToJSON(json: any): AdditionalPropertiesClass {
+    return AdditionalPropertiesClassToJSONTyped(json, false);
+}
 
-  export function AdditionalPropertiesClassToJSONTyped(value?: AdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
+export function AdditionalPropertiesClassToJSONTyped(value?: AdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
@@ -65,11 +65,11 @@ export function AllOfWithSingleRefFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-  export function AllOfWithSingleRefToJSON(json: any): AllOfWithSingleRef {
-      return AllOfWithSingleRefToJSONTyped(json, false);
-  }
+export function AllOfWithSingleRefToJSON(json: any): AllOfWithSingleRef {
+    return AllOfWithSingleRefToJSONTyped(json, false);
+}
 
-  export function AllOfWithSingleRefToJSONTyped(value?: AllOfWithSingleRef | null, ignoreDiscriminator: boolean = false): any {
+export function AllOfWithSingleRefToJSONTyped(value?: AllOfWithSingleRef | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
@@ -66,11 +66,11 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
     };
 }
 
-  export function AnimalToJSON(json: any): Animal {
-      return AnimalToJSONTyped(json, false);
-  }
+export function AnimalToJSON(json: any): Animal {
+    return AnimalToJSONTyped(json, false);
+}
 
-  export function AnimalToJSONTyped(value?: Animal | null, ignoreDiscriminator: boolean = false): any {
+export function AnimalToJSONTyped(value?: Animal | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
@@ -48,11 +48,11 @@ export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-  export function ArrayOfArrayOfNumberOnlyToJSON(json: any): ArrayOfArrayOfNumberOnly {
-      return ArrayOfArrayOfNumberOnlyToJSONTyped(json, false);
-  }
+export function ArrayOfArrayOfNumberOnlyToJSON(json: any): ArrayOfArrayOfNumberOnly {
+    return ArrayOfArrayOfNumberOnlyToJSONTyped(json, false);
+}
 
-  export function ArrayOfArrayOfNumberOnlyToJSONTyped(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
+export function ArrayOfArrayOfNumberOnlyToJSONTyped(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
@@ -48,11 +48,11 @@ export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-  export function ArrayOfNumberOnlyToJSON(json: any): ArrayOfNumberOnly {
-      return ArrayOfNumberOnlyToJSONTyped(json, false);
-  }
+export function ArrayOfNumberOnlyToJSON(json: any): ArrayOfNumberOnly {
+    return ArrayOfNumberOnlyToJSONTyped(json, false);
+}
 
-  export function ArrayOfNumberOnlyToJSONTyped(value?: ArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
+export function ArrayOfNumberOnlyToJSONTyped(value?: ArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
@@ -70,11 +70,11 @@ export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-  export function ArrayTestToJSON(json: any): ArrayTest {
-      return ArrayTestToJSONTyped(json, false);
-  }
+export function ArrayTestToJSON(json: any): ArrayTest {
+    return ArrayTestToJSONTyped(json, false);
+}
 
-  export function ArrayTestToJSONTyped(value?: ArrayTest | null, ignoreDiscriminator: boolean = false): any {
+export function ArrayTestToJSONTyped(value?: ArrayTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
@@ -84,11 +84,11 @@ export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-  export function CapitalizationToJSON(json: any): Capitalization {
-      return CapitalizationToJSONTyped(json, false);
-  }
+export function CapitalizationToJSON(json: any): Capitalization {
+    return CapitalizationToJSONTyped(json, false);
+}
 
-  export function CapitalizationToJSONTyped(value?: Capitalization | null, ignoreDiscriminator: boolean = false): any {
+export function CapitalizationToJSONTyped(value?: Capitalization | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
@@ -56,11 +56,11 @@ export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
     };
 }
 
-  export function CatToJSON(json: any): Cat {
-      return CatToJSONTyped(json, false);
-  }
+export function CatToJSON(json: any): Cat {
+    return CatToJSONTyped(json, false);
+}
 
-  export function CatToJSONTyped(value?: Cat | null, ignoreDiscriminator: boolean = false): any {
+export function CatToJSONTyped(value?: Cat | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
@@ -56,11 +56,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-  export function CategoryToJSON(json: any): Category {
-      return CategoryToJSONTyped(json, false);
-  }
+export function CategoryToJSON(json: any): Category {
+    return CategoryToJSONTyped(json, false);
+}
 
-  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
@@ -58,11 +58,11 @@ export function ChildWithNullableFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-  export function ChildWithNullableToJSON(json: any): ChildWithNullable {
-      return ChildWithNullableToJSONTyped(json, false);
-  }
+export function ChildWithNullableToJSON(json: any): ChildWithNullable {
+    return ChildWithNullableToJSONTyped(json, false);
+}
 
-  export function ChildWithNullableToJSONTyped(value?: ChildWithNullable | null, ignoreDiscriminator: boolean = false): any {
+export function ChildWithNullableToJSONTyped(value?: ChildWithNullable | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
@@ -48,11 +48,11 @@ export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-  export function ClassModelToJSON(json: any): ClassModel {
-      return ClassModelToJSONTyped(json, false);
-  }
+export function ClassModelToJSON(json: any): ClassModel {
+    return ClassModelToJSONTyped(json, false);
+}
 
-  export function ClassModelToJSONTyped(value?: ClassModel | null, ignoreDiscriminator: boolean = false): any {
+export function ClassModelToJSONTyped(value?: ClassModel | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
@@ -48,11 +48,11 @@ export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cl
     };
 }
 
-  export function ClientToJSON(json: any): Client {
-      return ClientToJSONTyped(json, false);
-  }
+export function ClientToJSON(json: any): Client {
+    return ClientToJSONTyped(json, false);
+}
 
-  export function ClientToJSONTyped(value?: Client | null, ignoreDiscriminator: boolean = false): any {
+export function ClientToJSONTyped(value?: Client | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
@@ -48,11 +48,11 @@ export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function DeprecatedObjectToJSON(json: any): DeprecatedObject {
-      return DeprecatedObjectToJSONTyped(json, false);
-  }
+export function DeprecatedObjectToJSON(json: any): DeprecatedObject {
+    return DeprecatedObjectToJSONTyped(json, false);
+}
 
-  export function DeprecatedObjectToJSONTyped(value?: DeprecatedObject | null, ignoreDiscriminator: boolean = false): any {
+export function DeprecatedObjectToJSONTyped(value?: DeprecatedObject | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
@@ -56,11 +56,11 @@ export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
     };
 }
 
-  export function DogToJSON(json: any): Dog {
-      return DogToJSONTyped(json, false);
-  }
+export function DogToJSON(json: any): Dog {
+    return DogToJSONTyped(json, false);
+}
 
-  export function DogToJSONTyped(value?: Dog | null, ignoreDiscriminator: boolean = false): any {
+export function DogToJSONTyped(value?: Dog | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
@@ -75,11 +75,11 @@ export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-  export function EnumArraysToJSON(json: any): EnumArrays {
-      return EnumArraysToJSONTyped(json, false);
-  }
+export function EnumArraysToJSON(json: any): EnumArrays {
+    return EnumArraysToJSONTyped(json, false);
+}
 
-  export function EnumArraysToJSONTyped(value?: EnumArrays | null, ignoreDiscriminator: boolean = false): any {
+export function EnumArraysToJSONTyped(value?: EnumArrays | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -167,11 +167,11 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-  export function EnumTestToJSON(json: any): EnumTest {
-      return EnumTestToJSONTyped(json, false);
-  }
+export function EnumTestToJSON(json: any): EnumTest {
+    return EnumTestToJSONTyped(json, false);
+}
 
-  export function EnumTestToJSONTyped(value?: EnumTest | null, ignoreDiscriminator: boolean = false): any {
+export function EnumTestToJSONTyped(value?: EnumTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
@@ -55,11 +55,11 @@ export function FakeBigDecimalMap200ResponseFromJSONTyped(json: any, ignoreDiscr
     };
 }
 
-  export function FakeBigDecimalMap200ResponseToJSON(json: any): FakeBigDecimalMap200Response {
-      return FakeBigDecimalMap200ResponseToJSONTyped(json, false);
-  }
+export function FakeBigDecimalMap200ResponseToJSON(json: any): FakeBigDecimalMap200Response {
+    return FakeBigDecimalMap200ResponseToJSONTyped(json, false);
+}
 
-  export function FakeBigDecimalMap200ResponseToJSONTyped(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator: boolean = false): any {
+export function FakeBigDecimalMap200ResponseToJSONTyped(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
@@ -55,11 +55,11 @@ export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator:
     };
 }
 
-  export function FileSchemaTestClassToJSON(json: any): FileSchemaTestClass {
-      return FileSchemaTestClassToJSONTyped(json, false);
-  }
+export function FileSchemaTestClassToJSON(json: any): FileSchemaTestClass {
+    return FileSchemaTestClassToJSONTyped(json, false);
+}
 
-  export function FileSchemaTestClassToJSONTyped(value?: FileSchemaTestClass | null, ignoreDiscriminator: boolean = false): any {
+export function FileSchemaTestClassToJSONTyped(value?: FileSchemaTestClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
@@ -48,11 +48,11 @@ export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
     };
 }
 
-  export function FooToJSON(json: any): Foo {
-      return FooToJSONTyped(json, false);
-  }
+export function FooToJSON(json: any): Foo {
+    return FooToJSONTyped(json, false);
+}
 
-  export function FooToJSONTyped(value?: Foo | null, ignoreDiscriminator: boolean = false): any {
+export function FooToJSONTyped(value?: Foo | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
@@ -56,11 +56,11 @@ export function FooGetDefaultResponseFromJSONTyped(json: any, ignoreDiscriminato
     };
 }
 
-  export function FooGetDefaultResponseToJSON(json: any): FooGetDefaultResponse {
-      return FooGetDefaultResponseToJSONTyped(json, false);
-  }
+export function FooGetDefaultResponseToJSON(json: any): FooGetDefaultResponse {
+    return FooGetDefaultResponseToJSONTyped(json, false);
+}
 
-  export function FooGetDefaultResponseToJSONTyped(value?: FooGetDefaultResponse | null, ignoreDiscriminator: boolean = false): any {
+export function FooGetDefaultResponseToJSONTyped(value?: FooGetDefaultResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
@@ -157,11 +157,11 @@ export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-  export function FormatTestToJSON(json: any): FormatTest {
-      return FormatTestToJSONTyped(json, false);
-  }
+export function FormatTestToJSON(json: any): FormatTest {
+    return FormatTestToJSONTyped(json, false);
+}
 
-  export function FormatTestToJSONTyped(value?: FormatTest | null, ignoreDiscriminator: boolean = false): any {
+export function FormatTestToJSONTyped(value?: FormatTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
@@ -55,11 +55,11 @@ export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-  export function HasOnlyReadOnlyToJSON(json: any): HasOnlyReadOnly {
-      return HasOnlyReadOnlyToJSONTyped(json, false);
-  }
+export function HasOnlyReadOnlyToJSON(json: any): HasOnlyReadOnly {
+    return HasOnlyReadOnlyToJSONTyped(json, false);
+}
 
-  export function HasOnlyReadOnlyToJSONTyped(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null, ignoreDiscriminator: boolean = false): any {
+export function HasOnlyReadOnlyToJSONTyped(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
@@ -48,11 +48,11 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-  export function HealthCheckResultToJSON(json: any): HealthCheckResult {
-      return HealthCheckResultToJSONTyped(json, false);
-  }
+export function HealthCheckResultToJSON(json: any): HealthCheckResult {
+    return HealthCheckResultToJSONTyped(json, false);
+}
 
-  export function HealthCheckResultToJSONTyped(value?: HealthCheckResult | null, ignoreDiscriminator: boolean = false): any {
+export function HealthCheckResultToJSONTyped(value?: HealthCheckResult | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
@@ -48,11 +48,11 @@ export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List
     };
 }
 
-  export function ListToJSON(json: any): List {
-      return ListToJSONTyped(json, false);
-  }
+export function ListToJSON(json: any): List {
+    return ListToJSONTyped(json, false);
+}
 
-  export function ListToJSONTyped(value?: List | null, ignoreDiscriminator: boolean = false): any {
+export function ListToJSONTyped(value?: List | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
@@ -80,11 +80,11 @@ export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): M
     };
 }
 
-  export function MapTestToJSON(json: any): MapTest {
-      return MapTestToJSONTyped(json, false);
-  }
+export function MapTestToJSON(json: any): MapTest {
+    return MapTestToJSONTyped(json, false);
+}
 
-  export function MapTestToJSONTyped(value?: MapTest | null, ignoreDiscriminator: boolean = false): any {
+export function MapTestToJSONTyped(value?: MapTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -70,11 +70,11 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: a
     };
 }
 
-  export function MixedPropertiesAndAdditionalPropertiesClassToJSON(json: any): MixedPropertiesAndAdditionalPropertiesClass {
-      return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(json, false);
-  }
+export function MixedPropertiesAndAdditionalPropertiesClassToJSON(json: any): MixedPropertiesAndAdditionalPropertiesClass {
+    return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(json, false);
+}
 
-  export function MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
+export function MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
@@ -55,11 +55,11 @@ export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function Model200ResponseToJSON(json: any): Model200Response {
-      return Model200ResponseToJSONTyped(json, false);
-  }
+export function Model200ResponseToJSON(json: any): Model200Response {
+    return Model200ResponseToJSONTyped(json, false);
+}
 
-  export function Model200ResponseToJSONTyped(value?: Model200Response | null, ignoreDiscriminator: boolean = false): any {
+export function Model200ResponseToJSONTyped(value?: Model200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
@@ -62,11 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-      return ModelApiResponseToJSONTyped(json, false);
-  }
+export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+    return ModelApiResponseToJSONTyped(json, false);
+}
 
-  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
@@ -48,11 +48,11 @@ export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-  export function ModelFileToJSON(json: any): ModelFile {
-      return ModelFileToJSONTyped(json, false);
-  }
+export function ModelFileToJSON(json: any): ModelFile {
+    return ModelFileToJSONTyped(json, false);
+}
 
-  export function ModelFileToJSONTyped(value?: ModelFile | null, ignoreDiscriminator: boolean = false): any {
+export function ModelFileToJSONTyped(value?: ModelFile | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
@@ -70,11 +70,11 @@ export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name
     };
 }
 
-  export function NameToJSON(json: any): Name {
-      return NameToJSONTyped(json, false);
-  }
+export function NameToJSON(json: any): Name {
+    return NameToJSONTyped(json, false);
+}
 
-  export function NameToJSONTyped(value?: Omit<Name, 'snake_case'|'123Number'> | null, ignoreDiscriminator: boolean = false): any {
+export function NameToJSONTyped(value?: Omit<Name, 'snake_case'|'123Number'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -127,11 +127,11 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-  export function NullableClassToJSON(json: any): NullableClass {
-      return NullableClassToJSONTyped(json, false);
-  }
+export function NullableClassToJSON(json: any): NullableClass {
+    return NullableClassToJSONTyped(json, false);
+}
 
-  export function NullableClassToJSONTyped(value?: NullableClass | null, ignoreDiscriminator: boolean = false): any {
+export function NullableClassToJSONTyped(value?: NullableClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
@@ -48,11 +48,11 @@ export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-  export function NumberOnlyToJSON(json: any): NumberOnly {
-      return NumberOnlyToJSONTyped(json, false);
-  }
+export function NumberOnlyToJSON(json: any): NumberOnly {
+    return NumberOnlyToJSONTyped(json, false);
+}
 
-  export function NumberOnlyToJSONTyped(value?: NumberOnly | null, ignoreDiscriminator: boolean = false): any {
+export function NumberOnlyToJSONTyped(value?: NumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
@@ -80,11 +80,11 @@ export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscrim
     };
 }
 
-  export function ObjectWithDeprecatedFieldsToJSON(json: any): ObjectWithDeprecatedFields {
-      return ObjectWithDeprecatedFieldsToJSONTyped(json, false);
-  }
+export function ObjectWithDeprecatedFieldsToJSON(json: any): ObjectWithDeprecatedFields {
+    return ObjectWithDeprecatedFieldsToJSONTyped(json, false);
+}
 
-  export function ObjectWithDeprecatedFieldsToJSONTyped(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator: boolean = false): any {
+export function ObjectWithDeprecatedFieldsToJSONTyped(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
@@ -95,11 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-  export function OrderToJSON(json: any): Order {
-      return OrderToJSONTyped(json, false);
-  }
+export function OrderToJSON(json: any): Order {
+    return OrderToJSONTyped(json, false);
+}
 
-  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
@@ -62,11 +62,11 @@ export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-  export function OuterCompositeToJSON(json: any): OuterComposite {
-      return OuterCompositeToJSONTyped(json, false);
-  }
+export function OuterCompositeToJSON(json: any): OuterComposite {
+    return OuterCompositeToJSONTyped(json, false);
+}
 
-  export function OuterCompositeToJSONTyped(value?: OuterComposite | null, ignoreDiscriminator: boolean = false): any {
+export function OuterCompositeToJSONTyped(value?: OuterComposite | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
@@ -59,11 +59,11 @@ export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscri
     };
 }
 
-  export function OuterObjectWithEnumPropertyToJSON(json: any): OuterObjectWithEnumProperty {
-      return OuterObjectWithEnumPropertyToJSONTyped(json, false);
-  }
+export function OuterObjectWithEnumPropertyToJSON(json: any): OuterObjectWithEnumProperty {
+    return OuterObjectWithEnumPropertyToJSONTyped(json, false);
+}
 
-  export function OuterObjectWithEnumPropertyToJSONTyped(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator: boolean = false): any {
+export function OuterObjectWithEnumPropertyToJSONTyped(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -71,11 +71,11 @@ export function ParentWithNullableFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-  export function ParentWithNullableToJSON(json: any): ParentWithNullable {
-      return ParentWithNullableToJSONTyped(json, false);
-  }
+export function ParentWithNullableToJSON(json: any): ParentWithNullable {
+    return ParentWithNullableToJSONTyped(json, false);
+}
 
-  export function ParentWithNullableToJSONTyped(value?: ParentWithNullable | null, ignoreDiscriminator: boolean = false): any {
+export function ParentWithNullableToJSONTyped(value?: ParentWithNullable | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
@@ -112,11 +112,11 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-  export function PetToJSON(json: any): Pet {
-      return PetToJSONTyped(json, false);
-  }
+export function PetToJSON(json: any): Pet {
+    return PetToJSONTyped(json, false);
+}
 
-  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
@@ -55,11 +55,11 @@ export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-  export function ReadOnlyFirstToJSON(json: any): ReadOnlyFirst {
-      return ReadOnlyFirstToJSONTyped(json, false);
-  }
+export function ReadOnlyFirstToJSON(json: any): ReadOnlyFirst {
+    return ReadOnlyFirstToJSONTyped(json, false);
+}
 
-  export function ReadOnlyFirstToJSONTyped(value?: Omit<ReadOnlyFirst, 'bar'> | null, ignoreDiscriminator: boolean = false): any {
+export function ReadOnlyFirstToJSONTyped(value?: Omit<ReadOnlyFirst, 'bar'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
@@ -48,11 +48,11 @@ export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Re
     };
 }
 
-  export function ReturnToJSON(json: any): Return {
-      return ReturnToJSONTyped(json, false);
-  }
+export function ReturnToJSON(json: any): Return {
+    return ReturnToJSONTyped(json, false);
+}
 
-  export function ReturnToJSONTyped(value?: Return | null, ignoreDiscriminator: boolean = false): any {
+export function ReturnToJSONTyped(value?: Return | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
@@ -48,11 +48,11 @@ export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function SpecialModelNameToJSON(json: any): SpecialModelName {
-      return SpecialModelNameToJSONTyped(json, false);
-  }
+export function SpecialModelNameToJSON(json: any): SpecialModelName {
+    return SpecialModelNameToJSONTyped(json, false);
+}
 
-  export function SpecialModelNameToJSONTyped(value?: SpecialModelName | null, ignoreDiscriminator: boolean = false): any {
+export function SpecialModelNameToJSONTyped(value?: SpecialModelName | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
@@ -55,11 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-  export function TagToJSON(json: any): Tag {
-      return TagToJSONTyped(json, false);
-  }
+export function TagToJSON(json: any): Tag {
+    return TagToJSONTyped(json, false);
+}
 
-  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
@@ -50,11 +50,11 @@ export function TestInlineFreeformAdditionalPropertiesRequestFromJSONTyped(json:
     };
 }
 
-  export function TestInlineFreeformAdditionalPropertiesRequestToJSON(json: any): TestInlineFreeformAdditionalPropertiesRequest {
-      return TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(json, false);
-  }
+export function TestInlineFreeformAdditionalPropertiesRequestToJSON(json: any): TestInlineFreeformAdditionalPropertiesRequest {
+    return TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(json, false);
+}
 
-  export function TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(value?: TestInlineFreeformAdditionalPropertiesRequest | null, ignoreDiscriminator: boolean = false): any {
+export function TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(value?: TestInlineFreeformAdditionalPropertiesRequest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
@@ -97,11 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-  export function UserToJSON(json: any): User {
-      return UserToJSONTyped(json, false);
-  }
+export function UserToJSON(json: any): User {
+    return UserToJSONTyped(json, false);
+}
 
-  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
@@ -55,11 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-  export function CategoryToJSON(json: any): Category {
-      return CategoryToJSONTyped(json, false);
-  }
+export function CategoryToJSON(json: any): Category {
+    return CategoryToJSONTyped(json, false);
+}
 
-  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
@@ -62,11 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-      return ModelApiResponseToJSONTyped(json, false);
-  }
+export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+    return ModelApiResponseToJSONTyped(json, false);
+}
 
-  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
@@ -95,11 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-  export function OrderToJSON(json: any): Order {
-      return OrderToJSONTyped(json, false);
-  }
+export function OrderToJSON(json: any): Order {
+    return OrderToJSONTyped(json, false);
+}
 
-  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
@@ -112,11 +112,11 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-  export function PetToJSON(json: any): Pet {
-      return PetToJSONTyped(json, false);
-  }
+export function PetToJSON(json: any): Pet {
+    return PetToJSONTyped(json, false);
+}
 
-  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
@@ -55,11 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-  export function TagToJSON(json: any): Tag {
-      return TagToJSONTyped(json, false);
-  }
+export function TagToJSON(json: any): Tag {
+    return TagToJSONTyped(json, false);
+}
 
-  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
@@ -97,11 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-  export function UserToJSON(json: any): User {
-      return UserToJSONTyped(json, false);
-  }
+export function UserToJSON(json: any): User {
+    return UserToJSONTyped(json, false);
+}
 
-  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -86,11 +86,11 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-  export function EnumPatternObjectToJSON(json: any): EnumPatternObject {
-      return EnumPatternObjectToJSONTyped(json, false);
-  }
+export function EnumPatternObjectToJSON(json: any): EnumPatternObject {
+    return EnumPatternObjectToJSONTyped(json, false);
+}
 
-  export function EnumPatternObjectToJSONTyped(value?: EnumPatternObject | null, ignoreDiscriminator: boolean = false): any {
+export function EnumPatternObjectToJSONTyped(value?: EnumPatternObject | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
@@ -111,11 +111,11 @@ export function FakeEnumRequestGetInline200ResponseFromJSONTyped(json: any, igno
     };
 }
 
-  export function FakeEnumRequestGetInline200ResponseToJSON(json: any): FakeEnumRequestGetInline200Response {
-      return FakeEnumRequestGetInline200ResponseToJSONTyped(json, false);
-  }
+export function FakeEnumRequestGetInline200ResponseToJSON(json: any): FakeEnumRequestGetInline200Response {
+    return FakeEnumRequestGetInline200ResponseToJSONTyped(json, false);
+}
 
-  export function FakeEnumRequestGetInline200ResponseToJSONTyped(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator: boolean = false): any {
+export function FakeEnumRequestGetInline200ResponseToJSONTyped(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
@@ -55,11 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-  export function CategoryToJSON(json: any): Category {
-      return CategoryToJSONTyped(json, false);
-  }
+export function CategoryToJSON(json: any): Category {
+    return CategoryToJSONTyped(json, false);
+}
 
-  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
@@ -62,11 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-      return ModelApiResponseToJSONTyped(json, false);
-  }
+export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+    return ModelApiResponseToJSONTyped(json, false);
+}
 
-  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
@@ -95,11 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-  export function OrderToJSON(json: any): Order {
-      return OrderToJSONTyped(json, false);
-  }
+export function OrderToJSON(json: any): Order {
+    return OrderToJSONTyped(json, false);
+}
 
-  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
@@ -112,11 +112,11 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-  export function PetToJSON(json: any): Pet {
-      return PetToJSONTyped(json, false);
-  }
+export function PetToJSON(json: any): Pet {
+    return PetToJSONTyped(json, false);
+}
 
-  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
@@ -55,11 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-  export function TagToJSON(json: any): Tag {
-      return TagToJSONTyped(json, false);
-  }
+export function TagToJSON(json: any): Tag {
+    return TagToJSONTyped(json, false);
+}
 
-  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
@@ -97,11 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-  export function UserToJSON(json: any): User {
-      return UserToJSONTyped(json, false);
-  }
+export function UserToJSON(json: any): User {
+    return UserToJSONTyped(json, false);
+}
 
-  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
@@ -55,11 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-  export function CategoryToJSON(json: any): Category {
-      return CategoryToJSONTyped(json, false);
-  }
+export function CategoryToJSON(json: any): Category {
+    return CategoryToJSONTyped(json, false);
+}
 
-  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
@@ -62,11 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-      return ModelApiResponseToJSONTyped(json, false);
-  }
+export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+    return ModelApiResponseToJSONTyped(json, false);
+}
 
-  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
@@ -95,11 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-  export function OrderToJSON(json: any): Order {
-      return OrderToJSONTyped(json, false);
-  }
+export function OrderToJSON(json: any): Order {
+    return OrderToJSONTyped(json, false);
+}
 
-  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
@@ -112,11 +112,11 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-  export function PetToJSON(json: any): Pet {
-      return PetToJSONTyped(json, false);
-  }
+export function PetToJSON(json: any): Pet {
+    return PetToJSONTyped(json, false);
+}
 
-  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
@@ -55,11 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-  export function TagToJSON(json: any): Tag {
-      return TagToJSONTyped(json, false);
-  }
+export function TagToJSON(json: any): Tag {
+    return TagToJSONTyped(json, false);
+}
 
-  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
@@ -97,11 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-  export function UserToJSON(json: any): User {
-      return UserToJSONTyped(json, false);
-  }
+export function UserToJSON(json: any): User {
+    return UserToJSONTyped(json, false);
+}
 
-  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestA.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestA.ts
@@ -49,11 +49,11 @@ export function TestAFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tes
     };
 }
 
-  export function TestAToJSON(json: any): TestA {
-      return TestAToJSONTyped(json, false);
-  }
+export function TestAToJSON(json: any): TestA {
+    return TestAToJSONTyped(json, false);
+}
 
-  export function TestAToJSONTyped(value?: TestA | null, ignoreDiscriminator: boolean = false): any {
+export function TestAToJSONTyped(value?: TestA | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestB.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestB.ts
@@ -49,11 +49,11 @@ export function TestBFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tes
     };
 }
 
-  export function TestBToJSON(json: any): TestB {
-      return TestBToJSONTyped(json, false);
-  }
+export function TestBToJSON(json: any): TestB {
+    return TestBToJSONTyped(json, false);
+}
 
-  export function TestBToJSONTyped(value?: TestB | null, ignoreDiscriminator: boolean = false): any {
+export function TestBToJSONTyped(value?: TestB | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestResponse.ts
@@ -52,7 +52,11 @@ export function TestResponseFromJSONTyped(json: any, ignoreDiscriminator: boolea
     return {} as any;
 }
 
-export function TestResponseToJSON(value?: TestResponse | null): any {
+export function TestResponseToJSON(json: any): any {
+    return TestResponseToJSONTyped(json, false);
+}
+
+export function TestResponseToJSONTyped(value?: TestResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
@@ -55,11 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-  export function CategoryToJSON(json: any): Category {
-      return CategoryToJSONTyped(json, false);
-  }
+export function CategoryToJSON(json: any): Category {
+    return CategoryToJSONTyped(json, false);
+}
 
-  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
@@ -62,11 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-      return ModelApiResponseToJSONTyped(json, false);
-  }
+export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+    return ModelApiResponseToJSONTyped(json, false);
+}
 
-  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
@@ -95,11 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-  export function OrderToJSON(json: any): Order {
-      return OrderToJSONTyped(json, false);
-  }
+export function OrderToJSON(json: any): Order {
+    return OrderToJSONTyped(json, false);
+}
 
-  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
@@ -112,11 +112,11 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-  export function PetToJSON(json: any): Pet {
-      return PetToJSONTyped(json, false);
-  }
+export function PetToJSON(json: any): Pet {
+    return PetToJSONTyped(json, false);
+}
 
-  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
@@ -55,11 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-  export function TagToJSON(json: any): Tag {
-      return TagToJSONTyped(json, false);
-  }
+export function TagToJSON(json: any): Tag {
+    return TagToJSONTyped(json, false);
+}
 
-  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
@@ -97,11 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-  export function UserToJSON(json: any): User {
-      return UserToJSONTyped(json, false);
-  }
+export function UserToJSON(json: any): User {
+    return UserToJSONTyped(json, false);
+}
 
-  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
@@ -55,11 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-  export function CategoryToJSON(json: any): Category {
-      return CategoryToJSONTyped(json, false);
-  }
+export function CategoryToJSON(json: any): Category {
+    return CategoryToJSONTyped(json, false);
+}
 
-  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
@@ -57,11 +57,11 @@ export function DefaultMetaOnlyResponseFromJSONTyped(json: any, ignoreDiscrimina
     };
 }
 
-  export function DefaultMetaOnlyResponseToJSON(json: any): DefaultMetaOnlyResponse {
-      return DefaultMetaOnlyResponseToJSONTyped(json, false);
-  }
+export function DefaultMetaOnlyResponseToJSON(json: any): DefaultMetaOnlyResponse {
+    return DefaultMetaOnlyResponseToJSONTyped(json, false);
+}
 
-  export function DefaultMetaOnlyResponseToJSONTyped(value?: DefaultMetaOnlyResponse | null, ignoreDiscriminator: boolean = false): any {
+export function DefaultMetaOnlyResponseToJSONTyped(value?: DefaultMetaOnlyResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
@@ -71,11 +71,11 @@ export function FindPetsByStatusResponseFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-  export function FindPetsByStatusResponseToJSON(json: any): FindPetsByStatusResponse {
-      return FindPetsByStatusResponseToJSONTyped(json, false);
-  }
+export function FindPetsByStatusResponseToJSON(json: any): FindPetsByStatusResponse {
+    return FindPetsByStatusResponseToJSONTyped(json, false);
+}
 
-  export function FindPetsByStatusResponseToJSONTyped(value?: FindPetsByStatusResponse | null, ignoreDiscriminator: boolean = false): any {
+export function FindPetsByStatusResponseToJSONTyped(value?: FindPetsByStatusResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
@@ -71,11 +71,11 @@ export function FindPetsByUserResponseFromJSONTyped(json: any, ignoreDiscriminat
     };
 }
 
-  export function FindPetsByUserResponseToJSON(json: any): FindPetsByUserResponse {
-      return FindPetsByUserResponseToJSONTyped(json, false);
-  }
+export function FindPetsByUserResponseToJSON(json: any): FindPetsByUserResponse {
+    return FindPetsByUserResponseToJSONTyped(json, false);
+}
 
-  export function FindPetsByUserResponseToJSONTyped(value?: FindPetsByUserResponse | null, ignoreDiscriminator: boolean = false): any {
+export function FindPetsByUserResponseToJSONTyped(value?: FindPetsByUserResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
@@ -64,11 +64,11 @@ export function GetBehaviorPermissionsResponseFromJSONTyped(json: any, ignoreDis
     };
 }
 
-  export function GetBehaviorPermissionsResponseToJSON(json: any): GetBehaviorPermissionsResponse {
-      return GetBehaviorPermissionsResponseToJSONTyped(json, false);
-  }
+export function GetBehaviorPermissionsResponseToJSON(json: any): GetBehaviorPermissionsResponse {
+    return GetBehaviorPermissionsResponseToJSONTyped(json, false);
+}
 
-  export function GetBehaviorPermissionsResponseToJSONTyped(value?: GetBehaviorPermissionsResponse | null, ignoreDiscriminator: boolean = false): any {
+export function GetBehaviorPermissionsResponseToJSONTyped(value?: GetBehaviorPermissionsResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
@@ -73,11 +73,11 @@ export function GetBehaviorTypeResponseFromJSONTyped(json: any, ignoreDiscrimina
     };
 }
 
-  export function GetBehaviorTypeResponseToJSON(json: any): GetBehaviorTypeResponse {
-      return GetBehaviorTypeResponseToJSONTyped(json, false);
-  }
+export function GetBehaviorTypeResponseToJSON(json: any): GetBehaviorTypeResponse {
+    return GetBehaviorTypeResponseToJSONTyped(json, false);
+}
 
-  export function GetBehaviorTypeResponseToJSONTyped(value?: GetBehaviorTypeResponse | null, ignoreDiscriminator: boolean = false): any {
+export function GetBehaviorTypeResponseToJSONTyped(value?: GetBehaviorTypeResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
@@ -71,11 +71,11 @@ export function GetMatchingPartsResponseFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-  export function GetMatchingPartsResponseToJSON(json: any): GetMatchingPartsResponse {
-      return GetMatchingPartsResponseToJSONTyped(json, false);
-  }
+export function GetMatchingPartsResponseToJSON(json: any): GetMatchingPartsResponse {
+    return GetMatchingPartsResponseToJSONTyped(json, false);
+}
 
-  export function GetMatchingPartsResponseToJSONTyped(value?: GetMatchingPartsResponse | null, ignoreDiscriminator: boolean = false): any {
+export function GetMatchingPartsResponseToJSONTyped(value?: GetMatchingPartsResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
@@ -73,11 +73,11 @@ export function GetPetPartTypeResponseFromJSONTyped(json: any, ignoreDiscriminat
     };
 }
 
-  export function GetPetPartTypeResponseToJSON(json: any): GetPetPartTypeResponse {
-      return GetPetPartTypeResponseToJSONTyped(json, false);
-  }
+export function GetPetPartTypeResponseToJSON(json: any): GetPetPartTypeResponse {
+    return GetPetPartTypeResponseToJSONTyped(json, false);
+}
 
-  export function GetPetPartTypeResponseToJSONTyped(value?: GetPetPartTypeResponse | null, ignoreDiscriminator: boolean = false): any {
+export function GetPetPartTypeResponseToJSONTyped(value?: GetPetPartTypeResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
@@ -57,11 +57,11 @@ export function ItemIdFromJSONTyped(json: any, ignoreDiscriminator: boolean): It
     };
 }
 
-  export function ItemIdToJSON(json: any): ItemId {
-      return ItemIdToJSONTyped(json, false);
-  }
+export function ItemIdToJSON(json: any): ItemId {
+    return ItemIdToJSONTyped(json, false);
+}
 
-  export function ItemIdToJSONTyped(value?: ItemId | null, ignoreDiscriminator: boolean = false): any {
+export function ItemIdToJSONTyped(value?: ItemId | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
@@ -65,11 +65,11 @@ export function MatchingPartsFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-  export function MatchingPartsToJSON(json: any): MatchingParts {
-      return MatchingPartsToJSONTyped(json, false);
-  }
+export function MatchingPartsToJSON(json: any): MatchingParts {
+    return MatchingPartsToJSONTyped(json, false);
+}
 
-  export function MatchingPartsToJSONTyped(value?: MatchingParts | null, ignoreDiscriminator: boolean = false): any {
+export function MatchingPartsToJSONTyped(value?: MatchingParts | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
@@ -62,11 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-      return ModelApiResponseToJSONTyped(json, false);
-  }
+export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+    return ModelApiResponseToJSONTyped(json, false);
+}
 
-  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
@@ -78,11 +78,11 @@ export function ModelErrorFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-  export function ModelErrorToJSON(json: any): ModelError {
-      return ModelErrorToJSONTyped(json, false);
-  }
+export function ModelErrorToJSON(json: any): ModelError {
+    return ModelErrorToJSONTyped(json, false);
+}
 
-  export function ModelErrorToJSONTyped(value?: ModelError | null, ignoreDiscriminator: boolean = false): any {
+export function ModelErrorToJSONTyped(value?: ModelError | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
@@ -95,11 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-  export function OrderToJSON(json: any): Order {
-      return OrderToJSONTyped(json, false);
-  }
+export function OrderToJSON(json: any): Order {
+    return OrderToJSONTyped(json, false);
+}
 
-  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
@@ -57,11 +57,11 @@ export function PartFromJSONTyped(json: any, ignoreDiscriminator: boolean): Part
     };
 }
 
-  export function PartToJSON(json: any): Part {
-      return PartToJSONTyped(json, false);
-  }
+export function PartToJSON(json: any): Part {
+    return PartToJSONTyped(json, false);
+}
 
-  export function PartToJSONTyped(value?: Part | null, ignoreDiscriminator: boolean = false): any {
+export function PartToJSONTyped(value?: Part | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
@@ -243,11 +243,11 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-  export function PetToJSON(json: any): Pet {
-      return PetToJSONTyped(json, false);
-  }
+export function PetToJSON(json: any): Pet {
+    return PetToJSONTyped(json, false);
+}
 
-  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
@@ -64,11 +64,11 @@ export function PetRegionsResponseFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-  export function PetRegionsResponseToJSON(json: any): PetRegionsResponse {
-      return PetRegionsResponseToJSONTyped(json, false);
-  }
+export function PetRegionsResponseToJSON(json: any): PetRegionsResponse {
+    return PetRegionsResponseToJSONTyped(json, false);
+}
 
-  export function PetRegionsResponseToJSONTyped(value?: PetRegionsResponse | null, ignoreDiscriminator: boolean = false): any {
+export function PetRegionsResponseToJSONTyped(value?: PetRegionsResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
@@ -124,11 +124,11 @@ export function ResponseMetaFromJSONTyped(json: any, ignoreDiscriminator: boolea
     };
 }
 
-  export function ResponseMetaToJSON(json: any): ResponseMeta {
-      return ResponseMetaToJSONTyped(json, false);
-  }
+export function ResponseMetaToJSON(json: any): ResponseMeta {
+    return ResponseMetaToJSONTyped(json, false);
+}
 
-  export function ResponseMetaToJSONTyped(value?: ResponseMeta | null, ignoreDiscriminator: boolean = false): any {
+export function ResponseMetaToJSONTyped(value?: ResponseMeta | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
@@ -55,11 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-  export function TagToJSON(json: any): Tag {
-      return TagToJSONTyped(json, false);
-  }
+export function TagToJSON(json: any): Tag {
+    return TagToJSONTyped(json, false);
+}
 
-  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
@@ -113,11 +113,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-  export function UserToJSON(json: any): User {
-      return UserToJSONTyped(json, false);
-  }
+export function UserToJSON(json: any): User {
+    return UserToJSONTyped(json, false);
+}
 
-  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
@@ -55,11 +55,11 @@ export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscrimi
     };
 }
 
-  export function AdditionalPropertiesClassToJSON(json: any): AdditionalPropertiesClass {
-      return AdditionalPropertiesClassToJSONTyped(json, false);
-  }
+export function AdditionalPropertiesClassToJSON(json: any): AdditionalPropertiesClass {
+    return AdditionalPropertiesClassToJSONTyped(json, false);
+}
 
-  export function AdditionalPropertiesClassToJSONTyped(value?: AdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
+export function AdditionalPropertiesClassToJSONTyped(value?: AdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
@@ -65,11 +65,11 @@ export function AllOfWithSingleRefFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-  export function AllOfWithSingleRefToJSON(json: any): AllOfWithSingleRef {
-      return AllOfWithSingleRefToJSONTyped(json, false);
-  }
+export function AllOfWithSingleRefToJSON(json: any): AllOfWithSingleRef {
+    return AllOfWithSingleRefToJSONTyped(json, false);
+}
 
-  export function AllOfWithSingleRefToJSONTyped(value?: AllOfWithSingleRef | null, ignoreDiscriminator: boolean = false): any {
+export function AllOfWithSingleRefToJSONTyped(value?: AllOfWithSingleRef | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
@@ -66,11 +66,11 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
     };
 }
 
-  export function AnimalToJSON(json: any): Animal {
-      return AnimalToJSONTyped(json, false);
-  }
+export function AnimalToJSON(json: any): Animal {
+    return AnimalToJSONTyped(json, false);
+}
 
-  export function AnimalToJSONTyped(value?: Animal | null, ignoreDiscriminator: boolean = false): any {
+export function AnimalToJSONTyped(value?: Animal | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
@@ -48,11 +48,11 @@ export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-  export function ArrayOfArrayOfNumberOnlyToJSON(json: any): ArrayOfArrayOfNumberOnly {
-      return ArrayOfArrayOfNumberOnlyToJSONTyped(json, false);
-  }
+export function ArrayOfArrayOfNumberOnlyToJSON(json: any): ArrayOfArrayOfNumberOnly {
+    return ArrayOfArrayOfNumberOnlyToJSONTyped(json, false);
+}
 
-  export function ArrayOfArrayOfNumberOnlyToJSONTyped(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
+export function ArrayOfArrayOfNumberOnlyToJSONTyped(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
@@ -48,11 +48,11 @@ export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-  export function ArrayOfNumberOnlyToJSON(json: any): ArrayOfNumberOnly {
-      return ArrayOfNumberOnlyToJSONTyped(json, false);
-  }
+export function ArrayOfNumberOnlyToJSON(json: any): ArrayOfNumberOnly {
+    return ArrayOfNumberOnlyToJSONTyped(json, false);
+}
 
-  export function ArrayOfNumberOnlyToJSONTyped(value?: ArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
+export function ArrayOfNumberOnlyToJSONTyped(value?: ArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
@@ -70,11 +70,11 @@ export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-  export function ArrayTestToJSON(json: any): ArrayTest {
-      return ArrayTestToJSONTyped(json, false);
-  }
+export function ArrayTestToJSON(json: any): ArrayTest {
+    return ArrayTestToJSONTyped(json, false);
+}
 
-  export function ArrayTestToJSONTyped(value?: ArrayTest | null, ignoreDiscriminator: boolean = false): any {
+export function ArrayTestToJSONTyped(value?: ArrayTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
@@ -84,11 +84,11 @@ export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-  export function CapitalizationToJSON(json: any): Capitalization {
-      return CapitalizationToJSONTyped(json, false);
-  }
+export function CapitalizationToJSON(json: any): Capitalization {
+    return CapitalizationToJSONTyped(json, false);
+}
 
-  export function CapitalizationToJSONTyped(value?: Capitalization | null, ignoreDiscriminator: boolean = false): any {
+export function CapitalizationToJSONTyped(value?: Capitalization | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
@@ -56,11 +56,11 @@ export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
     };
 }
 
-  export function CatToJSON(json: any): Cat {
-      return CatToJSONTyped(json, false);
-  }
+export function CatToJSON(json: any): Cat {
+    return CatToJSONTyped(json, false);
+}
 
-  export function CatToJSONTyped(value?: Cat | null, ignoreDiscriminator: boolean = false): any {
+export function CatToJSONTyped(value?: Cat | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
@@ -56,11 +56,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-  export function CategoryToJSON(json: any): Category {
-      return CategoryToJSONTyped(json, false);
-  }
+export function CategoryToJSON(json: any): Category {
+    return CategoryToJSONTyped(json, false);
+}
 
-  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
@@ -48,11 +48,11 @@ export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-  export function ClassModelToJSON(json: any): ClassModel {
-      return ClassModelToJSONTyped(json, false);
-  }
+export function ClassModelToJSON(json: any): ClassModel {
+    return ClassModelToJSONTyped(json, false);
+}
 
-  export function ClassModelToJSONTyped(value?: ClassModel | null, ignoreDiscriminator: boolean = false): any {
+export function ClassModelToJSONTyped(value?: ClassModel | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
@@ -48,11 +48,11 @@ export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cl
     };
 }
 
-  export function ClientToJSON(json: any): Client {
-      return ClientToJSONTyped(json, false);
-  }
+export function ClientToJSON(json: any): Client {
+    return ClientToJSONTyped(json, false);
+}
 
-  export function ClientToJSONTyped(value?: Client | null, ignoreDiscriminator: boolean = false): any {
+export function ClientToJSONTyped(value?: Client | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
@@ -48,11 +48,11 @@ export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function DeprecatedObjectToJSON(json: any): DeprecatedObject {
-      return DeprecatedObjectToJSONTyped(json, false);
-  }
+export function DeprecatedObjectToJSON(json: any): DeprecatedObject {
+    return DeprecatedObjectToJSONTyped(json, false);
+}
 
-  export function DeprecatedObjectToJSONTyped(value?: DeprecatedObject | null, ignoreDiscriminator: boolean = false): any {
+export function DeprecatedObjectToJSONTyped(value?: DeprecatedObject | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
@@ -56,11 +56,11 @@ export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
     };
 }
 
-  export function DogToJSON(json: any): Dog {
-      return DogToJSONTyped(json, false);
-  }
+export function DogToJSON(json: any): Dog {
+    return DogToJSONTyped(json, false);
+}
 
-  export function DogToJSONTyped(value?: Dog | null, ignoreDiscriminator: boolean = false): any {
+export function DogToJSONTyped(value?: Dog | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
@@ -75,11 +75,11 @@ export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-  export function EnumArraysToJSON(json: any): EnumArrays {
-      return EnumArraysToJSONTyped(json, false);
-  }
+export function EnumArraysToJSON(json: any): EnumArrays {
+    return EnumArraysToJSONTyped(json, false);
+}
 
-  export function EnumArraysToJSONTyped(value?: EnumArrays | null, ignoreDiscriminator: boolean = false): any {
+export function EnumArraysToJSONTyped(value?: EnumArrays | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
@@ -167,11 +167,11 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-  export function EnumTestToJSON(json: any): EnumTest {
-      return EnumTestToJSONTyped(json, false);
-  }
+export function EnumTestToJSON(json: any): EnumTest {
+    return EnumTestToJSONTyped(json, false);
+}
 
-  export function EnumTestToJSONTyped(value?: EnumTest | null, ignoreDiscriminator: boolean = false): any {
+export function EnumTestToJSONTyped(value?: EnumTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
@@ -55,11 +55,11 @@ export function FakeBigDecimalMap200ResponseFromJSONTyped(json: any, ignoreDiscr
     };
 }
 
-  export function FakeBigDecimalMap200ResponseToJSON(json: any): FakeBigDecimalMap200Response {
-      return FakeBigDecimalMap200ResponseToJSONTyped(json, false);
-  }
+export function FakeBigDecimalMap200ResponseToJSON(json: any): FakeBigDecimalMap200Response {
+    return FakeBigDecimalMap200ResponseToJSONTyped(json, false);
+}
 
-  export function FakeBigDecimalMap200ResponseToJSONTyped(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator: boolean = false): any {
+export function FakeBigDecimalMap200ResponseToJSONTyped(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
@@ -55,11 +55,11 @@ export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator:
     };
 }
 
-  export function FileSchemaTestClassToJSON(json: any): FileSchemaTestClass {
-      return FileSchemaTestClassToJSONTyped(json, false);
-  }
+export function FileSchemaTestClassToJSON(json: any): FileSchemaTestClass {
+    return FileSchemaTestClassToJSONTyped(json, false);
+}
 
-  export function FileSchemaTestClassToJSONTyped(value?: FileSchemaTestClass | null, ignoreDiscriminator: boolean = false): any {
+export function FileSchemaTestClassToJSONTyped(value?: FileSchemaTestClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
@@ -48,11 +48,11 @@ export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
     };
 }
 
-  export function FooToJSON(json: any): Foo {
-      return FooToJSONTyped(json, false);
-  }
+export function FooToJSON(json: any): Foo {
+    return FooToJSONTyped(json, false);
+}
 
-  export function FooToJSONTyped(value?: Foo | null, ignoreDiscriminator: boolean = false): any {
+export function FooToJSONTyped(value?: Foo | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
@@ -56,11 +56,11 @@ export function FooGetDefaultResponseFromJSONTyped(json: any, ignoreDiscriminato
     };
 }
 
-  export function FooGetDefaultResponseToJSON(json: any): FooGetDefaultResponse {
-      return FooGetDefaultResponseToJSONTyped(json, false);
-  }
+export function FooGetDefaultResponseToJSON(json: any): FooGetDefaultResponse {
+    return FooGetDefaultResponseToJSONTyped(json, false);
+}
 
-  export function FooGetDefaultResponseToJSONTyped(value?: FooGetDefaultResponse | null, ignoreDiscriminator: boolean = false): any {
+export function FooGetDefaultResponseToJSONTyped(value?: FooGetDefaultResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
@@ -157,11 +157,11 @@ export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-  export function FormatTestToJSON(json: any): FormatTest {
-      return FormatTestToJSONTyped(json, false);
-  }
+export function FormatTestToJSON(json: any): FormatTest {
+    return FormatTestToJSONTyped(json, false);
+}
 
-  export function FormatTestToJSONTyped(value?: FormatTest | null, ignoreDiscriminator: boolean = false): any {
+export function FormatTestToJSONTyped(value?: FormatTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
@@ -55,11 +55,11 @@ export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-  export function HasOnlyReadOnlyToJSON(json: any): HasOnlyReadOnly {
-      return HasOnlyReadOnlyToJSONTyped(json, false);
-  }
+export function HasOnlyReadOnlyToJSON(json: any): HasOnlyReadOnly {
+    return HasOnlyReadOnlyToJSONTyped(json, false);
+}
 
-  export function HasOnlyReadOnlyToJSONTyped(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null, ignoreDiscriminator: boolean = false): any {
+export function HasOnlyReadOnlyToJSONTyped(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
@@ -48,11 +48,11 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-  export function HealthCheckResultToJSON(json: any): HealthCheckResult {
-      return HealthCheckResultToJSONTyped(json, false);
-  }
+export function HealthCheckResultToJSON(json: any): HealthCheckResult {
+    return HealthCheckResultToJSONTyped(json, false);
+}
 
-  export function HealthCheckResultToJSONTyped(value?: HealthCheckResult | null, ignoreDiscriminator: boolean = false): any {
+export function HealthCheckResultToJSONTyped(value?: HealthCheckResult | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
@@ -48,11 +48,11 @@ export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List
     };
 }
 
-  export function ListToJSON(json: any): List {
-      return ListToJSONTyped(json, false);
-  }
+export function ListToJSON(json: any): List {
+    return ListToJSONTyped(json, false);
+}
 
-  export function ListToJSONTyped(value?: List | null, ignoreDiscriminator: boolean = false): any {
+export function ListToJSONTyped(value?: List | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
@@ -80,11 +80,11 @@ export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): M
     };
 }
 
-  export function MapTestToJSON(json: any): MapTest {
-      return MapTestToJSONTyped(json, false);
-  }
+export function MapTestToJSON(json: any): MapTest {
+    return MapTestToJSONTyped(json, false);
+}
 
-  export function MapTestToJSONTyped(value?: MapTest | null, ignoreDiscriminator: boolean = false): any {
+export function MapTestToJSONTyped(value?: MapTest | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -70,11 +70,11 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: a
     };
 }
 
-  export function MixedPropertiesAndAdditionalPropertiesClassToJSON(json: any): MixedPropertiesAndAdditionalPropertiesClass {
-      return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(json, false);
-  }
+export function MixedPropertiesAndAdditionalPropertiesClassToJSON(json: any): MixedPropertiesAndAdditionalPropertiesClass {
+    return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(json, false);
+}
 
-  export function MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
+export function MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
@@ -55,11 +55,11 @@ export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function Model200ResponseToJSON(json: any): Model200Response {
-      return Model200ResponseToJSONTyped(json, false);
-  }
+export function Model200ResponseToJSON(json: any): Model200Response {
+    return Model200ResponseToJSONTyped(json, false);
+}
 
-  export function Model200ResponseToJSONTyped(value?: Model200Response | null, ignoreDiscriminator: boolean = false): any {
+export function Model200ResponseToJSONTyped(value?: Model200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
@@ -62,11 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-      return ModelApiResponseToJSONTyped(json, false);
-  }
+export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+    return ModelApiResponseToJSONTyped(json, false);
+}
 
-  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
@@ -48,11 +48,11 @@ export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-  export function ModelFileToJSON(json: any): ModelFile {
-      return ModelFileToJSONTyped(json, false);
-  }
+export function ModelFileToJSON(json: any): ModelFile {
+    return ModelFileToJSONTyped(json, false);
+}
 
-  export function ModelFileToJSONTyped(value?: ModelFile | null, ignoreDiscriminator: boolean = false): any {
+export function ModelFileToJSONTyped(value?: ModelFile | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
@@ -70,11 +70,11 @@ export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name
     };
 }
 
-  export function NameToJSON(json: any): Name {
-      return NameToJSONTyped(json, false);
-  }
+export function NameToJSON(json: any): Name {
+    return NameToJSONTyped(json, false);
+}
 
-  export function NameToJSONTyped(value?: Omit<Name, 'snake_case'|'123Number'> | null, ignoreDiscriminator: boolean = false): any {
+export function NameToJSONTyped(value?: Omit<Name, 'snake_case'|'123Number'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
@@ -127,11 +127,11 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-  export function NullableClassToJSON(json: any): NullableClass {
-      return NullableClassToJSONTyped(json, false);
-  }
+export function NullableClassToJSON(json: any): NullableClass {
+    return NullableClassToJSONTyped(json, false);
+}
 
-  export function NullableClassToJSONTyped(value?: NullableClass | null, ignoreDiscriminator: boolean = false): any {
+export function NullableClassToJSONTyped(value?: NullableClass | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
@@ -48,11 +48,11 @@ export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-  export function NumberOnlyToJSON(json: any): NumberOnly {
-      return NumberOnlyToJSONTyped(json, false);
-  }
+export function NumberOnlyToJSON(json: any): NumberOnly {
+    return NumberOnlyToJSONTyped(json, false);
+}
 
-  export function NumberOnlyToJSONTyped(value?: NumberOnly | null, ignoreDiscriminator: boolean = false): any {
+export function NumberOnlyToJSONTyped(value?: NumberOnly | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
@@ -80,11 +80,11 @@ export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscrim
     };
 }
 
-  export function ObjectWithDeprecatedFieldsToJSON(json: any): ObjectWithDeprecatedFields {
-      return ObjectWithDeprecatedFieldsToJSONTyped(json, false);
-  }
+export function ObjectWithDeprecatedFieldsToJSON(json: any): ObjectWithDeprecatedFields {
+    return ObjectWithDeprecatedFieldsToJSONTyped(json, false);
+}
 
-  export function ObjectWithDeprecatedFieldsToJSONTyped(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator: boolean = false): any {
+export function ObjectWithDeprecatedFieldsToJSONTyped(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
@@ -95,11 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-  export function OrderToJSON(json: any): Order {
-      return OrderToJSONTyped(json, false);
-  }
+export function OrderToJSON(json: any): Order {
+    return OrderToJSONTyped(json, false);
+}
 
-  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
@@ -62,11 +62,11 @@ export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-  export function OuterCompositeToJSON(json: any): OuterComposite {
-      return OuterCompositeToJSONTyped(json, false);
-  }
+export function OuterCompositeToJSON(json: any): OuterComposite {
+    return OuterCompositeToJSONTyped(json, false);
+}
 
-  export function OuterCompositeToJSONTyped(value?: OuterComposite | null, ignoreDiscriminator: boolean = false): any {
+export function OuterCompositeToJSONTyped(value?: OuterComposite | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
@@ -59,11 +59,11 @@ export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscri
     };
 }
 
-  export function OuterObjectWithEnumPropertyToJSON(json: any): OuterObjectWithEnumProperty {
-      return OuterObjectWithEnumPropertyToJSONTyped(json, false);
-  }
+export function OuterObjectWithEnumPropertyToJSON(json: any): OuterObjectWithEnumProperty {
+    return OuterObjectWithEnumPropertyToJSONTyped(json, false);
+}
 
-  export function OuterObjectWithEnumPropertyToJSONTyped(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator: boolean = false): any {
+export function OuterObjectWithEnumPropertyToJSONTyped(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
@@ -112,11 +112,11 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-  export function PetToJSON(json: any): Pet {
-      return PetToJSONTyped(json, false);
-  }
+export function PetToJSON(json: any): Pet {
+    return PetToJSONTyped(json, false);
+}
 
-  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
@@ -55,11 +55,11 @@ export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-  export function ReadOnlyFirstToJSON(json: any): ReadOnlyFirst {
-      return ReadOnlyFirstToJSONTyped(json, false);
-  }
+export function ReadOnlyFirstToJSON(json: any): ReadOnlyFirst {
+    return ReadOnlyFirstToJSONTyped(json, false);
+}
 
-  export function ReadOnlyFirstToJSONTyped(value?: Omit<ReadOnlyFirst, 'bar'> | null, ignoreDiscriminator: boolean = false): any {
+export function ReadOnlyFirstToJSONTyped(value?: Omit<ReadOnlyFirst, 'bar'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
@@ -48,11 +48,11 @@ export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Re
     };
 }
 
-  export function ReturnToJSON(json: any): Return {
-      return ReturnToJSONTyped(json, false);
-  }
+export function ReturnToJSON(json: any): Return {
+    return ReturnToJSONTyped(json, false);
+}
 
-  export function ReturnToJSONTyped(value?: Return | null, ignoreDiscriminator: boolean = false): any {
+export function ReturnToJSONTyped(value?: Return | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
@@ -48,11 +48,11 @@ export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function SpecialModelNameToJSON(json: any): SpecialModelName {
-      return SpecialModelNameToJSONTyped(json, false);
-  }
+export function SpecialModelNameToJSON(json: any): SpecialModelName {
+    return SpecialModelNameToJSONTyped(json, false);
+}
 
-  export function SpecialModelNameToJSONTyped(value?: SpecialModelName | null, ignoreDiscriminator: boolean = false): any {
+export function SpecialModelNameToJSONTyped(value?: SpecialModelName | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
@@ -55,11 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-  export function TagToJSON(json: any): Tag {
-      return TagToJSONTyped(json, false);
-  }
+export function TagToJSON(json: any): Tag {
+    return TagToJSONTyped(json, false);
+}
 
-  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
@@ -97,11 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-  export function UserToJSON(json: any): User {
-      return UserToJSONTyped(json, false);
-  }
+export function UserToJSON(json: any): User {
+    return UserToJSONTyped(json, false);
+}
 
-  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
@@ -55,11 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-  export function CategoryToJSON(json: any): Category {
-      return CategoryToJSONTyped(json, false);
-  }
+export function CategoryToJSON(json: any): Category {
+    return CategoryToJSONTyped(json, false);
+}
 
-  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
@@ -62,11 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-      return ModelApiResponseToJSONTyped(json, false);
-  }
+export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+    return ModelApiResponseToJSONTyped(json, false);
+}
 
-  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
@@ -97,11 +97,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-  export function OrderToJSON(json: any): Order {
-      return OrderToJSONTyped(json, false);
-  }
+export function OrderToJSON(json: any): Order {
+    return OrderToJSONTyped(json, false);
+}
 
-  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
@@ -113,11 +113,11 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-  export function PetToJSON(json: any): Pet {
-      return PetToJSONTyped(json, false);
-  }
+export function PetToJSON(json: any): Pet {
+    return PetToJSONTyped(json, false);
+}
 
-  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
@@ -55,11 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-  export function TagToJSON(json: any): Tag {
-      return TagToJSONTyped(json, false);
-  }
+export function TagToJSON(json: any): Tag {
+    return TagToJSONTyped(json, false);
+}
 
-  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
@@ -97,11 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-  export function UserToJSON(json: any): User {
-      return UserToJSONTyped(json, false);
-  }
+export function UserToJSON(json: any): User {
+    return UserToJSONTyped(json, false);
+}
 
-  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
@@ -55,11 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-  export function CategoryToJSON(json: any): Category {
-      return CategoryToJSONTyped(json, false);
-  }
+export function CategoryToJSON(json: any): Category {
+    return CategoryToJSONTyped(json, false);
+}
 
-  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
@@ -62,11 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-      return ModelApiResponseToJSONTyped(json, false);
-  }
+export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+    return ModelApiResponseToJSONTyped(json, false);
+}
 
-  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
@@ -95,11 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-  export function OrderToJSON(json: any): Order {
-      return OrderToJSONTyped(json, false);
-  }
+export function OrderToJSON(json: any): Order {
+    return OrderToJSONTyped(json, false);
+}
 
-  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
@@ -112,11 +112,11 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-  export function PetToJSON(json: any): Pet {
-      return PetToJSONTyped(json, false);
-  }
+export function PetToJSON(json: any): Pet {
+    return PetToJSONTyped(json, false);
+}
 
-  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
@@ -55,11 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-  export function TagToJSON(json: any): Tag {
-      return TagToJSONTyped(json, false);
-  }
+export function TagToJSON(json: any): Tag {
+    return TagToJSONTyped(json, false);
+}
 
-  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
@@ -97,11 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-  export function UserToJSON(json: any): User {
-      return UserToJSONTyped(json, false);
-  }
+export function UserToJSON(json: any): User {
+    return UserToJSONTyped(json, false);
+}
 
-  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
@@ -55,11 +55,11 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-  export function CategoryToJSON(json: any): Category {
-      return CategoryToJSONTyped(json, false);
-  }
+export function CategoryToJSON(json: any): Category {
+    return CategoryToJSONTyped(json, false);
+}
 
-  export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
@@ -62,11 +62,11 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-  export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-      return ModelApiResponseToJSONTyped(json, false);
-  }
+export function ModelApiResponseToJSON(json: any): ModelApiResponse {
+    return ModelApiResponseToJSONTyped(json, false);
+}
 
-  export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
@@ -95,11 +95,11 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-  export function OrderToJSON(json: any): Order {
-      return OrderToJSONTyped(json, false);
-  }
+export function OrderToJSON(json: any): Order {
+    return OrderToJSONTyped(json, false);
+}
 
-  export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
@@ -112,11 +112,11 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-  export function PetToJSON(json: any): Pet {
-      return PetToJSONTyped(json, false);
-  }
+export function PetToJSON(json: any): Pet {
+    return PetToJSONTyped(json, false);
+}
 
-  export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
@@ -55,11 +55,11 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-  export function TagToJSON(json: any): Tag {
-      return TagToJSONTyped(json, false);
-  }
+export function TagToJSON(json: any): Tag {
+    return TagToJSONTyped(json, false);
+}
 
-  export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
@@ -97,11 +97,11 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-  export function UserToJSON(json: any): User {
-      return UserToJSONTyped(json, false);
-  }
+export function UserToJSON(json: any): User {
+    return UserToJSONTyped(json, false);
+}
 
-  export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
@@ -86,11 +86,11 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-  export function EnumPatternObjectToJSON(json: any): EnumPatternObject {
-      return EnumPatternObjectToJSONTyped(json, false);
-  }
+export function EnumPatternObjectToJSON(json: any): EnumPatternObject {
+    return EnumPatternObjectToJSONTyped(json, false);
+}
 
-  export function EnumPatternObjectToJSONTyped(value?: EnumPatternObject | null, ignoreDiscriminator: boolean = false): any {
+export function EnumPatternObjectToJSONTyped(value?: EnumPatternObject | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
@@ -107,11 +107,11 @@ export function FakeEnumRequestGetInline200ResponseFromJSONTyped(json: any, igno
     };
 }
 
-  export function FakeEnumRequestGetInline200ResponseToJSON(json: any): FakeEnumRequestGetInline200Response {
-      return FakeEnumRequestGetInline200ResponseToJSONTyped(json, false);
-  }
+export function FakeEnumRequestGetInline200ResponseToJSON(json: any): FakeEnumRequestGetInline200Response {
+    return FakeEnumRequestGetInline200ResponseToJSONTyped(json, false);
+}
 
-  export function FakeEnumRequestGetInline200ResponseToJSONTyped(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator: boolean = false): any {
+export function FakeEnumRequestGetInline200ResponseToJSONTyped(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }


### PR DESCRIPTION
Fixes #19858

Bug introduced in #19524

@wing328 this is needed for `7.10.0` otherwise the `typescript-fetch` generator will be broken in this this release.

CC @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
