### PR TITLE
fixes(java/restclient) Force usage of custom converter

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
@@ -156,9 +156,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
         {{/withXml}}
         Consumer<List<HttpMessageConverter<?>>> messageConverters = converters -> {
-            converters.add(new MappingJackson2HttpMessageConverter(mapper));
+            converters.add(0, new MappingJackson2HttpMessageConverter(mapper));
             {{#withXml}}
-            converters.add(new MappingJackson2XmlHttpMessageConverter(xmlMapper));
+            converters.add(0, new MappingJackson2XmlHttpMessageConverter(xmlMapper));
             {{/withXml}}
         };
 

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -141,7 +141,7 @@ public class ApiClient extends JavaTimeFormatter {
     */
     public static RestClient.Builder buildRestClientBuilder(ObjectMapper mapper) {
         Consumer<List<HttpMessageConverter<?>>> messageConverters = converters -> {
-            converters.add(new MappingJackson2HttpMessageConverter(mapper));
+            converters.add(0, new MappingJackson2HttpMessageConverter(mapper));
         };
 
         return RestClient.builder().messageConverters(messageConverters);

--- a/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -139,7 +139,7 @@ public class ApiClient extends JavaTimeFormatter {
     */
     public static RestClient.Builder buildRestClientBuilder(ObjectMapper mapper) {
         Consumer<List<HttpMessageConverter<?>>> messageConverters = converters -> {
-            converters.add(new MappingJackson2HttpMessageConverter(mapper));
+            converters.add(0, new MappingJackson2HttpMessageConverter(mapper));
         };
 
         return RestClient.builder().messageConverters(messageConverters);

--- a/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
@@ -139,7 +139,7 @@ public class ApiClient extends JavaTimeFormatter {
     */
     public static RestClient.Builder buildRestClientBuilder(ObjectMapper mapper) {
         Consumer<List<HttpMessageConverter<?>>> messageConverters = converters -> {
-            converters.add(new MappingJackson2HttpMessageConverter(mapper));
+            converters.add(0, new MappingJackson2HttpMessageConverter(mapper));
         };
 
         return RestClient.builder().messageConverters(messageConverters);

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -145,7 +145,7 @@ public class ApiClient extends JavaTimeFormatter {
     */
     public static RestClient.Builder buildRestClientBuilder(ObjectMapper mapper) {
         Consumer<List<HttpMessageConverter<?>>> messageConverters = converters -> {
-            converters.add(new MappingJackson2HttpMessageConverter(mapper));
+            converters.add(0, new MappingJackson2HttpMessageConverter(mapper));
         };
 
         return RestClient.builder().messageConverters(messageConverters);

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
@@ -145,7 +145,7 @@ public class ApiClient extends JavaTimeFormatter {
     */
     public static RestClient.Builder buildRestClientBuilder(ObjectMapper mapper) {
         Consumer<List<HttpMessageConverter<?>>> messageConverters = converters -> {
-            converters.add(new MappingJackson2HttpMessageConverter(mapper));
+            converters.add(0, new MappingJackson2HttpMessageConverter(mapper));
         };
 
         return RestClient.builder().messageConverters(messageConverters);

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -145,7 +145,7 @@ public class ApiClient extends JavaTimeFormatter {
     */
     public static RestClient.Builder buildRestClientBuilder(ObjectMapper mapper) {
         Consumer<List<HttpMessageConverter<?>>> messageConverters = converters -> {
-            converters.add(new MappingJackson2HttpMessageConverter(mapper));
+            converters.add(0, new MappingJackson2HttpMessageConverter(mapper));
         };
 
         return RestClient.builder().messageConverters(messageConverters);


### PR DESCRIPTION
Insert custom converter at the beginning of the `RestClientBuilder` converter list so as not to use default `MappingJackson2HttpMessageConverter`

See #20111
