### PR TITLE
[swift6] Add conditional Hashable conformance to NullEncodable

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/Models.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/Models.mustache
@@ -38,12 +38,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum NullEncodable<Wrapped: Hashable>: Hashable {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -38,12 +38,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-public enum NullEncodable<Wrapped: Hashable>: Hashable {
+public enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -38,12 +38,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-public enum NullEncodable<Wrapped: Hashable>: Hashable {
+public enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -37,12 +37,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-public enum NullEncodable<Wrapped: Hashable>: Hashable {
+public enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -37,12 +37,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-public enum NullEncodable<Wrapped: Hashable>: Hashable {
+public enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Models.swift
@@ -37,12 +37,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-public enum NullEncodable<Wrapped: Hashable>: Hashable {
+public enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -37,12 +37,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-public enum NullEncodable<Wrapped: Hashable>: Hashable {
+public enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -37,12 +37,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-public enum NullEncodable<Wrapped: Hashable>: Hashable {
+public enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -37,12 +37,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-public enum NullEncodable<Wrapped: Hashable>: Hashable {
+public enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -37,12 +37,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-public enum NullEncodable<Wrapped: Hashable>: Hashable {
+public enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -37,12 +37,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-internal enum NullEncodable<Wrapped: Hashable>: Hashable {
+internal enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -37,12 +37,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-public enum NullEncodable<Wrapped: Hashable>: Hashable {
+public enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -37,12 +37,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-public enum NullEncodable<Wrapped: Hashable>: Hashable {
+public enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -37,12 +37,14 @@ extension CaseIterableDefaultsLast {
 
 /// A flexible type that can be encoded (`.encodeNull` or `.encodeValue`)
 /// or not encoded (`.encodeNothing`). Intended for request payloads.
-public enum NullEncodable<Wrapped: Hashable>: Hashable {
+public enum NullEncodable<Wrapped> {
     case encodeNothing
     case encodeNull
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Equatable where Wrapped: Equatable {}
+extension NullEncodable: Hashable where Wrapped: Hashable {}
 extension NullEncodable: Sendable where Wrapped: Sendable {}
 
 extension NullEncodable: Codable where Wrapped: Codable {


### PR DESCRIPTION
NullEncodable currently assumes that all usages conform to Hashable. This could lead to compilation errors in the generated code.

@jgavris @ehyche @Edubits @jaz-ah @4brunu @dydus0x14

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
