### PR TITLE
[Draft] A comment for content_type discriminator issues

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
@@ -20,6 +20,9 @@ export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};
 */
 export class {{classname}}Class {
     {{#discriminator}}
+    // This will get transformed to contentType if the content_type is used as a discriminator in the OpenAPI spec
+    // It will then fail in runtime during deserialization with the error "TypeError: typeMap[type].getAttributeTypeMap is not a function"
+    // We need to make sure "content_type" is used, or that the "content_type" is transformed to "contentType" (might not be desirable)
     static readonly discriminator: string | undefined = "{{discriminatorName}}";
     {{/discriminator}}
     {{^discriminator}}


### PR DESCRIPTION
This isn't the full fix yet, I'd like to get a guidance for the next way to proceed.

**Bug:**
The  `discriminatorName` in `oneOf` template is set to `contentType` if the `content_type` is used as a discriminator in the OpenAPI spec.
It will then fail in runtime during response deserialization with the error `TypeError: typeMap[type].getAttributeTypeMap is not a function`.
Same might happen for serialization, didn't test that yet.

We need to make sure "content_type" is used, or that the "content_type" is transformed to "contentType" (might not be desirable).

What are the best next steps?

@amakhrov
@davidgamero 
@mkusaka
@joscha
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] **[Not Yet, see description]** Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
