### PR TITLE
[typescript] fix Inversify type checks on CI

### DIFF
--- a/bin/configs/typescript-consolidated-inversify.yaml
+++ b/bin/configs/typescript-consolidated-inversify.yaml
@@ -8,3 +8,4 @@ additionalProperties:
   useInversify: true
   projectName: ts-petstore-client
   moduleName: petstore
+  supportsES6: true

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
-import * as FormData from "form-data";
+import  FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
-import * as FormData from "form-data";
+import  FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
@@ -2,7 +2,7 @@
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
 import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
-import * as FormData from "form-data";
+import  FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
@@ -1,5 +1,5 @@
 // TODO: evaluate if we can easily get rid of this library
-import * as FormData from "form-data";
+import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/package.json
@@ -15,10 +15,11 @@
   ],
   "license": "Unlicense",
   "main": "./dist/index.js",
-  "type": "commonjs",
+  "type": "module",
+  "module": "./dist/index.js",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.js"
     }
   },

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/tsconfig.json
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "strict": true,
     /* Basic Options */
-    "target": "es5",
+    "target": "es6",
+    "esModuleInterop": true,
     "moduleResolution": "node",
     "declaration": true,
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

On the current `master` branch, the "TypeScript clients type checks" check is failing with:

```
➤ samples/openapi3/client/petstore/typescript/builds/inversify

added 26 packages in 2s
Error: node_modules/@inversifyjs/common/lib/cjs/services/models/LazyServiceIdentifier.d.ts(4,5): error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
Error: node_modules/@inversifyjs/core/lib/cjs/legacyTarget/models/LegacyTargetImpl.d.ts(10,5): error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
Error: Process completed with exit code 2.
```

Let's enable `supportsES6` in the sample testing to get rid of the error.

There is https://github.com/OpenAPITools/openapi-generator/pull/16187 which will enable es6 across the board by default, but it doesn't seem to be ready just yet.

Tagging the technical committee: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
