### PR TITLE
[R] improve binary/text response handling

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/ApiResponse.mustache
+++ b/modules/openapi-generator/src/main/resources/r/ApiResponse.mustache
@@ -50,9 +50,6 @@ ApiResponse <- R6::R6Class(
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
-      if (is.na(text_response)) {
-        warning("The response is binary and will not be converted to text.")
-      }
       return(text_response)
     }
   )

--- a/modules/openapi-generator/src/main/resources/r/ApiResponse.mustache
+++ b/modules/openapi-generator/src/main/resources/r/ApiResponse.mustache
@@ -45,7 +45,7 @@ ApiResponse <- R6::R6Class(
     #'
     #' @param from_encoding The encoding of the raw response.
     #' @param to_encoding The target encoding of the return value.
-    ResponseAsText = function(from_encoding = "", to_encoding = "UTF-8") {
+    response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
       if (is.null(self$response)) {
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }

--- a/modules/openapi-generator/src/main/resources/r/ApiResponse.mustache
+++ b/modules/openapi-generator/src/main/resources/r/ApiResponse.mustache
@@ -45,7 +45,7 @@ ApiResponse <- R6::R6Class(
     #'
     #' @param from_encoding The encoding of the raw response.
     #' @param to_encoding The target encoding of the return value.
-    response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+    ResponseAsText = function(from_encoding = "", to_encoding = "UTF-8") {
       if (is.null(self$response)) {
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }

--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -153,11 +153,7 @@
 
       {{/vendorExtensions.x-streaming}}
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -547,12 +547,9 @@
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         {{#returnType}}
         {{#isPrimitiveType}}
-        local_var_content <- local_var_resp$response
-          local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE
-        )
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_content, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         ApiResponse$new(content,resp)
@@ -560,11 +557,11 @@
         {{^isPrimitiveType}}
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "{{returnType}}"),
           error = function(e) {
             {{#useDefaultExceptionHandling}}
             stop("Failed to deserialize response")
@@ -646,24 +643,50 @@
     {{/operation}}
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("{{packageName}}")))
     }
   )
 )

--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -545,7 +545,7 @@
         {{#isPrimitiveType}}
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         ApiResponse$new(content,resp)
@@ -553,11 +553,11 @@
         {{^isPrimitiveType}}
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "{{returnType}}"),
+          self$api_client$DeserializeResponse(local_var_resp, "{{returnType}}"),
           error = function(e) {
             {{#useDefaultExceptionHandling}}
             stop("Failed to deserialize response")
@@ -579,7 +579,7 @@
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
       {{#returnExceptionOnFailure}}
         
@@ -638,53 +638,6 @@
       }
     }{{^-last}},{{/-last}}
     {{/operation}}
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("{{packageName}}")))
-    }
   )
 )
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -577,9 +577,12 @@
         local_var_resp$content <- NULL
         {{/returnType}}
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
       {{#returnExceptionOnFailure}}
-        local_var_error_msg <- local_var_resp$response
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -597,7 +600,6 @@
         {{/returnExceptionOnFailure}}
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         {{#returnExceptionOnFailure}}
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -615,7 +617,6 @@
         {{/returnExceptionOnFailure}}
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
         {{#returnExceptionOnFailure}}
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -676,7 +677,7 @@
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -153,13 +153,17 @@
 
       {{/vendorExtensions.x-streaming}}
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -548,7 +552,7 @@
         )
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_content, data_file)
+          private$WriteFile(local_var_content, data_file, local_var_accepts)
         }
 
         ApiResponse$new(content,resp)
@@ -556,11 +560,11 @@
         {{^isPrimitiveType}}
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "{{returnType}}", loadNamespace("{{packageName}}")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             {{#useDefaultExceptionHandling}}
             stop("Failed to deserialize response")
@@ -579,7 +583,7 @@
         {{! Returning the ApiResponse object with NULL object when the endpoint doesn't return anything}}
         local_var_resp$content <- NULL
         {{/returnType}}
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
       {{#returnExceptionOnFailure}}
         local_var_error_msg <- local_var_resp$response
@@ -635,11 +639,32 @@
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
         {{/returnExceptionOnFailure}}
       }
     }{{^-last}},{{/-last}}
     {{/operation}}
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+    }
   )
 )
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/r/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api_client.mustache
@@ -430,6 +430,52 @@ ApiClient <- R6::R6Class(
         # not json mime type, simply return the first one
         return(headers[1])
       }
+    },
+
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    DeserializeResponse = function(local_var_resp, return_type = NULL) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
+      }
+      return(self$deserialize(text, return_type, loadNamespace("{{packageName}}")))
+    },
+
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (self$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
+      } else {
+        response <- self$DeserializeResponse(local_var_resp)
+        base::write(response, file)
+      }
+    },
+
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     }
   )
 )

--- a/modules/openapi-generator/src/main/resources/r/api_exception.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api_exception.mustache
@@ -32,7 +32,7 @@ ApiException <- R6::R6Class(
     initialize = function(status = NULL, reason = NULL, http_response = NULL) {
       if (!is.null(http_response)) {
         self$status <- http_response$status_code
-        errorMsg <- http_response$response
+        errorMsg <- http_response$ResponseAsText()
         if (is.null(errorMsg) || errorMsg == "") {
           errorMsg <- "Api exception encountered. No details given."
         }
@@ -40,7 +40,7 @@ ApiException <- R6::R6Class(
         self$headers <- http_response$headers
         self$reason <- http_response$http_status_desc
         {{#errorObjectType}}
-        self$error_object <- {{errorObjectType}}$new()$fromJSONString(http_response$response)
+        self$error_object <- {{errorObjectType}}$new()$fromJSONString(http_response$ResponseAsText())
         {{/errorObjectType}}
       } else {
         self$status <- status

--- a/modules/openapi-generator/src/main/resources/r/api_exception.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api_exception.mustache
@@ -32,7 +32,7 @@ ApiException <- R6::R6Class(
     initialize = function(status = NULL, reason = NULL, http_response = NULL) {
       if (!is.null(http_response)) {
         self$status <- http_response$status_code
-        errorMsg <- http_response$ResponseAsText()
+        errorMsg <- http_response$response_as_text()
         if (is.null(errorMsg) || errorMsg == "") {
           errorMsg <- "Api exception encountered. No details given."
         }
@@ -40,7 +40,7 @@ ApiException <- R6::R6Class(
         self$headers <- http_response$headers
         self$reason <- http_response$http_status_desc
         {{#errorObjectType}}
-        self$error_object <- {{errorObjectType}}$new()$fromJSONString(http_response$ResponseAsText())
+        self$error_object <- {{errorObjectType}}$new()$fromJSONString(http_response$response_as_text())
         {{/errorObjectType}}
       } else {
         self$status <- status

--- a/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
@@ -443,6 +443,52 @@ ApiClient  <- R6::R6Class(
         # not json mime type, simply return the first one
         return(headers[1])
       }
+    },
+
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    DeserializeResponse = function(local_var_resp, return_type = NULL) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
+      }
+      return(self$deserialize(text, return_type, loadNamespace("{{packageName}}")))
+    },
+
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (self$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
+      } else {
+        response <- self$DeserializeResponse(local_var_resp)
+        base::write(response, file)
+      }
+    },
+
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     }
   )
 )

--- a/samples/client/echo_api/r/R/api_client.R
+++ b/samples/client/echo_api/r/R/api_client.R
@@ -382,6 +382,52 @@ ApiClient <- R6::R6Class(
         # not json mime type, simply return the first one
         return(headers[1])
       }
+    },
+
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    DeserializeResponse = function(local_var_resp, return_type = NULL) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
+      }
+      return(self$deserialize(text, return_type, loadNamespace("openapi")))
+    },
+
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (self$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
+      } else {
+        response <- self$DeserializeResponse(local_var_resp)
+        base::write(response, file)
+      }
+    },
+
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     }
   )
 )

--- a/samples/client/echo_api/r/R/api_response.R
+++ b/samples/client/echo_api/r/R/api_response.R
@@ -57,9 +57,6 @@ ApiResponse <- R6::R6Class(
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
-      if (is.na(text_response)) {
-        warning("The response is binary and will not be converted to text.")
-      }
       return(text_response)
     }
   )

--- a/samples/client/echo_api/r/R/api_response.R
+++ b/samples/client/echo_api/r/R/api_response.R
@@ -52,7 +52,7 @@ ApiResponse <- R6::R6Class(
     #'
     #' @param from_encoding The encoding of the raw response.
     #' @param to_encoding The target encoding of the return value.
-    response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+    ResponseAsText = function(from_encoding = "", to_encoding = "UTF-8") {
       if (is.null(self$response)) {
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }

--- a/samples/client/echo_api/r/R/api_response.R
+++ b/samples/client/echo_api/r/R/api_response.R
@@ -52,7 +52,7 @@ ApiResponse <- R6::R6Class(
     #'
     #' @param from_encoding The encoding of the raw response.
     #' @param to_encoding The target encoding of the return value.
-    ResponseAsText = function(from_encoding = "", to_encoding = "UTF-8") {
+    response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
       if (is.null(self$response)) {
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }

--- a/samples/client/echo_api/r/R/auth_api.R
+++ b/samples/client/echo_api/r/R/auth_api.R
@@ -137,11 +137,11 @@ AuthApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -229,11 +229,11 @@ AuthApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -253,24 +253,50 @@ AuthApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("openapi")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/auth_api.R
+++ b/samples/client/echo_api/r/R/auth_api.R
@@ -78,11 +78,7 @@ AuthApi <- R6::R6Class(
     TestAuthHttpBasic = function(data_file = NULL, ...) {
       local_var_response <- self$TestAuthHttpBasicWithHttpInfo(data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -170,11 +166,7 @@ AuthApi <- R6::R6Class(
     TestAuthHttpBearer = function(data_file = NULL, ...) {
       local_var_response <- self$TestAuthHttpBearerWithHttpInfo(data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/echo_api/r/R/auth_api.R
+++ b/samples/client/echo_api/r/R/auth_api.R
@@ -144,7 +144,10 @@ AuthApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -232,7 +235,10 @@ AuthApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -282,7 +288,7 @@ AuthApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/echo_api/r/R/auth_api.R
+++ b/samples/client/echo_api/r/R/auth_api.R
@@ -133,11 +133,11 @@ AuthApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -146,7 +146,7 @@ AuthApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -224,11 +224,11 @@ AuthApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -237,7 +237,7 @@ AuthApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -248,53 +248,6 @@ AuthApi <- R6::R6Class(
         }
         return(local_var_resp)
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("openapi")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/body_api.R
+++ b/samples/client/echo_api/r/R/body_api.R
@@ -184,13 +184,17 @@ BodyApi <- R6::R6Class(
     TestBinaryGif = function(data_file = NULL, ...) {
       local_var_response <- self$TestBinaryGifWithHttpInfo(data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -235,17 +239,17 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "data.frame", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -254,7 +258,7 @@ BodyApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -269,13 +273,17 @@ BodyApi <- R6::R6Class(
     TestBodyApplicationOctetstreamBinary = function(body = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestBodyApplicationOctetstreamBinaryWithHttpInfo(body, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -328,17 +336,17 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -347,7 +355,7 @@ BodyApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -362,13 +370,17 @@ BodyApi <- R6::R6Class(
     TestBodyMultipartFormdataArrayOfBinary = function(files, data_file = NULL, ...) {
       local_var_response <- self$TestBodyMultipartFormdataArrayOfBinaryWithHttpInfo(files, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -420,17 +432,17 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -439,7 +451,7 @@ BodyApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -454,13 +466,17 @@ BodyApi <- R6::R6Class(
     TestBodyMultipartFormdataSingleBinary = function(my_file = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestBodyMultipartFormdataSingleBinaryWithHttpInfo(my_file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -508,17 +524,17 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -527,7 +543,7 @@ BodyApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -542,13 +558,17 @@ BodyApi <- R6::R6Class(
     TestEchoBodyAllOfPet = function(pet = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEchoBodyAllOfPetWithHttpInfo(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -601,17 +621,17 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -620,7 +640,7 @@ BodyApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -635,13 +655,17 @@ BodyApi <- R6::R6Class(
     TestEchoBodyFreeFormObjectResponseString = function(body = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEchoBodyFreeFormObjectResponseStringWithHttpInfo(body, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -694,17 +718,17 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -713,7 +737,7 @@ BodyApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -728,13 +752,17 @@ BodyApi <- R6::R6Class(
     TestEchoBodyPet = function(pet = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEchoBodyPetWithHttpInfo(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -787,17 +815,17 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -806,7 +834,7 @@ BodyApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -821,13 +849,17 @@ BodyApi <- R6::R6Class(
     TestEchoBodyPetResponseString = function(pet = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEchoBodyPetResponseStringWithHttpInfo(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -880,17 +912,17 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -899,7 +931,7 @@ BodyApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -914,13 +946,17 @@ BodyApi <- R6::R6Class(
     TestEchoBodyStringEnum = function(body = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEchoBodyStringEnumWithHttpInfo(body, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -973,17 +1009,17 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "StringEnumRef", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -992,7 +1028,7 @@ BodyApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -1007,13 +1043,17 @@ BodyApi <- R6::R6Class(
     TestEchoBodyTagResponseString = function(tag = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEchoBodyTagResponseStringWithHttpInfo(tag, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1066,17 +1106,17 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -1085,8 +1125,29 @@ BodyApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/body_api.R
+++ b/samples/client/echo_api/r/R/body_api.R
@@ -184,11 +184,7 @@ BodyApi <- R6::R6Class(
     TestBinaryGif = function(data_file = NULL, ...) {
       local_var_response <- self$TestBinaryGifWithHttpInfo(data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -273,11 +269,7 @@ BodyApi <- R6::R6Class(
     TestBodyApplicationOctetstreamBinary = function(body = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestBodyApplicationOctetstreamBinaryWithHttpInfo(body, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -370,11 +362,7 @@ BodyApi <- R6::R6Class(
     TestBodyMultipartFormdataArrayOfBinary = function(files, data_file = NULL, ...) {
       local_var_response <- self$TestBodyMultipartFormdataArrayOfBinaryWithHttpInfo(files, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -466,11 +454,7 @@ BodyApi <- R6::R6Class(
     TestBodyMultipartFormdataSingleBinary = function(my_file = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestBodyMultipartFormdataSingleBinaryWithHttpInfo(my_file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -558,11 +542,7 @@ BodyApi <- R6::R6Class(
     TestEchoBodyAllOfPet = function(pet = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEchoBodyAllOfPetWithHttpInfo(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -655,11 +635,7 @@ BodyApi <- R6::R6Class(
     TestEchoBodyFreeFormObjectResponseString = function(body = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEchoBodyFreeFormObjectResponseStringWithHttpInfo(body, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -752,11 +728,7 @@ BodyApi <- R6::R6Class(
     TestEchoBodyPet = function(pet = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEchoBodyPetWithHttpInfo(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -849,11 +821,7 @@ BodyApi <- R6::R6Class(
     TestEchoBodyPetResponseString = function(pet = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEchoBodyPetResponseStringWithHttpInfo(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -946,11 +914,7 @@ BodyApi <- R6::R6Class(
     TestEchoBodyStringEnum = function(body = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEchoBodyStringEnumWithHttpInfo(body, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1043,11 +1007,7 @@ BodyApi <- R6::R6Class(
     TestEchoBodyTagResponseString = function(tag = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEchoBodyTagResponseStringWithHttpInfo(tag, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/echo_api/r/R/body_api.R
+++ b/samples/client/echo_api/r/R/body_api.R
@@ -239,11 +239,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "data.frame"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -336,11 +336,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -432,11 +432,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -524,11 +524,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -621,11 +621,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -718,11 +718,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -815,11 +815,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -912,11 +912,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -1009,11 +1009,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "StringEnumRef"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -1106,11 +1106,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -1130,24 +1130,50 @@ BodyApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("openapi")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/body_api.R
+++ b/samples/client/echo_api/r/R/body_api.R
@@ -235,11 +235,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "data.frame"),
+          self$api_client$DeserializeResponse(local_var_resp, "data.frame"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -248,7 +248,7 @@ BodyApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -331,11 +331,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -344,7 +344,7 @@ BodyApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -426,11 +426,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -439,7 +439,7 @@ BodyApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -517,11 +517,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -530,7 +530,7 @@ BodyApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -613,11 +613,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -626,7 +626,7 @@ BodyApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -709,11 +709,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -722,7 +722,7 @@ BodyApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -805,11 +805,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -818,7 +818,7 @@ BodyApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -901,11 +901,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -914,7 +914,7 @@ BodyApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -997,11 +997,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "StringEnumRef"),
+          self$api_client$DeserializeResponse(local_var_resp, "StringEnumRef"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -1010,7 +1010,7 @@ BodyApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -1093,11 +1093,11 @@ BodyApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -1106,7 +1106,7 @@ BodyApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -1117,53 +1117,6 @@ BodyApi <- R6::R6Class(
         }
         return(local_var_resp)
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("openapi")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/body_api.R
+++ b/samples/client/echo_api/r/R/body_api.R
@@ -246,7 +246,10 @@ BodyApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -339,7 +342,10 @@ BodyApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -431,7 +437,10 @@ BodyApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -519,7 +528,10 @@ BodyApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -612,7 +624,10 @@ BodyApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -705,7 +720,10 @@ BodyApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -798,7 +816,10 @@ BodyApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -891,7 +912,10 @@ BodyApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -984,7 +1008,10 @@ BodyApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -1077,7 +1104,10 @@ BodyApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -1127,7 +1157,7 @@ BodyApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/echo_api/r/R/form_api.R
+++ b/samples/client/echo_api/r/R/form_api.R
@@ -157,11 +157,11 @@ FormApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -170,7 +170,7 @@ FormApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -252,11 +252,11 @@ FormApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -265,7 +265,7 @@ FormApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -363,11 +363,11 @@ FormApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -376,7 +376,7 @@ FormApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -387,53 +387,6 @@ FormApi <- R6::R6Class(
         }
         return(local_var_resp)
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("openapi")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/form_api.R
+++ b/samples/client/echo_api/r/R/form_api.R
@@ -168,7 +168,10 @@ FormApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -260,7 +263,10 @@ FormApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -368,7 +374,10 @@ FormApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -418,7 +427,7 @@ FormApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/echo_api/r/R/form_api.R
+++ b/samples/client/echo_api/r/R/form_api.R
@@ -97,13 +97,17 @@ FormApi <- R6::R6Class(
     TestFormIntegerBooleanString = function(integer_form = NULL, boolean_form = NULL, string_form = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestFormIntegerBooleanStringWithHttpInfo(integer_form, boolean_form, string_form, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -157,17 +161,17 @@ FormApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -176,7 +180,7 @@ FormApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -191,13 +195,17 @@ FormApi <- R6::R6Class(
     TestFormObjectMultipart = function(marker, data_file = NULL, ...) {
       local_var_response <- self$TestFormObjectMultipartWithHttpInfo(marker, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -249,17 +257,17 @@ FormApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -268,7 +276,7 @@ FormApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -288,13 +296,17 @@ FormApi <- R6::R6Class(
     TestFormOneof = function(form1 = NULL, form2 = NULL, form3 = NULL, form4 = NULL, id = NULL, name = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestFormOneofWithHttpInfo(form1, form2, form3, form4, id, name, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -357,17 +369,17 @@ FormApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -376,8 +388,29 @@ FormApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/form_api.R
+++ b/samples/client/echo_api/r/R/form_api.R
@@ -97,11 +97,7 @@ FormApi <- R6::R6Class(
     TestFormIntegerBooleanString = function(integer_form = NULL, boolean_form = NULL, string_form = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestFormIntegerBooleanStringWithHttpInfo(integer_form, boolean_form, string_form, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -195,11 +191,7 @@ FormApi <- R6::R6Class(
     TestFormObjectMultipart = function(marker, data_file = NULL, ...) {
       local_var_response <- self$TestFormObjectMultipartWithHttpInfo(marker, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -296,11 +288,7 @@ FormApi <- R6::R6Class(
     TestFormOneof = function(form1 = NULL, form2 = NULL, form3 = NULL, form4 = NULL, id = NULL, name = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestFormOneofWithHttpInfo(form1, form2, form3, form4, id, name, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/echo_api/r/R/form_api.R
+++ b/samples/client/echo_api/r/R/form_api.R
@@ -161,11 +161,11 @@ FormApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -257,11 +257,11 @@ FormApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -369,11 +369,11 @@ FormApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -393,24 +393,50 @@ FormApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("openapi")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/header_api.R
+++ b/samples/client/echo_api/r/R/header_api.R
@@ -68,11 +68,7 @@ HeaderApi <- R6::R6Class(
     TestHeaderIntegerBooleanStringEnums = function(integer_header = NULL, boolean_header = NULL, string_header = NULL, enum_nonref_string_header = NULL, enum_ref_string_header = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestHeaderIntegerBooleanStringEnumsWithHttpInfo(integer_header, boolean_header, string_header, enum_nonref_string_header, enum_ref_string_header, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/echo_api/r/R/header_api.R
+++ b/samples/client/echo_api/r/R/header_api.R
@@ -150,7 +150,10 @@ HeaderApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -200,7 +203,7 @@ HeaderApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/echo_api/r/R/header_api.R
+++ b/samples/client/echo_api/r/R/header_api.R
@@ -139,11 +139,11 @@ HeaderApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -152,7 +152,7 @@ HeaderApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -163,53 +163,6 @@ HeaderApi <- R6::R6Class(
         }
         return(local_var_resp)
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("openapi")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/header_api.R
+++ b/samples/client/echo_api/r/R/header_api.R
@@ -143,11 +143,11 @@ HeaderApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -167,24 +167,50 @@ HeaderApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("openapi")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/path_api.R
+++ b/samples/client/echo_api/r/R/path_api.R
@@ -66,11 +66,7 @@ PathApi <- R6::R6Class(
     TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath = function(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, data_file = NULL, ...) {
       local_var_response <- self$TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/echo_api/r/R/path_api.R
+++ b/samples/client/echo_api/r/R/path_api.R
@@ -66,13 +66,17 @@ PathApi <- R6::R6Class(
     TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath = function(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, data_file = NULL, ...) {
       local_var_response <- self$TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -157,17 +161,17 @@ PathApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -176,8 +180,29 @@ PathApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/path_api.R
+++ b/samples/client/echo_api/r/R/path_api.R
@@ -161,11 +161,11 @@ PathApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -185,24 +185,50 @@ PathApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("openapi")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/path_api.R
+++ b/samples/client/echo_api/r/R/path_api.R
@@ -157,11 +157,11 @@ PathApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -170,7 +170,7 @@ PathApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -181,53 +181,6 @@ PathApi <- R6::R6Class(
         }
         return(local_var_resp)
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("openapi")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/path_api.R
+++ b/samples/client/echo_api/r/R/path_api.R
@@ -168,7 +168,10 @@ PathApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -218,7 +221,7 @@ PathApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/echo_api/r/R/query_api.R
+++ b/samples/client/echo_api/r/R/query_api.R
@@ -265,7 +265,10 @@ QueryApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -364,7 +367,10 @@ QueryApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -463,7 +469,10 @@ QueryApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -552,7 +561,10 @@ QueryApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -641,7 +653,10 @@ QueryApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -731,7 +746,10 @@ QueryApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -821,7 +839,10 @@ QueryApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -910,7 +931,10 @@ QueryApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -999,7 +1023,10 @@ QueryApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -1088,7 +1115,10 @@ QueryApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
         ApiResponse$new("API client error", local_var_resp)
@@ -1138,7 +1168,7 @@ QueryApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/echo_api/r/R/query_api.R
+++ b/samples/client/echo_api/r/R/query_api.R
@@ -192,13 +192,17 @@ QueryApi <- R6::R6Class(
     TestEnumRefString = function(enum_nonref_string_query = NULL, enum_ref_string_query = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEnumRefStringWithHttpInfo(enum_nonref_string_query, enum_ref_string_query, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -254,17 +258,17 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -273,7 +277,7 @@ QueryApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -290,13 +294,17 @@ QueryApi <- R6::R6Class(
     TestQueryDatetimeDateString = function(datetime_query = NULL, date_query = NULL, string_query = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryDatetimeDateStringWithHttpInfo(datetime_query, date_query, string_query, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -353,17 +361,17 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -372,7 +380,7 @@ QueryApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -389,13 +397,17 @@ QueryApi <- R6::R6Class(
     TestQueryIntegerBooleanString = function(integer_query = NULL, boolean_query = NULL, string_query = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryIntegerBooleanStringWithHttpInfo(integer_query, boolean_query, string_query, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -452,17 +464,17 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -471,7 +483,7 @@ QueryApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -486,13 +498,17 @@ QueryApi <- R6::R6Class(
     TestQueryStyleDeepObjectExplodeTrueObject = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleDeepObjectExplodeTrueObjectWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -541,17 +557,17 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -560,7 +576,7 @@ QueryApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -575,13 +591,17 @@ QueryApi <- R6::R6Class(
     TestQueryStyleDeepObjectExplodeTrueObjectAllOf = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleDeepObjectExplodeTrueObjectAllOfWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -630,17 +650,17 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -649,7 +669,7 @@ QueryApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -664,13 +684,17 @@ QueryApi <- R6::R6Class(
     TestQueryStyleFormExplodeFalseArrayInteger = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleFormExplodeFalseArrayIntegerWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -720,17 +744,17 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -739,7 +763,7 @@ QueryApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -754,13 +778,17 @@ QueryApi <- R6::R6Class(
     TestQueryStyleFormExplodeFalseArrayString = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleFormExplodeFalseArrayStringWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -810,17 +838,17 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -829,7 +857,7 @@ QueryApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -844,13 +872,17 @@ QueryApi <- R6::R6Class(
     TestQueryStyleFormExplodeTrueArrayString = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleFormExplodeTrueArrayStringWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -899,17 +931,17 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -918,7 +950,7 @@ QueryApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -933,13 +965,17 @@ QueryApi <- R6::R6Class(
     TestQueryStyleFormExplodeTrueObject = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleFormExplodeTrueObjectWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -988,17 +1024,17 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -1007,7 +1043,7 @@ QueryApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
     },
 
@@ -1022,13 +1058,17 @@ QueryApi <- R6::R6Class(
     TestQueryStyleFormExplodeTrueObjectAllOf = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleFormExplodeTrueObjectAllOfWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1077,17 +1117,17 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             stop("Failed to deserialize response")
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -1096,8 +1136,29 @@ QueryApi <- R6::R6Class(
         if (is.null(local_var_resp$response) || local_var_resp$response == "") {
           local_var_resp$response <- "API server error"
         }
-        local_var_resp
+        return(local_var_resp)
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/query_api.R
+++ b/samples/client/echo_api/r/R/query_api.R
@@ -192,11 +192,7 @@ QueryApi <- R6::R6Class(
     TestEnumRefString = function(enum_nonref_string_query = NULL, enum_ref_string_query = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestEnumRefStringWithHttpInfo(enum_nonref_string_query, enum_ref_string_query, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -294,11 +290,7 @@ QueryApi <- R6::R6Class(
     TestQueryDatetimeDateString = function(datetime_query = NULL, date_query = NULL, string_query = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryDatetimeDateStringWithHttpInfo(datetime_query, date_query, string_query, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -397,11 +389,7 @@ QueryApi <- R6::R6Class(
     TestQueryIntegerBooleanString = function(integer_query = NULL, boolean_query = NULL, string_query = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryIntegerBooleanStringWithHttpInfo(integer_query, boolean_query, string_query, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -498,11 +486,7 @@ QueryApi <- R6::R6Class(
     TestQueryStyleDeepObjectExplodeTrueObject = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleDeepObjectExplodeTrueObjectWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -591,11 +575,7 @@ QueryApi <- R6::R6Class(
     TestQueryStyleDeepObjectExplodeTrueObjectAllOf = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleDeepObjectExplodeTrueObjectAllOfWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -684,11 +664,7 @@ QueryApi <- R6::R6Class(
     TestQueryStyleFormExplodeFalseArrayInteger = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleFormExplodeFalseArrayIntegerWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -778,11 +754,7 @@ QueryApi <- R6::R6Class(
     TestQueryStyleFormExplodeFalseArrayString = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleFormExplodeFalseArrayStringWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -872,11 +844,7 @@ QueryApi <- R6::R6Class(
     TestQueryStyleFormExplodeTrueArrayString = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleFormExplodeTrueArrayStringWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -965,11 +933,7 @@ QueryApi <- R6::R6Class(
     TestQueryStyleFormExplodeTrueObject = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleFormExplodeTrueObjectWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1058,11 +1022,7 @@ QueryApi <- R6::R6Class(
     TestQueryStyleFormExplodeTrueObjectAllOf = function(query_object = NULL, data_file = NULL, ...) {
       local_var_response <- self$TestQueryStyleFormExplodeTrueObjectAllOfWithHttpInfo(query_object, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/echo_api/r/R/query_api.R
+++ b/samples/client/echo_api/r/R/query_api.R
@@ -258,11 +258,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -361,11 +361,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -464,11 +464,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -557,11 +557,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -650,11 +650,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -744,11 +744,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -838,11 +838,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -931,11 +931,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -1024,11 +1024,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -1117,11 +1117,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -1141,24 +1141,50 @@ QueryApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("openapi")))
     }
   )
 )

--- a/samples/client/echo_api/r/R/query_api.R
+++ b/samples/client/echo_api/r/R/query_api.R
@@ -254,11 +254,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -267,7 +267,7 @@ QueryApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -356,11 +356,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -369,7 +369,7 @@ QueryApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -458,11 +458,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -471,7 +471,7 @@ QueryApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -550,11 +550,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -563,7 +563,7 @@ QueryApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -642,11 +642,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -655,7 +655,7 @@ QueryApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -735,11 +735,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -748,7 +748,7 @@ QueryApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -828,11 +828,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -841,7 +841,7 @@ QueryApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -920,11 +920,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -933,7 +933,7 @@ QueryApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -1012,11 +1012,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -1025,7 +1025,7 @@ QueryApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -1104,11 +1104,11 @@ QueryApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             stop("Failed to deserialize response")
           }
@@ -1117,7 +1117,7 @@ QueryApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
@@ -1128,53 +1128,6 @@ QueryApi <- R6::R6Class(
         }
         return(local_var_resp)
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("openapi")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2-wrapper/R/api_client.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_client.R
@@ -46,7 +46,7 @@ ApiClient  <- R6::R6Class(
   "ApiClient",
   public = list(
     # base path of all requests
-    base_path = "http://localhost/v2",
+    base_path = "http://petstore.swagger.io/v2",
     # user agent in the HTTP request
     user_agent = "PetstoreAgent",
     # default headers in the HTTP request
@@ -432,6 +432,52 @@ ApiClient  <- R6::R6Class(
         # not json mime type, simply return the first one
         return(headers[1])
       }
+    },
+
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    DeserializeResponse = function(local_var_resp, return_type = NULL) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
+      }
+      return(self$deserialize(text, return_type, loadNamespace("petstore")))
+    },
+
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (self$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
+      } else {
+        response <- self$DeserializeResponse(local_var_resp)
+        base::write(response, file)
+      }
+    },
+
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     }
   )
 )

--- a/samples/client/petstore/R-httr2-wrapper/R/api_client.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_client.R
@@ -46,7 +46,7 @@ ApiClient  <- R6::R6Class(
   "ApiClient",
   public = list(
     # base path of all requests
-    base_path = "http://petstore.swagger.io/v2",
+    base_path = "http://localhost/v2",
     # user agent in the HTTP request
     user_agent = "PetstoreAgent",
     # default headers in the HTTP request

--- a/samples/client/petstore/R-httr2-wrapper/R/api_exception.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_exception.R
@@ -33,14 +33,14 @@ ApiException <- R6::R6Class(
     initialize = function(status = NULL, reason = NULL, http_response = NULL) {
       if (!is.null(http_response)) {
         self$status <- http_response$status_code
-        errorMsg <- http_response$ResponseAsText()
+        errorMsg <- http_response$response_as_text()
         if (is.null(errorMsg) || errorMsg == "") {
           errorMsg <- "Api exception encountered. No details given."
         }
         self$body <- errorMsg
         self$headers <- http_response$headers
         self$reason <- http_response$http_status_desc
-        self$error_object <- ModelApiResponse$new()$fromJSONString(http_response$ResponseAsText())
+        self$error_object <- ModelApiResponse$new()$fromJSONString(http_response$response_as_text())
       } else {
         self$status <- status
         self$reason <- reason

--- a/samples/client/petstore/R-httr2-wrapper/R/api_exception.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_exception.R
@@ -33,14 +33,14 @@ ApiException <- R6::R6Class(
     initialize = function(status = NULL, reason = NULL, http_response = NULL) {
       if (!is.null(http_response)) {
         self$status <- http_response$status_code
-        errorMsg <- http_response$response
+        errorMsg <- http_response$ResponseAsText()
         if (is.null(errorMsg) || errorMsg == "") {
           errorMsg <- "Api exception encountered. No details given."
         }
         self$body <- errorMsg
         self$headers <- http_response$headers
         self$reason <- http_response$http_status_desc
-        self$error_object <- ModelApiResponse$new()$fromJSONString(http_response$response)
+        self$error_object <- ModelApiResponse$new()$fromJSONString(http_response$ResponseAsText())
       } else {
         self$status <- status
         self$reason <- reason

--- a/samples/client/petstore/R-httr2-wrapper/R/api_response.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_response.R
@@ -56,9 +56,6 @@ ApiResponse <- R6::R6Class(
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
-      if (is.na(text_response)) {
-        warning("The response is binary and will not be converted to text.")
-      }
       return(text_response)
     }
   )

--- a/samples/client/petstore/R-httr2-wrapper/R/api_response.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_response.R
@@ -51,7 +51,7 @@ ApiResponse <- R6::R6Class(
     #'
     #' @param from_encoding The encoding of the raw response.
     #' @param to_encoding The target encoding of the return value.
-    response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+    ResponseAsText = function(from_encoding = "", to_encoding = "UTF-8") {
       if (is.null(self$response)) {
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }

--- a/samples/client/petstore/R-httr2-wrapper/R/api_response.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_response.R
@@ -51,7 +51,7 @@ ApiResponse <- R6::R6Class(
     #'
     #' @param from_encoding The encoding of the raw response.
     #' @param to_encoding The target encoding of the return value.
-    ResponseAsText = function(from_encoding = "", to_encoding = "UTF-8") {
+    response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
       if (is.null(self$response)) {
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }

--- a/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
@@ -193,13 +193,17 @@ FakeApi <- R6::R6Class(
     add_pet_optional = function(pet = NULL, data_file = NULL, ...) {
       local_var_response <- self$add_pet_optional_with_http_info(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -256,11 +260,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -268,7 +272,7 @@ FakeApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -308,13 +312,17 @@ FakeApi <- R6::R6Class(
     fake_data_file = function(dummy, var_data_file = NULL, data_file = NULL, ...) {
       local_var_response <- self$fake_data_file_with_http_info(dummy, var_data_file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -374,11 +382,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "User", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -386,7 +394,7 @@ FakeApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -424,13 +432,17 @@ FakeApi <- R6::R6Class(
     fake_path_array = function(path_array, ...) {
       local_var_response <- self$fake_path_array_with_http_info(path_array, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -486,7 +498,7 @@ FakeApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -524,13 +536,17 @@ FakeApi <- R6::R6Class(
     fake_regular_expression = function(reg_exp_test, ...) {
       local_var_response <- self$fake_regular_expression_with_http_info(reg_exp_test, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -590,7 +606,7 @@ FakeApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -629,13 +645,17 @@ FakeApi <- R6::R6Class(
     fake_set_query = function(set_dummy, array_dummy, ...) {
       local_var_response <- self$fake_set_query_with_http_info(set_dummy, array_dummy, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -713,7 +733,7 @@ FakeApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -739,6 +759,27 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
@@ -260,11 +260,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -382,11 +382,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "User"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -762,24 +762,50 @@ FakeApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
@@ -193,11 +193,7 @@ FakeApi <- R6::R6Class(
     add_pet_optional = function(pet = NULL, data_file = NULL, ...) {
       local_var_response <- self$add_pet_optional_with_http_info(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -312,11 +308,7 @@ FakeApi <- R6::R6Class(
     fake_data_file = function(dummy, var_data_file = NULL, data_file = NULL, ...) {
       local_var_response <- self$fake_data_file_with_http_info(dummy, var_data_file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -432,11 +424,7 @@ FakeApi <- R6::R6Class(
     fake_path_array = function(path_array, ...) {
       local_var_response <- self$fake_path_array_with_http_info(path_array, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -536,11 +524,7 @@ FakeApi <- R6::R6Class(
     fake_regular_expression = function(reg_exp_test, ...) {
       local_var_response <- self$fake_regular_expression_with_http_info(reg_exp_test, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -645,11 +629,7 @@ FakeApi <- R6::R6Class(
     fake_set_query = function(set_dummy, array_dummy, ...) {
       local_var_response <- self$fake_set_query_with_http_info(set_dummy, array_dummy, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
@@ -256,11 +256,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -271,7 +271,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -375,11 +375,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "User"),
+          self$api_client$DeserializeResponse(local_var_resp, "User"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -390,7 +390,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -491,7 +491,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -596,7 +596,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -720,7 +720,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -744,53 +744,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
@@ -269,8 +269,11 @@ FakeApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -278,7 +281,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -286,7 +288,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -387,8 +388,11 @@ FakeApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -396,7 +400,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -404,7 +407,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -487,8 +489,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -496,7 +501,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -504,7 +508,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -591,8 +594,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -600,7 +606,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -608,7 +613,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -714,8 +718,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -723,7 +730,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -731,7 +737,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -779,7 +784,7 @@ FakeApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
@@ -479,8 +479,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -488,7 +491,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -496,7 +498,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -587,8 +588,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -596,7 +600,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -604,7 +607,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -713,8 +715,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -722,7 +727,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -730,7 +734,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -827,8 +830,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -836,7 +842,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -844,7 +849,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -946,8 +950,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -955,7 +962,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -963,7 +969,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1076,8 +1081,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1085,7 +1093,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1093,7 +1100,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1204,8 +1210,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1213,7 +1222,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1221,7 +1229,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1324,8 +1331,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1333,7 +1343,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1341,7 +1350,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1432,8 +1440,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1441,7 +1452,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1449,7 +1459,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1558,8 +1567,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1567,7 +1579,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1575,7 +1586,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1623,7 +1633,7 @@ PetApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
@@ -396,11 +396,7 @@ PetApi <- R6::R6Class(
     add_pet = function(pet, data_file = NULL, ...) {
       local_var_response <- self$add_pet_with_http_info(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -521,11 +517,7 @@ PetApi <- R6::R6Class(
     delete_pet = function(pet_id, api_key = NULL, ...) {
       local_var_response <- self$delete_pet_with_http_info(pet_id, api_key, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -633,11 +625,7 @@ PetApi <- R6::R6Class(
     find_pets_by_status = function(status, data_file = NULL, ...) {
       local_var_response <- self$find_pets_by_status_with_http_info(status, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -763,11 +751,7 @@ PetApi <- R6::R6Class(
     find_pets_by_tags = function(tags, data_file = NULL, ...) {
       local_var_response <- self$find_pets_by_tags_with_http_info(tags, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -881,11 +865,7 @@ PetApi <- R6::R6Class(
     get_pet_by_id = function(pet_id, data_file = NULL, ...) {
       local_var_response <- self$get_pet_by_id_with_http_info(pet_id, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1009,11 +989,7 @@ PetApi <- R6::R6Class(
       }
 
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1143,11 +1119,7 @@ PetApi <- R6::R6Class(
       }
 
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1270,11 +1242,7 @@ PetApi <- R6::R6Class(
     update_pet = function(pet, data_file = NULL, ...) {
       local_var_response <- self$update_pet_with_http_info(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1395,11 +1363,7 @@ PetApi <- R6::R6Class(
     update_pet_with_form = function(pet_id, name = NULL, status = NULL, ...) {
       local_var_response <- self$update_pet_with_form_with_http_info(pet_id, name, status, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1508,11 +1472,7 @@ PetApi <- R6::R6Class(
     upload_file = function(pet_id, additional_metadata = NULL, file = NULL, data_file = NULL, ...) {
       local_var_response <- self$upload_file_with_http_info(pet_id, additional_metadata, file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
@@ -470,11 +470,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -712,11 +712,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "array[Pet]"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -830,11 +830,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "array[Pet]"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -953,11 +953,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1087,11 +1087,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1219,11 +1219,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1343,11 +1343,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1585,11 +1585,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "ModelApiResponse"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1626,24 +1626,50 @@ PetApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
@@ -396,13 +396,17 @@ PetApi <- R6::R6Class(
     add_pet = function(pet, data_file = NULL, ...) {
       local_var_response <- self$add_pet_with_http_info(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -466,11 +470,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -478,7 +482,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -517,13 +521,17 @@ PetApi <- R6::R6Class(
     delete_pet = function(pet_id, api_key = NULL, ...) {
       local_var_response <- self$delete_pet_with_http_info(pet_id, api_key, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -586,7 +594,7 @@ PetApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -625,13 +633,17 @@ PetApi <- R6::R6Class(
     find_pets_by_status = function(status, data_file = NULL, ...) {
       local_var_response <- self$find_pets_by_status_with_http_info(status, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -700,11 +712,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "array[Pet]", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -712,7 +724,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -751,13 +763,17 @@ PetApi <- R6::R6Class(
     find_pets_by_tags = function(tags, data_file = NULL, ...) {
       local_var_response <- self$find_pets_by_tags_with_http_info(tags, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -814,11 +830,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "array[Pet]", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -826,7 +842,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -865,13 +881,17 @@ PetApi <- R6::R6Class(
     get_pet_by_id = function(pet_id, data_file = NULL, ...) {
       local_var_response <- self$get_pet_by_id_with_http_info(pet_id, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -933,11 +953,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -945,7 +965,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -989,13 +1009,17 @@ PetApi <- R6::R6Class(
       }
 
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1063,11 +1087,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1075,7 +1099,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1119,13 +1143,17 @@ PetApi <- R6::R6Class(
       }
 
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1191,11 +1219,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1203,7 +1231,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1242,13 +1270,17 @@ PetApi <- R6::R6Class(
     update_pet = function(pet, data_file = NULL, ...) {
       local_var_response <- self$update_pet_with_http_info(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1311,11 +1343,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1323,7 +1355,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1363,13 +1395,17 @@ PetApi <- R6::R6Class(
     update_pet_with_form = function(pet_id, name = NULL, status = NULL, ...) {
       local_var_response <- self$update_pet_with_form_with_http_info(pet_id, name, status, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1431,7 +1467,7 @@ PetApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1472,13 +1508,17 @@ PetApi <- R6::R6Class(
     upload_file = function(pet_id, additional_metadata = NULL, file = NULL, data_file = NULL, ...) {
       local_var_response <- self$upload_file_with_http_info(pet_id, additional_metadata, file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1545,11 +1585,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "ModelApiResponse", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1557,7 +1597,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1583,6 +1623,27 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
@@ -466,11 +466,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -481,7 +481,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -590,7 +590,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -702,11 +702,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "array[Pet]"),
+          self$api_client$DeserializeResponse(local_var_resp, "array[Pet]"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -717,7 +717,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -817,11 +817,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "array[Pet]"),
+          self$api_client$DeserializeResponse(local_var_resp, "array[Pet]"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -832,7 +832,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -937,11 +937,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -952,7 +952,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1068,11 +1068,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1083,7 +1083,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1197,11 +1197,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1212,7 +1212,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1318,11 +1318,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1333,7 +1333,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1442,7 +1442,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1554,11 +1554,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "ModelApiResponse"),
+          self$api_client$DeserializeResponse(local_var_resp, "ModelApiResponse"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1569,7 +1569,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1593,53 +1593,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2-wrapper/R/store_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/store_api.R
@@ -236,7 +236,7 @@ StoreApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -327,11 +327,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "map(integer)"),
+          self$api_client$DeserializeResponse(local_var_resp, "map(integer)"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -342,7 +342,7 @@ StoreApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -455,11 +455,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Order"),
+          self$api_client$DeserializeResponse(local_var_resp, "Order"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -470,7 +470,7 @@ StoreApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -573,11 +573,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Order"),
+          self$api_client$DeserializeResponse(local_var_resp, "Order"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -588,7 +588,7 @@ StoreApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -612,53 +612,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2-wrapper/R/store_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/store_api.R
@@ -171,11 +171,7 @@ StoreApi <- R6::R6Class(
     delete_order = function(order_id, ...) {
       local_var_response <- self$delete_order_with_http_info(order_id, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -275,11 +271,7 @@ StoreApi <- R6::R6Class(
     get_inventory = function(data_file = NULL, ...) {
       local_var_response <- self$get_inventory_with_http_info(data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -385,11 +377,7 @@ StoreApi <- R6::R6Class(
     get_order_by_id = function(order_id, data_file = NULL, ...) {
       local_var_response <- self$get_order_by_id_with_http_info(order_id, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -516,11 +504,7 @@ StoreApi <- R6::R6Class(
     place_order = function(order, data_file = NULL, ...) {
       local_var_response <- self$place_order_with_http_info(order, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/petstore/R-httr2-wrapper/R/store_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/store_api.R
@@ -334,11 +334,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "map(integer)"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -465,11 +465,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Order"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -586,11 +586,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Order"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -627,24 +627,50 @@ StoreApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2-wrapper/R/store_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/store_api.R
@@ -234,8 +234,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -243,7 +246,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -251,7 +253,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -339,8 +340,11 @@ StoreApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -348,7 +352,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -356,7 +359,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -466,8 +468,11 @@ StoreApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -475,7 +480,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -483,7 +487,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -583,8 +586,11 @@ StoreApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -592,7 +598,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -600,7 +605,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -648,7 +652,7 @@ StoreApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/petstore/R-httr2-wrapper/R/store_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/store_api.R
@@ -171,13 +171,17 @@ StoreApi <- R6::R6Class(
     delete_order = function(order_id, ...) {
       local_var_response <- self$delete_order_with_http_info(order_id, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -233,7 +237,7 @@ StoreApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -271,13 +275,17 @@ StoreApi <- R6::R6Class(
     get_inventory = function(data_file = NULL, ...) {
       local_var_response <- self$get_inventory_with_http_info(data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -326,11 +334,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "map(integer)", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -338,7 +346,7 @@ StoreApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -377,13 +385,17 @@ StoreApi <- R6::R6Class(
     get_order_by_id = function(order_id, data_file = NULL, ...) {
       local_var_response <- self$get_order_by_id_with_http_info(order_id, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -453,11 +465,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Order", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -465,7 +477,7 @@ StoreApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -504,13 +516,17 @@ StoreApi <- R6::R6Class(
     place_order = function(order, data_file = NULL, ...) {
       local_var_response <- self$place_order_with_http_info(order, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -570,11 +586,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Order", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -582,7 +598,7 @@ StoreApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -608,6 +624,27 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2-wrapper/R/user_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/user_api.R
@@ -280,11 +280,7 @@ UserApi <- R6::R6Class(
     create_user = function(user, ...) {
       local_var_response <- self$create_user_with_http_info(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -390,11 +386,7 @@ UserApi <- R6::R6Class(
     create_users_with_array_input = function(user, ...) {
       local_var_response <- self$create_users_with_array_input_with_http_info(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -503,11 +495,7 @@ UserApi <- R6::R6Class(
     create_users_with_list_input = function(user, ...) {
       local_var_response <- self$create_users_with_list_input_with_http_info(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -616,11 +604,7 @@ UserApi <- R6::R6Class(
     delete_user = function(username, ...) {
       local_var_response <- self$delete_user_with_http_info(username, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -725,11 +709,7 @@ UserApi <- R6::R6Class(
     get_user_by_name = function(username, data_file = NULL, ...) {
       local_var_response <- self$get_user_by_name_with_http_info(username, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -845,11 +825,7 @@ UserApi <- R6::R6Class(
     login_user = function(username, password, data_file = NULL, ...) {
       local_var_response <- self$login_user_with_http_info(username, password, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -977,11 +953,7 @@ UserApi <- R6::R6Class(
     logout_user = function(...) {
       local_var_response <- self$logout_user_with_http_info(...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1073,11 +1045,7 @@ UserApi <- R6::R6Class(
     update_user = function(username, user, ...) {
       local_var_response <- self$update_user_with_http_info(username, user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/petstore/R-httr2-wrapper/R/user_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/user_api.R
@@ -351,7 +351,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -461,7 +461,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -571,7 +571,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -676,7 +676,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -777,11 +777,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "User"),
+          self$api_client$DeserializeResponse(local_var_resp, "User"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -792,7 +792,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -909,11 +909,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -924,7 +924,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1015,7 +1015,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1136,7 +1136,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1160,53 +1160,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2-wrapper/R/user_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/user_api.R
@@ -349,8 +349,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -358,7 +361,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -366,7 +368,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -458,8 +459,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -467,7 +471,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -475,7 +478,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -567,8 +569,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -576,7 +581,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -584,7 +588,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -671,8 +674,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -680,7 +686,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -688,7 +693,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -786,8 +790,11 @@ UserApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -795,7 +802,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -803,7 +809,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -917,8 +922,11 @@ UserApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -926,7 +934,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -934,7 +941,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1007,8 +1013,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1016,7 +1025,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1024,7 +1032,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1127,8 +1134,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1136,7 +1146,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1144,7 +1153,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1192,7 +1200,7 @@ UserApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/petstore/R-httr2-wrapper/R/user_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/user_api.R
@@ -280,13 +280,17 @@ UserApi <- R6::R6Class(
     create_user = function(user, ...) {
       local_var_response <- self$create_user_with_http_info(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -348,7 +352,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -386,13 +390,17 @@ UserApi <- R6::R6Class(
     create_users_with_array_input = function(user, ...) {
       local_var_response <- self$create_users_with_array_input_with_http_info(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -457,7 +465,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -495,13 +503,17 @@ UserApi <- R6::R6Class(
     create_users_with_list_input = function(user, ...) {
       local_var_response <- self$create_users_with_list_input_with_http_info(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -566,7 +578,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -604,13 +616,17 @@ UserApi <- R6::R6Class(
     delete_user = function(username, ...) {
       local_var_response <- self$delete_user_with_http_info(username, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -670,7 +686,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -709,13 +725,17 @@ UserApi <- R6::R6Class(
     get_user_by_name = function(username, data_file = NULL, ...) {
       local_var_response <- self$get_user_by_name_with_http_info(username, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -773,11 +793,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "User", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -785,7 +805,7 @@ UserApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -825,13 +845,17 @@ UserApi <- R6::R6Class(
     login_user = function(username, password, data_file = NULL, ...) {
       local_var_response <- self$login_user_with_http_info(username, password, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -904,11 +928,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -916,7 +940,7 @@ UserApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -953,13 +977,17 @@ UserApi <- R6::R6Class(
     logout_user = function(...) {
       local_var_response <- self$logout_user_with_http_info(...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1006,7 +1034,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1045,13 +1073,17 @@ UserApi <- R6::R6Class(
     update_user = function(username, user, ...) {
       local_var_response <- self$update_user_with_http_info(username, user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1126,7 +1158,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1152,6 +1184,27 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2/R/api_client.R
+++ b/samples/client/petstore/R-httr2/R/api_client.R
@@ -432,6 +432,52 @@ ApiClient  <- R6::R6Class(
         # not json mime type, simply return the first one
         return(headers[1])
       }
+    },
+
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    DeserializeResponse = function(local_var_resp, return_type = NULL) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
+      }
+      return(self$deserialize(text, return_type, loadNamespace("petstore")))
+    },
+
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (self$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
+      } else {
+        response <- self$DeserializeResponse(local_var_resp)
+        base::write(response, file)
+      }
+    },
+
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     }
   )
 )

--- a/samples/client/petstore/R-httr2/R/api_exception.R
+++ b/samples/client/petstore/R-httr2/R/api_exception.R
@@ -33,14 +33,14 @@ ApiException <- R6::R6Class(
     initialize = function(status = NULL, reason = NULL, http_response = NULL) {
       if (!is.null(http_response)) {
         self$status <- http_response$status_code
-        errorMsg <- http_response$ResponseAsText()
+        errorMsg <- http_response$response_as_text()
         if (is.null(errorMsg) || errorMsg == "") {
           errorMsg <- "Api exception encountered. No details given."
         }
         self$body <- errorMsg
         self$headers <- http_response$headers
         self$reason <- http_response$http_status_desc
-        self$error_object <- ModelApiResponse$new()$fromJSONString(http_response$ResponseAsText())
+        self$error_object <- ModelApiResponse$new()$fromJSONString(http_response$response_as_text())
       } else {
         self$status <- status
         self$reason <- reason

--- a/samples/client/petstore/R-httr2/R/api_exception.R
+++ b/samples/client/petstore/R-httr2/R/api_exception.R
@@ -33,14 +33,14 @@ ApiException <- R6::R6Class(
     initialize = function(status = NULL, reason = NULL, http_response = NULL) {
       if (!is.null(http_response)) {
         self$status <- http_response$status_code
-        errorMsg <- http_response$response
+        errorMsg <- http_response$ResponseAsText()
         if (is.null(errorMsg) || errorMsg == "") {
           errorMsg <- "Api exception encountered. No details given."
         }
         self$body <- errorMsg
         self$headers <- http_response$headers
         self$reason <- http_response$http_status_desc
-        self$error_object <- ModelApiResponse$new()$fromJSONString(http_response$response)
+        self$error_object <- ModelApiResponse$new()$fromJSONString(http_response$ResponseAsText())
       } else {
         self$status <- status
         self$reason <- reason

--- a/samples/client/petstore/R-httr2/R/api_response.R
+++ b/samples/client/petstore/R-httr2/R/api_response.R
@@ -56,9 +56,6 @@ ApiResponse <- R6::R6Class(
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
-      if (is.na(text_response)) {
-        warning("The response is binary and will not be converted to text.")
-      }
       return(text_response)
     }
   )

--- a/samples/client/petstore/R-httr2/R/api_response.R
+++ b/samples/client/petstore/R-httr2/R/api_response.R
@@ -51,7 +51,7 @@ ApiResponse <- R6::R6Class(
     #'
     #' @param from_encoding The encoding of the raw response.
     #' @param to_encoding The target encoding of the return value.
-    response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+    ResponseAsText = function(from_encoding = "", to_encoding = "UTF-8") {
       if (is.null(self$response)) {
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }

--- a/samples/client/petstore/R-httr2/R/api_response.R
+++ b/samples/client/petstore/R-httr2/R/api_response.R
@@ -51,7 +51,7 @@ ApiResponse <- R6::R6Class(
     #'
     #' @param from_encoding The encoding of the raw response.
     #' @param to_encoding The target encoding of the return value.
-    ResponseAsText = function(from_encoding = "", to_encoding = "UTF-8") {
+    response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
       if (is.null(self$response)) {
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }

--- a/samples/client/petstore/R-httr2/R/fake_api.R
+++ b/samples/client/petstore/R-httr2/R/fake_api.R
@@ -260,11 +260,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -382,11 +382,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "User"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -762,24 +762,50 @@ FakeApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2/R/fake_api.R
+++ b/samples/client/petstore/R-httr2/R/fake_api.R
@@ -256,11 +256,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -271,7 +271,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -375,11 +375,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "User"),
+          self$api_client$DeserializeResponse(local_var_resp, "User"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -390,7 +390,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -491,7 +491,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -596,7 +596,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -720,7 +720,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -744,53 +744,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2/R/fake_api.R
+++ b/samples/client/petstore/R-httr2/R/fake_api.R
@@ -193,13 +193,17 @@ FakeApi <- R6::R6Class(
     add_pet_optional = function(pet = NULL, data_file = NULL, ...) {
       local_var_response <- self$add_pet_optional_with_http_info(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -256,11 +260,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -268,7 +272,7 @@ FakeApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -308,13 +312,17 @@ FakeApi <- R6::R6Class(
     fake_data_file = function(dummy, var_data_file = NULL, data_file = NULL, ...) {
       local_var_response <- self$fake_data_file_with_http_info(dummy, var_data_file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -374,11 +382,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "User", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -386,7 +394,7 @@ FakeApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -424,13 +432,17 @@ FakeApi <- R6::R6Class(
     fake_path_array = function(path_array_parameter, ...) {
       local_var_response <- self$fake_path_array_with_http_info(path_array_parameter, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -486,7 +498,7 @@ FakeApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -524,13 +536,17 @@ FakeApi <- R6::R6Class(
     fake_regular_expression = function(reg_exp_test, ...) {
       local_var_response <- self$fake_regular_expression_with_http_info(reg_exp_test, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -590,7 +606,7 @@ FakeApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -629,13 +645,17 @@ FakeApi <- R6::R6Class(
     fake_set_query = function(set_dummy, array_dummy, ...) {
       local_var_response <- self$fake_set_query_with_http_info(set_dummy, array_dummy, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -713,7 +733,7 @@ FakeApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -739,6 +759,27 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2/R/fake_api.R
+++ b/samples/client/petstore/R-httr2/R/fake_api.R
@@ -269,8 +269,11 @@ FakeApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -278,7 +281,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -286,7 +288,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -387,8 +388,11 @@ FakeApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -396,7 +400,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -404,7 +407,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -487,8 +489,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -496,7 +501,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -504,7 +508,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -591,8 +594,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -600,7 +606,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -608,7 +613,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -714,8 +718,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -723,7 +730,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -731,7 +737,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -779,7 +784,7 @@ FakeApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/petstore/R-httr2/R/fake_api.R
+++ b/samples/client/petstore/R-httr2/R/fake_api.R
@@ -193,11 +193,7 @@ FakeApi <- R6::R6Class(
     add_pet_optional = function(pet = NULL, data_file = NULL, ...) {
       local_var_response <- self$add_pet_optional_with_http_info(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -312,11 +308,7 @@ FakeApi <- R6::R6Class(
     fake_data_file = function(dummy, var_data_file = NULL, data_file = NULL, ...) {
       local_var_response <- self$fake_data_file_with_http_info(dummy, var_data_file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -432,11 +424,7 @@ FakeApi <- R6::R6Class(
     fake_path_array = function(path_array_parameter, ...) {
       local_var_response <- self$fake_path_array_with_http_info(path_array_parameter, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -536,11 +524,7 @@ FakeApi <- R6::R6Class(
     fake_regular_expression = function(reg_exp_test, ...) {
       local_var_response <- self$fake_regular_expression_with_http_info(reg_exp_test, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -645,11 +629,7 @@ FakeApi <- R6::R6Class(
     fake_set_query = function(set_dummy, array_dummy, ...) {
       local_var_response <- self$fake_set_query_with_http_info(set_dummy, array_dummy, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/petstore/R-httr2/R/pet_api.R
+++ b/samples/client/petstore/R-httr2/R/pet_api.R
@@ -479,8 +479,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -488,7 +491,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -496,7 +498,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -587,8 +588,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -596,7 +600,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -604,7 +607,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -713,8 +715,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -722,7 +727,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -730,7 +734,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -827,8 +830,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -836,7 +842,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -844,7 +849,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -946,8 +950,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -955,7 +962,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -963,7 +969,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1076,8 +1081,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1085,7 +1093,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1093,7 +1100,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1204,8 +1210,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1213,7 +1222,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1221,7 +1229,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1324,8 +1331,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1333,7 +1343,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1341,7 +1350,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1432,8 +1440,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1441,7 +1452,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1449,7 +1459,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1558,8 +1567,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1567,7 +1579,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1575,7 +1586,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1623,7 +1633,7 @@ PetApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/petstore/R-httr2/R/pet_api.R
+++ b/samples/client/petstore/R-httr2/R/pet_api.R
@@ -396,11 +396,7 @@ PetApi <- R6::R6Class(
     add_pet = function(pet, data_file = NULL, ...) {
       local_var_response <- self$add_pet_with_http_info(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -521,11 +517,7 @@ PetApi <- R6::R6Class(
     delete_pet = function(pet_id, api_key = NULL, ...) {
       local_var_response <- self$delete_pet_with_http_info(pet_id, api_key, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -633,11 +625,7 @@ PetApi <- R6::R6Class(
     find_pets_by_status = function(status, data_file = NULL, ...) {
       local_var_response <- self$find_pets_by_status_with_http_info(status, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -763,11 +751,7 @@ PetApi <- R6::R6Class(
     find_pets_by_tags = function(tags, data_file = NULL, ...) {
       local_var_response <- self$find_pets_by_tags_with_http_info(tags, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -881,11 +865,7 @@ PetApi <- R6::R6Class(
     get_pet_by_id = function(pet_id, data_file = NULL, ...) {
       local_var_response <- self$get_pet_by_id_with_http_info(pet_id, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1009,11 +989,7 @@ PetApi <- R6::R6Class(
       }
 
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1143,11 +1119,7 @@ PetApi <- R6::R6Class(
       }
 
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1270,11 +1242,7 @@ PetApi <- R6::R6Class(
     update_pet = function(pet, data_file = NULL, ...) {
       local_var_response <- self$update_pet_with_http_info(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1395,11 +1363,7 @@ PetApi <- R6::R6Class(
     update_pet_with_form = function(pet_id, name = NULL, status = NULL, ...) {
       local_var_response <- self$update_pet_with_form_with_http_info(pet_id, name, status, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1508,11 +1472,7 @@ PetApi <- R6::R6Class(
     upload_file = function(pet_id, additional_metadata = NULL, file = NULL, data_file = NULL, ...) {
       local_var_response <- self$upload_file_with_http_info(pet_id, additional_metadata, file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/petstore/R-httr2/R/pet_api.R
+++ b/samples/client/petstore/R-httr2/R/pet_api.R
@@ -470,11 +470,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -712,11 +712,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "array[Pet]"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -830,11 +830,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "array[Pet]"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -953,11 +953,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1087,11 +1087,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1219,11 +1219,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1343,11 +1343,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1585,11 +1585,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "ModelApiResponse"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1626,24 +1626,50 @@ PetApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2/R/pet_api.R
+++ b/samples/client/petstore/R-httr2/R/pet_api.R
@@ -396,13 +396,17 @@ PetApi <- R6::R6Class(
     add_pet = function(pet, data_file = NULL, ...) {
       local_var_response <- self$add_pet_with_http_info(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -466,11 +470,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -478,7 +482,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -517,13 +521,17 @@ PetApi <- R6::R6Class(
     delete_pet = function(pet_id, api_key = NULL, ...) {
       local_var_response <- self$delete_pet_with_http_info(pet_id, api_key, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -586,7 +594,7 @@ PetApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -625,13 +633,17 @@ PetApi <- R6::R6Class(
     find_pets_by_status = function(status, data_file = NULL, ...) {
       local_var_response <- self$find_pets_by_status_with_http_info(status, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -700,11 +712,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "array[Pet]", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -712,7 +724,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -751,13 +763,17 @@ PetApi <- R6::R6Class(
     find_pets_by_tags = function(tags, data_file = NULL, ...) {
       local_var_response <- self$find_pets_by_tags_with_http_info(tags, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -814,11 +830,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "array[Pet]", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -826,7 +842,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -865,13 +881,17 @@ PetApi <- R6::R6Class(
     get_pet_by_id = function(pet_id, data_file = NULL, ...) {
       local_var_response <- self$get_pet_by_id_with_http_info(pet_id, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -933,11 +953,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -945,7 +965,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -989,13 +1009,17 @@ PetApi <- R6::R6Class(
       }
 
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1063,11 +1087,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1075,7 +1099,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1119,13 +1143,17 @@ PetApi <- R6::R6Class(
       }
 
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1191,11 +1219,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1203,7 +1231,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1242,13 +1270,17 @@ PetApi <- R6::R6Class(
     update_pet = function(pet, data_file = NULL, ...) {
       local_var_response <- self$update_pet_with_http_info(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1311,11 +1343,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1323,7 +1355,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1363,13 +1395,17 @@ PetApi <- R6::R6Class(
     update_pet_with_form = function(pet_id, name = NULL, status = NULL, ...) {
       local_var_response <- self$update_pet_with_form_with_http_info(pet_id, name, status, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1431,7 +1467,7 @@ PetApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1472,13 +1508,17 @@ PetApi <- R6::R6Class(
     upload_file = function(pet_id, additional_metadata = NULL, file = NULL, data_file = NULL, ...) {
       local_var_response <- self$upload_file_with_http_info(pet_id, additional_metadata, file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1545,11 +1585,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "ModelApiResponse", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1557,7 +1597,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1583,6 +1623,27 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2/R/pet_api.R
+++ b/samples/client/petstore/R-httr2/R/pet_api.R
@@ -466,11 +466,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -481,7 +481,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -590,7 +590,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -702,11 +702,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "array[Pet]"),
+          self$api_client$DeserializeResponse(local_var_resp, "array[Pet]"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -717,7 +717,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -817,11 +817,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "array[Pet]"),
+          self$api_client$DeserializeResponse(local_var_resp, "array[Pet]"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -832,7 +832,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -937,11 +937,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -952,7 +952,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1068,11 +1068,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1083,7 +1083,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1197,11 +1197,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1212,7 +1212,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1318,11 +1318,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1333,7 +1333,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1442,7 +1442,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1554,11 +1554,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "ModelApiResponse"),
+          self$api_client$DeserializeResponse(local_var_resp, "ModelApiResponse"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1569,7 +1569,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1593,53 +1593,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2/R/store_api.R
+++ b/samples/client/petstore/R-httr2/R/store_api.R
@@ -236,7 +236,7 @@ StoreApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -327,11 +327,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "map(integer)"),
+          self$api_client$DeserializeResponse(local_var_resp, "map(integer)"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -342,7 +342,7 @@ StoreApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -455,11 +455,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Order"),
+          self$api_client$DeserializeResponse(local_var_resp, "Order"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -470,7 +470,7 @@ StoreApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -573,11 +573,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Order"),
+          self$api_client$DeserializeResponse(local_var_resp, "Order"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -588,7 +588,7 @@ StoreApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -612,53 +612,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2/R/store_api.R
+++ b/samples/client/petstore/R-httr2/R/store_api.R
@@ -171,11 +171,7 @@ StoreApi <- R6::R6Class(
     delete_order = function(order_id, ...) {
       local_var_response <- self$delete_order_with_http_info(order_id, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -275,11 +271,7 @@ StoreApi <- R6::R6Class(
     get_inventory = function(data_file = NULL, ...) {
       local_var_response <- self$get_inventory_with_http_info(data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -385,11 +377,7 @@ StoreApi <- R6::R6Class(
     get_order_by_id = function(order_id, data_file = NULL, ...) {
       local_var_response <- self$get_order_by_id_with_http_info(order_id, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -516,11 +504,7 @@ StoreApi <- R6::R6Class(
     place_order = function(order, data_file = NULL, ...) {
       local_var_response <- self$place_order_with_http_info(order, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/petstore/R-httr2/R/store_api.R
+++ b/samples/client/petstore/R-httr2/R/store_api.R
@@ -334,11 +334,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "map(integer)"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -465,11 +465,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Order"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -586,11 +586,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Order"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -627,24 +627,50 @@ StoreApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2/R/store_api.R
+++ b/samples/client/petstore/R-httr2/R/store_api.R
@@ -234,8 +234,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -243,7 +246,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -251,7 +253,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -339,8 +340,11 @@ StoreApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -348,7 +352,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -356,7 +359,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -466,8 +468,11 @@ StoreApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -475,7 +480,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -483,7 +487,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -583,8 +586,11 @@ StoreApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -592,7 +598,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -600,7 +605,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -648,7 +652,7 @@ StoreApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/petstore/R-httr2/R/store_api.R
+++ b/samples/client/petstore/R-httr2/R/store_api.R
@@ -171,13 +171,17 @@ StoreApi <- R6::R6Class(
     delete_order = function(order_id, ...) {
       local_var_response <- self$delete_order_with_http_info(order_id, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -233,7 +237,7 @@ StoreApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -271,13 +275,17 @@ StoreApi <- R6::R6Class(
     get_inventory = function(data_file = NULL, ...) {
       local_var_response <- self$get_inventory_with_http_info(data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -326,11 +334,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "map(integer)", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -338,7 +346,7 @@ StoreApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -377,13 +385,17 @@ StoreApi <- R6::R6Class(
     get_order_by_id = function(order_id, data_file = NULL, ...) {
       local_var_response <- self$get_order_by_id_with_http_info(order_id, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -453,11 +465,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Order", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -465,7 +477,7 @@ StoreApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -504,13 +516,17 @@ StoreApi <- R6::R6Class(
     place_order = function(order, data_file = NULL, ...) {
       local_var_response <- self$place_order_with_http_info(order, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -570,11 +586,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Order", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -582,7 +598,7 @@ StoreApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -608,6 +624,27 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2/R/user_api.R
+++ b/samples/client/petstore/R-httr2/R/user_api.R
@@ -280,11 +280,7 @@ UserApi <- R6::R6Class(
     create_user = function(user, ...) {
       local_var_response <- self$create_user_with_http_info(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -390,11 +386,7 @@ UserApi <- R6::R6Class(
     create_users_with_array_input = function(user, ...) {
       local_var_response <- self$create_users_with_array_input_with_http_info(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -503,11 +495,7 @@ UserApi <- R6::R6Class(
     create_users_with_list_input = function(user, ...) {
       local_var_response <- self$create_users_with_list_input_with_http_info(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -616,11 +604,7 @@ UserApi <- R6::R6Class(
     delete_user = function(username, ...) {
       local_var_response <- self$delete_user_with_http_info(username, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -725,11 +709,7 @@ UserApi <- R6::R6Class(
     get_user_by_name = function(username, data_file = NULL, ...) {
       local_var_response <- self$get_user_by_name_with_http_info(username, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -845,11 +825,7 @@ UserApi <- R6::R6Class(
     login_user = function(username, password, data_file = NULL, ...) {
       local_var_response <- self$login_user_with_http_info(username, password, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -977,11 +953,7 @@ UserApi <- R6::R6Class(
     logout_user = function(...) {
       local_var_response <- self$logout_user_with_http_info(...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1073,11 +1045,7 @@ UserApi <- R6::R6Class(
     update_user = function(username, user, ...) {
       local_var_response <- self$update_user_with_http_info(username, user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/petstore/R-httr2/R/user_api.R
+++ b/samples/client/petstore/R-httr2/R/user_api.R
@@ -351,7 +351,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -461,7 +461,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -571,7 +571,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -676,7 +676,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -777,11 +777,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "User"),
+          self$api_client$DeserializeResponse(local_var_resp, "User"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -792,7 +792,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -909,11 +909,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -924,7 +924,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1015,7 +1015,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1136,7 +1136,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1160,53 +1160,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R-httr2/R/user_api.R
+++ b/samples/client/petstore/R-httr2/R/user_api.R
@@ -349,8 +349,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -358,7 +361,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -366,7 +368,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -458,8 +459,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -467,7 +471,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -475,7 +478,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -567,8 +569,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -576,7 +581,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -584,7 +588,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -671,8 +674,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -680,7 +686,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -688,7 +693,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -786,8 +790,11 @@ UserApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -795,7 +802,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -803,7 +809,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -917,8 +922,11 @@ UserApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -926,7 +934,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -934,7 +941,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1007,8 +1013,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1016,7 +1025,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1024,7 +1032,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1127,8 +1134,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1136,7 +1146,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1144,7 +1153,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1192,7 +1200,7 @@ UserApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/petstore/R-httr2/R/user_api.R
+++ b/samples/client/petstore/R-httr2/R/user_api.R
@@ -280,13 +280,17 @@ UserApi <- R6::R6Class(
     create_user = function(user, ...) {
       local_var_response <- self$create_user_with_http_info(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -348,7 +352,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -386,13 +390,17 @@ UserApi <- R6::R6Class(
     create_users_with_array_input = function(user, ...) {
       local_var_response <- self$create_users_with_array_input_with_http_info(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -457,7 +465,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -495,13 +503,17 @@ UserApi <- R6::R6Class(
     create_users_with_list_input = function(user, ...) {
       local_var_response <- self$create_users_with_list_input_with_http_info(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -566,7 +578,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -604,13 +616,17 @@ UserApi <- R6::R6Class(
     delete_user = function(username, ...) {
       local_var_response <- self$delete_user_with_http_info(username, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -670,7 +686,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -709,13 +725,17 @@ UserApi <- R6::R6Class(
     get_user_by_name = function(username, data_file = NULL, ...) {
       local_var_response <- self$get_user_by_name_with_http_info(username, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -773,11 +793,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "User", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -785,7 +805,7 @@ UserApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -825,13 +845,17 @@ UserApi <- R6::R6Class(
     login_user = function(username, password, data_file = NULL, ...) {
       local_var_response <- self$login_user_with_http_info(username, password, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -904,11 +928,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -916,7 +940,7 @@ UserApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -953,13 +977,17 @@ UserApi <- R6::R6Class(
     logout_user = function(...) {
       local_var_response <- self$logout_user_with_http_info(...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1006,7 +1034,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1045,13 +1073,17 @@ UserApi <- R6::R6Class(
     update_user = function(username, user, ...) {
       local_var_response <- self$update_user_with_http_info(username, user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1126,7 +1158,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1152,6 +1184,27 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/petstore/R/R/api_client.R
+++ b/samples/client/petstore/R/R/api_client.R
@@ -411,6 +411,52 @@ ApiClient <- R6::R6Class(
         # not json mime type, simply return the first one
         return(headers[1])
       }
+    },
+
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    DeserializeResponse = function(local_var_resp, return_type = NULL) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
+      }
+      return(self$deserialize(text, return_type, loadNamespace("petstore")))
+    },
+
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (self$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
+      } else {
+        response <- self$DeserializeResponse(local_var_resp)
+        base::write(response, file)
+      }
+    },
+
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     }
   )
 )

--- a/samples/client/petstore/R/R/api_exception.R
+++ b/samples/client/petstore/R/R/api_exception.R
@@ -33,14 +33,14 @@ ApiException <- R6::R6Class(
     initialize = function(status = NULL, reason = NULL, http_response = NULL) {
       if (!is.null(http_response)) {
         self$status <- http_response$status_code
-        errorMsg <- http_response$ResponseAsText()
+        errorMsg <- http_response$response_as_text()
         if (is.null(errorMsg) || errorMsg == "") {
           errorMsg <- "Api exception encountered. No details given."
         }
         self$body <- errorMsg
         self$headers <- http_response$headers
         self$reason <- http_response$http_status_desc
-        self$error_object <- ModelApiResponse$new()$fromJSONString(http_response$ResponseAsText())
+        self$error_object <- ModelApiResponse$new()$fromJSONString(http_response$response_as_text())
       } else {
         self$status <- status
         self$reason <- reason

--- a/samples/client/petstore/R/R/api_exception.R
+++ b/samples/client/petstore/R/R/api_exception.R
@@ -33,14 +33,14 @@ ApiException <- R6::R6Class(
     initialize = function(status = NULL, reason = NULL, http_response = NULL) {
       if (!is.null(http_response)) {
         self$status <- http_response$status_code
-        errorMsg <- http_response$response
+        errorMsg <- http_response$ResponseAsText()
         if (is.null(errorMsg) || errorMsg == "") {
           errorMsg <- "Api exception encountered. No details given."
         }
         self$body <- errorMsg
         self$headers <- http_response$headers
         self$reason <- http_response$http_status_desc
-        self$error_object <- ModelApiResponse$new()$fromJSONString(http_response$response)
+        self$error_object <- ModelApiResponse$new()$fromJSONString(http_response$ResponseAsText())
       } else {
         self$status <- status
         self$reason <- reason

--- a/samples/client/petstore/R/R/api_response.R
+++ b/samples/client/petstore/R/R/api_response.R
@@ -56,9 +56,6 @@ ApiResponse <- R6::R6Class(
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
-      if (is.na(text_response)) {
-        warning("The response is binary and will not be converted to text.")
-      }
       return(text_response)
     }
   )

--- a/samples/client/petstore/R/R/api_response.R
+++ b/samples/client/petstore/R/R/api_response.R
@@ -51,7 +51,7 @@ ApiResponse <- R6::R6Class(
     #'
     #' @param from_encoding The encoding of the raw response.
     #' @param to_encoding The target encoding of the return value.
-    response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+    ResponseAsText = function(from_encoding = "", to_encoding = "UTF-8") {
       if (is.null(self$response)) {
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }

--- a/samples/client/petstore/R/R/api_response.R
+++ b/samples/client/petstore/R/R/api_response.R
@@ -51,7 +51,7 @@ ApiResponse <- R6::R6Class(
     #'
     #' @param from_encoding The encoding of the raw response.
     #' @param to_encoding The target encoding of the return value.
-    ResponseAsText = function(from_encoding = "", to_encoding = "UTF-8") {
+    response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
       if (is.null(self$response)) {
         self$response <- charToRaw(jsonlite::toJSON("NULL"))
       }

--- a/samples/client/petstore/R/R/fake_api.R
+++ b/samples/client/petstore/R/R/fake_api.R
@@ -193,11 +193,7 @@ FakeApi <- R6::R6Class(
     AddPetOptional = function(pet = NULL, data_file = NULL, ...) {
       local_var_response <- self$AddPetOptionalWithHttpInfo(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -312,11 +308,7 @@ FakeApi <- R6::R6Class(
     FakeDataFile = function(dummy, var_data_file = NULL, data_file = NULL, ...) {
       local_var_response <- self$FakeDataFileWithHttpInfo(dummy, var_data_file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -432,11 +424,7 @@ FakeApi <- R6::R6Class(
     FakePathArray = function(path_array, ...) {
       local_var_response <- self$FakePathArrayWithHttpInfo(path_array, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -536,11 +524,7 @@ FakeApi <- R6::R6Class(
     FakeRegularExpression = function(reg_exp_test, ...) {
       local_var_response <- self$FakeRegularExpressionWithHttpInfo(reg_exp_test, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -645,11 +629,7 @@ FakeApi <- R6::R6Class(
     FakeSetQuery = function(set_dummy, array_dummy, ...) {
       local_var_response <- self$FakeSetQueryWithHttpInfo(set_dummy, array_dummy, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/petstore/R/R/fake_api.R
+++ b/samples/client/petstore/R/R/fake_api.R
@@ -260,11 +260,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -382,11 +382,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "User"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -762,24 +762,50 @@ FakeApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R/R/fake_api.R
+++ b/samples/client/petstore/R/R/fake_api.R
@@ -256,11 +256,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -271,7 +271,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -375,11 +375,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "User"),
+          self$api_client$DeserializeResponse(local_var_resp, "User"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -390,7 +390,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -491,7 +491,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -596,7 +596,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -720,7 +720,7 @@ FakeApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -744,53 +744,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R/R/fake_api.R
+++ b/samples/client/petstore/R/R/fake_api.R
@@ -193,13 +193,17 @@ FakeApi <- R6::R6Class(
     AddPetOptional = function(pet = NULL, data_file = NULL, ...) {
       local_var_response <- self$AddPetOptionalWithHttpInfo(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -256,11 +260,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -268,7 +272,7 @@ FakeApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -308,13 +312,17 @@ FakeApi <- R6::R6Class(
     FakeDataFile = function(dummy, var_data_file = NULL, data_file = NULL, ...) {
       local_var_response <- self$FakeDataFileWithHttpInfo(dummy, var_data_file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -374,11 +382,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "User", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -386,7 +394,7 @@ FakeApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -424,13 +432,17 @@ FakeApi <- R6::R6Class(
     FakePathArray = function(path_array, ...) {
       local_var_response <- self$FakePathArrayWithHttpInfo(path_array, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -486,7 +498,7 @@ FakeApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -524,13 +536,17 @@ FakeApi <- R6::R6Class(
     FakeRegularExpression = function(reg_exp_test, ...) {
       local_var_response <- self$FakeRegularExpressionWithHttpInfo(reg_exp_test, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -590,7 +606,7 @@ FakeApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -629,13 +645,17 @@ FakeApi <- R6::R6Class(
     FakeSetQuery = function(set_dummy, array_dummy, ...) {
       local_var_response <- self$FakeSetQueryWithHttpInfo(set_dummy, array_dummy, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -713,7 +733,7 @@ FakeApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -739,6 +759,27 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/petstore/R/R/fake_api.R
+++ b/samples/client/petstore/R/R/fake_api.R
@@ -269,8 +269,11 @@ FakeApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -278,7 +281,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -286,7 +288,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -387,8 +388,11 @@ FakeApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -396,7 +400,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -404,7 +407,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -487,8 +489,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -496,7 +501,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -504,7 +508,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -591,8 +594,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -600,7 +606,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -608,7 +613,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -714,8 +718,11 @@ FakeApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -723,7 +730,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -731,7 +737,6 @@ FakeApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -779,7 +784,7 @@ FakeApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -396,11 +396,7 @@ PetApi <- R6::R6Class(
     AddPet = function(pet, data_file = NULL, ...) {
       local_var_response <- self$AddPetWithHttpInfo(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -521,11 +517,7 @@ PetApi <- R6::R6Class(
     DeletePet = function(pet_id, api_key = NULL, ...) {
       local_var_response <- self$DeletePetWithHttpInfo(pet_id, api_key, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -633,11 +625,7 @@ PetApi <- R6::R6Class(
     FindPetsByStatus = function(status, data_file = NULL, ...) {
       local_var_response <- self$FindPetsByStatusWithHttpInfo(status, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -763,11 +751,7 @@ PetApi <- R6::R6Class(
     FindPetsByTags = function(tags, data_file = NULL, ...) {
       local_var_response <- self$FindPetsByTagsWithHttpInfo(tags, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -881,11 +865,7 @@ PetApi <- R6::R6Class(
     GetPetById = function(pet_id, data_file = NULL, ...) {
       local_var_response <- self$GetPetByIdWithHttpInfo(pet_id, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1009,11 +989,7 @@ PetApi <- R6::R6Class(
       }
 
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1143,11 +1119,7 @@ PetApi <- R6::R6Class(
       }
 
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1270,11 +1242,7 @@ PetApi <- R6::R6Class(
     UpdatePet = function(pet, data_file = NULL, ...) {
       local_var_response <- self$UpdatePetWithHttpInfo(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1395,11 +1363,7 @@ PetApi <- R6::R6Class(
     UpdatePetWithForm = function(pet_id, name = NULL, status = NULL, ...) {
       local_var_response <- self$UpdatePetWithFormWithHttpInfo(pet_id, name, status, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1508,11 +1472,7 @@ PetApi <- R6::R6Class(
     UploadFile = function(pet_id, additional_metadata = NULL, file = NULL, data_file = NULL, ...) {
       local_var_response <- self$UploadFileWithHttpInfo(pet_id, additional_metadata, file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -479,8 +479,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -488,7 +491,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -496,7 +498,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -587,8 +588,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -596,7 +600,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -604,7 +607,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -713,8 +715,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -722,7 +727,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -730,7 +734,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -827,8 +830,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -836,7 +842,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -844,7 +849,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -946,8 +950,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -955,7 +962,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -963,7 +969,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1076,8 +1081,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1085,7 +1093,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1093,7 +1100,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1204,8 +1210,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1213,7 +1222,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1221,7 +1229,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1324,8 +1331,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1333,7 +1343,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1341,7 +1350,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1432,8 +1440,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1441,7 +1452,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1449,7 +1459,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1558,8 +1567,11 @@ PetApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1567,7 +1579,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1575,7 +1586,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1623,7 +1633,7 @@ PetApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -396,13 +396,17 @@ PetApi <- R6::R6Class(
     AddPet = function(pet, data_file = NULL, ...) {
       local_var_response <- self$AddPetWithHttpInfo(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -466,11 +470,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -478,7 +482,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -517,13 +521,17 @@ PetApi <- R6::R6Class(
     DeletePet = function(pet_id, api_key = NULL, ...) {
       local_var_response <- self$DeletePetWithHttpInfo(pet_id, api_key, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -586,7 +594,7 @@ PetApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -625,13 +633,17 @@ PetApi <- R6::R6Class(
     FindPetsByStatus = function(status, data_file = NULL, ...) {
       local_var_response <- self$FindPetsByStatusWithHttpInfo(status, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -700,11 +712,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "array[Pet]", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -712,7 +724,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -751,13 +763,17 @@ PetApi <- R6::R6Class(
     FindPetsByTags = function(tags, data_file = NULL, ...) {
       local_var_response <- self$FindPetsByTagsWithHttpInfo(tags, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -814,11 +830,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "array[Pet]", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -826,7 +842,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -865,13 +881,17 @@ PetApi <- R6::R6Class(
     GetPetById = function(pet_id, data_file = NULL, ...) {
       local_var_response <- self$GetPetByIdWithHttpInfo(pet_id, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -933,11 +953,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -945,7 +965,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -989,13 +1009,17 @@ PetApi <- R6::R6Class(
       }
 
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1063,11 +1087,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1075,7 +1099,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1119,13 +1143,17 @@ PetApi <- R6::R6Class(
       }
 
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1191,11 +1219,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1203,7 +1231,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1242,13 +1270,17 @@ PetApi <- R6::R6Class(
     UpdatePet = function(pet, data_file = NULL, ...) {
       local_var_response <- self$UpdatePetWithHttpInfo(pet, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1311,11 +1343,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1323,7 +1355,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1363,13 +1395,17 @@ PetApi <- R6::R6Class(
     UpdatePetWithForm = function(pet_id, name = NULL, status = NULL, ...) {
       local_var_response <- self$UpdatePetWithFormWithHttpInfo(pet_id, name, status, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1431,7 +1467,7 @@ PetApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1472,13 +1508,17 @@ PetApi <- R6::R6Class(
     UploadFile = function(pet_id, additional_metadata = NULL, file = NULL, data_file = NULL, ...) {
       local_var_response <- self$UploadFileWithHttpInfo(pet_id, additional_metadata, file, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1545,11 +1585,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "ModelApiResponse", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1557,7 +1597,7 @@ PetApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1583,6 +1623,27 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -470,11 +470,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -712,11 +712,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "array[Pet]"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -830,11 +830,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "array[Pet]"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -953,11 +953,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1087,11 +1087,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1219,11 +1219,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1343,11 +1343,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1585,11 +1585,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "ModelApiResponse"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1626,24 +1626,50 @@ PetApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -466,11 +466,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -481,7 +481,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -590,7 +590,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -702,11 +702,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "array[Pet]"),
+          self$api_client$DeserializeResponse(local_var_resp, "array[Pet]"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -717,7 +717,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -817,11 +817,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "array[Pet]"),
+          self$api_client$DeserializeResponse(local_var_resp, "array[Pet]"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -832,7 +832,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -937,11 +937,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -952,7 +952,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1068,11 +1068,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1083,7 +1083,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1197,11 +1197,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1212,7 +1212,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1318,11 +1318,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Pet"),
+          self$api_client$DeserializeResponse(local_var_resp, "Pet"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1333,7 +1333,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1442,7 +1442,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1554,11 +1554,11 @@ PetApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "ModelApiResponse"),
+          self$api_client$DeserializeResponse(local_var_resp, "ModelApiResponse"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1569,7 +1569,7 @@ PetApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1593,53 +1593,6 @@ PetApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -236,7 +236,7 @@ StoreApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -327,11 +327,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "map(integer)"),
+          self$api_client$DeserializeResponse(local_var_resp, "map(integer)"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -342,7 +342,7 @@ StoreApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -455,11 +455,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Order"),
+          self$api_client$DeserializeResponse(local_var_resp, "Order"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -470,7 +470,7 @@ StoreApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -573,11 +573,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "Order"),
+          self$api_client$DeserializeResponse(local_var_resp, "Order"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -588,7 +588,7 @@ StoreApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -612,53 +612,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -334,11 +334,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "map(integer)"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -465,11 +465,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Order"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -586,11 +586,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
+          private$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp),
+          private$Deserialize(local_var_resp, "Order"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -627,24 +627,50 @@ StoreApi <- R6::R6Class(
     }
   ),
   private = list(
-    WriteFile = function(x, file, accepts) {
-      if (private$IsBinary(accepts)) {
-        writeBin(x, file)
+    #' @description
+    #' Write response to a file
+    #' 
+    #' The function will write out data. 
+    #' 
+    #' 1. If binary data is detected it will use `writeBin`
+    #' 2. If the raw response is coercable to text, the text will be written to a file
+    #' 3. If the raw response is not coercable to text, the raw response will be written
+    #' 
+    #' @param local_var_resp The API response
+    #' @param file The name of the data file to save the result
+    WriteFile = function(local_var_resp, file) {
+      if (private$IsBinary(local_var_resp$response)) {
+        writeBin(local_var_resp$response, file)
       } else {
-        base::write(x, file)
+        response <- private$Deserialize(local_var_resp)
+        base::write(response, file)
       }
     },
 
-    IsBinary = function(accepts) {
-      return(any(grepl("gzip", as.character(accepts))))
+    #' @description
+    #' Check response for binary content
+    #' 
+    #' @param local_var_resp The API response
+    IsBinary = function(x) {
+      # ref: https://stackoverflow.com/a/17098690/1785752
+      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
+      return(max(b) > 128)
     },
 
-    Deserialize = function(local_var_resp) {
+    #' @description
+    #' Deserialize the response
+    #' 
+    #' @param local_var_resp The API response
+    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
+    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
+    Deserialize = function(local_var_resp, return_type = NULL) {
       text <- local_var_resp$response_as_text()
       if (is.na(text)) {
         return(local_var_resp$response)
+      } else if (is.null(return_type)) {
+        return(text)
       }
-      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
+      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -234,8 +234,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -243,7 +246,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -251,7 +253,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -339,8 +340,11 @@ StoreApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -348,7 +352,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -356,7 +359,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -466,8 +468,11 @@ StoreApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -475,7 +480,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -483,7 +487,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -583,8 +586,11 @@ StoreApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -592,7 +598,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -600,7 +605,6 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -648,7 +652,7 @@ StoreApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -171,11 +171,7 @@ StoreApi <- R6::R6Class(
     DeleteOrder = function(order_id, ...) {
       local_var_response <- self$DeleteOrderWithHttpInfo(order_id, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -275,11 +271,7 @@ StoreApi <- R6::R6Class(
     GetInventory = function(data_file = NULL, ...) {
       local_var_response <- self$GetInventoryWithHttpInfo(data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -385,11 +377,7 @@ StoreApi <- R6::R6Class(
     GetOrderById = function(order_id, data_file = NULL, ...) {
       local_var_response <- self$GetOrderByIdWithHttpInfo(order_id, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -516,11 +504,7 @@ StoreApi <- R6::R6Class(
     PlaceOrder = function(order, data_file = NULL, ...) {
       local_var_response <- self$PlaceOrderWithHttpInfo(order, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -171,13 +171,17 @@ StoreApi <- R6::R6Class(
     DeleteOrder = function(order_id, ...) {
       local_var_response <- self$DeleteOrderWithHttpInfo(order_id, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -233,7 +237,7 @@ StoreApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -271,13 +275,17 @@ StoreApi <- R6::R6Class(
     GetInventory = function(data_file = NULL, ...) {
       local_var_response <- self$GetInventoryWithHttpInfo(data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -326,11 +334,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "map(integer)", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -338,7 +346,7 @@ StoreApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -377,13 +385,17 @@ StoreApi <- R6::R6Class(
     GetOrderById = function(order_id, data_file = NULL, ...) {
       local_var_response <- self$GetOrderByIdWithHttpInfo(order_id, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -453,11 +465,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Order", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -465,7 +477,7 @@ StoreApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -504,13 +516,17 @@ StoreApi <- R6::R6Class(
     PlaceOrder = function(order, data_file = NULL, ...) {
       local_var_response <- self$PlaceOrderWithHttpInfo(order, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -570,11 +586,11 @@ StoreApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "Order", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -582,7 +598,7 @@ StoreApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -608,6 +624,27 @@ StoreApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/petstore/R/R/user_api.R
+++ b/samples/client/petstore/R/R/user_api.R
@@ -351,7 +351,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -461,7 +461,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -571,7 +571,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -676,7 +676,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -777,11 +777,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "User"),
+          self$api_client$DeserializeResponse(local_var_resp, "User"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -792,7 +792,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -909,11 +909,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          private$WriteFile(local_var_resp, data_file)
+          self$api_client$WriteFile(local_var_resp, data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          private$Deserialize(local_var_resp, "character"),
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -924,7 +924,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1015,7 +1015,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1136,7 +1136,7 @@ UserApi <- R6::R6Class(
         return(local_var_resp)
       } 
       
-      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      local_var_error_msg <- local_var_resp$response_as_text()      
       if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         
         if (local_var_error_msg == "") {
@@ -1160,53 +1160,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
-    }
-  ),
-  private = list(
-    #' @description
-    #' Write response to a file
-    #' 
-    #' The function will write out data. 
-    #' 
-    #' 1. If binary data is detected it will use `writeBin`
-    #' 2. If the raw response is coercable to text, the text will be written to a file
-    #' 3. If the raw response is not coercable to text, the raw response will be written
-    #' 
-    #' @param local_var_resp The API response
-    #' @param file The name of the data file to save the result
-    WriteFile = function(local_var_resp, file) {
-      if (private$IsBinary(local_var_resp$response)) {
-        writeBin(local_var_resp$response, file)
-      } else {
-        response <- private$Deserialize(local_var_resp)
-        base::write(response, file)
-      }
-    },
-
-    #' @description
-    #' Check response for binary content
-    #' 
-    #' @param local_var_resp The API response
-    IsBinary = function(x) {
-      # ref: https://stackoverflow.com/a/17098690/1785752
-      b <- readBin(x, "int", n = 1000, size=1, signed=FALSE)
-      return(max(b) > 128)
-    },
-
-    #' @description
-    #' Deserialize the response
-    #' 
-    #' @param local_var_resp The API response
-    #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
-    #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
-    Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$ResponseAsText()
-      if (is.na(text)) {
-        return(local_var_resp$response)
-      } else if (is.null(return_type)) {
-        return(text)
-      }
-      return(self$api_client$deserialize(text, return_type, loadNamespace("petstore")))
     }
   )
 )

--- a/samples/client/petstore/R/R/user_api.R
+++ b/samples/client/petstore/R/R/user_api.R
@@ -280,13 +280,17 @@ UserApi <- R6::R6Class(
     CreateUser = function(user, ...) {
       local_var_response <- self$CreateUserWithHttpInfo(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -348,7 +352,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -386,13 +390,17 @@ UserApi <- R6::R6Class(
     CreateUsersWithArrayInput = function(user, ...) {
       local_var_response <- self$CreateUsersWithArrayInputWithHttpInfo(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -457,7 +465,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -495,13 +503,17 @@ UserApi <- R6::R6Class(
     CreateUsersWithListInput = function(user, ...) {
       local_var_response <- self$CreateUsersWithListInputWithHttpInfo(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -566,7 +578,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -604,13 +616,17 @@ UserApi <- R6::R6Class(
     DeleteUser = function(username, ...) {
       local_var_response <- self$DeleteUserWithHttpInfo(username, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -670,7 +686,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -709,13 +725,17 @@ UserApi <- R6::R6Class(
     GetUserByName = function(username, data_file = NULL, ...) {
       local_var_response <- self$GetUserByNameWithHttpInfo(username, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -773,11 +793,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "User", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -785,7 +805,7 @@ UserApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -825,13 +845,17 @@ UserApi <- R6::R6Class(
     LoginUser = function(username, password, data_file = NULL, ...) {
       local_var_response <- self$LoginUserWithHttpInfo(username, password, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -904,11 +928,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-          write(local_var_resp$response, data_file)
+          private$WriteFile(local_var_resp$response, data_file, local_var_accepts)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("petstore")),
+          private$Deserialize(local_var_resp),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -916,7 +940,7 @@ UserApi <- R6::R6Class(
           }
         )
         local_var_resp$content <- deserialized_resp_obj
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -953,13 +977,17 @@ UserApi <- R6::R6Class(
     LogoutUser = function(...) {
       local_var_response <- self$LogoutUserWithHttpInfo(...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1006,7 +1034,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1045,13 +1073,17 @@ UserApi <- R6::R6Class(
     UpdateUser = function(username, user, ...) {
       local_var_response <- self$UpdateUserWithHttpInfo(username, user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        local_var_response$content
+        if (is.raw(local_var_response$content)) {
+          return(local_var_response)
+        } else {
+          return(local_var_response$content)
+        }
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
-        local_var_response
+        return(local_var_response)
       } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
-        local_var_response
+        return(local_var_response)
       }
     },
 
@@ -1126,7 +1158,7 @@ UserApi <- R6::R6Class(
 
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
-        local_var_resp
+        return(local_var_resp)
       } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
         local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
@@ -1152,6 +1184,27 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       }
+    }
+  ),
+  private = list(
+    WriteFile = function(x, file, accepts) {
+      if (private$IsBinary(accepts)) {
+        writeBin(x, file)
+      } else {
+        base::write(x, file)
+      }
+    },
+
+    IsBinary = function(accepts) {
+      return(any(grepl("gzip", as.character(accepts))))
+    },
+
+    Deserialize = function(local_var_resp) {
+      text <- local_var_resp$response_as_text()
+      if (is.na(text)) {
+        return(local_var_resp$response)
+      }
+      return(self$api_client$deserialize(text, "object", loadNamespace("k8s.client")))
     }
   )
 )

--- a/samples/client/petstore/R/R/user_api.R
+++ b/samples/client/petstore/R/R/user_api.R
@@ -349,8 +349,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -358,7 +361,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -366,7 +368,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -458,8 +459,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -467,7 +471,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -475,7 +478,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -567,8 +569,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -576,7 +581,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -584,7 +588,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -671,8 +674,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -680,7 +686,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -688,7 +693,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -786,8 +790,11 @@ UserApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -795,7 +802,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -803,7 +809,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -917,8 +922,11 @@ UserApi <- R6::R6Class(
         )
         local_var_resp$content <- deserialized_resp_obj
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -926,7 +934,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -934,7 +941,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1007,8 +1013,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1016,7 +1025,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1024,7 +1032,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1127,8 +1134,11 @@ UserApi <- R6::R6Class(
       if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
         local_var_resp$content <- NULL
         return(local_var_resp)
-      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
-        local_var_error_msg <- local_var_resp$response
+      } 
+      
+      local_var_error_msg <- local_var_resp$ResponseAsText()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        
         if (local_var_error_msg == "") {
           local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
         }
@@ -1136,7 +1146,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api client exception encountered."
         }
@@ -1144,7 +1153,6 @@ UserApi <- R6::R6Class(
                      .subclass = "ApiException",
                      ApiException = ApiException$new(http_response = local_var_resp))
       } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
-        local_var_error_msg <- local_var_resp$response
         if (local_var_error_msg == "") {
           local_var_error_msg <- "Api server exception encountered."
         }
@@ -1192,7 +1200,7 @@ UserApi <- R6::R6Class(
     #' @param return_type The target return type for the endpoint (e.g., `"object"`). If `NULL` text will be left as-is.
     #' @return If the raw response is corecable to text, return the text. Otherwise return the raw resposne.
     Deserialize = function(local_var_resp, return_type = NULL) {
-      text <- local_var_resp$response_as_text()
+      text <- local_var_resp$ResponseAsText()
       if (is.na(text)) {
         return(local_var_resp$response)
       } else if (is.null(return_type)) {

--- a/samples/client/petstore/R/R/user_api.R
+++ b/samples/client/petstore/R/R/user_api.R
@@ -280,11 +280,7 @@ UserApi <- R6::R6Class(
     CreateUser = function(user, ...) {
       local_var_response <- self$CreateUserWithHttpInfo(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -390,11 +386,7 @@ UserApi <- R6::R6Class(
     CreateUsersWithArrayInput = function(user, ...) {
       local_var_response <- self$CreateUsersWithArrayInputWithHttpInfo(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -503,11 +495,7 @@ UserApi <- R6::R6Class(
     CreateUsersWithListInput = function(user, ...) {
       local_var_response <- self$CreateUsersWithListInputWithHttpInfo(user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -616,11 +604,7 @@ UserApi <- R6::R6Class(
     DeleteUser = function(username, ...) {
       local_var_response <- self$DeleteUserWithHttpInfo(username, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -725,11 +709,7 @@ UserApi <- R6::R6Class(
     GetUserByName = function(username, data_file = NULL, ...) {
       local_var_response <- self$GetUserByNameWithHttpInfo(username, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -845,11 +825,7 @@ UserApi <- R6::R6Class(
     LoginUser = function(username, password, data_file = NULL, ...) {
       local_var_response <- self$LoginUserWithHttpInfo(username, password, data_file = data_file, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -977,11 +953,7 @@ UserApi <- R6::R6Class(
     LogoutUser = function(...) {
       local_var_response <- self$LogoutUserWithHttpInfo(...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
@@ -1073,11 +1045,7 @@ UserApi <- R6::R6Class(
     UpdateUser = function(username, user, ...) {
       local_var_response <- self$UpdateUserWithHttpInfo(username, user, ...)
       if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
-        if (is.raw(local_var_response$content)) {
-          return(local_var_response)
-        } else {
-          return(local_var_response$content)
-        }
+        return(local_var_response$content)
       } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
         return(local_var_response)
       } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {


### PR DESCRIPTION
@Ramanth, @saigiridhar21, @wing328 

This PR fixes a bug when handling an endpoint that returns binary data (e.g. `application/gzip`). It is really a follow-up to #17626.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
