### PR TITLE
erlang-server: Extend provided return and make the type available

### DIFF
--- a/modules/openapi-generator/src/main/resources/erlang-server/logic_handler.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/logic_handler.mustache
@@ -22,7 +22,8 @@
 -type context() :: #{_ := _}.
 
 -export_type([context/0, api_key_callback/0,
-              accept_callback_return/0, accept_callback/0, provide_callback/0]).
+              accept_callback_return/0, provide_callback_return/0,
+              accept_callback/0, provide_callback/0]).
 
 -optional_callbacks([api_key_callback/2]).
 

--- a/samples/server/echo_api/erlang-server/src/openapi_logic_handler.erl
+++ b/samples/server/echo_api/erlang-server/src/openapi_logic_handler.erl
@@ -22,7 +22,8 @@
 -type context() :: #{_ := _}.
 
 -export_type([context/0, api_key_callback/0,
-              accept_callback_return/0, accept_callback/0, provide_callback/0]).
+              accept_callback_return/0, provide_callback_return/0,
+              accept_callback/0, provide_callback/0]).
 
 -optional_callbacks([api_key_callback/2]).
 

--- a/samples/server/petstore/erlang-server/src/openapi_logic_handler.erl
+++ b/samples/server/petstore/erlang-server/src/openapi_logic_handler.erl
@@ -22,7 +22,8 @@
 -type context() :: #{_ := _}.
 
 -export_type([context/0, api_key_callback/0,
-              accept_callback_return/0, accept_callback/0, provide_callback/0]).
+              accept_callback_return/0, provide_callback_return/0,
+              accept_callback/0, provide_callback/0]).
 
 -optional_callbacks([api_key_callback/2]).
 


### PR DESCRIPTION
I'm afraid I forgot in the previous https://github.com/OpenAPITools/openapi-generator/pull/20087 to export the newly created type. It should all be correct now 🥲 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.