### PR TITLE
[typescript-fetch] [BUG] Fix duplication of ModelNamePrefix in import statements

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -477,7 +477,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
                 HashMap<String, String> tsImport = new HashMap<>();
                 // TVG: This is used as class name in the import statements of the model file
                 tsImport.put("classname", im);
-                tsImport.put("filename", toModelFilename(im));
+                tsImport.put("filename", convertUsingFileNamingConvention(im));
                 tsImports.add(tsImport);
             }
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -266,6 +266,22 @@ public class TypeScriptFetchClientCodegenTest {
                 codegen.toApiFilename("FirstSimpleController"));
     }
 
+    @Test(description = "Verify names of files generated in kebab-case and imports with additional model prefix")
+    public void testGeneratedFilenamesInPascalCaseWithAdditionalModelPrefix() throws IOException {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("fileNaming", TypeScriptFetchClientCodegen.PASCAL_CASE);
+        properties.put(CodegenConstants.MODEL_NAME_PREFIX, "SomePrefix");
+
+        File output = generate(properties);
+
+        Path pet = Paths.get(output + "/models/SomePrefixPet.ts");
+        TestUtils.assertFileExists(pet);
+        TestUtils.assertFileContains(pet, "} from './SomePrefixPetCategory';");
+        TestUtils.assertFileExists(Paths.get(output + "/models/SomePrefixPetCategory.ts"));
+        TestUtils.assertFileExists(Paths.get(output + "/apis/PetControllerApi.ts"));
+    }
+
     @Test(description = "Verify names of files generated in kebab-case and imports")
     public void testGeneratedFilenamesInKebabCase() throws IOException {
 
@@ -281,6 +297,22 @@ public class TypeScriptFetchClientCodegenTest {
         TestUtils.assertFileExists(Paths.get(output + "/apis/pet-controller-api.ts"));
     }
 
+    @Test(description = "Verify names of files generated in kebab-case and imports with additional model prefix")
+    public void testGeneratedFilenamesInKebabCaseWithAdditionalModelPrefix() throws IOException {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("fileNaming", TypeScriptFetchClientCodegen.KEBAB_CASE);
+        properties.put(CodegenConstants.MODEL_NAME_PREFIX, "SomePrefix");
+
+        File output = generate(properties);
+
+        Path pet = Paths.get(output + "/models/some-prefix-pet.ts");
+        TestUtils.assertFileExists(pet);
+        TestUtils.assertFileContains(pet, "} from './some-prefix-pet-category';");
+        TestUtils.assertFileExists(Paths.get(output + "/models/some-prefix-pet-category.ts"));
+        TestUtils.assertFileExists(Paths.get(output + "/apis/pet-controller-api.ts"));
+    }
+
     @Test(description = "Verify names of files generated in camelCase and imports")
     public void testGeneratedFilenamesInCamelCase() throws IOException {
 
@@ -293,6 +325,22 @@ public class TypeScriptFetchClientCodegenTest {
         TestUtils.assertFileExists(pet);
         TestUtils.assertFileContains(pet, "} from './petCategory';");
         TestUtils.assertFileExists(Paths.get(output + "/models/petCategory.ts"));
+        TestUtils.assertFileExists(Paths.get(output + "/apis/petControllerApi.ts"));
+    }
+
+    @Test(description = "Verify names of files generated in camelCase and imports with additional model prefix")
+    public void testGeneratedFilenamesInCamelCaseWithAdditionalModelPrefix() throws IOException {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("fileNaming", TypeScriptFetchClientCodegen.CAMEL_CASE);
+        properties.put(CodegenConstants.MODEL_NAME_PREFIX, "SomePrefix");
+
+        File output = generate(properties);
+
+        Path pet = Paths.get(output + "/models/somePrefixPet.ts");
+        TestUtils.assertFileExists(pet);
+        TestUtils.assertFileContains(pet, "} from './somePrefixPetCategory';");
+        TestUtils.assertFileExists(Paths.get(output + "/models/somePrefixPetCategory.ts"));
         TestUtils.assertFileExists(Paths.get(output + "/apis/petControllerApi.ts"));
     }
 


### PR DESCRIPTION
This fixes an issue introduced in version 7.6.0. When using the ModelNamePrefix option with typescript-fetch, the given prefix is duplicated in import statements leading to compilation failure (see issue for how to reproduce). 

The root case is that the method `toModelFilename` that is adding prefix and suffix is called twice when generating the variables used to create import statements. 

Fixes https://github.com/OpenAPITools/openapi-generator/issues/19039

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)
