### PR TITLE
[typescript] make TypeScript version configurable and default to v5

### DIFF
--- a/docs/generators/typescript.md
+++ b/docs/generators/typescript.md
@@ -42,6 +42,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |supportsES6|Generate code that conforms to ES6.| |false|
+|typescriptMajorVersion|Specify the major version of TypeScript to use in the client code. Default is 5.| |5|
 |useInversify|Enable this to generate decorators and service identifiers for the InversifyJS inversion of control container. If you set 'deno' as 'platform', the generator will process this value as 'disable'.| |false|
 |useObjectParameters|Use aggregate parameter objects as function arguments for api operations instead of passing each parameter as a separate function argument.| |false|
 |useRxJS|Enable this to internally use rxjs observables. If disabled, a stub is used instead. This is required for the 'angular' framework.| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -76,6 +76,9 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
     private static final String USE_OBJECT_PARAMS_SWITCH = "useObjectParameters";
     private static final String USE_OBJECT_PARAMS_DESC = "Use aggregate parameter objects as function arguments for api operations instead of passing each parameter as a separate function argument.";
 
+    protected static final String TYPESCRIPT_MAJOR_VERSION_SWTICH = "typescriptMajorVersion";
+    private static final String TYPESCRIPT_MAJOR_VERSION_DESC = "Specify the major version of TypeScript to use in the client code. Default is 5.";
+
     private final Map<String, String> frameworkToHttpLibMap;
 
     // NPM Options
@@ -86,6 +89,9 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
     protected String npmRepository = null;
     protected String snapshot = null;
     protected ENUM_PROPERTY_NAMING_TYPE enumPropertyNaming = ENUM_PROPERTY_NAMING_TYPE.PascalCase;
+
+    @Getter @Setter
+    protected String typescriptMajorVersion = "5";
 
     private final DateTimeFormatter iso8601Date = DateTimeFormatter.ISO_DATE;
     private final DateTimeFormatter iso8601DateTime = DateTimeFormatter.ISO_DATE_TIME;
@@ -119,6 +125,7 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
         cliOptions.add(new CliOption(TypeScriptClientCodegen.USE_RXJS_SWITCH, TypeScriptClientCodegen.USE_RXJS_SWITCH_DESC).defaultValue("false"));
         cliOptions.add(new CliOption(TypeScriptClientCodegen.USE_OBJECT_PARAMS_SWITCH, TypeScriptClientCodegen.USE_OBJECT_PARAMS_DESC).defaultValue("false"));
         cliOptions.add(new CliOption(TypeScriptClientCodegen.USE_INVERSIFY_SWITCH, TypeScriptClientCodegen.USE_INVERSIFY_SWITCH_DESC).defaultValue("false"));
+        cliOptions.add(new CliOption(TypeScriptClientCodegen.TYPESCRIPT_MAJOR_VERSION_SWTICH, TypeScriptClientCodegen.TYPESCRIPT_MAJOR_VERSION_DESC).defaultValue(this.getTypescriptMajorVersion()));
         cliOptions.add(new CliOption(TypeScriptClientCodegen.IMPORT_FILE_EXTENSION_SWITCH, TypeScriptClientCodegen.IMPORT_FILE_EXTENSION_SWITCH_DESC));
 
         CliOption frameworkOption = new CliOption(TypeScriptClientCodegen.FRAMEWORK_SWITCH, TypeScriptClientCodegen.FRAMEWORK_SWITCH_DESC);
@@ -459,6 +466,8 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
         if (additionalProperties.containsKey(NPM_REPOSITORY)) {
             setNpmRepository(additionalProperties.get(NPM_REPOSITORY).toString());
         }
+
+        additionalProperties.put(TYPESCRIPT_MAJOR_VERSION_SWTICH, typescriptMajorVersion);
     }
 
     private String getHttpLibForFramework(String object) {

--- a/modules/openapi-generator/src/main/resources/typescript/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/package.mustache
@@ -75,7 +75,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^{{typescriptMajorVersion}}.0",
     "@types/url-parse": "1.4.4"
   }{{#npmRepository}},{{/npmRepository}}
 {{#npmRepository}}

--- a/samples/client/others/typescript/builds/array-of-lists/package.json
+++ b/samples/client/others/typescript/builds/array-of-lists/package.json
@@ -36,7 +36,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^5.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/client/others/typescript/builds/enum-single-value/package.json
+++ b/samples/client/others/typescript/builds/enum-single-value/package.json
@@ -36,7 +36,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^5.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/client/others/typescript/builds/null-types-simple/package.json
+++ b/samples/client/others/typescript/builds/null-types-simple/package.json
@@ -36,7 +36,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^5.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/client/others/typescript/builds/with-unique-items/package.json
+++ b/samples/client/others/typescript/builds/with-unique-items/package.json
@@ -36,7 +36,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^5.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/client/others/typescript/encode-decode/build/package.json
+++ b/samples/client/others/typescript/encode-decode/build/package.json
@@ -39,7 +39,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^5.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/browser/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/package.json
@@ -37,7 +37,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^5.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/package.json
@@ -36,7 +36,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^5.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/default/package.json
@@ -39,7 +39,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^5.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/package.json
@@ -39,7 +39,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^5.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/package.json
@@ -41,7 +41,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^5.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/package.json
@@ -37,7 +37,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^5.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/package.json
@@ -36,7 +36,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^5.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/package.json
@@ -39,7 +39,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^4.0",
+    "typescript": "^5.0",
     "@types/url-parse": "1.4.4"
   }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

TypeScript 5 was [released](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/) in March of 2023, and has been adopted by many projects by now. The `typescript` client generator still defaults to v4, and will probably run into problems at some point.

Let's make the TypeScript version configurable, and default to v5 in all samples.

**Not sure if the bump to v5 would be considered a breaking change**. If it is, happy to keep the default at v4 for now. However, I assume most folks will be maintaining their own `package.json` with other versions in real projects.

Tagging the technical committee: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
