### PR TITLE
[swift6] Change Response to struct

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/Models.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/Models.mustache
@@ -90,7 +90,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     case generalError(Error)
 }
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class Response<T> {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} struct Response<T> {
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let statusCode: Int
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let header: [String: String]
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let body: T
@@ -103,7 +103,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
         self.bodyData = bodyData
     }
 
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -113,7 +113,8 @@ extension NullEncodable: Codable where Wrapped: Codable {
         }
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
-}{{#useAlamofire}}
+}
+extension Response : Sendable where T : Sendable {}{{#useAlamofire}}
 
 /// Type-erased ResponseSerializer
 ///

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -90,7 +90,7 @@ public enum DecodableRequestBuilderError: Error {
     case generalError(Error)
 }
 
-open class Response<T> {
+public struct Response<T> {
     public let statusCode: Int
     public let header: [String: String]
     public let body: T
@@ -103,7 +103,7 @@ open class Response<T> {
         self.bodyData = bodyData
     }
 
-    public convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    public init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -114,6 +114,7 @@ open class Response<T> {
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
 }
+extension Response : Sendable where T : Sendable {}
 
 /// Type-erased ResponseSerializer
 ///

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -90,7 +90,7 @@ public enum DecodableRequestBuilderError: Error {
     case generalError(Error)
 }
 
-open class Response<T> {
+public struct Response<T> {
     public let statusCode: Int
     public let header: [String: String]
     public let body: T
@@ -103,7 +103,7 @@ open class Response<T> {
         self.bodyData = bodyData
     }
 
-    public convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    public init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -114,6 +114,7 @@ open class Response<T> {
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
 }
+extension Response : Sendable where T : Sendable {}
 
 /// Type-erased ResponseSerializer
 ///

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -89,7 +89,7 @@ public enum DecodableRequestBuilderError: Error {
     case generalError(Error)
 }
 
-open class Response<T> {
+public struct Response<T> {
     public let statusCode: Int
     public let header: [String: String]
     public let body: T
@@ -102,7 +102,7 @@ open class Response<T> {
         self.bodyData = bodyData
     }
 
-    public convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    public init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -113,6 +113,7 @@ open class Response<T> {
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
 }
+extension Response : Sendable where T : Sendable {}
 
 public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -89,7 +89,7 @@ public enum DecodableRequestBuilderError: Error {
     case generalError(Error)
 }
 
-open class Response<T> {
+public struct Response<T> {
     public let statusCode: Int
     public let header: [String: String]
     public let body: T
@@ -102,7 +102,7 @@ open class Response<T> {
         self.bodyData = bodyData
     }
 
-    public convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    public init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -113,6 +113,7 @@ open class Response<T> {
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
 }
+extension Response : Sendable where T : Sendable {}
 
 public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Models.swift
@@ -89,7 +89,7 @@ public enum DecodableRequestBuilderError: Error {
     case generalError(Error)
 }
 
-open class Response<T> {
+public struct Response<T> {
     public let statusCode: Int
     public let header: [String: String]
     public let body: T
@@ -102,7 +102,7 @@ open class Response<T> {
         self.bodyData = bodyData
     }
 
-    public convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    public init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -113,6 +113,7 @@ open class Response<T> {
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
 }
+extension Response : Sendable where T : Sendable {}
 
 public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -89,7 +89,7 @@ public enum DecodableRequestBuilderError: Error {
     case generalError(Error)
 }
 
-open class Response<T> {
+public struct Response<T> {
     public let statusCode: Int
     public let header: [String: String]
     public let body: T
@@ -102,7 +102,7 @@ open class Response<T> {
         self.bodyData = bodyData
     }
 
-    public convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    public init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -113,6 +113,7 @@ open class Response<T> {
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
 }
+extension Response : Sendable where T : Sendable {}
 
 public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -89,7 +89,7 @@ public enum DecodableRequestBuilderError: Error {
     case generalError(Error)
 }
 
-open class Response<T> {
+public struct Response<T> {
     public let statusCode: Int
     public let header: [String: String]
     public let body: T
@@ -102,7 +102,7 @@ open class Response<T> {
         self.bodyData = bodyData
     }
 
-    public convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    public init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -113,6 +113,7 @@ open class Response<T> {
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
 }
+extension Response : Sendable where T : Sendable {}
 
 public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -89,7 +89,7 @@ public enum DecodableRequestBuilderError: Error {
     case generalError(Error)
 }
 
-open class Response<T> {
+public struct Response<T> {
     public let statusCode: Int
     public let header: [String: String]
     public let body: T
@@ -102,7 +102,7 @@ open class Response<T> {
         self.bodyData = bodyData
     }
 
-    public convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    public init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -113,6 +113,7 @@ open class Response<T> {
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
 }
+extension Response : Sendable where T : Sendable {}
 
 public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -89,7 +89,7 @@ public enum DecodableRequestBuilderError: Error {
     case generalError(Error)
 }
 
-open class Response<T> {
+public struct Response<T> {
     public let statusCode: Int
     public let header: [String: String]
     public let body: T
@@ -102,7 +102,7 @@ open class Response<T> {
         self.bodyData = bodyData
     }
 
-    public convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    public init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -113,6 +113,7 @@ open class Response<T> {
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
 }
+extension Response : Sendable where T : Sendable {}
 
 public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -89,7 +89,7 @@ internal enum DecodableRequestBuilderError: Error {
     case generalError(Error)
 }
 
-internal class Response<T> {
+internal struct Response<T> {
     internal let statusCode: Int
     internal let header: [String: String]
     internal let body: T
@@ -102,7 +102,7 @@ internal class Response<T> {
         self.bodyData = bodyData
     }
 
-    internal convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    internal init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -113,6 +113,7 @@ internal class Response<T> {
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
 }
+extension Response : Sendable where T : Sendable {}
 
 internal final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -89,7 +89,7 @@ public enum DecodableRequestBuilderError: Error {
     case generalError(Error)
 }
 
-open class Response<T> {
+public struct Response<T> {
     public let statusCode: Int
     public let header: [String: String]
     public let body: T
@@ -102,7 +102,7 @@ open class Response<T> {
         self.bodyData = bodyData
     }
 
-    public convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    public init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -113,6 +113,7 @@ open class Response<T> {
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
 }
+extension Response : Sendable where T : Sendable {}
 
 public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -89,7 +89,7 @@ public enum DecodableRequestBuilderError: Error {
     case generalError(Error)
 }
 
-open class Response<T> {
+public struct Response<T> {
     public let statusCode: Int
     public let header: [String: String]
     public let body: T
@@ -102,7 +102,7 @@ open class Response<T> {
         self.bodyData = bodyData
     }
 
-    public convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    public init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -113,6 +113,7 @@ open class Response<T> {
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
 }
+extension Response : Sendable where T : Sendable {}
 
 public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -89,7 +89,7 @@ public enum DecodableRequestBuilderError: Error {
     case generalError(Error)
 }
 
-open class Response<T> {
+public struct Response<T> {
     public let statusCode: Int
     public let header: [String: String]
     public let body: T
@@ -102,7 +102,7 @@ open class Response<T> {
         self.bodyData = bodyData
     }
 
-    public convenience init(response: HTTPURLResponse, body: T, bodyData: Data?) {
+    public init(response: HTTPURLResponse, body: T, bodyData: Data?) {
         let rawHeader = response.allHeaderFields
         var responseHeader = [String: String]()
         for (key, value) in rawHeader {
@@ -113,6 +113,7 @@ open class Response<T> {
         self.init(statusCode: response.statusCode, header: responseHeader, body: body, bodyData: bodyData)
     }
 }
+extension Response : Sendable where T : Sendable {}
 
 public final class RequestTask: @unchecked Sendable {
     private let lock = NSRecursiveLock()


### PR DESCRIPTION
This PR changes the Response open class to a struct. This is a breaking change, but I think there's a lot of benefits to not allowing Response to be overridden. The primary benefit is conformance to Sendable, which is important for Swift 6 specifically.

@jgavris @ehyche @Edubits @jaz-ah @4brunu @dydus0x14

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
