### PR TITLE
PHP8.4 comptible, php-symfony resources

### DIFF
--- a/.github/workflows/samples-php8.yaml
+++ b/.github/workflows/samples-php8.yaml
@@ -16,6 +16,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        php:
+          - "8.1"
+          - "8.2"
+          - "8.3"
         sample:
           # servers
           - samples/server/petstore/php-symfony/SymfonyBundle-php/
@@ -25,7 +29,7 @@ jobs:
       - name: Setup PHP with tools
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: "${{ matrix.php }}"
           tools: php-cs-fixer, phpunit
       - name: composer install
         working-directory: ${{ matrix.sample }}

--- a/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
@@ -151,7 +151,7 @@ class Controller extends AbstractController
      *
      * @return array|null
      */
-    private function exceptionToArray(\Throwable $exception = null): ?array
+    private function exceptionToArray(?\Throwable $exception = null): ?array
     {
         if (null === $exception) {
             return null;

--- a/modules/openapi-generator/src/main/resources/php-symfony/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/model_generic.mustache
@@ -6,7 +6,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}
      * Constructor
      * @param array|null $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         {{#parentSchema}}
         parent::__construct($data);

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
@@ -161,7 +161,7 @@ class Controller extends AbstractController
      *
      * @return array|null
      */
-    private function exceptionToArray(\Throwable $exception = null): ?array
+    private function exceptionToArray(?\Throwable $exception = null): ?array
     {
         if (null === $exception) {
             return null;

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/ApiResponse.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/ApiResponse.php
@@ -73,7 +73,7 @@ class ApiResponse
      * Constructor
      * @param array|null $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if (is_array($data)) {
             $this->code = array_key_exists('code', $data) ? $data['code'] : $this->code;

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Category.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Category.php
@@ -66,7 +66,7 @@ class Category
      * Constructor
      * @param array|null $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if (is_array($data)) {
             $this->id = array_key_exists('id', $data) ? $data['id'] : $this->id;

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
@@ -100,7 +100,7 @@ class Order
      * Constructor
      * @param array|null $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if (is_array($data)) {
             $this->id = array_key_exists('id', $data) ? $data['id'] : $this->id;

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
@@ -106,7 +106,7 @@ class Pet
      * Constructor
      * @param array|null $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if (is_array($data)) {
             $this->id = array_key_exists('id', $data) ? $data['id'] : $this->id;

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Tag.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Tag.php
@@ -65,7 +65,7 @@ class Tag
      * Constructor
      * @param array|null $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if (is_array($data)) {
             $this->id = array_key_exists('id', $data) ? $data['id'] : $this->id;

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/User.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/User.php
@@ -115,7 +115,7 @@ class User
      * Constructor
      * @param array|null $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if (is_array($data)) {
             $this->id = array_key_exists('id', $data) ? $data['id'] : $this->id;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


add PHP 8.4 support

https://www.php.net/releases/8.4/en.php

In PHP 8.4, when using default arguments set to null, you are required to specify a type hint that includes either nullable or a union type with null. If this is not specified, a deprecated error will be displayed starting in PHP 8.4. This change is being addressed.
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Additionally, matrix build settings have been added to ensure the project is built across multiple PHP versions.