### PR TITLE
Fix explicit KSerializer's name & generation when used in container

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -111,7 +111,7 @@ import {{packageName}}.infrastructure.ITransformForStorage
      */
     {{^multiplatform}}
     {{#kotlinx_serialization}}
-    {{#serializableModel}}@KSerializable{{/serializableModel}}{{^serializableModel}}@Serializable{{#enumUnknownDefaultCase}}(with = {{classname}}Serializer::class){{/enumUnknownDefaultCase}}{{/serializableModel}}
+    {{#serializableModel}}@KSerializable{{/serializableModel}}{{^serializableModel}}@Serializable{{#enumUnknownDefaultCase}}(with = {{{nameInPascalCase}}}Serializer::class){{/enumUnknownDefaultCase}}{{/serializableModel}}
     {{/kotlinx_serialization}}
     {{#moshi}}
     @JsonClass(generateAdapter = false)

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -148,16 +148,16 @@ import {{packageName}}.infrastructure.ITransformForStorage
 
     @Serializer(forClass = {{{nameInPascalCase}}}::class)
     internal object {{nameInPascalCase}}Serializer : KSerializer<{{nameInPascalCase}}> {
-        override val descriptor = {{{dataType}}}.serializer().descriptor
+        override val descriptor = {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}kotlin.String{{/isContainer}}.serializer().descriptor
 
         override fun deserialize(decoder: Decoder): {{nameInPascalCase}} {
-            val value = decoder.decodeSerializableValue({{{dataType}}}.serializer())
+            val value = decoder.decodeSerializableValue({{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}kotlin.String{{/isContainer}}.serializer())
             return {{nameInPascalCase}}.values().firstOrNull { it.value == value }
                 ?: {{nameInPascalCase}}.{{#allowableValues}}{{#enumVars}}{{#-last}}{{&name}}{{/-last}}{{/enumVars}}{{/allowableValues}}
         }
 
         override fun serialize(encoder: Encoder, value: {{nameInPascalCase}}) {
-            encoder.encodeSerializableValue({{{dataType}}}.serializer(), value.value)
+            encoder.encodeSerializableValue({{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}kotlin.String{{/isContainer}}.serializer(), value.value)
         }
     }
     {{/enumUnknownDefaultCase}}

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -68,7 +68,7 @@ data class Order (
      *
      * Values: placed,approved,delivered,unknown_default_open_api
      */
-    @Serializable(with = OrderSerializer::class)
+    @Serializable(with = StatusSerializer::class)
     enum class Status(val value: kotlin.String) {
         @SerialName(value = "placed") placed("placed"),
         @SerialName(value = "approved") approved("approved"),

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -70,7 +70,7 @@ data class Pet (
      *
      * Values: available,pending,sold,unknown_default_open_api
      */
-    @Serializable(with = PetSerializer::class)
+    @Serializable(with = StatusSerializer::class)
     enum class Status(val value: kotlin.String) {
         @SerialName(value = "available") available("available"),
         @SerialName(value = "pending") pending("pending"),


### PR DESCRIPTION
This PR fixes two issues for explicit generation of KSerializer for enums (with auto unknown case):

- KSerializer's name - the referencing side was ok, but the referenced side was using the wrong variable (output shows the change)
- When the enum was a part of the container, the KSerializer was generated incorrectly (non-compiling). I copied the pattern from line 123 and it works flawlessly now. I am unable to show it in the generated code without changing pets schema.

@e5l

THIS IS FOLLOW UP FOR #20092

Example of the second issue:

Before:
```kotlin
@Serializable
data class CreatorFanclubPutRequestBodyDto (
    @SerialName(value = "creator_fanclub_types")
    val creatorFanclubTypes: kotlin.collections.List<CreatorFanclubPutRequestBodyDto.CreatorFanclubTypes>

) {
    @Serializable(with = CreatorFanclubTypesSerializer::class)
    enum class CreatorFanclubTypes(val value: kotlin.String) {
        @SerialName(value = "actors") ACTORS("actors"),
        @SerialName(value = "actresses") ACTRESSES("actresses"),
        @SerialName(value = "unknown_default_open_api") UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
    }

    internal object CreatorFanclubTypesSerializer : KSerializer<CreatorFanclubTypes> {
        override val descriptor = kotlin.collections.List&lt;kotlin.String&gt;.serializer().descriptor

        override fun deserialize(decoder: Decoder): CreatorFanclubTypes {
            val value = decoder.decodeSerializableValue(kotlin.collections.List&lt;kotlin.String&gt;.serializer())
            return CreatorFanclubTypes.values().firstOrNull { it.value == value }
                ?: CreatorFanclubTypes.UNKNOWN_DEFAULT_OPEN_API
        }

        override fun serialize(encoder: Encoder, value: CreatorFanclubTypes) {
            encoder.encodeSerializableValue(kotlin.collections.List&lt;kotlin.String&gt;.serializer(), value.value)
        }
    }
}

```

After:
```kotlin
@Serializable
data class CreatorFanclubPutRequestBodyDto (
    @SerialName(value = "creator_fanclub_types")
    val creatorFanclubTypes: kotlin.collections.List<CreatorFanclubPutRequestBodyDto.CreatorFanclubTypes>
) {
    @Serializable(with = CreatorFanclubTypesSerializer::class)
    enum class CreatorFanclubTypes(val value: kotlin.String) {
        @SerialName(value = "actors") ACTORS("actors"),
        @SerialName(value = "actresses") ACTRESSES("actresses"),
        @SerialName(value = "unknown_default_open_api") UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
    }

    internal object CreatorFanclubTypesSerializer : KSerializer<CreatorFanclubTypes> {
        override val descriptor = kotlin.String.serializer().descriptor

        override fun deserialize(decoder: Decoder): CreatorFanclubTypes {
            val value = decoder.decodeSerializableValue(kotlin.String.serializer())
            return CreatorFanclubTypes.values().firstOrNull { it.value == value }
                ?: CreatorFanclubTypes.UNKNOWN_DEFAULT_OPEN_API
        }

        override fun serialize(encoder: Encoder, value: CreatorFanclubTypes) {
            encoder.encodeSerializableValue(kotlin.String.serializer(), value.value)
        }
    }
}
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
