### PR TITLE
[Elm] Add missing operation summary

### DIFF
--- a/modules/openapi-generator/src/main/resources/elm/operation.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/operation.mustache
@@ -30,10 +30,9 @@ import File exposing (File){{/includeFile}}
 {{#operations}}
 {{#operation}}
 
-{{#notes}}
-{-| {{{notes}}}
+{{#summary}}{-| {{{summary}}}{{#notes}}. {{{notes}}}{{/notes}}
 -}
-{{/notes}}
+{{/summary}}
 {{#lambda.removeWhitespace}}
 {{operationId}} : {{#allParams}}{{>operationParameter}} -> {{/allParams}}
     {{#authMethods}}{{#isBasicBearer}}String -> {{/isBasicBearer}}{{/authMethods}}Api.Request

--- a/modules/openapi-generator/src/main/resources/elm/operation.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/operation.mustache
@@ -13,11 +13,11 @@ import Json.Decode
 import Json.Encode{{#includeUuid}}
 import Uuid exposing (Uuid){{/includeUuid}}{{#includeFile}}
 import File exposing (File){{/includeFile}}
+
 {{#operations}}
 {{#operation}}
 {{#allParams}}
 {{#isEnum}}
-
 
 {{>customType}}
 
@@ -28,11 +28,15 @@ import File exposing (File){{/includeFile}}
 {{/operation}}
 {{/operations}}
 {{#operations}}
-{{#operation}}
+{{#operation}}{{#summary}}
+{-| {{{summary}}}
+{{#notes}}
 
-{{#summary}}{-| {{{summary}}}{{#notes}}. {{{notes}}}{{/notes}}
--}
-{{/summary}}
+{{{notes}}}
+
+{{/notes}}
+-}{{/summary}}{{^summary}}{{#notes}}{-| {{{notes}}}
+-}{{/notes}}{{/summary}}
 {{#lambda.removeWhitespace}}
 {{operationId}} : {{#allParams}}{{>operationParameter}} -> {{/allParams}}
     {{#authMethods}}{{#isBasicBearer}}String -> {{/isBasicBearer}}{{/authMethods}}Api.Request

--- a/samples/client/petstore/elm/src/Api/Request/Pet.elm
+++ b/samples/client/petstore/elm/src/Api/Request/Pet.elm
@@ -89,7 +89,10 @@ deletePet petId_path apiKey_header =
         (Json.Decode.succeed ())
 
 
-{-| Finds Pets by status. Multiple status values can be provided with comma separated strings
+{-| Finds Pets by status
+
+Multiple status values can be provided with comma separated strings
+
 -}
 findPetsByStatus : List Status -> Api.Request (List Api.Data.Pet)
 findPetsByStatus status_query =
@@ -103,7 +106,10 @@ findPetsByStatus status_query =
         (Json.Decode.list Api.Data.petDecoder)
 
 
-{-| Finds Pets by tags. Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+{-| Finds Pets by tags
+
+Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+
 -}
 findPetsByTags : List String -> Api.Request (List Api.Data.Pet)
 findPetsByTags tags_query =
@@ -117,7 +123,10 @@ findPetsByTags tags_query =
         (Json.Decode.list Api.Data.petDecoder)
 
 
-{-| Find pet by ID. Returns a single pet
+{-| Find pet by ID
+
+Returns a single pet
+
 -}
 getPetById : Int -> Api.Request Api.Data.Pet
 getPetById petId_path =

--- a/samples/client/petstore/elm/src/Api/Request/Pet.elm
+++ b/samples/client/petstore/elm/src/Api/Request/Pet.elm
@@ -61,6 +61,8 @@ stringFromStatus model =
 
 
 
+{-| Add a new pet to the store
+-}
 addPet : Api.Data.Pet -> Api.Request Api.Data.Pet
 addPet pet_body =
     Api.request
@@ -73,6 +75,8 @@ addPet pet_body =
         Api.Data.petDecoder
 
 
+{-| Deletes a pet
+-}
 deletePet : Int -> Maybe String -> Api.Request ()
 deletePet petId_path apiKey_header =
     Api.request
@@ -85,7 +89,7 @@ deletePet petId_path apiKey_header =
         (Json.Decode.succeed ())
 
 
-{-| Multiple status values can be provided with comma separated strings
+{-| Finds Pets by status. Multiple status values can be provided with comma separated strings
 -}
 findPetsByStatus : List Status -> Api.Request (List Api.Data.Pet)
 findPetsByStatus status_query =
@@ -99,7 +103,7 @@ findPetsByStatus status_query =
         (Json.Decode.list Api.Data.petDecoder)
 
 
-{-| Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+{-| Finds Pets by tags. Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
 -}
 findPetsByTags : List String -> Api.Request (List Api.Data.Pet)
 findPetsByTags tags_query =
@@ -113,7 +117,7 @@ findPetsByTags tags_query =
         (Json.Decode.list Api.Data.petDecoder)
 
 
-{-| Returns a single pet
+{-| Find pet by ID. Returns a single pet
 -}
 getPetById : Int -> Api.Request Api.Data.Pet
 getPetById petId_path =
@@ -127,6 +131,8 @@ getPetById petId_path =
         Api.Data.petDecoder
 
 
+{-| Update an existing pet
+-}
 updatePet : Api.Data.Pet -> Api.Request Api.Data.Pet
 updatePet pet_body =
     Api.request
@@ -139,6 +145,8 @@ updatePet pet_body =
         Api.Data.petDecoder
 
 
+{-| Updates a pet in the store with form data
+-}
 updatePetWithForm : Int -> Maybe String -> Maybe String -> Api.Request ()
 updatePetWithForm petId_path name status =
     Api.request
@@ -151,6 +159,8 @@ updatePetWithForm petId_path name status =
         (Json.Decode.succeed ())
 
 
+{-| uploads an image
+-}
 uploadFile : Int -> Maybe String -> Maybe File -> Api.Request Api.Data.ApiResponse
 uploadFile petId_path additionalMetadata file =
     Api.request

--- a/samples/client/petstore/elm/src/Api/Request/Store.elm
+++ b/samples/client/petstore/elm/src/Api/Request/Store.elm
@@ -27,7 +27,7 @@ import Http
 import Json.Decode
 import Json.Encode
 
-{-| For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+{-| Delete purchase order by ID. For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
 -}
 deleteOrder : String -> Api.Request ()
 deleteOrder orderId_path =
@@ -41,7 +41,7 @@ deleteOrder orderId_path =
         (Json.Decode.succeed ())
 
 
-{-| Returns a map of status codes to quantities
+{-| Returns pet inventories by status. Returns a map of status codes to quantities
 -}
 getInventory : Api.Request (Dict.Dict String Int)
 getInventory =
@@ -55,7 +55,7 @@ getInventory =
         (Json.Decode.dict Json.Decode.int)
 
 
-{-| For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+{-| Find purchase order by ID. For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
 -}
 getOrderById : Int -> Api.Request Api.Data.Order_
 getOrderById orderId_path =
@@ -69,6 +69,8 @@ getOrderById orderId_path =
         Api.Data.orderDecoder
 
 
+{-| Place an order for a pet
+-}
 placeOrder : Api.Data.Order_ -> Api.Request Api.Data.Order_
 placeOrder order_body =
     Api.request

--- a/samples/client/petstore/elm/src/Api/Request/Store.elm
+++ b/samples/client/petstore/elm/src/Api/Request/Store.elm
@@ -27,7 +27,11 @@ import Http
 import Json.Decode
 import Json.Encode
 
-{-| Delete purchase order by ID. For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+
+{-| Delete purchase order by ID
+
+For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+
 -}
 deleteOrder : String -> Api.Request ()
 deleteOrder orderId_path =
@@ -41,7 +45,10 @@ deleteOrder orderId_path =
         (Json.Decode.succeed ())
 
 
-{-| Returns pet inventories by status. Returns a map of status codes to quantities
+{-| Returns pet inventories by status
+
+Returns a map of status codes to quantities
+
 -}
 getInventory : Api.Request (Dict.Dict String Int)
 getInventory =
@@ -55,7 +62,10 @@ getInventory =
         (Json.Decode.dict Json.Decode.int)
 
 
-{-| Find purchase order by ID. For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+{-| Find purchase order by ID
+
+For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+
 -}
 getOrderById : Int -> Api.Request Api.Data.Order_
 getOrderById orderId_path =

--- a/samples/client/petstore/elm/src/Api/Request/User.elm
+++ b/samples/client/petstore/elm/src/Api/Request/User.elm
@@ -31,7 +31,7 @@ import Http
 import Json.Decode
 import Json.Encode
 
-{-| This can only be done by the logged in user.
+{-| Create user. This can only be done by the logged in user.
 -}
 createUser : Api.Data.User -> Api.Request ()
 createUser user_body =
@@ -45,6 +45,8 @@ createUser user_body =
         (Json.Decode.succeed ())
 
 
+{-| Creates list of users with given input array
+-}
 createUsersWithArrayInput : List Api.Data.User -> Api.Request ()
 createUsersWithArrayInput user_body =
     Api.request
@@ -57,6 +59,8 @@ createUsersWithArrayInput user_body =
         (Json.Decode.succeed ())
 
 
+{-| Creates list of users with given input array
+-}
 createUsersWithListInput : List Api.Data.User -> Api.Request ()
 createUsersWithListInput user_body =
     Api.request
@@ -69,7 +73,7 @@ createUsersWithListInput user_body =
         (Json.Decode.succeed ())
 
 
-{-| This can only be done by the logged in user.
+{-| Delete user. This can only be done by the logged in user.
 -}
 deleteUser : String -> Api.Request ()
 deleteUser username_path =
@@ -83,6 +87,8 @@ deleteUser username_path =
         (Json.Decode.succeed ())
 
 
+{-| Get user by user name
+-}
 getUserByName : String -> Api.Request Api.Data.User
 getUserByName username_path =
     Api.request
@@ -95,6 +101,8 @@ getUserByName username_path =
         Api.Data.userDecoder
 
 
+{-| Logs user into the system
+-}
 loginUser : String -> String -> Api.Request String
 loginUser username_query password_query =
     Api.request
@@ -107,6 +115,8 @@ loginUser username_query password_query =
         Json.Decode.string
 
 
+{-| Logs out current logged in user session
+-}
 logoutUser : Api.Request ()
 logoutUser =
     Api.request
@@ -119,7 +129,7 @@ logoutUser =
         (Json.Decode.succeed ())
 
 
-{-| This can only be done by the logged in user.
+{-| Updated user. This can only be done by the logged in user.
 -}
 updateUser : String -> Api.Data.User -> Api.Request ()
 updateUser username_path user_body =

--- a/samples/client/petstore/elm/src/Api/Request/User.elm
+++ b/samples/client/petstore/elm/src/Api/Request/User.elm
@@ -31,7 +31,11 @@ import Http
 import Json.Decode
 import Json.Encode
 
-{-| Create user. This can only be done by the logged in user.
+
+{-| Create user
+
+This can only be done by the logged in user.
+
 -}
 createUser : Api.Data.User -> Api.Request ()
 createUser user_body =
@@ -73,7 +77,10 @@ createUsersWithListInput user_body =
         (Json.Decode.succeed ())
 
 
-{-| Delete user. This can only be done by the logged in user.
+{-| Delete user
+
+This can only be done by the logged in user.
+
 -}
 deleteUser : String -> Api.Request ()
 deleteUser username_path =
@@ -129,7 +136,10 @@ logoutUser =
         (Json.Decode.succeed ())
 
 
-{-| Updated user. This can only be done by the logged in user.
+{-| Updated user
+
+This can only be done by the logged in user.
+
 -}
 updateUser : String -> Api.Data.User -> Api.Request ()
 updateUser username_path user_body =

--- a/samples/openapi3/client/elm/src/Api/Request/Default.elm
+++ b/samples/openapi3/client/elm/src/Api/Request/Default.elm
@@ -54,7 +54,6 @@ stringFromHeaderType model =
 
 
 
-
 type Enumeration
     = EnumerationA
     | EnumerationB
@@ -80,7 +79,6 @@ stringFromEnumeration model =
 
         EnumerationC ->
             "c"
-
 
 
 

--- a/samples/openapi3/client/elm/src/Api/Request/Default.elm
+++ b/samples/openapi3/client/elm/src/Api/Request/Default.elm
@@ -160,6 +160,8 @@ queryGet string_query int_query enum_query =
         (Json.Decode.succeed ())
 
 
+{-| Secured endpoint
+-}
 securedPost : String -> Api.Request ()
 securedPost auth_token =
     Api.request

--- a/samples/openapi3/client/elm/src/Api/Request/Primitive.elm
+++ b/samples/openapi3/client/elm/src/Api/Request/Primitive.elm
@@ -24,6 +24,7 @@ import Http
 import Json.Decode
 import Json.Encode
 
+
 update : Api.Data.Primitive -> Api.Request Api.Data.Primitive
 update primitive_body =
     Api.request


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

We currently only print the notes in a doc comment if they exist. This PR fixes so both the summary and notes are printed as expected.


<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
