### PR TITLE
[Elm] Fix not compiling all elm files in test suite

### DIFF
--- a/.github/workflows/samples-elm.yaml
+++ b/.github/workflows/samples-elm.yaml
@@ -32,4 +32,4 @@ jobs:
         # An .elm file couldn't be compiled
         # No .elm files were found
         # No elm.json file could be found in the root of the working directory
-        run: elm make $(find . -name *.elm) --output=/dev/null
+        run: elm make $(find . -name "*.elm") --output=/dev/null

--- a/.github/workflows/samples-elm.yaml
+++ b/.github/workflows/samples-elm.yaml
@@ -3,10 +3,12 @@ name: Samples Elm
 on:
   push:
     paths:
+      - .github/workflows/samples-elm.yaml
       - samples/client/petstore/elm/**
       - samples/openapi3/client/elm/**
   pull_request:
     paths:
+      - .github/workflows/samples-elm.yaml
       - samples/client/petstore/elm/**
       - samples/openapi3/client/elm/**
 jobs:


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The find command that tries to find all elm files didn't have quotes around the pattern, which meant that it only found the .elm files in the current folder and only tried to compile that.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
