### PR TITLE
Update minimum supported version of python in docs

### DIFF
--- a/docs/generators/python.md
+++ b/docs/generators/python.md
@@ -10,7 +10,7 @@ title: Documentation for the python Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Python | |
-| generator language version | 3.7+ | |
+| generator language version | 3.8+ | |
 | generator default templating engine | mustache | |
 | helpTxt | Generates a Python client library. | |
 


### PR DESCRIPTION
Seems to have changed since: https://github.com/OpenAPITools/openapi-generator/pull/19694/files