### PR TITLE
[Rust-Axum] [Breaking Changes] Prevent Operation response with internal Error

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-axum/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/apis.mustache
@@ -72,7 +72,7 @@ pub trait {{classnamePascalCase}} {
     {{#x-consumes-multipart-related}}
         body: axum::body::Body,
     {{/x-consumes-multipart-related}}
-    ) -> Result<{{{operationId}}}Response, String>;
+    ) -> Result<{{{operationId}}}Response, ()>;
   {{/vendorExtensions}}
   {{^-last}}
 

--- a/modules/openapi-generator/src/main/resources/rust-axum/server-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/server-operation.mustache
@@ -338,8 +338,6 @@ where
 {{/responses}}
                                             },
                                             Err(_) => {
-                                                // Application code returned an error. This should not happen, as the implementation should
-                                                // return a valid response.
                                                 response.status(500).body(Body::empty())
                                             },
                                         };

--- a/samples/server/petstore/rust-axum/output/apikey-auths/src/apis/payments.rs
+++ b/samples/server/petstore/rust-axum/output/apikey-auths/src/apis/payments.rs
@@ -48,7 +48,7 @@ pub trait Payments {
         host: Host,
         cookies: CookieJar,
         path_params: models::GetPaymentMethodByIdPathParams,
-    ) -> Result<GetPaymentMethodByIdResponse, String>;
+    ) -> Result<GetPaymentMethodByIdResponse, ()>;
 
     /// Get payment methods.
     ///
@@ -58,7 +58,7 @@ pub trait Payments {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<GetPaymentMethodsResponse, String>;
+    ) -> Result<GetPaymentMethodsResponse, ()>;
 
     /// Make a payment.
     ///
@@ -70,5 +70,5 @@ pub trait Payments {
         cookies: CookieJar,
         token_in_cookie: Option<String>,
         body: Option<models::Payment>,
-    ) -> Result<PostMakePaymentResponse, String>;
+    ) -> Result<PostMakePaymentResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/apikey-auths/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/apikey-auths/src/server/mod.rs
@@ -119,11 +119,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -193,11 +189,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -316,11 +308,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {

--- a/samples/server/petstore/rust-axum/output/multipart-v3/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/src/apis/default.rs
@@ -42,7 +42,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: axum::body::Body,
-    ) -> Result<MultipartRelatedRequestPostResponse, String>;
+    ) -> Result<MultipartRelatedRequestPostResponse, ()>;
 
     /// MultipartRequestPost - POST /multipart_request
     async fn multipart_request_post(
@@ -51,7 +51,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: Multipart,
-    ) -> Result<MultipartRequestPostResponse, String>;
+    ) -> Result<MultipartRequestPostResponse, ()>;
 
     /// MultipleIdenticalMimeTypesPost - POST /multiple-identical-mime-types
     async fn multiple_identical_mime_types_post(
@@ -60,5 +60,5 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: axum::body::Body,
-    ) -> Result<MultipleIdenticalMimeTypesPostResponse, String>;
+    ) -> Result<MultipleIdenticalMimeTypesPostResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/multipart-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/src/server/mod.rs
@@ -76,11 +76,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -132,11 +128,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -189,11 +181,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/default.rs
@@ -282,7 +282,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         query_params: models::AnyOfGetQueryParams,
-    ) -> Result<AnyOfGetResponse, String>;
+    ) -> Result<AnyOfGetResponse, ()>;
 
     /// CallbackWithHeaderPost - POST /callback-with-header
     async fn callback_with_header_post(
@@ -291,7 +291,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         query_params: models::CallbackWithHeaderPostQueryParams,
-    ) -> Result<CallbackWithHeaderPostResponse, String>;
+    ) -> Result<CallbackWithHeaderPostResponse, ()>;
 
     /// ComplexQueryParamGet - GET /complex-query-param
     async fn complex_query_param_get(
@@ -300,7 +300,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         query_params: models::ComplexQueryParamGetQueryParams,
-    ) -> Result<ComplexQueryParamGetResponse, String>;
+    ) -> Result<ComplexQueryParamGetResponse, ()>;
 
     /// EnumInPathPathParamGet - GET /enum_in_path/{path_param}
     async fn enum_in_path_path_param_get(
@@ -309,7 +309,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         path_params: models::EnumInPathPathParamGetPathParams,
-    ) -> Result<EnumInPathPathParamGetResponse, String>;
+    ) -> Result<EnumInPathPathParamGetResponse, ()>;
 
     /// Test a Form Post.
     ///
@@ -320,7 +320,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: models::FormTestRequest,
-    ) -> Result<FormTestResponse, String>;
+    ) -> Result<FormTestResponse, ()>;
 
     /// GetWithBooleanParameter - GET /get-with-bool
     async fn get_with_boolean_parameter(
@@ -329,7 +329,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         query_params: models::GetWithBooleanParameterQueryParams,
-    ) -> Result<GetWithBooleanParameterResponse, String>;
+    ) -> Result<GetWithBooleanParameterResponse, ()>;
 
     /// JsonComplexQueryParamGet - GET /json-complex-query-param
     async fn json_complex_query_param_get(
@@ -338,7 +338,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         query_params: models::JsonComplexQueryParamGetQueryParams,
-    ) -> Result<JsonComplexQueryParamGetResponse, String>;
+    ) -> Result<JsonComplexQueryParamGetResponse, ()>;
 
     /// MandatoryRequestHeaderGet - GET /mandatory-request-header
     async fn mandatory_request_header_get(
@@ -347,7 +347,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         header_params: models::MandatoryRequestHeaderGetHeaderParams,
-    ) -> Result<MandatoryRequestHeaderGetResponse, String>;
+    ) -> Result<MandatoryRequestHeaderGetResponse, ()>;
 
     /// MergePatchJsonGet - GET /merge-patch-json
     async fn merge_patch_json_get(
@@ -355,7 +355,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<MergePatchJsonGetResponse, String>;
+    ) -> Result<MergePatchJsonGetResponse, ()>;
 
     /// Get some stuff..
     ///
@@ -365,7 +365,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<MultigetGetResponse, String>;
+    ) -> Result<MultigetGetResponse, ()>;
 
     /// MultipleAuthSchemeGet - GET /multiple_auth_scheme
     async fn multiple_auth_scheme_get(
@@ -373,7 +373,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<MultipleAuthSchemeGetResponse, String>;
+    ) -> Result<MultipleAuthSchemeGetResponse, ()>;
 
     /// MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGet - GET /multiple-path-params-with-very-long-path-to-test-formatting/{path_param_a}/{path_param_b}
     async fn multiple_path_params_with_very_long_path_to_test_formatting_path_param_a_path_param_b_get(
@@ -382,10 +382,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         path_params: models::MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGetPathParams,
-    ) -> Result<
-        MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGetResponse,
-        String,
-    >;
+    ) -> Result<MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGetResponse, ()>;
 
     /// OneOfGet - GET /one-of
     async fn one_of_get(
@@ -393,7 +390,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<OneOfGetResponse, String>;
+    ) -> Result<OneOfGetResponse, ()>;
 
     /// OverrideServerGet - GET /override-server
     async fn override_server_get(
@@ -401,7 +398,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<OverrideServerGetResponse, String>;
+    ) -> Result<OverrideServerGetResponse, ()>;
 
     /// Get some stuff with parameters..
     ///
@@ -412,7 +409,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         query_params: models::ParamgetGetQueryParams,
-    ) -> Result<ParamgetGetResponse, String>;
+    ) -> Result<ParamgetGetResponse, ()>;
 
     /// ReadonlyAuthSchemeGet - GET /readonly_auth_scheme
     async fn readonly_auth_scheme_get(
@@ -420,7 +417,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<ReadonlyAuthSchemeGetResponse, String>;
+    ) -> Result<ReadonlyAuthSchemeGetResponse, ()>;
 
     /// RegisterCallbackPost - POST /register-callback
     async fn register_callback_post(
@@ -429,7 +426,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         query_params: models::RegisterCallbackPostQueryParams,
-    ) -> Result<RegisterCallbackPostResponse, String>;
+    ) -> Result<RegisterCallbackPostResponse, ()>;
 
     /// RequiredOctetStreamPut - PUT /required_octet_stream
     async fn required_octet_stream_put(
@@ -438,7 +435,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: Bytes,
-    ) -> Result<RequiredOctetStreamPutResponse, String>;
+    ) -> Result<RequiredOctetStreamPutResponse, ()>;
 
     /// ResponsesWithHeadersGet - GET /responses_with_headers
     async fn responses_with_headers_get(
@@ -446,7 +443,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<ResponsesWithHeadersGetResponse, String>;
+    ) -> Result<ResponsesWithHeadersGetResponse, ()>;
 
     /// Rfc7807Get - GET /rfc7807
     async fn rfc7807_get(
@@ -454,7 +451,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Rfc7807GetResponse, String>;
+    ) -> Result<Rfc7807GetResponse, ()>;
 
     /// TwoFirstLetterHeaders - POST /operation-two-first-letter-headers
     async fn two_first_letter_headers(
@@ -463,7 +460,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         header_params: models::TwoFirstLetterHeadersHeaderParams,
-    ) -> Result<TwoFirstLetterHeadersResponse, String>;
+    ) -> Result<TwoFirstLetterHeadersResponse, ()>;
 
     /// UntypedPropertyGet - GET /untyped_property
     async fn untyped_property_get(
@@ -472,7 +469,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: Option<models::ObjectUntypedProps>,
-    ) -> Result<UntypedPropertyGetResponse, String>;
+    ) -> Result<UntypedPropertyGetResponse, ()>;
 
     /// UuidGet - GET /uuid
     async fn uuid_get(
@@ -480,7 +477,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<UuidGetResponse, String>;
+    ) -> Result<UuidGetResponse, ()>;
 
     /// XmlExtraPost - POST /xml_extra
     async fn xml_extra_post(
@@ -489,7 +486,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: Bytes,
-    ) -> Result<XmlExtraPostResponse, String>;
+    ) -> Result<XmlExtraPostResponse, ()>;
 
     /// XmlOtherPost - POST /xml_other
     async fn xml_other_post(
@@ -498,7 +495,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: Bytes,
-    ) -> Result<XmlOtherPostResponse, String>;
+    ) -> Result<XmlOtherPostResponse, ()>;
 
     /// XmlOtherPut - PUT /xml_other
     async fn xml_other_put(
@@ -507,7 +504,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: Bytes,
-    ) -> Result<XmlOtherPutResponse, String>;
+    ) -> Result<XmlOtherPutResponse, ()>;
 
     /// Post an array.  It's important we test apostrophes, so include one here..
     ///
@@ -518,7 +515,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: Bytes,
-    ) -> Result<XmlPostResponse, String>;
+    ) -> Result<XmlPostResponse, ()>;
 
     /// XmlPut - PUT /xml
     async fn xml_put(
@@ -527,5 +524,5 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: Bytes,
-    ) -> Result<XmlPutResponse, String>;
+    ) -> Result<XmlPutResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/info_repo.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/info_repo.rs
@@ -26,5 +26,5 @@ pub trait InfoRepo {
         host: Host,
         cookies: CookieJar,
         path_params: models::GetRepoInfoPathParams,
-    ) -> Result<GetRepoInfoResponse, String>;
+    ) -> Result<GetRepoInfoResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/repo.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/repo.rs
@@ -26,5 +26,5 @@ pub trait Repo {
         host: Host,
         cookies: CookieJar,
         body: models::ObjectParam,
-    ) -> Result<CreateRepoResponse, String>;
+    ) -> Result<CreateRepoResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/server/mod.rs
@@ -216,11 +216,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -273,11 +269,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -330,11 +322,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -387,11 +375,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -452,11 +436,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -509,11 +489,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -566,11 +542,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -656,11 +628,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -727,11 +695,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -912,11 +876,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -966,8 +926,6 @@ where
                                                 },
                                             },
                                             Err(_) => {
-                                                // Application code returned an error. This should not happen, as the implementation should
-                                                // return a valid response.
                                                 response.status(500).body(Body::empty())
                                             },
                                         };
@@ -1041,8 +999,6 @@ where
                                                 },
                                             },
                                             Err(_) => {
-                                                // Application code returned an error. This should not happen, as the implementation should
-                                                // return a valid response.
                                                 response.status(500).body(Body::empty())
                                             },
                                         };
@@ -1108,11 +1064,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1160,11 +1112,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1236,11 +1184,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1290,8 +1234,6 @@ where
                                                 },
                                             },
                                             Err(_) => {
-                                                // Application code returned an error. This should not happen, as the implementation should
-                                                // return a valid response.
                                                 response.status(500).body(Body::empty())
                                             },
                                         };
@@ -1346,11 +1288,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1407,11 +1345,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1567,11 +1501,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1674,11 +1604,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1774,11 +1700,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1843,8 +1765,6 @@ where
                                                 },
                                             },
                                             Err(_) => {
-                                                // Application code returned an error. This should not happen, as the implementation should
-                                                // return a valid response.
                                                 response.status(500).body(Body::empty())
                                             },
                                         };
@@ -1910,11 +1830,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1973,11 +1889,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2048,11 +1960,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2111,11 +2019,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2174,11 +2078,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2234,11 +2134,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2310,11 +2206,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2375,11 +2267,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {

--- a/samples/server/petstore/rust-axum/output/ops-v3/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/ops-v3/src/apis/default.rs
@@ -313,7 +313,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op10GetResponse, String>;
+    ) -> Result<Op10GetResponse, ()>;
 
     /// Op11Get - GET /op11
     async fn op11_get(
@@ -321,7 +321,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op11GetResponse, String>;
+    ) -> Result<Op11GetResponse, ()>;
 
     /// Op12Get - GET /op12
     async fn op12_get(
@@ -329,7 +329,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op12GetResponse, String>;
+    ) -> Result<Op12GetResponse, ()>;
 
     /// Op13Get - GET /op13
     async fn op13_get(
@@ -337,7 +337,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op13GetResponse, String>;
+    ) -> Result<Op13GetResponse, ()>;
 
     /// Op14Get - GET /op14
     async fn op14_get(
@@ -345,7 +345,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op14GetResponse, String>;
+    ) -> Result<Op14GetResponse, ()>;
 
     /// Op15Get - GET /op15
     async fn op15_get(
@@ -353,7 +353,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op15GetResponse, String>;
+    ) -> Result<Op15GetResponse, ()>;
 
     /// Op16Get - GET /op16
     async fn op16_get(
@@ -361,7 +361,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op16GetResponse, String>;
+    ) -> Result<Op16GetResponse, ()>;
 
     /// Op17Get - GET /op17
     async fn op17_get(
@@ -369,7 +369,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op17GetResponse, String>;
+    ) -> Result<Op17GetResponse, ()>;
 
     /// Op18Get - GET /op18
     async fn op18_get(
@@ -377,7 +377,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op18GetResponse, String>;
+    ) -> Result<Op18GetResponse, ()>;
 
     /// Op19Get - GET /op19
     async fn op19_get(
@@ -385,7 +385,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op19GetResponse, String>;
+    ) -> Result<Op19GetResponse, ()>;
 
     /// Op1Get - GET /op1
     async fn op1_get(
@@ -393,7 +393,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op1GetResponse, String>;
+    ) -> Result<Op1GetResponse, ()>;
 
     /// Op20Get - GET /op20
     async fn op20_get(
@@ -401,7 +401,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op20GetResponse, String>;
+    ) -> Result<Op20GetResponse, ()>;
 
     /// Op21Get - GET /op21
     async fn op21_get(
@@ -409,7 +409,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op21GetResponse, String>;
+    ) -> Result<Op21GetResponse, ()>;
 
     /// Op22Get - GET /op22
     async fn op22_get(
@@ -417,7 +417,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op22GetResponse, String>;
+    ) -> Result<Op22GetResponse, ()>;
 
     /// Op23Get - GET /op23
     async fn op23_get(
@@ -425,7 +425,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op23GetResponse, String>;
+    ) -> Result<Op23GetResponse, ()>;
 
     /// Op24Get - GET /op24
     async fn op24_get(
@@ -433,7 +433,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op24GetResponse, String>;
+    ) -> Result<Op24GetResponse, ()>;
 
     /// Op25Get - GET /op25
     async fn op25_get(
@@ -441,7 +441,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op25GetResponse, String>;
+    ) -> Result<Op25GetResponse, ()>;
 
     /// Op26Get - GET /op26
     async fn op26_get(
@@ -449,7 +449,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op26GetResponse, String>;
+    ) -> Result<Op26GetResponse, ()>;
 
     /// Op27Get - GET /op27
     async fn op27_get(
@@ -457,7 +457,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op27GetResponse, String>;
+    ) -> Result<Op27GetResponse, ()>;
 
     /// Op28Get - GET /op28
     async fn op28_get(
@@ -465,7 +465,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op28GetResponse, String>;
+    ) -> Result<Op28GetResponse, ()>;
 
     /// Op29Get - GET /op29
     async fn op29_get(
@@ -473,7 +473,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op29GetResponse, String>;
+    ) -> Result<Op29GetResponse, ()>;
 
     /// Op2Get - GET /op2
     async fn op2_get(
@@ -481,7 +481,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op2GetResponse, String>;
+    ) -> Result<Op2GetResponse, ()>;
 
     /// Op30Get - GET /op30
     async fn op30_get(
@@ -489,7 +489,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op30GetResponse, String>;
+    ) -> Result<Op30GetResponse, ()>;
 
     /// Op31Get - GET /op31
     async fn op31_get(
@@ -497,7 +497,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op31GetResponse, String>;
+    ) -> Result<Op31GetResponse, ()>;
 
     /// Op32Get - GET /op32
     async fn op32_get(
@@ -505,7 +505,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op32GetResponse, String>;
+    ) -> Result<Op32GetResponse, ()>;
 
     /// Op33Get - GET /op33
     async fn op33_get(
@@ -513,7 +513,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op33GetResponse, String>;
+    ) -> Result<Op33GetResponse, ()>;
 
     /// Op34Get - GET /op34
     async fn op34_get(
@@ -521,7 +521,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op34GetResponse, String>;
+    ) -> Result<Op34GetResponse, ()>;
 
     /// Op35Get - GET /op35
     async fn op35_get(
@@ -529,7 +529,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op35GetResponse, String>;
+    ) -> Result<Op35GetResponse, ()>;
 
     /// Op36Get - GET /op36
     async fn op36_get(
@@ -537,7 +537,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op36GetResponse, String>;
+    ) -> Result<Op36GetResponse, ()>;
 
     /// Op37Get - GET /op37
     async fn op37_get(
@@ -545,7 +545,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op37GetResponse, String>;
+    ) -> Result<Op37GetResponse, ()>;
 
     /// Op3Get - GET /op3
     async fn op3_get(
@@ -553,7 +553,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op3GetResponse, String>;
+    ) -> Result<Op3GetResponse, ()>;
 
     /// Op4Get - GET /op4
     async fn op4_get(
@@ -561,7 +561,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op4GetResponse, String>;
+    ) -> Result<Op4GetResponse, ()>;
 
     /// Op5Get - GET /op5
     async fn op5_get(
@@ -569,7 +569,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op5GetResponse, String>;
+    ) -> Result<Op5GetResponse, ()>;
 
     /// Op6Get - GET /op6
     async fn op6_get(
@@ -577,7 +577,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op6GetResponse, String>;
+    ) -> Result<Op6GetResponse, ()>;
 
     /// Op7Get - GET /op7
     async fn op7_get(
@@ -585,7 +585,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op7GetResponse, String>;
+    ) -> Result<Op7GetResponse, ()>;
 
     /// Op8Get - GET /op8
     async fn op8_get(
@@ -593,7 +593,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op8GetResponse, String>;
+    ) -> Result<Op8GetResponse, ()>;
 
     /// Op9Get - GET /op9
     async fn op9_get(
@@ -601,5 +601,5 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Op9GetResponse, String>;
+    ) -> Result<Op9GetResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/ops-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/ops-v3/src/server/mod.rs
@@ -99,11 +99,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -151,11 +147,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -203,11 +195,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -255,11 +243,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -307,11 +291,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -359,11 +339,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -411,11 +387,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -463,11 +435,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -515,11 +483,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -567,11 +531,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -619,11 +579,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -671,11 +627,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -723,11 +675,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -775,11 +723,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -827,11 +771,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -879,11 +819,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -931,11 +867,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -983,11 +915,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1035,11 +963,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1087,11 +1011,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1139,11 +1059,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1191,11 +1107,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1243,11 +1155,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1295,11 +1203,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1347,11 +1251,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1399,11 +1299,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1451,11 +1347,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1503,11 +1395,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1555,11 +1443,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1607,11 +1491,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1659,11 +1539,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1711,11 +1587,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1763,11 +1635,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1815,11 +1683,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1867,11 +1731,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1919,11 +1779,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1971,11 +1827,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/another_fake.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/another_fake.rs
@@ -28,5 +28,5 @@ pub trait AnotherFake {
         host: Host,
         cookies: CookieJar,
         body: models::Client,
-    ) -> Result<TestSpecialTagsResponse, String>;
+    ) -> Result<TestSpecialTagsResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/fake.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/fake.rs
@@ -125,7 +125,7 @@ pub trait Fake {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<Call123exampleResponse, String>;
+    ) -> Result<Call123exampleResponse, ()>;
 
     /// FakeOuterBooleanSerialize - POST /v2/fake/outer/boolean
     async fn fake_outer_boolean_serialize(
@@ -134,7 +134,7 @@ pub trait Fake {
         host: Host,
         cookies: CookieJar,
         body: Option<models::OuterBoolean>,
-    ) -> Result<FakeOuterBooleanSerializeResponse, String>;
+    ) -> Result<FakeOuterBooleanSerializeResponse, ()>;
 
     /// FakeOuterCompositeSerialize - POST /v2/fake/outer/composite
     async fn fake_outer_composite_serialize(
@@ -143,7 +143,7 @@ pub trait Fake {
         host: Host,
         cookies: CookieJar,
         body: Option<models::OuterComposite>,
-    ) -> Result<FakeOuterCompositeSerializeResponse, String>;
+    ) -> Result<FakeOuterCompositeSerializeResponse, ()>;
 
     /// FakeOuterNumberSerialize - POST /v2/fake/outer/number
     async fn fake_outer_number_serialize(
@@ -152,7 +152,7 @@ pub trait Fake {
         host: Host,
         cookies: CookieJar,
         body: Option<models::OuterNumber>,
-    ) -> Result<FakeOuterNumberSerializeResponse, String>;
+    ) -> Result<FakeOuterNumberSerializeResponse, ()>;
 
     /// FakeOuterStringSerialize - POST /v2/fake/outer/string
     async fn fake_outer_string_serialize(
@@ -161,7 +161,7 @@ pub trait Fake {
         host: Host,
         cookies: CookieJar,
         body: Option<models::OuterString>,
-    ) -> Result<FakeOuterStringSerializeResponse, String>;
+    ) -> Result<FakeOuterStringSerializeResponse, ()>;
 
     /// FakeResponseWithNumericalDescription - GET /v2/fake/response-with-numerical-description
     async fn fake_response_with_numerical_description(
@@ -169,7 +169,7 @@ pub trait Fake {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<FakeResponseWithNumericalDescriptionResponse, String>;
+    ) -> Result<FakeResponseWithNumericalDescriptionResponse, ()>;
 
     /// HyphenParam - GET /v2/fake/hyphenParam/{hyphen-param}
     async fn hyphen_param(
@@ -178,7 +178,7 @@ pub trait Fake {
         host: Host,
         cookies: CookieJar,
         path_params: models::HyphenParamPathParams,
-    ) -> Result<HyphenParamResponse, String>;
+    ) -> Result<HyphenParamResponse, ()>;
 
     /// TestBodyWithQueryParams - PUT /v2/fake/body-with-query-params
     async fn test_body_with_query_params(
@@ -188,7 +188,7 @@ pub trait Fake {
         cookies: CookieJar,
         query_params: models::TestBodyWithQueryParamsQueryParams,
         body: models::User,
-    ) -> Result<TestBodyWithQueryParamsResponse, String>;
+    ) -> Result<TestBodyWithQueryParamsResponse, ()>;
 
     /// To test \"client\" model.
     ///
@@ -199,7 +199,7 @@ pub trait Fake {
         host: Host,
         cookies: CookieJar,
         body: models::Client,
-    ) -> Result<TestClientModelResponse, String>;
+    ) -> Result<TestClientModelResponse, ()>;
 
     /// Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트.
     ///
@@ -210,7 +210,7 @@ pub trait Fake {
         host: Host,
         cookies: CookieJar,
         body: models::TestEndpointParametersRequest,
-    ) -> Result<TestEndpointParametersResponse, String>;
+    ) -> Result<TestEndpointParametersResponse, ()>;
 
     /// To test enum parameters.
     ///
@@ -223,7 +223,7 @@ pub trait Fake {
         header_params: models::TestEnumParametersHeaderParams,
         query_params: models::TestEnumParametersQueryParams,
         body: Option<models::TestEnumParametersRequest>,
-    ) -> Result<TestEnumParametersResponse, String>;
+    ) -> Result<TestEnumParametersResponse, ()>;
 
     /// test inline additionalProperties.
     ///
@@ -234,7 +234,7 @@ pub trait Fake {
         host: Host,
         cookies: CookieJar,
         body: std::collections::HashMap<String, String>,
-    ) -> Result<TestInlineAdditionalPropertiesResponse, String>;
+    ) -> Result<TestInlineAdditionalPropertiesResponse, ()>;
 
     /// test json serialization of form data.
     ///
@@ -245,5 +245,5 @@ pub trait Fake {
         host: Host,
         cookies: CookieJar,
         body: models::TestJsonFormDataRequest,
-    ) -> Result<TestJsonFormDataResponse, String>;
+    ) -> Result<TestJsonFormDataResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/fake_classname_tags123.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/fake_classname_tags123.rs
@@ -28,5 +28,5 @@ pub trait FakeClassnameTags123 {
         host: Host,
         cookies: CookieJar,
         body: models::Client,
-    ) -> Result<TestClassnameResponse, String>;
+    ) -> Result<TestClassnameResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/pet.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/pet.rs
@@ -96,7 +96,7 @@ pub trait Pet {
         host: Host,
         cookies: CookieJar,
         body: models::Pet,
-    ) -> Result<AddPetResponse, String>;
+    ) -> Result<AddPetResponse, ()>;
 
     /// Deletes a pet.
     ///
@@ -108,7 +108,7 @@ pub trait Pet {
         cookies: CookieJar,
         header_params: models::DeletePetHeaderParams,
         path_params: models::DeletePetPathParams,
-    ) -> Result<DeletePetResponse, String>;
+    ) -> Result<DeletePetResponse, ()>;
 
     /// Finds Pets by status.
     ///
@@ -119,7 +119,7 @@ pub trait Pet {
         host: Host,
         cookies: CookieJar,
         query_params: models::FindPetsByStatusQueryParams,
-    ) -> Result<FindPetsByStatusResponse, String>;
+    ) -> Result<FindPetsByStatusResponse, ()>;
 
     /// Finds Pets by tags.
     ///
@@ -130,7 +130,7 @@ pub trait Pet {
         host: Host,
         cookies: CookieJar,
         query_params: models::FindPetsByTagsQueryParams,
-    ) -> Result<FindPetsByTagsResponse, String>;
+    ) -> Result<FindPetsByTagsResponse, ()>;
 
     /// Find pet by ID.
     ///
@@ -142,7 +142,7 @@ pub trait Pet {
         cookies: CookieJar,
         token_in_header: Option<String>,
         path_params: models::GetPetByIdPathParams,
-    ) -> Result<GetPetByIdResponse, String>;
+    ) -> Result<GetPetByIdResponse, ()>;
 
     /// Update an existing pet.
     ///
@@ -153,7 +153,7 @@ pub trait Pet {
         host: Host,
         cookies: CookieJar,
         body: models::Pet,
-    ) -> Result<UpdatePetResponse, String>;
+    ) -> Result<UpdatePetResponse, ()>;
 
     /// Updates a pet in the store with form data.
     ///
@@ -165,7 +165,7 @@ pub trait Pet {
         cookies: CookieJar,
         path_params: models::UpdatePetWithFormPathParams,
         body: Option<models::UpdatePetWithFormRequest>,
-    ) -> Result<UpdatePetWithFormResponse, String>;
+    ) -> Result<UpdatePetWithFormResponse, ()>;
 
     /// uploads an image.
     ///
@@ -177,5 +177,5 @@ pub trait Pet {
         cookies: CookieJar,
         path_params: models::UploadFilePathParams,
         body: Multipart,
-    ) -> Result<UploadFileResponse, String>;
+    ) -> Result<UploadFileResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/store.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/store.rs
@@ -60,7 +60,7 @@ pub trait Store {
         host: Host,
         cookies: CookieJar,
         path_params: models::DeleteOrderPathParams,
-    ) -> Result<DeleteOrderResponse, String>;
+    ) -> Result<DeleteOrderResponse, ()>;
 
     /// Returns pet inventories by status.
     ///
@@ -71,7 +71,7 @@ pub trait Store {
         host: Host,
         cookies: CookieJar,
         token_in_header: Option<String>,
-    ) -> Result<GetInventoryResponse, String>;
+    ) -> Result<GetInventoryResponse, ()>;
 
     /// Find purchase order by ID.
     ///
@@ -82,7 +82,7 @@ pub trait Store {
         host: Host,
         cookies: CookieJar,
         path_params: models::GetOrderByIdPathParams,
-    ) -> Result<GetOrderByIdResponse, String>;
+    ) -> Result<GetOrderByIdResponse, ()>;
 
     /// Place an order for a pet.
     ///
@@ -93,5 +93,5 @@ pub trait Store {
         host: Host,
         cookies: CookieJar,
         body: models::Order,
-    ) -> Result<PlaceOrderResponse, String>;
+    ) -> Result<PlaceOrderResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/user.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/user.rs
@@ -98,7 +98,7 @@ pub trait User {
         host: Host,
         cookies: CookieJar,
         body: models::User,
-    ) -> Result<CreateUserResponse, String>;
+    ) -> Result<CreateUserResponse, ()>;
 
     /// Creates list of users with given input array.
     ///
@@ -109,7 +109,7 @@ pub trait User {
         host: Host,
         cookies: CookieJar,
         body: Vec<models::User>,
-    ) -> Result<CreateUsersWithArrayInputResponse, String>;
+    ) -> Result<CreateUsersWithArrayInputResponse, ()>;
 
     /// Creates list of users with given input array.
     ///
@@ -120,7 +120,7 @@ pub trait User {
         host: Host,
         cookies: CookieJar,
         body: Vec<models::User>,
-    ) -> Result<CreateUsersWithListInputResponse, String>;
+    ) -> Result<CreateUsersWithListInputResponse, ()>;
 
     /// Delete user.
     ///
@@ -131,7 +131,7 @@ pub trait User {
         host: Host,
         cookies: CookieJar,
         path_params: models::DeleteUserPathParams,
-    ) -> Result<DeleteUserResponse, String>;
+    ) -> Result<DeleteUserResponse, ()>;
 
     /// Get user by user name.
     ///
@@ -142,7 +142,7 @@ pub trait User {
         host: Host,
         cookies: CookieJar,
         path_params: models::GetUserByNamePathParams,
-    ) -> Result<GetUserByNameResponse, String>;
+    ) -> Result<GetUserByNameResponse, ()>;
 
     /// Logs user into the system.
     ///
@@ -153,7 +153,7 @@ pub trait User {
         host: Host,
         cookies: CookieJar,
         query_params: models::LoginUserQueryParams,
-    ) -> Result<LoginUserResponse, String>;
+    ) -> Result<LoginUserResponse, ()>;
 
     /// Logs out current logged in user session.
     ///
@@ -163,7 +163,7 @@ pub trait User {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<LogoutUserResponse, String>;
+    ) -> Result<LogoutUserResponse, ()>;
 
     /// Updated user.
     ///
@@ -175,5 +175,5 @@ pub trait User {
         cookies: CookieJar,
         path_params: models::UpdateUserPathParams,
         body: models::User,
-    ) -> Result<UpdateUserResponse, String>;
+    ) -> Result<UpdateUserResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -182,11 +182,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -237,11 +233,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -327,11 +319,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -417,11 +405,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -507,11 +491,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -597,11 +577,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -654,11 +630,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -714,11 +686,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -788,11 +756,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -875,11 +839,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -947,11 +907,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1086,11 +1042,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1154,11 +1106,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1222,11 +1170,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1311,11 +1255,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1374,11 +1314,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1466,11 +1402,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1543,11 +1475,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1620,11 +1548,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1712,11 +1636,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1788,11 +1708,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1868,11 +1784,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1948,11 +1860,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2012,11 +1920,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2098,11 +2002,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2178,11 +2078,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2262,11 +2158,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2330,11 +2222,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2399,11 +2287,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2468,11 +2352,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2532,11 +2412,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2612,11 +2488,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2725,11 +2597,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2777,11 +2645,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -2852,11 +2716,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {

--- a/samples/server/petstore/rust-axum/output/petstore/src/apis/pet.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/apis/pet.rs
@@ -100,7 +100,7 @@ pub trait Pet {
         host: Host,
         cookies: CookieJar,
         body: models::Pet,
-    ) -> Result<AddPetResponse, String>;
+    ) -> Result<AddPetResponse, ()>;
 
     /// Deletes a pet.
     ///
@@ -112,7 +112,7 @@ pub trait Pet {
         cookies: CookieJar,
         header_params: models::DeletePetHeaderParams,
         path_params: models::DeletePetPathParams,
-    ) -> Result<DeletePetResponse, String>;
+    ) -> Result<DeletePetResponse, ()>;
 
     /// Finds Pets by status.
     ///
@@ -123,7 +123,7 @@ pub trait Pet {
         host: Host,
         cookies: CookieJar,
         query_params: models::FindPetsByStatusQueryParams,
-    ) -> Result<FindPetsByStatusResponse, String>;
+    ) -> Result<FindPetsByStatusResponse, ()>;
 
     /// Finds Pets by tags.
     ///
@@ -134,7 +134,7 @@ pub trait Pet {
         host: Host,
         cookies: CookieJar,
         query_params: models::FindPetsByTagsQueryParams,
-    ) -> Result<FindPetsByTagsResponse, String>;
+    ) -> Result<FindPetsByTagsResponse, ()>;
 
     /// Find pet by ID.
     ///
@@ -146,7 +146,7 @@ pub trait Pet {
         cookies: CookieJar,
         token_in_header: Option<String>,
         path_params: models::GetPetByIdPathParams,
-    ) -> Result<GetPetByIdResponse, String>;
+    ) -> Result<GetPetByIdResponse, ()>;
 
     /// Update an existing pet.
     ///
@@ -157,7 +157,7 @@ pub trait Pet {
         host: Host,
         cookies: CookieJar,
         body: models::Pet,
-    ) -> Result<UpdatePetResponse, String>;
+    ) -> Result<UpdatePetResponse, ()>;
 
     /// Updates a pet in the store with form data.
     ///
@@ -169,7 +169,7 @@ pub trait Pet {
         cookies: CookieJar,
         path_params: models::UpdatePetWithFormPathParams,
         body: Option<models::UpdatePetWithFormRequest>,
-    ) -> Result<UpdatePetWithFormResponse, String>;
+    ) -> Result<UpdatePetWithFormResponse, ()>;
 
     /// uploads an image.
     ///
@@ -181,5 +181,5 @@ pub trait Pet {
         cookies: CookieJar,
         path_params: models::UploadFilePathParams,
         body: Multipart,
-    ) -> Result<UploadFileResponse, String>;
+    ) -> Result<UploadFileResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/petstore/src/apis/store.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/apis/store.rs
@@ -60,7 +60,7 @@ pub trait Store {
         host: Host,
         cookies: CookieJar,
         path_params: models::DeleteOrderPathParams,
-    ) -> Result<DeleteOrderResponse, String>;
+    ) -> Result<DeleteOrderResponse, ()>;
 
     /// Returns pet inventories by status.
     ///
@@ -71,7 +71,7 @@ pub trait Store {
         host: Host,
         cookies: CookieJar,
         token_in_header: Option<String>,
-    ) -> Result<GetInventoryResponse, String>;
+    ) -> Result<GetInventoryResponse, ()>;
 
     /// Find purchase order by ID.
     ///
@@ -82,7 +82,7 @@ pub trait Store {
         host: Host,
         cookies: CookieJar,
         path_params: models::GetOrderByIdPathParams,
-    ) -> Result<GetOrderByIdResponse, String>;
+    ) -> Result<GetOrderByIdResponse, ()>;
 
     /// Place an order for a pet.
     ///
@@ -93,5 +93,5 @@ pub trait Store {
         host: Host,
         cookies: CookieJar,
         body: models::Order,
-    ) -> Result<PlaceOrderResponse, String>;
+    ) -> Result<PlaceOrderResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/petstore/src/apis/user.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/apis/user.rs
@@ -100,7 +100,7 @@ pub trait User {
         cookies: CookieJar,
         token_in_header: Option<String>,
         body: models::User,
-    ) -> Result<CreateUserResponse, String>;
+    ) -> Result<CreateUserResponse, ()>;
 
     /// Creates list of users with given input array.
     ///
@@ -112,7 +112,7 @@ pub trait User {
         cookies: CookieJar,
         token_in_header: Option<String>,
         body: Vec<models::User>,
-    ) -> Result<CreateUsersWithArrayInputResponse, String>;
+    ) -> Result<CreateUsersWithArrayInputResponse, ()>;
 
     /// Creates list of users with given input array.
     ///
@@ -124,7 +124,7 @@ pub trait User {
         cookies: CookieJar,
         token_in_header: Option<String>,
         body: Vec<models::User>,
-    ) -> Result<CreateUsersWithListInputResponse, String>;
+    ) -> Result<CreateUsersWithListInputResponse, ()>;
 
     /// Delete user.
     ///
@@ -136,7 +136,7 @@ pub trait User {
         cookies: CookieJar,
         token_in_header: Option<String>,
         path_params: models::DeleteUserPathParams,
-    ) -> Result<DeleteUserResponse, String>;
+    ) -> Result<DeleteUserResponse, ()>;
 
     /// Get user by user name.
     ///
@@ -147,7 +147,7 @@ pub trait User {
         host: Host,
         cookies: CookieJar,
         path_params: models::GetUserByNamePathParams,
-    ) -> Result<GetUserByNameResponse, String>;
+    ) -> Result<GetUserByNameResponse, ()>;
 
     /// Logs user into the system.
     ///
@@ -158,7 +158,7 @@ pub trait User {
         host: Host,
         cookies: CookieJar,
         query_params: models::LoginUserQueryParams,
-    ) -> Result<LoginUserResponse, String>;
+    ) -> Result<LoginUserResponse, ()>;
 
     /// Logs out current logged in user session.
     ///
@@ -169,7 +169,7 @@ pub trait User {
         host: Host,
         cookies: CookieJar,
         token_in_header: Option<String>,
-    ) -> Result<LogoutUserResponse, String>;
+    ) -> Result<LogoutUserResponse, ()>;
 
     /// Updated user.
     ///
@@ -182,5 +182,5 @@ pub trait User {
         token_in_header: Option<String>,
         path_params: models::UpdateUserPathParams,
         body: models::User,
-    ) -> Result<UpdateUserResponse, String>;
+    ) -> Result<UpdateUserResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/petstore/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/server/mod.rs
@@ -122,11 +122,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -214,11 +210,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -291,11 +283,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -368,11 +356,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -460,11 +444,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -552,11 +532,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -632,11 +608,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -712,11 +684,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -776,11 +744,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -862,11 +826,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -942,11 +902,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1026,11 +982,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1106,11 +1058,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1187,11 +1135,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1268,11 +1212,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1344,11 +1284,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1424,11 +1360,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1553,11 +1485,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1620,11 +1548,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -1707,11 +1631,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {

--- a/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/apis/default.rs
@@ -25,5 +25,5 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<PingGetResponse, String>;
+    ) -> Result<PingGetResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/server/mod.rs
@@ -63,11 +63,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {

--- a/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/apis/default.rs
@@ -26,5 +26,5 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         header_params: models::UsersPostHeaderParams,
-    ) -> Result<UsersPostResponse, String>;
+    ) -> Result<UsersPostResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/server/mod.rs
@@ -123,11 +123,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/src/apis/default.rs
@@ -89,7 +89,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<AllOfGetResponse, String>;
+    ) -> Result<AllOfGetResponse, ()>;
 
     /// A dummy endpoint to make the spec valid..
     ///
@@ -99,7 +99,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<DummyGetResponse, String>;
+    ) -> Result<DummyGetResponse, ()>;
 
     /// DummyPut - PUT /dummy
     async fn dummy_put(
@@ -108,7 +108,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: models::FooDummyPutRequest,
-    ) -> Result<DummyPutResponse, String>;
+    ) -> Result<DummyPutResponse, ()>;
 
     /// Get a file.
     ///
@@ -118,7 +118,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<FileResponseGetResponse, String>;
+    ) -> Result<FileResponseGetResponse, ()>;
 
     /// GetStructuredYaml - GET /get-structured-yaml
     async fn get_structured_yaml(
@@ -126,7 +126,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<GetStructuredYamlResponse, String>;
+    ) -> Result<GetStructuredYamlResponse, ()>;
 
     /// Test HTML handling.
     ///
@@ -137,7 +137,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: String,
-    ) -> Result<HtmlPostResponse, String>;
+    ) -> Result<HtmlPostResponse, ()>;
 
     /// PostYaml - POST /post-yaml
     async fn post_yaml(
@@ -146,7 +146,7 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: String,
-    ) -> Result<PostYamlResponse, String>;
+    ) -> Result<PostYamlResponse, ()>;
 
     /// Get an arbitrary JSON blob..
     ///
@@ -156,7 +156,7 @@ pub trait Default {
         method: Method,
         host: Host,
         cookies: CookieJar,
-    ) -> Result<RawJsonGetResponse, String>;
+    ) -> Result<RawJsonGetResponse, ()>;
 
     /// Send an arbitrary JSON blob.
     ///
@@ -167,5 +167,5 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: crate::types::Object,
-    ) -> Result<SoloObjectPostResponse, String>;
+    ) -> Result<SoloObjectPostResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/src/server/mod.rs
@@ -89,11 +89,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -141,11 +137,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -209,11 +201,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -283,11 +271,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -350,11 +334,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -424,11 +404,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -486,11 +462,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -557,11 +529,7 @@ where
                 response.body(Body::from(body_content))
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {
@@ -624,11 +592,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {

--- a/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/apis/default.rs
@@ -26,5 +26,5 @@ pub trait Default {
         host: Host,
         cookies: CookieJar,
         body: models::Email,
-    ) -> Result<MailPutResponse, String>;
+    ) -> Result<MailPutResponse, ()>;
 }

--- a/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/server/mod.rs
@@ -51,11 +51,7 @@ where
                 response.body(Body::empty())
             }
         },
-        Err(_) => {
-            // Application code returned an error. This should not happen, as the implementation should
-            // return a valid response.
-            response.status(500).body(Body::empty())
-        }
+        Err(_) => response.status(500).body(Body::empty()),
     };
 
     resp.map_err(|e| {


### PR DESCRIPTION
For security reason, Operation should not return Internal Server Error to client. User of Rust-Axum can custom this behavior by custom templates.

However, as default, should prevent!

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
