### PR TITLE
[kotlin][client] do not generate Serializable(forClass) annotation as the serializer is already defined

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -146,7 +146,6 @@ import {{packageName}}.infrastructure.ITransformForStorage
     {{#kotlinx_serialization}}
     {{#enumUnknownDefaultCase}}
 
-    @Serializer(forClass = {{{nameInPascalCase}}}::class)
     internal object {{nameInPascalCase}}Serializer : KSerializer<{{nameInPascalCase}}> {
         override val descriptor = {{{dataType}}}.serializer().descriptor
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -97,7 +97,6 @@ import kotlinx.serialization.*
     }
 }{{#kotlinx_serialization}}{{#enumUnknownDefaultCase}}
 
-@Serializer(forClass = {{classname}}::class)
 internal object {{classname}}Serializer : KSerializer<{{classname}}> {
     override val descriptor = {{{dataType}}}.serializer().descriptor
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/AtomicBooleanAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/AtomicBooleanAdapter.kt.mustache
@@ -1,7 +1,6 @@
 package {{packageName}}.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.concurrent.atomic.AtomicBoolean
 
-@Serializer(forClass = AtomicBoolean::class)
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object AtomicBooleanAdapter : KSerializer<AtomicBoolean> {
     override fun serialize(encoder: Encoder, value: AtomicBoolean) {
         encoder.encodeBoolean(value.get())

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/AtomicIntegerAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/AtomicIntegerAdapter.kt.mustache
@@ -1,7 +1,6 @@
 package {{packageName}}.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.concurrent.atomic.AtomicInteger
 
-@Serializer(forClass = AtomicInteger::class)
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object AtomicIntegerAdapter : KSerializer<AtomicInteger> {
     override fun serialize(encoder: Encoder, value: AtomicInteger) {
         encoder.encodeInt(value.get())

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/AtomicLongAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/AtomicLongAdapter.kt.mustache
@@ -1,7 +1,6 @@
 package {{packageName}}.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.concurrent.atomic.AtomicLong
 
-@Serializer(forClass = AtomicLong::class)
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object AtomicLongAdapter : KSerializer<AtomicLong> {
     override fun serialize(encoder: Encoder, value: AtomicLong) {
         encoder.encodeLong(value.get())

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/BigDecimalAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/BigDecimalAdapter.kt.mustache
@@ -2,7 +2,6 @@ package {{packageName}}.infrastructure
 
 {{#kotlinx_serialization}}
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -16,7 +15,6 @@ import com.squareup.moshi.ToJson
 import java.math.BigDecimal
 
 {{#kotlinx_serialization}}
-@Serializer(forClass = BigDecimal::class)
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object BigDecimalAdapter : KSerializer<BigDecimal> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigDecimal", PrimitiveKind.STRING)
     override fun deserialize(decoder: Decoder): BigDecimal = BigDecimal(decoder.decodeString())

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/BigIntegerAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/BigIntegerAdapter.kt.mustache
@@ -2,7 +2,6 @@ package {{packageName}}.infrastructure
 
 {{#kotlinx_serialization}}
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -16,7 +15,6 @@ import com.squareup.moshi.ToJson
 import java.math.BigInteger
 
 {{#kotlinx_serialization}}
-@Serializer(forClass = BigInteger::class)
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object BigIntegerAdapter : KSerializer<BigInteger> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigInteger", PrimitiveKind.STRING)
     override fun deserialize(decoder: Decoder): BigInteger {

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/LocalDateAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/LocalDateAdapter.kt.mustache
@@ -13,7 +13,6 @@ import java.io.IOException
 {{/gson}}
 {{#kotlinx_serialization}}
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -87,7 +86,6 @@ import kotlinx.datetime.LocalDate
 {{/gson}}
 {{#kotlinx_serialization}}
 {{^kotlinx-datetime}}
-@Serializer(forClass = LocalDate::class)
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object LocalDateAdapter : KSerializer<LocalDate> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDate", PrimitiveKind.STRING)
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/LocalDateTimeAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/LocalDateTimeAdapter.kt.mustache
@@ -13,7 +13,6 @@ import java.io.IOException
 {{/gson}}
 {{#kotlinx_serialization}}
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -87,7 +86,6 @@ import kotlinx.datetime.LocalDateTime
 {{/gson}}
 {{#kotlinx_serialization}}
 {{^kotlinx-datetime}}
-@Serializer(forClass = LocalDateTime::class)
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object LocalDateTimeAdapter : KSerializer<LocalDateTime> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/OffsetDateTimeAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/OffsetDateTimeAdapter.kt.mustache
@@ -13,7 +13,6 @@ import java.io.IOException
 {{/gson}}
 {{#kotlinx_serialization}}
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -71,7 +70,6 @@ import org.threeten.bp.format.DateTimeFormatter
 }
 {{/gson}}
 {{#kotlinx_serialization}}
-@Serializer(forClass = OffsetDateTime::class)
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object OffsetDateTimeAdapter : KSerializer<OffsetDateTime> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("OffsetDateTime", PrimitiveKind.STRING)
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/StringBuilderAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/StringBuilderAdapter.kt.mustache
@@ -1,14 +1,12 @@
 package {{packageName}}.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 
-@Serializer(forClass = StringBuilder::class)
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object StringBuilderAdapter : KSerializer<StringBuilder> {
     override fun serialize(encoder: Encoder, value: StringBuilder) {
         encoder.encodeString(value.toString())

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/URIAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/URIAdapter.kt.mustache
@@ -2,7 +2,6 @@ package {{packageName}}.infrastructure
 
 {{#kotlinx_serialization}}
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -25,7 +24,6 @@ import java.net.URI
 }
 {{/moshi}}
 {{#kotlinx_serialization}}
-@Serializer(forClass = URI::class)
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object URIAdapter : KSerializer<URI> {
     override fun serialize(encoder: Encoder, value: URI) {
         encoder.encodeString(value.toASCIIString())

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/URLAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/URLAdapter.kt.mustache
@@ -1,7 +1,6 @@
 package {{packageName}}.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.net.URL
 
-@Serializer(forClass = URL::class)
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object URLAdapter : KSerializer<URL> {
     override fun serialize(encoder: Encoder, value: URL) {
         encoder.encodeString(value.toExternalForm())

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/UUIDAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/UUIDAdapter.kt.mustache
@@ -2,7 +2,6 @@ package {{packageName}}.infrastructure
 
 {{#kotlinx_serialization}}
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -25,7 +24,6 @@ import java.util.UUID
 }
 {{/moshi}}
 {{#kotlinx_serialization}}
-@Serializer(forClass = UUID::class)
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object UUIDAdapter : KSerializer<UUID> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/AtomicBooleanAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/AtomicBooleanAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.concurrent.atomic.AtomicBoolean
 
-@Serializer(forClass = AtomicBoolean::class)
 object AtomicBooleanAdapter : KSerializer<AtomicBoolean> {
     override fun serialize(encoder: Encoder, value: AtomicBoolean) {
         encoder.encodeBoolean(value.get())

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/AtomicIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/AtomicIntegerAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.concurrent.atomic.AtomicInteger
 
-@Serializer(forClass = AtomicInteger::class)
 object AtomicIntegerAdapter : KSerializer<AtomicInteger> {
     override fun serialize(encoder: Encoder, value: AtomicInteger) {
         encoder.encodeInt(value.get())

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/AtomicLongAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/AtomicLongAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.concurrent.atomic.AtomicLong
 
-@Serializer(forClass = AtomicLong::class)
 object AtomicLongAdapter : KSerializer<AtomicLong> {
     override fun serialize(encoder: Encoder, value: AtomicLong) {
         encoder.encodeLong(value.get())

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.math.BigDecimal
 
-@Serializer(forClass = BigDecimal::class)
 object BigDecimalAdapter : KSerializer<BigDecimal> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigDecimal", PrimitiveKind.STRING)
     override fun deserialize(decoder: Decoder): BigDecimal = BigDecimal(decoder.decodeString())

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.math.BigInteger
 
-@Serializer(forClass = BigInteger::class)
 object BigIntegerAdapter : KSerializer<BigInteger> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigInteger", PrimitiveKind.STRING)
     override fun deserialize(decoder: Decoder): BigInteger {

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -10,7 +9,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-@Serializer(forClass = LocalDate::class)
 object LocalDateAdapter : KSerializer<LocalDate> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDate", PrimitiveKind.STRING)
 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -10,7 +9,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-@Serializer(forClass = LocalDateTime::class)
 object LocalDateTimeAdapter : KSerializer<LocalDateTime> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -10,7 +9,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
-@Serializer(forClass = OffsetDateTime::class)
 object OffsetDateTimeAdapter : KSerializer<OffsetDateTime> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("OffsetDateTime", PrimitiveKind.STRING)
 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/StringBuilderAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/StringBuilderAdapter.kt
@@ -1,14 +1,12 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 
-@Serializer(forClass = StringBuilder::class)
 object StringBuilderAdapter : KSerializer<StringBuilder> {
     override fun serialize(encoder: Encoder, value: StringBuilder) {
         encoder.encodeString(value.toString())

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/URIAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/URIAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.net.URI
 
-@Serializer(forClass = URI::class)
 object URIAdapter : KSerializer<URI> {
     override fun serialize(encoder: Encoder, value: URI) {
         encoder.encodeString(value.toASCIIString())

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/URLAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/URLAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.net.URL
 
-@Serializer(forClass = URL::class)
 object URLAdapter : KSerializer<URL> {
     override fun serialize(encoder: Encoder, value: URL) {
         encoder.encodeString(value.toExternalForm())

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/UUIDAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/UUIDAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.UUID
 
-@Serializer(forClass = UUID::class)
 object UUIDAdapter : KSerializer<UUID> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -76,7 +76,6 @@ data class Order (
         @SerialName(value = "unknown_default_open_api") unknown_default_open_api("unknown_default_open_api");
     }
 
-    @Serializer(forClass = Status::class)
     internal object StatusSerializer : KSerializer<Status> {
         override val descriptor = kotlin.String.serializer().descriptor
 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -78,7 +78,6 @@ data class Pet (
         @SerialName(value = "unknown_default_open_api") unknown_default_open_api("unknown_default_open_api");
     }
 
-    @Serializer(forClass = Status::class)
     internal object StatusSerializer : KSerializer<Status> {
         override val descriptor = kotlin.String.serializer().descriptor
 

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/AtomicBooleanAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/AtomicBooleanAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.concurrent.atomic.AtomicBoolean
 
-@Serializer(forClass = AtomicBoolean::class)
 object AtomicBooleanAdapter : KSerializer<AtomicBoolean> {
     override fun serialize(encoder: Encoder, value: AtomicBoolean) {
         encoder.encodeBoolean(value.get())

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/AtomicIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/AtomicIntegerAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.concurrent.atomic.AtomicInteger
 
-@Serializer(forClass = AtomicInteger::class)
 object AtomicIntegerAdapter : KSerializer<AtomicInteger> {
     override fun serialize(encoder: Encoder, value: AtomicInteger) {
         encoder.encodeInt(value.get())

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/AtomicLongAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/AtomicLongAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.concurrent.atomic.AtomicLong
 
-@Serializer(forClass = AtomicLong::class)
 object AtomicLongAdapter : KSerializer<AtomicLong> {
     override fun serialize(encoder: Encoder, value: AtomicLong) {
         encoder.encodeLong(value.get())

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.math.BigDecimal
 
-@Serializer(forClass = BigDecimal::class)
 object BigDecimalAdapter : KSerializer<BigDecimal> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigDecimal", PrimitiveKind.STRING)
     override fun deserialize(decoder: Decoder): BigDecimal = BigDecimal(decoder.decodeString())

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.math.BigInteger
 
-@Serializer(forClass = BigInteger::class)
 object BigIntegerAdapter : KSerializer<BigInteger> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigInteger", PrimitiveKind.STRING)
     override fun deserialize(decoder: Decoder): BigInteger {

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -10,7 +9,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-@Serializer(forClass = LocalDate::class)
 object LocalDateAdapter : KSerializer<LocalDate> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDate", PrimitiveKind.STRING)
 

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -10,7 +9,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-@Serializer(forClass = LocalDateTime::class)
 object LocalDateTimeAdapter : KSerializer<LocalDateTime> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
 

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -10,7 +9,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
-@Serializer(forClass = OffsetDateTime::class)
 object OffsetDateTimeAdapter : KSerializer<OffsetDateTime> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("OffsetDateTime", PrimitiveKind.STRING)
 

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/StringBuilderAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/StringBuilderAdapter.kt
@@ -1,14 +1,12 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 
-@Serializer(forClass = StringBuilder::class)
 object StringBuilderAdapter : KSerializer<StringBuilder> {
     override fun serialize(encoder: Encoder, value: StringBuilder) {
         encoder.encodeString(value.toString())

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/URIAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/URIAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.net.URI
 
-@Serializer(forClass = URI::class)
 object URIAdapter : KSerializer<URI> {
     override fun serialize(encoder: Encoder, value: URI) {
         encoder.encodeString(value.toASCIIString())

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/URLAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/URLAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.net.URL
 
-@Serializer(forClass = URL::class)
 object URLAdapter : KSerializer<URL> {
     override fun serialize(encoder: Encoder, value: URL) {
         encoder.encodeString(value.toExternalForm())

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/UUIDAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/UUIDAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.UUID
 
-@Serializer(forClass = UUID::class)
 object UUIDAdapter : KSerializer<UUID> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
 

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/AtomicBooleanAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/AtomicBooleanAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.concurrent.atomic.AtomicBoolean
 
-@Serializer(forClass = AtomicBoolean::class)
 object AtomicBooleanAdapter : KSerializer<AtomicBoolean> {
     override fun serialize(encoder: Encoder, value: AtomicBoolean) {
         encoder.encodeBoolean(value.get())

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/AtomicIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/AtomicIntegerAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.concurrent.atomic.AtomicInteger
 
-@Serializer(forClass = AtomicInteger::class)
 object AtomicIntegerAdapter : KSerializer<AtomicInteger> {
     override fun serialize(encoder: Encoder, value: AtomicInteger) {
         encoder.encodeInt(value.get())

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/AtomicLongAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/AtomicLongAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.concurrent.atomic.AtomicLong
 
-@Serializer(forClass = AtomicLong::class)
 object AtomicLongAdapter : KSerializer<AtomicLong> {
     override fun serialize(encoder: Encoder, value: AtomicLong) {
         encoder.encodeLong(value.get())

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.math.BigDecimal
 
-@Serializer(forClass = BigDecimal::class)
 object BigDecimalAdapter : KSerializer<BigDecimal> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigDecimal", PrimitiveKind.STRING)
     override fun deserialize(decoder: Decoder): BigDecimal = BigDecimal(decoder.decodeString())

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.math.BigInteger
 
-@Serializer(forClass = BigInteger::class)
 object BigIntegerAdapter : KSerializer<BigInteger> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigInteger", PrimitiveKind.STRING)
     override fun deserialize(decoder: Decoder): BigInteger {

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -10,7 +9,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-@Serializer(forClass = LocalDate::class)
 object LocalDateAdapter : KSerializer<LocalDate> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDate", PrimitiveKind.STRING)
 

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -10,7 +9,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-@Serializer(forClass = LocalDateTime::class)
 object LocalDateTimeAdapter : KSerializer<LocalDateTime> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
 

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -10,7 +9,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
-@Serializer(forClass = OffsetDateTime::class)
 object OffsetDateTimeAdapter : KSerializer<OffsetDateTime> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("OffsetDateTime", PrimitiveKind.STRING)
 

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/StringBuilderAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/StringBuilderAdapter.kt
@@ -1,14 +1,12 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 
-@Serializer(forClass = StringBuilder::class)
 object StringBuilderAdapter : KSerializer<StringBuilder> {
     override fun serialize(encoder: Encoder, value: StringBuilder) {
         encoder.encodeString(value.toString())

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/URIAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/URIAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.net.URI
 
-@Serializer(forClass = URI::class)
 object URIAdapter : KSerializer<URI> {
     override fun serialize(encoder: Encoder, value: URI) {
         encoder.encodeString(value.toASCIIString())

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/URLAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/URLAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.net.URL
 
-@Serializer(forClass = URL::class)
 object URLAdapter : KSerializer<URL> {
     override fun serialize(encoder: Encoder, value: URL) {
         encoder.encodeString(value.toExternalForm())

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/UUIDAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/UUIDAdapter.kt
@@ -1,7 +1,6 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import java.util.UUID
 
-@Serializer(forClass = UUID::class)
 object UUIDAdapter : KSerializer<UUID> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
 

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/models/PetEnum.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/models/PetEnum.kt
@@ -68,7 +68,6 @@ enum class PetEnum(val value: kotlin.String) {
     }
 }
 
-@Serializer(forClass = PetEnum::class)
 internal object PetEnumSerializer : KSerializer<PetEnum> {
     override val descriptor = kotlin.String.serializer().descriptor
 


### PR DESCRIPTION
This removes excessive annotation that newly produces a warning that may prevent compilation of the generated code.

`@Serializable(forClass=x)` is intended for the Kotlin Serialization plugin to generate the serializable logic automatically. But since this generator generates this logic, there is nothing to be generated from the serialization plugin's side.

The error: 

`@Serializer annotation has no effect on class 'XXX', because all members of KSerializer are already overridden`

Documentation: https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md#deriving-external-serializer-for-another-kotlin-class-experimental


@e5l 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
