### PR TITLE
[GO]Returning the correct data type from the GO server function `New{{{classname}}}FromValue` Update model.mustache

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/model.mustache
@@ -51,7 +51,8 @@ func New{{{classname}}}FromValue(v {{{format}}}{{^format}}{{dataType}}{{/format}
 		return ev, nil
 	}
 
-	return "", fmt.Errorf("invalid value '%v' for {{{classname}}}: valid values are %v", v, Allowed{{{classname}}}EnumValues)
+	noValue := new({{{classname}}})
+	return *noValue, fmt.Errorf("invalid value '%v' for {{{classname}}}: valid values are %v", v, Allowed{{{classname}}}EnumValues)
 }
 
 {{/isEnum}}{{^isEnum}}{{#description}}


### PR DESCRIPTION
Fixes https://github.com/OpenAPITools/openapi-generator/issues/20084
Returns the correct data type

Returning the correct data type from the GO server function `New{{{classname}}}FromValue`
The current implementation has a bug since it always returns an empty string when the `ev` is not valid.

Previous bugged code
```go
func NewErrorCodesFromValue(v int32) (ErrorCodes, error) {
	ev := ErrorCodes(v)
	if ev.IsValid() {
		return ev, nil
	}

	return "", fmt.Errorf("invalid value '%v' for ErrorCodes: valid values are %v", v, AllowedErrorCodesEnumValues)
}
```

The fixed code 
```go
func NewErrorCodesFromValue(v int32) (ErrorCodes, error) {
	ev := ErrorCodes(v)
	if ev.IsValid() {
		return ev, nil
	}
	noValue := new(ErrorCodes)
	return *noValue, fmt.Errorf("invalid value '%v' for ErrorCodes: valid values are %v", v, AllowedErrorCodesEnumValues)
}
```
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
