### PR TITLE
[swift6] Add Identifiable conformance to supported models

### DIFF
--- a/bin/configs/swift6-objcCompatible.yaml
+++ b/bin/configs/swift6-objcCompatible.yaml
@@ -6,6 +6,7 @@ generateAliasAsModel: true
 additionalProperties:
   responseAs: ObjcBlock
   podAuthors: ""
+  identifiableModels: false
   podSummary: PetstoreClient
   objcCompatible: true
   projectName: PetstoreClient

--- a/docs/generators/swift6.md
+++ b/docs/generators/swift6.md
@@ -28,6 +28,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |generateModelAdditionalProperties|Generate model additional properties (default: true)| |true|
 |hashableModels|Make hashable models (default: true)| |true|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
+|identifiableModels|Make models conform to Identifiable when an id is present (default: true)| |true|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |library|Library template (sub-template) to use|<dl><dt>**urlsession**</dt><dd>[DEFAULT] HTTP client: URLSession</dd><dt>**alamofire**</dt><dd>HTTP client: Alamofire</dd><dt>**vapor**</dt><dd>HTTP client: Vapor</dd></dl>|urlsession|
 |mapFileBinaryToData|Map File and Binary to Data (default: false)| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
@@ -70,6 +70,7 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
     public static final String USE_BACKTICK_ESCAPES = "useBacktickEscapes";
     public static final String GENERATE_MODEL_ADDITIONAL_PROPERTIES = "generateModelAdditionalProperties";
     public static final String HASHABLE_MODELS = "hashableModels";
+    public static final String IDENTIFIABLE_MODELS = "identifiableModels";
     public static final String USE_JSON_ENCODABLE = "useJsonEncodable";
     public static final String MAP_FILE_BINARY_TO_DATA = "mapFileBinaryToData";
     public static final String USE_CUSTOM_DATE_WITHOUT_TIME = "useCustomDateWithoutTime";
@@ -98,6 +99,7 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
     @Setter protected boolean useBacktickEscapes = false;
     @Setter protected boolean generateModelAdditionalProperties = true;
     @Setter protected boolean hashableModels = true;
+    @Setter protected boolean identifiableModels = true;
     @Setter protected boolean useJsonEncodable = true;
     @Getter @Setter protected boolean mapFileBinaryToData = false;
     @Setter protected boolean useCustomDateWithoutTime = false;
@@ -305,6 +307,10 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
 
         cliOptions.add(new CliOption(HASHABLE_MODELS,
                 "Make hashable models (default: true)")
+                .defaultValue(Boolean.TRUE.toString()));
+
+        cliOptions.add(new CliOption(IDENTIFIABLE_MODELS,
+                "Make models conform to Identifiable when an id is present (default: true)")
                 .defaultValue(Boolean.TRUE.toString()));
 
         cliOptions.add(new CliOption(USE_JSON_ENCODABLE,
@@ -526,6 +532,11 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
             setHashableModels(convertPropertyToBooleanAndWriteBack(HASHABLE_MODELS));
         }
         additionalProperties.put(HASHABLE_MODELS, hashableModels);
+
+        if (additionalProperties.containsKey(IDENTIFIABLE_MODELS)) {
+            setIdentifiableModels(convertPropertyToBooleanAndWriteBack(IDENTIFIABLE_MODELS));
+        }
+        additionalProperties.put(IDENTIFIABLE_MODELS, identifiableModels);
 
         if (additionalProperties.containsKey(USE_JSON_ENCODABLE)) {
             setUseJsonEncodable(convertPropertyToBooleanAndWriteBack(USE_JSON_ENCODABLE));
@@ -972,6 +983,15 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
         }
         if (hashableModels) {
             codegenModel.vendorExtensions.put("x-swift-hashable", true);
+        }
+        if (identifiableModels && !codegenModel.vendorExtensions.containsKey("x-swift-identifiable")) {
+            for (CodegenProperty cp : codegenModel.getVars()) {
+                if (!cp.getBaseName().equals("id")) continue;
+                if (cp.isString || cp.isUuid || cp.isInteger || cp.isLong) {
+                    codegenModel.vendorExtensions.put("x-swift-identifiable", true);
+                    break;
+                }
+            }
         }
         return codegenModel;
     }

--- a/modules/openapi-generator/src/main/resources/swift6/model.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/model.mustache
@@ -24,4 +24,7 @@ extension {{projectName}}API {
 {{> modelObject}}{{/isEnum}}{{/isArray}}{{/vendorExtensions.x-is-one-of-interface}}{{/model}}{{/models}}
 {{#swiftUseApiNamespace}}
 }
-{{/swiftUseApiNamespace}}
+{{/swiftUseApiNamespace}}{{#models}}{{#model}}{{#vendorExtensions.x-swift-identifiable}}
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension {{#swiftUseApiNamespace}}{{projectName}}API.{{/swiftUseApiNamespace}}{{{classname}}}: Identifiable {}
+{{/vendorExtensions.x-swift-identifiable}}{{/model}}{{/models}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/Swift6ClientCodegenOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/Swift6ClientCodegenOptionsProvider.java
@@ -48,6 +48,7 @@ public class Swift6ClientCodegenOptionsProvider implements OptionsProvider {
     public static final String USE_BACKTICKS_ESCAPES_VALUE = "false";
     public static final String GENERATE_MODEL_ADDITIONAL_PROPERTIES_VALUE = "true";
     public static final String HASHABLE_MODELS_VALUE = "true";
+    public static final String IDENTIFIABLE_MODELS_VALUE = "true";
     public static final String USE_JSON_ENCODABLE_VALUE = "true";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String PREPEND_FORM_OR_BODY_PARAMETERS_VALUE = "true";
@@ -98,15 +99,16 @@ public class Swift6ClientCodegenOptionsProvider implements OptionsProvider {
                 .put(Swift6ClientCodegen.GENERATE_MODEL_ADDITIONAL_PROPERTIES,
                         GENERATE_MODEL_ADDITIONAL_PROPERTIES_VALUE)
                 .put(Swift6ClientCodegen.HASHABLE_MODELS, HASHABLE_MODELS_VALUE)
+                .put(Swift6ClientCodegen.IDENTIFIABLE_MODELS, IDENTIFIABLE_MODELS_VALUE)
                 .put(Swift6ClientCodegen.USE_JSON_ENCODABLE, USE_JSON_ENCODABLE_VALUE)
                 .put(Swift6ClientCodegen.MAP_FILE_BINARY_TO_DATA, "false")
                 .put(Swift6ClientCodegen.USE_CUSTOM_DATE_WITHOUT_TIME, "false")
                 .put(Swift6ClientCodegen.VALIDATABLE, "true")
                 .put(Swift6ClientCodegen.ONE_OF_UNKNOWN_DEFAULT_CASE, "false")
                 .put(Swift6ClientCodegen.USE_CLASSES, "false")
-                .put(Swift6ClientCodegen.API_STATIC_METHOD, 
+                .put(Swift6ClientCodegen.API_STATIC_METHOD,
                         API_STATIC_METHOD_VALUE)
-                .put(Swift6ClientCodegen.COMBINE_DEFERRED, 
+                .put(Swift6ClientCodegen.COMBINE_DEFERRED,
                         COMBINE_DEFERRED_VALUE)
                 .put(CodegenConstants.ENUM_UNKNOWN_DEFAULT_CASE, ENUM_UNKNOWN_DEFAULT_CASE_VALUE)
                 .build();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenOptionsTest.java
@@ -53,6 +53,7 @@ public class Swift6ClientCodegenOptionsTest extends AbstractOptionsTest {
         verify(clientCodegen).setGenerateModelAdditionalProperties(
                 Boolean.parseBoolean(Swift6ClientCodegenOptionsProvider.GENERATE_MODEL_ADDITIONAL_PROPERTIES_VALUE));
         verify(clientCodegen).setHashableModels(Boolean.parseBoolean(Swift6ClientCodegenOptionsProvider.HASHABLE_MODELS_VALUE));
+        verify(clientCodegen).setIdentifiableModels(Boolean.parseBoolean(Swift6ClientCodegenOptionsProvider.IDENTIFIABLE_MODELS_VALUE));
         verify(clientCodegen)
                 .setEnumUnknownDefaultCase(Boolean.parseBoolean(Swift6ClientCodegenOptionsProvider.ENUM_UNKNOWN_DEFAULT_CASE_VALUE));
         verify(clientCodegen).setApiStaticMethod(Boolean.parseBoolean(Swift6ClientCodegenOptionsProvider.API_STATIC_METHOD_VALUE));

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/Category.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/Category.swift
@@ -31,3 +31,6 @@ public struct Category: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Category: Identifiable {}

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/Order.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/Order.swift
@@ -53,3 +53,6 @@ public struct Order: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Order: Identifiable {}

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/Pet.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/Pet.swift
@@ -56,3 +56,6 @@ public struct Pet: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Pet: Identifiable {}

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/Tag.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/Tag.swift
@@ -31,3 +31,6 @@ public struct Tag: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Tag: Identifiable {}

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/User.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/User.swift
@@ -56,3 +56,6 @@ public struct User: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension User: Identifiable {}

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/Category.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/Category.swift
@@ -31,3 +31,6 @@ public struct Category: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Category: Identifiable {}

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/Order.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/Order.swift
@@ -53,3 +53,6 @@ public struct Order: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Order: Identifiable {}

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/Pet.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/Pet.swift
@@ -56,3 +56,6 @@ public struct Pet: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Pet: Identifiable {}

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/Tag.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/Tag.swift
@@ -31,3 +31,6 @@ public struct Tag: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Tag: Identifiable {}

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/User.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/User.swift
@@ -56,3 +56,6 @@ public struct User: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension User: Identifiable {}

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/Category.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/Category.swift
@@ -31,3 +31,6 @@ public struct Category: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Category: Identifiable {}

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/Order.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/Order.swift
@@ -53,3 +53,6 @@ public struct Order: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Order: Identifiable {}

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/Pet.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/Pet.swift
@@ -56,3 +56,6 @@ public struct Pet: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Pet: Identifiable {}

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/Tag.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/Tag.swift
@@ -31,3 +31,6 @@ public struct Tag: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Tag: Identifiable {}

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/User.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/User.swift
@@ -56,3 +56,6 @@ public struct User: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension User: Identifiable {}

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -31,3 +31,6 @@ public struct Category: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Category: Identifiable {}

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -53,3 +53,6 @@ public struct Order: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Order: Identifiable {}

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -56,3 +56,6 @@ public struct Pet: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Pet: Identifiable {}

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -31,3 +31,6 @@ public struct Tag: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Tag: Identifiable {}

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -56,3 +56,6 @@ public struct User: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension User: Identifiable {}

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/Category.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/Category.swift
@@ -31,3 +31,6 @@ public struct Category: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Category: Identifiable {}

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/Order.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/Order.swift
@@ -53,3 +53,6 @@ public struct Order: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Order: Identifiable {}

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/Pet.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/Pet.swift
@@ -56,3 +56,6 @@ public struct Pet: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Pet: Identifiable {}

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/Tag.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/Tag.swift
@@ -31,3 +31,6 @@ public struct Tag: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Tag: Identifiable {}

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/User.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/User.swift
@@ -56,3 +56,6 @@ public struct User: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension User: Identifiable {}

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Models/Category.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Models/Category.swift
@@ -31,3 +31,6 @@ public struct Category: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Category: Identifiable {}

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Models/Order.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Models/Order.swift
@@ -53,3 +53,6 @@ public struct Order: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Order: Identifiable {}

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Models/Pet.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Models/Pet.swift
@@ -54,3 +54,6 @@ public struct Pet: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Pet: Identifiable {}

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Models/Tag.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Models/Tag.swift
@@ -31,3 +31,6 @@ public struct Tag: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Tag: Identifiable {}

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Models/User.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Models/User.swift
@@ -56,3 +56,6 @@ public struct User: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension User: Identifiable {}

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -31,3 +31,6 @@ public struct Category: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Category: Identifiable {}

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -53,3 +53,6 @@ public struct Order: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Order: Identifiable {}

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -56,3 +56,6 @@ public struct Pet: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Pet: Identifiable {}

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -31,3 +31,6 @@ public struct Tag: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Tag: Identifiable {}

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -56,3 +56,6 @@ public struct User: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension User: Identifiable {}

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -31,3 +31,6 @@ internal struct Category: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Category: Identifiable {}

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -54,3 +54,6 @@ internal struct Order: Sendable, Codable, JSONEncodable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Order: Identifiable {}

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -57,3 +57,6 @@ internal struct Pet: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Pet: Identifiable {}

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -31,3 +31,6 @@ internal struct Tag: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Tag: Identifiable {}

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -56,3 +56,6 @@ internal struct User: Sendable, Codable, JSONEncodable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension User: Identifiable {}

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -31,3 +31,6 @@ public struct Category: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Category: Identifiable {}

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -53,3 +53,6 @@ public struct Order: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Order: Identifiable {}

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -56,3 +56,6 @@ public struct Pet: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Pet: Identifiable {}

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -31,3 +31,6 @@ public struct Tag: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Tag: Identifiable {}

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -56,3 +56,6 @@ public struct User: Sendable, Codable, JSONEncodable, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension User: Identifiable {}

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/Category.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/Category.swift
@@ -49,3 +49,6 @@ public final class Category: @unchecked Sendable, Codable, JSONEncodable, Hashab
 }
 
 }
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension PetstoreClientAPI.Category: Identifiable {}

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/Order.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/Order.swift
@@ -79,3 +79,6 @@ public final class Order: @unchecked Sendable, Codable, JSONEncodable, Hashable 
 }
 
 }
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension PetstoreClientAPI.Order: Identifiable {}

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/Pet.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/Pet.swift
@@ -82,3 +82,6 @@ public final class Pet: @unchecked Sendable, Codable, JSONEncodable, Hashable {
 }
 
 }
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension PetstoreClientAPI.Pet: Identifiable {}

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/Tag.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/Tag.swift
@@ -49,3 +49,6 @@ public final class Tag: @unchecked Sendable, Codable, JSONEncodable, Hashable {
 }
 
 }
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension PetstoreClientAPI.Tag: Identifiable {}

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/User.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/User.swift
@@ -86,3 +86,6 @@ public final class User: @unchecked Sendable, Codable, JSONEncodable, Hashable {
 }
 
 }
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension PetstoreClientAPI.User: Identifiable {}

--- a/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/Models/Category.swift
+++ b/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/Models/Category.swift
@@ -44,3 +44,6 @@ public final class Category: Content, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Category: Identifiable {}

--- a/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/Models/Order.swift
+++ b/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/Models/Order.swift
@@ -74,3 +74,6 @@ public final class Order: Content, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Order: Identifiable {}

--- a/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/Models/Pet.swift
+++ b/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/Models/Pet.swift
@@ -75,3 +75,6 @@ public final class Pet: Content, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Pet: Identifiable {}

--- a/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/Models/Tag.swift
+++ b/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/Models/Tag.swift
@@ -44,3 +44,6 @@ public final class Tag: Content, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension Tag: Identifiable {}

--- a/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/Models/User.swift
+++ b/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/Models/User.swift
@@ -81,3 +81,6 @@ public final class User: Content, Hashable {
     }
 }
 
+
+@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
+extension User: Identifiable {}


### PR DESCRIPTION
This PR adds a new compiler option (enabled by default) that adds conformance to the Identifiable protocol to models that have an `id` property of type string, UUID or any integer. Specs can override this per-model by adding the `x-swift-identifiable` extension.

Resolves #20143

@jgavris @ehyche @Edubits @jaz-ah @4brunu @dydus0x14

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
