### PR TITLE
erlang-server: add jesse to app.up release

### DIFF
--- a/modules/openapi-generator/src/main/resources/erlang-server/app.src.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/app.src.mustache
@@ -4,7 +4,7 @@
    {{#appDescription}}"{{.}}"{{/appDescription}}{{^appDescription}}"OpenAPI rest server library"{{/appDescription}}},
   {vsn, "{{apiVersion}}"},
   {registered, []},
-  {applications, [kernel, stdlib, public_key, ssl, inets, ranch, cowboy]},
+  {applications, [kernel, stdlib, public_key, ssl, inets, ranch, cowboy, jesse]},
   {env, []},
   {modules, []},
   {licenses, [{{#licenseInfo}}"{{.}}"{{/licenseInfo}}]},

--- a/modules/openapi-generator/src/main/resources/erlang-server/rebar.config.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/rebar.config.mustache
@@ -8,7 +8,7 @@
 
 {dialyzer,
  [{plt_extra_apps, [cowboy, cowlib, ranch, jesse]},
-  {warnings, [missing_return, unknown]}
+  {warnings, [no_match, no_unused, missing_return, unknown]}
 ]}.
 
 {xref_checks,

--- a/samples/server/echo_api/erlang-server/rebar.config
+++ b/samples/server/echo_api/erlang-server/rebar.config
@@ -8,7 +8,7 @@
 
 {dialyzer,
  [{plt_extra_apps, [cowboy, cowlib, ranch, jesse]},
-  {warnings, [missing_return, unknown]}
+  {warnings, [no_match, no_unused, missing_return, unknown]}
 ]}.
 
 {xref_checks,

--- a/samples/server/echo_api/erlang-server/src/openapi.app.src
+++ b/samples/server/echo_api/erlang-server/src/openapi.app.src
@@ -4,7 +4,7 @@
    "Echo Server API"},
   {vsn, "1.0.0"},
   {registered, []},
-  {applications, [kernel, stdlib, public_key, ssl, inets, ranch, cowboy]},
+  {applications, [kernel, stdlib, public_key, ssl, inets, ranch, cowboy, jesse]},
   {env, []},
   {modules, []},
   {licenses, ["Apache 2.0"]},

--- a/samples/server/petstore/erlang-server/rebar.config
+++ b/samples/server/petstore/erlang-server/rebar.config
@@ -8,7 +8,7 @@
 
 {dialyzer,
  [{plt_extra_apps, [cowboy, cowlib, ranch, jesse]},
-  {warnings, [missing_return, unknown]}
+  {warnings, [no_match, no_unused, missing_return, unknown]}
 ]}.
 
 {xref_checks,

--- a/samples/server/petstore/erlang-server/src/openapi.app.src
+++ b/samples/server/petstore/erlang-server/src/openapi.app.src
@@ -4,7 +4,7 @@
    "This is a sample server Petstore server. For this sample, you can use the api key &#x60;special-key&#x60; to test the authorization filters."},
   {vsn, "1.0.0"},
   {registered, []},
-  {applications, [kernel, stdlib, public_key, ssl, inets, ranch, cowboy]},
+  {applications, [kernel, stdlib, public_key, ssl, inets, ranch, cowboy, jesse]},
   {env, []},
   {modules, []},
   {licenses, ["Apache-2.0"]},


### PR DESCRIPTION
Adding jesse to the release app.up specs. This should have popped up in a more barebones project but I'd previously tested this in much bigger projects where someone else was already using jesse as a dependency and therefore code passed correctly. Now going on with something smaller: https://github.com/esl/amoc-arsenal/pull/5 :)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.