### PR TITLE
fix(typescript): remove incorrect file extensions

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -1,10 +1,10 @@
 {{#platforms}}
 {{#node}}
 // TODO: evaluate if we can easily get rid of this library
-import {{^supportsES6}}* as{{/supportsES6}} FormData from "form-data{{importFileExtension}}";
-import { URL, URLSearchParams } from 'url{{importFileExtension}}';
-import * as http from 'http{{importFileExtension}}';
-import * as https from 'https{{importFileExtension}}';
+import {{^supportsES6}}* as{{/supportsES6}} FormData from "form-data";
+import { URL, URLSearchParams } from 'url';
+import * as http from 'http';
+import * as https from 'https';
 {{/node}}
 {{/platforms}}
 import { Observable, from } from {{#useRxJS}}'rxjs'{{/useRxJS}}{{^useRxJS}}'../rxjsStub{{importFileExtension}}'{{/useRxJS}};
@@ -169,7 +169,7 @@ export class RequestContext {
     }
     {{#platforms}}
     {{#node}}
-    
+
     public setAgent(agent: http.Agent | https.Agent) {
         this.agent = agent;
     }

--- a/samples/client/others/typescript/encode-decode/build/http/http.ts
+++ b/samples/client/others/typescript/encode-decode/build/http/http.ts
@@ -134,7 +134,7 @@ export class RequestContext {
     public setHeaderParam(key: string, value: string): void  {
         this.headers[key] = value;
     }
-    
+
     public setAgent(agent: http.Agent | https.Agent) {
         this.agent = agent;
     }

--- a/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
@@ -134,7 +134,7 @@ export class RequestContext {
     public setHeaderParam(key: string, value: string): void  {
         this.headers[key] = value;
     }
-    
+
     public setAgent(agent: http.Agent | https.Agent) {
         this.agent = agent;
     }

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/http/http.ts
@@ -134,7 +134,7 @@ export class RequestContext {
     public setHeaderParam(key: string, value: string): void  {
         this.headers[key] = value;
     }
-    
+
     public setAgent(agent: http.Agent | https.Agent) {
         this.agent = agent;
     }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
@@ -134,7 +134,7 @@ export class RequestContext {
     public setHeaderParam(key: string, value: string): void  {
         this.headers[key] = value;
     }
-    
+
     public setAgent(agent: http.Agent | https.Agent) {
         this.agent = agent;
     }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
@@ -134,7 +134,7 @@ export class RequestContext {
     public setHeaderParam(key: string, value: string): void  {
         this.headers[key] = value;
     }
-    
+
     public setAgent(agent: http.Agent | https.Agent) {
         this.agent = agent;
     }


### PR DESCRIPTION
url, http, and https are Node.js core modules, and form-data should be loaded using a bare specifier. This commit removes the file extensions from these imports.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
