### PR TITLE
Added default headers to `ServerError<T>` for Kotlin OkHTTP generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiResponse.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiResponse.kt.mustache
@@ -39,5 +39,5 @@ package {{packageName}}.infrastructure
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val message: String? = null,
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ public class ServerError<T>(
     public val message: String? = null,
     public val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ internal class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
@@ -39,5 +39,5 @@ class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
-    override val headers: Map<String, List<String>>
+    override val headers: Map<String, List<String>> = mapOf()
 ): ApiResponse<T>(ResponseType.ServerError)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

See: https://github.com/OpenAPITools/openapi-generator/issues/20160

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
  - @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier @e5l 