### PR TITLE
static access to normalizeMediaType in typescript object serializer

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -287,7 +287,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/client/others/typescript/builds/array-of-lists/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/models/ObjectSerializer.ts
@@ -262,7 +262,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/client/others/typescript/builds/enum-single-value/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/enum-single-value/models/ObjectSerializer.ts
@@ -264,7 +264,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/client/others/typescript/builds/null-types-simple/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/null-types-simple/models/ObjectSerializer.ts
@@ -262,7 +262,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
@@ -259,7 +259,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/client/others/typescript/encode-decode/build/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/encode-decode/build/models/ObjectSerializer.ts
@@ -262,7 +262,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
@@ -276,7 +276,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
@@ -281,7 +281,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
@@ -276,7 +276,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
@@ -276,7 +276,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/models/ObjectSerializer.ts
@@ -276,7 +276,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/models/ObjectSerializer.ts
@@ -406,7 +406,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
@@ -276,7 +276,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
@@ -276,7 +276,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/models/ObjectSerializer.ts
@@ -260,7 +260,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
@@ -276,7 +276,7 @@ export class ObjectSerializer {
             return "application/json";
         }
 
-        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        const normalMediaTypes = mediaTypes.map(ObjectSerializer.normalizeMediaType);
 
         for (const predicate of supportedMimeTypePredicatesWithPriority) {
             for (const mediaType of normalMediaTypes) {


### PR DESCRIPTION
accessing `normalizeMediaType` should be done static in `ObjectSerializer`, as described in https://github.com/OpenAPITools/openapi-generator/issues/20201.

fix applies only to the `typescript` generator.

closes #20201 if accepted as solution by maintainers.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc: @joscha