### PR TITLE
[kotlin-server] Bump Kotlin/Gradle versions and improve CI triggers/config

### DIFF
--- a/.github/workflows/samples-kotlin-server-jdk17.yaml
+++ b/.github/workflows/samples-kotlin-server-jdk17.yaml
@@ -19,7 +19,7 @@ on:
       # - samples/server/petstore/kotlin-spring-default/**
 
 env:
-  GRADLE_VERSION: 7.4
+  GRADLE_VERSION: 7.6.4
 
 jobs:
   build:

--- a/.github/workflows/samples-kotlin-server-jdk17.yaml
+++ b/.github/workflows/samples-kotlin-server-jdk17.yaml
@@ -2,7 +2,7 @@ name: Samples Kotlin server (jdk17)
 
 on:
   push:
-    branches:
+    paths:
       - 'samples/server/petstore/kotlin-springboot-3*/**'
       - 'samples/server/petstore/kotlin-server/**'
       - 'samples/server/petstore/kotlin-server-modelMutable/**'

--- a/.github/workflows/samples-kotlin-server-jdk17.yaml
+++ b/.github/workflows/samples-kotlin-server-jdk17.yaml
@@ -19,7 +19,7 @@ on:
       # - samples/server/petstore/kotlin-spring-default/**
 
 env:
-  GRADLE_VERSION: 7.6.4
+  GRADLE_VERSION: 8.10
 
 jobs:
   build:

--- a/.github/workflows/samples-kotlin-server-jdk17.yaml
+++ b/.github/workflows/samples-kotlin-server-jdk17.yaml
@@ -19,7 +19,7 @@ on:
       # - samples/server/petstore/kotlin-spring-default/**
 
 env:
-  GRADLE_VERSION: 8.10
+  GRADLE_VERSION: '8.10'
 
 jobs:
   build:

--- a/.github/workflows/samples-kotlin-server-jdk17.yaml
+++ b/.github/workflows/samples-kotlin-server-jdk17.yaml
@@ -4,15 +4,17 @@ on:
   push:
     branches:
       - 'samples/server/petstore/kotlin-springboot-3*/**'
-      - 'samples/server/petstore/kotlin-server/javalin/**'
-      - 'samples/server/petstore/kotlin-server/javalin-6/**'
+      - 'samples/server/petstore/kotlin-server/**'
+      - 'samples/server/petstore/kotlin-server-modelMutable/**'
+      - 'samples/server/petstore/kotlin-springboot-*/**'
       # comment out due to gradle build failure
       # - samples/server/petstore/kotlin-spring-default/**
   pull_request:
     paths:
       - 'samples/server/petstore/kotlin-springboot-3*/**'
-      - 'samples/server/petstore/kotlin-server/javalin/**'
-      - 'samples/server/petstore/kotlin-server/javalin-6/**'
+      - 'samples/server/petstore/kotlin-server/**'
+      - 'samples/server/petstore/kotlin-server-modelMutable/**'
+      - 'samples/server/petstore/kotlin-springboot-*/**'
       # comment out due to gradle build failure
       # - samples/server/petstore/kotlin-spring-default/**
 
@@ -21,7 +23,7 @@ env:
 
 jobs:
   build:
-    name: Build Kotlin server
+    name: Build Kotlin server (jdk17)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -31,8 +33,11 @@ jobs:
           - samples/server/petstore/kotlin-springboot-3
           - samples/server/petstore/kotlin-springboot-delegate-nodefaults
           - samples/server/petstore/kotlin-springboot-request-cookie
+          - samples/server/petstore/kotlin-server/jaxrs-spec
+          - samples/server/petstore/kotlin-server/jaxrs-spec-mutiny
           - samples/server/petstore/kotlin-server/javalin
           - samples/server/petstore/kotlin-server/javalin-6
+          - samples/server/petstore/kotlin-server/ktor
           # comment out due to gradle build failure
           # - samples/server/petstore/kotlin-spring-default/
     steps:

--- a/.github/workflows/samples-kotlin-server-jdk21.yaml
+++ b/.github/workflows/samples-kotlin-server-jdk21.yaml
@@ -3,10 +3,10 @@ name: Samples Kotlin server (jdk21)
 on:
   push:
     paths:
-      - 'samples/server/petstore/kotlin-server/javalin-6/**'
+      - 'samples/server/petstore/kotlin-server/**'
   pull_request:
     paths:
-      - 'samples/server/petstore/kotlin-server/javalin-6/**'
+      - 'samples/server/petstore/kotlin-server/**'
 
 env:
   GRADLE_VERSION: 8.8
@@ -20,6 +20,9 @@ jobs:
       matrix:
         sample:
           - samples/server/petstore/kotlin-server/javalin-6
+          - samples/server/petstore/kotlin-server/jaxrs-spec
+          - samples/server/petstore/kotlin-server/jaxrs-spec-mutiny
+          - samples/server/petstore/kotlin-server/ktor
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/samples-kotlin-server-jdk21.yaml
+++ b/.github/workflows/samples-kotlin-server-jdk21.yaml
@@ -9,7 +9,7 @@ on:
       - 'samples/server/petstore/kotlin-server/**'
 
 env:
-  GRADLE_VERSION: 8.10
+  GRADLE_VERSION: '8.10'
 
 jobs:
   build:

--- a/.github/workflows/samples-kotlin-server-jdk21.yaml
+++ b/.github/workflows/samples-kotlin-server-jdk21.yaml
@@ -9,7 +9,7 @@ on:
       - 'samples/server/petstore/kotlin-server/**'
 
 env:
-  GRADLE_VERSION: 8.8
+  GRADLE_VERSION: 8.10
 
 jobs:
   build:
@@ -20,8 +20,6 @@ jobs:
       matrix:
         sample:
           - samples/server/petstore/kotlin-server/javalin-6
-          - samples/server/petstore/kotlin-server/jaxrs-spec
-          - samples/server/petstore/kotlin-server/jaxrs-spec-mutiny
           - samples/server/petstore/kotlin-server/ktor
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/samples-kotlin-server-jdk21.yaml
+++ b/.github/workflows/samples-kotlin-server-jdk21.yaml
@@ -2,7 +2,7 @@ name: Samples Kotlin server (jdk21)
 
 on:
   push:
-    branches:
+    paths:
       - 'samples/server/petstore/kotlin-server/javalin-6/**'
   pull_request:
     paths:

--- a/.github/workflows/samples-kotlin-server-jdk21.yaml
+++ b/.github/workflows/samples-kotlin-server-jdk21.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    name: Build Kotlin server
+    name: Build Kotlin server (jdk21)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/samples-kotlin-server.yaml
+++ b/.github/workflows/samples-kotlin-server.yaml
@@ -1,4 +1,4 @@
-name: Samples Kotlin server
+name: Samples Kotlin server (jdk8)
 
 on:
   push:
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build:
-    name: Build Kotlin server
+    name: Build Kotlin server (jdk8)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/samples-kotlin-server.yaml
+++ b/.github/workflows/samples-kotlin-server.yaml
@@ -2,7 +2,7 @@ name: Samples Kotlin server
 
 on:
   push:
-    branches:
+    paths:
       - samples/server/others/kotlin-server/jaxrs-spec/**
       - 'samples/server/petstore/kotlin*/**'
       - 'samples/server/others/kotlin-server/jaxrs-spec-array-response/**'

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/build.gradle.kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/build.gradle.kts.mustache
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.9.21"
+    kotlin("jvm") version "1.9.25"
 }
 
 group = "{{groupId}}"

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/build.gradle.kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/build.gradle.kts.mustache
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.0.0"
+    kotlin("jvm") version "2.0.21"
 }
 
 group = "{{groupId}}"

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradle-sb3-Kts.mustache
@@ -20,7 +20,7 @@ tasks.bootJar {
 
 {{/interfaceOnly}}
 plugins {
-    val kotlinVersion = "1.7.10"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradleKts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradleKts.mustache
@@ -27,7 +27,7 @@ tasks.bootJar {
 
 {{/interfaceOnly}}
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
@@ -14,7 +14,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.7.10"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradleKts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradleKts.mustache
@@ -21,7 +21,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-server/javalin-6/build.gradle.kts
+++ b/samples/server/petstore/kotlin-server/javalin-6/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.0.21"
+    kotlin("jvm") version "2.0.0"
 }
 
 group = "org.openapitools"

--- a/samples/server/petstore/kotlin-server/javalin-6/build.gradle.kts
+++ b/samples/server/petstore/kotlin-server/javalin-6/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.0.0"
+    kotlin("jvm") version "2.0.21"
 }
 
 group = "org.openapitools"

--- a/samples/server/petstore/kotlin-server/javalin/build.gradle.kts
+++ b/samples/server/petstore/kotlin-server/javalin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.9.21"
+    kotlin("jvm") version "1.9.25"
 }
 
 group = "org.openapitools"

--- a/samples/server/petstore/kotlin-server/javalin/build.gradle.kts
+++ b/samples/server/petstore/kotlin-server/javalin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.9.25"
+    kotlin("jvm") version "1.9.21"
 }
 
 group = "org.openapitools"

--- a/samples/server/petstore/kotlin-spring-cloud/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-cloud/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-spring-default/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-default/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-3/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-3/build.gradle.kts
@@ -14,7 +14,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.7.10"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-3/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-3/build.gradle.kts
@@ -14,7 +14,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.9.25"
+    val kotlinVersion = "1.7.10"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-bigdecimal-default/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-bigdecimal-default/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/build.gradle.kts
@@ -14,7 +14,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.7.10"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/build.gradle.kts
@@ -14,7 +14,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.9.25"
+    val kotlinVersion = "1.7.10"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-delegate/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-delegate/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-integer-enum/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-integer-enum/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.bootJar {
 }
 
 plugins {
-    val kotlinVersion = "1.7.10"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-modelMutable/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-multipart-request-model/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-multipart-request-model/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-reactive/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-reactive/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-request-cookie/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.bootJar {
 }
 
 plugins {
-    val kotlinVersion = "1.7.10"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-request-cookie/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.bootJar {
 }
 
 plugins {
-    val kotlinVersion = "1.9.25"
+    val kotlinVersion = "1.7.10"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot-springfox/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-springfox/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion

--- a/samples/server/petstore/kotlin-springboot/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.25"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

In https://github.com/OpenAPITools/openapi-generator/commit/3240c5baf0ba11d4a0408fb742d218ad4d694632, @wing328 bumped the version of `org.springdoc:springdoc-openapi-starter-webmvc-ui` to `2.6.0` for the `kotlin-springboot-request-cookie` sample.

In [this PR](https://github.com/OpenAPITools/openapi-generator/pull/20054), the tests for said sample are now failing with:

```
e: /home/runner/.gradle/caches/modules-2/files-2.1/org.springdoc/springdoc-openapi-starter-common/2.6.0/c8cf5fbd1f9e4c410d67f1de27dfc3529de13620/springdoc-openapi-starter-common-2.6.0.jar!/META-INF/springdoc-openapi-starter-common.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is 1.7.1.
```

Let's bump the Kotlin versions in the samples that are actively tested in CI ([here](https://github.com/OpenAPITools/openapi-generator/blob/master/.github/workflows/samples-kotlin-server-jdk17.yaml#L29)), and also ensure that the tests are triggered when anything changes in those folders.

Tagging the Kotlin technical committee: @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
