### PR TITLE
[rust] Add option to customize local var prefix

### DIFF
--- a/bin/configs/rust-reqwest-name-mapping.yaml
+++ b/bin/configs/rust-reqwest-name-mapping.yaml
@@ -6,6 +6,7 @@ templateDir: modules/openapi-generator/src/main/resources/rust
 additionalProperties:
   supportAsync: false
   packageName: petstore-name-mapping
+  varPrefix: ""
 nameMappings:
   _type: underscore_type
   type_: type_with_underscore

--- a/docs/generators/rust.md
+++ b/docs/generators/rust.md
@@ -34,6 +34,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |topLevelApiClient|Creates a top level `Api` trait and `ApiClient` struct that contain all Apis. This option is for 'reqwest-trait' library only| |false|
 |useBonBuilder|Use the bon crate for building parameter types. This option is for the 'reqwest-trait' library only| |false|
 |useSingleRequestParameter|Setting this property to true will generate functions with a single argument containing all API endpoint parameters instead of one argument per parameter.| |false|
+|varPrefix|Local variable prefix| |local_var_|
 |withAWSV4Signature|whether to include AWS v4 signature support| |false|
 
 ## IMPORT MAPPING

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -453,4 +453,7 @@ public class CodegenConstants {
     public static final String WAIT_TIME_OF_THREAD = "waitTimeMillis";
 
     public static final String USE_DEFAULT_VALUES_FOR_REQUIRED_VARS = "useDefaultValuesForRequiredVars";
+
+    public static final String VAR_PREFIX = "varPrefix";
+    public static final String VAR_PREFIX_DESC = "Local variable prefix";
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -100,10 +100,12 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
 
     @Setter protected String packageName = "openapi";
     @Setter protected String packageVersion = "1.0.0";
+    @Setter protected String varPrefix = "local_var_";
     protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
     protected String apiFolder = "src/apis";
     protected String modelFolder = "src/models";
+
 
     @Override
     public CodegenType getTag() {
@@ -242,6 +244,8 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
                 .defaultValue(Boolean.FALSE.toString()));
         cliOptions.add(new CliOption(BON_BUILDER, "Use the bon crate for building parameter types. This option is for the 'reqwest-trait' library only", SchemaTypeUtil.BOOLEAN_TYPE)
                 .defaultValue(Boolean.FALSE.toString()));
+        cliOptions.add(new CliOption(CodegenConstants.VAR_PREFIX, CodegenConstants.VAR_PREFIX_DESC)
+                .defaultValue("local_var_"));
 
         supportedLibraries.put(HYPER_LIBRARY, "HTTP client: Hyper (v1.x).");
         supportedLibraries.put(HYPER0X_LIBRARY, "HTTP client: Hyper (v0.x).");
@@ -369,6 +373,11 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
             setPackageVersion((String) additionalProperties.get(CodegenConstants.PACKAGE_VERSION));
         } else if (openAPI != null && openAPI.getInfo() != null && openAPI.getInfo().getVersion() != null) {
             setPackageVersion(openAPI.getInfo().getVersion());
+        }
+
+        // set varPrefix to default if none is provided
+        if (!additionalProperties.containsKey(CodegenConstants.VAR_PREFIX)) {
+            additionalProperties.put(CodegenConstants.VAR_PREFIX, varPrefix);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.USE_SINGLE_REQUEST_PARAMETER)) {

--- a/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
@@ -88,55 +88,55 @@ impl {{classname}} for {{classname}}Client {
     {{^vendorExtensions.x-group-parameters}}
     async fn {{{operationId}}}<{{#allParams}}'{{{paramName}}}{{^-last}}, {{/-last}}{{/allParams}}>(&self, {{#allParams}}{{{paramName}}}: {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{#isString}}{{#isArray}}Vec<{{/isArray}}{{^isUuid}}&'{{{paramName}}} str{{/isUuid}}{{#isArray}}>{{/isArray}}{{/isString}}{{#isUuid}}{{#isArray}}Vec<{{/isArray}}&str{{#isArray}}>{{/isArray}}{{/isUuid}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) -> Result<{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{{returnType}}}{{/supportMultipleResponses}}, Error<{{{operationIdCamelCase}}}Error>> {
     {{/vendorExtensions.x-group-parameters}}
-        let local_var_configuration = &self.configuration;
+        let {{{varPrefix}}}configuration = &self.configuration;
 
-        let local_var_client = &local_var_configuration.client;
+        let {{{varPrefix}}}client = &{{{varPrefix}}}configuration.client;
 
-        let local_var_uri_str = format!("{}{{{path}}}", local_var_configuration.base_path{{#pathParams}}, {{{baseName}}}={{#isString}}crate::apis::urlencode({{/isString}}{{{paramName}}}{{^required}}.unwrap(){{/required}}{{#required}}{{#isNullable}}.unwrap(){{/isNullable}}{{/required}}{{#isArray}}.join(",").as_ref(){{/isArray}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}.to_string(){{/isContainer}}{{/isPrimitiveType}}{{/isUuid}}{{/isString}}{{#isString}}){{/isString}}{{/pathParams}});
-        let mut local_var_req_builder = local_var_client.request(reqwest::Method::{{{httpMethod}}}, local_var_uri_str.as_str());
+        let {{{varPrefix}}}uri_str = format!("{}{{{path}}}", {{{varPrefix}}}configuration.base_path{{#pathParams}}, {{{baseName}}}={{#isString}}crate::apis::urlencode({{/isString}}{{{paramName}}}{{^required}}.unwrap(){{/required}}{{#required}}{{#isNullable}}.unwrap(){{/isNullable}}{{/required}}{{#isArray}}.join(",").as_ref(){{/isArray}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}.to_string(){{/isContainer}}{{/isPrimitiveType}}{{/isUuid}}{{/isString}}{{#isString}}){{/isString}}{{/pathParams}});
+        let mut {{{varPrefix}}}req_builder = {{{varPrefix}}}client.request(reqwest::Method::{{{httpMethod}}}, {{{varPrefix}}}uri_str.as_str());
 
         {{#queryParams}}
         {{#required}}
         {{#isArray}}
-        local_var_req_builder = match "{{collectionFormat}}" {
-            "multi" => local_var_req_builder.query(&{{{paramName}}}.into_iter().map(|p| ("{{{baseName}}}".to_owned(), p.to_string())).collect::<Vec<(std::string::String, std::string::String)>>()),
-            _ => local_var_req_builder.query(&[("{{{baseName}}}", &{{{paramName}}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(",").to_string())]),
+        {{{varPrefix}}}req_builder = match "{{collectionFormat}}" {
+            "multi" => {{{varPrefix}}}req_builder.query(&{{{paramName}}}.into_iter().map(|p| ("{{{baseName}}}".to_owned(), p.to_string())).collect::<Vec<(std::string::String, std::string::String)>>()),
+            _ => {{{varPrefix}}}req_builder.query(&[("{{{baseName}}}", &{{{paramName}}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(",").to_string())]),
         };
         {{/isArray}}
         {{^isArray}}
         {{^isNullable}}
-        local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &{{{paramName}}}.to_string())]);
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.query(&[("{{{baseName}}}", &{{{paramName}}}.to_string())]);
         {{/isNullable}}
         {{#isNullable}}
         {{#isDeepObject}}
-        if let Some(ref local_var_str) = {{{paramName}}} {
-            let params = crate::apis::parse_deep_object("{{{baseName}}}", local_var_str);
-            local_var_req_builder = local_var_req_builder.query(&params);
+        if let Some(ref {{{varPrefix}}}str) = {{{paramName}}} {
+            let params = crate::apis::parse_deep_object("{{{baseName}}}", {{{varPrefix}}}str);
+            {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.query(&params);
         };
         {{/isDeepObject}}
         {{^isDeepObject}}
-        if let Some(ref local_var_str) = {{{paramName}}} {
-            local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &local_var_str.to_string())]);
+        if let Some(ref {{{varPrefix}}}str) = {{{paramName}}} {
+            {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.query(&[("{{{baseName}}}", &{{{varPrefix}}}str.to_string())]);
         };
         {{/isDeepObject}}
         {{/isNullable}}
         {{/isArray}}
         {{/required}}
         {{^required}}
-        if let Some(ref local_var_str) = {{{paramName}}} {
+        if let Some(ref {{{varPrefix}}}str) = {{{paramName}}} {
             {{#isArray}}
-            local_var_req_builder = match "{{collectionFormat}}" {
-                "multi" => local_var_req_builder.query(&local_var_str.into_iter().map(|p| ("{{{baseName}}}".to_owned(), p.to_string())).collect::<Vec<(std::string::String, std::string::String)>>()),
-                _ => local_var_req_builder.query(&[("{{{baseName}}}", &local_var_str.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(",").to_string())]),
+            {{{varPrefix}}}req_builder = match "{{collectionFormat}}" {
+                "multi" => {{{varPrefix}}}req_builder.query(&{{{varPrefix}}}str.into_iter().map(|p| ("{{{baseName}}}".to_owned(), p.to_string())).collect::<Vec<(std::string::String, std::string::String)>>()),
+                _ => {{{varPrefix}}}req_builder.query(&[("{{{baseName}}}", &{{{varPrefix}}}str.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(",").to_string())]),
             };
             {{/isArray}}
             {{^isArray}}
             {{#isDeepObject}}
-            let params = crate::apis::parse_deep_object("{{{baseName}}}", local_var_str);
-            local_var_req_builder = local_var_req_builder.query(&params);
+            let params = crate::apis::parse_deep_object("{{{baseName}}}", {{{varPrefix}}}str);
+            {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.query(&params);
             {{/isDeepObject}}
             {{^isDeepObject}}
-            local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &local_var_str.to_string())]);
+            {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.query(&[("{{{baseName}}}", &{{{varPrefix}}}str.to_string())]);
             {{/isDeepObject}}
             {{/isArray}}
         }
@@ -146,13 +146,13 @@ impl {{classname}} for {{classname}}Client {
         {{#authMethods}}
         {{#isApiKey}}
         {{#isKeyInQuery}}
-        if let Some(ref local_var_apikey) = local_var_configuration.api_key {
-            let local_var_key = local_var_apikey.key.clone();
-            let local_var_value = match local_var_apikey.prefix {
-                Some(ref local_var_prefix) => format!("{} {}", local_var_prefix, local_var_key),
-                None => local_var_key,
+        if let Some(ref {{{varPrefix}}}apikey) = {{{varPrefix}}}configuration.api_key {
+            let {{{varPrefix}}}key = {{{varPrefix}}}apikey.key.clone();
+            let {{{varPrefix}}}value = match {{{varPrefix}}}apikey.prefix {
+                Some(ref {{{varPrefix}}}prefix) => format!("{} {}", {{{varPrefix}}}prefix, {{{varPrefix}}}key),
+                None => {{{varPrefix}}}key,
             };
-            local_var_req_builder = local_var_req_builder.query(&[("{{{keyParamName}}}", local_var_value)]);
+            {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.query(&[("{{{keyParamName}}}", {{{varPrefix}}}value)]);
         }
         {{/isKeyInQuery}}
         {{/isApiKey}}
@@ -160,9 +160,9 @@ impl {{classname}} for {{classname}}Client {
         {{/hasAuthMethods}}
         {{#hasAuthMethods}}
         {{#withAWSV4Signature}}
-        if let Some(ref local_var_aws_v4_key) = local_var_configuration.aws_v4_key {
-            let local_var_new_headers = match local_var_aws_v4_key.sign(
-            &local_var_uri_str,
+        if let Some(ref {{{varPrefix}}}aws_v4_key) = {{{varPrefix}}}configuration.aws_v4_key {
+            let {{{varPrefix}}}new_headers = match {{{varPrefix}}}aws_v4_key.sign(
+            &{{{varPrefix}}}uri_str,
             "{{{httpMethod}}}",
             {{#hasBodyParam}}
             {{#bodyParams}}
@@ -176,31 +176,31 @@ impl {{classname}} for {{classname}}Client {
             Ok(new_headers) => new_headers,
             Err(err) => return Err(Error::AWSV4SignatureError(err)),
             };
-        for (local_var_name, local_var_value) in local_var_new_headers.iter() {
-            local_var_req_builder = local_var_req_builder.header(local_var_name.as_str(), local_var_value.as_str());
+        for ({{{varPrefix}}}name, {{{varPrefix}}}value) in {{{varPrefix}}}new_headers.iter() {
+            {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header({{{varPrefix}}}name.as_str(), {{{varPrefix}}}value.as_str());
         }
         }
         {{/withAWSV4Signature}}
         {{/hasAuthMethods}}
-        if let Some(ref local_var_user_agent) = local_var_configuration.user_agent {
-            local_var_req_builder = local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
+        if let Some(ref {{{varPrefix}}}user_agent) = {{{varPrefix}}}configuration.user_agent {
+            {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header(reqwest::header::USER_AGENT, {{{varPrefix}}}user_agent.clone());
         }
         {{#hasHeaderParams}}
         {{#headerParams}}
         {{#required}}
         {{^isNullable}}
-        local_var_req_builder = local_var_req_builder.header("{{{baseName}}}", {{{paramName}}}{{#isArray}}.join(","){{/isArray}}.to_string());
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header("{{{baseName}}}", {{{paramName}}}{{#isArray}}.join(","){{/isArray}}.to_string());
         {{/isNullable}}
         {{#isNullable}}
         match {{{paramName}}} {
-            Some(local_var_param_value) => { local_var_req_builder = local_var_req_builder.header("{{{baseName}}}", local_var_param_value{{#isArray}}.join(","){{/isArray}}.to_string()); },
-            None => { local_var_req_builder = local_var_req_builder.header("{{{baseName}}}", ""); },
+            Some({{{varPrefix}}}param_value) => { {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header("{{{baseName}}}", {{{varPrefix}}}param_value{{#isArray}}.join(","){{/isArray}}.to_string()); },
+            None => { {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header("{{{baseName}}}", ""); },
         }
         {{/isNullable}}
         {{/required}}
         {{^required}}
-        if let Some(local_var_param_value) = {{{paramName}}} {
-            local_var_req_builder = local_var_req_builder.header("{{{baseName}}}", local_var_param_value{{#isArray}}.join(","){{/isArray}}.to_string());
+        if let Some({{{varPrefix}}}param_value) = {{{paramName}}} {
+            {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header("{{{baseName}}}", {{{varPrefix}}}param_value{{#isArray}}.join(","){{/isArray}}.to_string());
         }
         {{/required}}
         {{/headerParams}}
@@ -210,38 +210,38 @@ impl {{classname}} for {{classname}}Client {
         {{#supportTokenSource}}
         // Obtain a token from source provider.
         // Tokens can be Id or access tokens depending on the provider type and configuration.
-        let token = local_var_configuration.token_source.token().await.map_err(Error::TokenSource)?;
+        let token = {{{varPrefix}}}configuration.token_source.token().await.map_err(Error::TokenSource)?;
         // The token format is the responsibility of the provider, thus we just set the authorization header with whatever is given.
-        local_var_req_builder = local_var_req_builder.header(reqwest::header::AUTHORIZATION, token);
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header(reqwest::header::AUTHORIZATION, token);
         {{/supportTokenSource}}
         {{^supportTokenSource}}
         {{#isApiKey}}
         {{#isKeyInHeader}}
-        if let Some(ref local_var_apikey) = local_var_configuration.api_key {
-            let local_var_key = local_var_apikey.key.clone();
-            let local_var_value = match local_var_apikey.prefix {
-                Some(ref local_var_prefix) => format!("{} {}", local_var_prefix, local_var_key),
-                None => local_var_key,
+        if let Some(ref {{{varPrefix}}}apikey) = {{{varPrefix}}}configuration.api_key {
+            let {{{varPrefix}}}key = {{{varPrefix}}}apikey.key.clone();
+            let {{{varPrefix}}}value = match {{{varPrefix}}}apikey.prefix {
+                Some(ref {{{varPrefix}}}prefix) => format!("{} {}", {{{varPrefix}}}prefix, {{{varPrefix}}}key),
+                None => {{{varPrefix}}}key,
             };
-            local_var_req_builder = local_var_req_builder.header("{{{keyParamName}}}", local_var_value);
+            {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header("{{{keyParamName}}}", {{{varPrefix}}}value);
         };
         {{/isKeyInHeader}}
         {{/isApiKey}}
         {{#isBasic}}
         {{#isBasicBasic}}
-        if let Some(ref local_var_auth_conf) = local_var_configuration.basic_auth {
-            local_var_req_builder = local_var_req_builder.basic_auth(local_var_auth_conf.0.to_owned(), local_var_auth_conf.1.to_owned());
+        if let Some(ref {{{varPrefix}}}auth_conf) = {{{varPrefix}}}configuration.basic_auth {
+            {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.basic_auth({{{varPrefix}}}auth_conf.0.to_owned(), {{{varPrefix}}}auth_conf.1.to_owned());
         };
         {{/isBasicBasic}}
         {{#isBasicBearer}}
-        if let Some(ref local_var_token) = local_var_configuration.bearer_access_token {
-            local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
+        if let Some(ref {{{varPrefix}}}token) = {{{varPrefix}}}configuration.bearer_access_token {
+            {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.bearer_auth({{{varPrefix}}}token.to_owned());
         };
         {{/isBasicBearer}}
         {{/isBasic}}
         {{#isOAuth}}
-        if let Some(ref local_var_token) = local_var_configuration.oauth_access_token {
-            local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
+        if let Some(ref {{{varPrefix}}}token) = {{{varPrefix}}}configuration.oauth_access_token {
+            {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.bearer_auth({{{varPrefix}}}token.to_owned());
         };
         {{/isOAuth}}
         {{/supportTokenSource}}
@@ -249,7 +249,7 @@ impl {{classname}} for {{classname}}Client {
         {{/hasAuthMethods}}
         {{#isMultipart}}
         {{#hasFormParams}}
-        let mut local_var_form = reqwest::multipart::Form::new();
+        let mut {{{varPrefix}}}form = reqwest::multipart::Form::new();
         {{#formParams}}
         {{#isFile}}
         // TODO: support file upload for '{{{baseName}}}' parameter
@@ -257,99 +257,99 @@ impl {{classname}} for {{classname}}Client {
         {{^isFile}}
         {{#required}}
         {{^isNullable}}
-        local_var_form = local_var_form.text("{{{baseName}}}", {{{paramName}}}{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+        {{{varPrefix}}}form = {{{varPrefix}}}form.text("{{{baseName}}}", {{{paramName}}}{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
         {{/isNullable}}
         {{#isNullable}}
         match {{{paramName}}} {
-            Some(local_var_param_value) => { local_var_form = local_var_form.text("{{{baseName}}}", local_var_param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string()); },
-            None => { local_var_form = local_var_form.text("{{{baseName}}}", ""); },
+            Some({{{varPrefix}}}param_value) => { {{{varPrefix}}}form = {{{varPrefix}}}form.text("{{{baseName}}}", {{{varPrefix}}}param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string()); },
+            None => { {{{varPrefix}}}form = {{{varPrefix}}}form.text("{{{baseName}}}", ""); },
         }
         {{/isNullable}}
         {{/required}}
         {{^required}}
-        if let Some(local_var_param_value) = {{{paramName}}} {
-            local_var_form = local_var_form.text("{{{baseName}}}", local_var_param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+        if let Some({{{varPrefix}}}param_value) = {{{paramName}}} {
+            {{{varPrefix}}}form = {{{varPrefix}}}form.text("{{{baseName}}}", {{{varPrefix}}}param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
         }
         {{/required}}
         {{/isFile}}
         {{/formParams}}
-        local_var_req_builder = local_var_req_builder.multipart(local_var_form);
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.multipart({{{varPrefix}}}form);
         {{/hasFormParams}}
         {{/isMultipart}}
         {{^isMultipart}}
         {{#hasFormParams}}
-        let mut local_var_form_params = std::collections::HashMap::new();
+        let mut {{{varPrefix}}}form_params = std::collections::HashMap::new();
         {{#formParams}}
         {{#isFile}}
         {{#required}}
         {{^isNullable}}
-        local_var_form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content"));
+        {{{varPrefix}}}form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content"));
         {{/isNullable}}
         {{#isNullable}}
         match {{{paramName}}} {
-            Some(local_var_param_value) => { local_var_form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content")); },
+            Some({{{varPrefix}}}param_value) => { {{{varPrefix}}}form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content")); },
             None => { unimplemented!("Required nullable file form param not supported with x-www-form-urlencoded content"); },
         }
         {{/isNullable}}
         {{/required}}
         {{^required}}
-        if let Some(local_var_param_value) = {{{paramName}}} {
-            local_var_form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content"));
+        if let Some({{{varPrefix}}}param_value) = {{{paramName}}} {
+            {{{varPrefix}}}form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content"));
         }
         {{/required}}
         {{/isFile}}
         {{^isFile}}
         {{#required}}
         {{^isNullable}}
-        local_var_form_params.insert("{{{baseName}}}", {{{paramName}}}{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+        {{{varPrefix}}}form_params.insert("{{{baseName}}}", {{{paramName}}}{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
         {{/isNullable}}
         {{#isNullable}}
         match {{{paramName}}} {
-            Some(local_var_param_value) => { local_var_form_params.insert("{{{baseName}}}", local_var_param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string()); },
-            None => { local_var_form_params.insert("{{{baseName}}}", ""); },
+            Some({{{varPrefix}}}param_value) => { {{{varPrefix}}}form_params.insert("{{{baseName}}}", {{{varPrefix}}}param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string()); },
+            None => { {{{varPrefix}}}form_params.insert("{{{baseName}}}", ""); },
         }
         {{/isNullable}}
         {{/required}}
         {{^required}}
-        if let Some(local_var_param_value) = {{{paramName}}} {
-            local_var_form_params.insert("{{{baseName}}}", local_var_param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+        if let Some({{{varPrefix}}}param_value) = {{{paramName}}} {
+            {{{varPrefix}}}form_params.insert("{{{baseName}}}", {{{varPrefix}}}param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
         }
         {{/required}}
         {{/isFile}}
         {{/formParams}}
-        local_var_req_builder = local_var_req_builder.form(&local_var_form_params);
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.form(&{{{varPrefix}}}form_params);
         {{/hasFormParams}}
         {{/isMultipart}}
         {{#hasBodyParam}}
         {{#bodyParams}}
-        local_var_req_builder = local_var_req_builder.json(&{{{paramName}}});
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.json(&{{{paramName}}});
         {{/bodyParams}}
         {{/hasBodyParam}}
 
-        let local_var_req = local_var_req_builder.build()?;
-        let local_var_resp = local_var_client.execute(local_var_req).await?;
+        let {{{varPrefix}}}req = {{{varPrefix}}}req_builder.build()?;
+        let {{{varPrefix}}}resp = {{{varPrefix}}}client.execute({{{varPrefix}}}req).await?;
 
-        let local_var_status = local_var_resp.status();
-        let local_var_content = local_var_resp.text().await?;
+        let {{{varPrefix}}}status = {{{varPrefix}}}resp.status();
+        let {{{varPrefix}}}content = {{{varPrefix}}}resp.text().await?;
 
-        if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
+        if !{{{varPrefix}}}status.is_client_error() && !{{{varPrefix}}}status.is_server_error() {
             {{^supportMultipleResponses}}
             {{^returnType}}
             Ok(())
             {{/returnType}}
             {{#returnType}}
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            serde_json::from_str(&{{{varPrefix}}}content).map_err(Error::from)
             {{/returnType}}
             {{/supportMultipleResponses}}
             {{#supportMultipleResponses}}
-            let local_var_entity: Option<{{{operationIdCamelCase}}}Success> = serde_json::from_str(&local_var_content).ok();
-            let local_var_result = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
-            Ok(local_var_result)
+            let {{{varPrefix}}}entity: Option<{{{operationIdCamelCase}}}Success> = serde_json::from_str(&{{{varPrefix}}}content).ok();
+            let {{{varPrefix}}}result = ResponseContent { status: {{{varPrefix}}}status, content: {{{varPrefix}}}content, entity: {{{varPrefix}}}entity };
+            Ok({{{varPrefix}}}result)
             {{/supportMultipleResponses}}
         } else {
-            let local_var_entity: Option<{{{operationIdCamelCase}}}Error> = serde_json::from_str(&local_var_content).ok();
-            let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
-            Err(Error::ResponseError(local_var_error))
+            let {{{varPrefix}}}entity: Option<{{{operationIdCamelCase}}}Error> = serde_json::from_str(&{{{varPrefix}}}content).ok();
+            let {{{varPrefix}}}error = ResponseContent { status: {{{varPrefix}}}status, content: {{{varPrefix}}}content, entity: {{{varPrefix}}}entity };
+            Err(Error::ResponseError({{{varPrefix}}}error))
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -81,7 +81,7 @@ pub enum {{{operationIdCamelCase}}}Error {
 {{/notes}}
 {{#vendorExtensions.x-group-parameters}}
 pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: &configuration::Configuration{{#allParams}}{{#-first}}, params: {{{operationIdCamelCase}}}Params{{/-first}}{{/allParams}}) -> Result<{{#isResponseFile}}{{#supportAsync}}reqwest::Response{{/supportAsync}}{{^supportAsync}}reqwest::blocking::Response{{/supportAsync}}{{/isResponseFile}}{{^isResponseFile}}{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{{returnType}}}{{/supportMultipleResponses}}{{/isResponseFile}}, Error<{{{operationIdCamelCase}}}Error>> {
-    let local_var_configuration = configuration;
+    let {{{varPrefix}}}configuration = configuration;
 
     // unbox the parameters
     {{#allParams}}
@@ -91,56 +91,56 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
 {{/vendorExtensions.x-group-parameters}}
 {{^vendorExtensions.x-group-parameters}}
 pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: &configuration::Configuration, {{#allParams}}{{{paramName}}}: {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{#isString}}{{#isArray}}Vec<{{/isArray}}{{^isUuid}}&str{{/isUuid}}{{#isArray}}>{{/isArray}}{{/isString}}{{#isUuid}}{{#isArray}}Vec<{{/isArray}}&str{{#isArray}}>{{/isArray}}{{/isUuid}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) -> Result<{{#isResponseFile}}{{#supportAsync}}reqwest::Response{{/supportAsync}}{{^supportAsync}}reqwest::blocking::Response{{/supportAsync}}{{/isResponseFile}}{{^isResponseFile}}{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{{returnType}}}{{/supportMultipleResponses}}{{/isResponseFile}}, Error<{{{operationIdCamelCase}}}Error>> {
-    let local_var_configuration = configuration;
+    let {{{varPrefix}}}configuration = configuration;
 {{/vendorExtensions.x-group-parameters}}
 
-    let local_var_client = &local_var_configuration.client;
+    let {{{varPrefix}}}client = &{{{varPrefix}}}configuration.client;
 
-    let local_var_uri_str = format!("{}{{{path}}}", local_var_configuration.base_path{{#pathParams}}, {{{baseName}}}={{#isString}}crate::apis::urlencode({{/isString}}{{{paramName}}}{{^required}}.unwrap(){{/required}}{{#required}}{{#isNullable}}.unwrap(){{/isNullable}}{{/required}}{{#isArray}}.join(",").as_ref(){{/isArray}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}.to_string(){{/isContainer}}{{/isPrimitiveType}}{{/isUuid}}{{/isString}}{{#isString}}){{/isString}}{{/pathParams}});
-    let mut local_var_req_builder = local_var_client.request(reqwest::Method::{{{httpMethod}}}, local_var_uri_str.as_str());
+    let {{{varPrefix}}}uri_str = format!("{}{{{path}}}", {{{varPrefix}}}configuration.base_path{{#pathParams}}, {{{baseName}}}={{#isString}}crate::apis::urlencode({{/isString}}{{{paramName}}}{{^required}}.unwrap(){{/required}}{{#required}}{{#isNullable}}.unwrap(){{/isNullable}}{{/required}}{{#isArray}}.join(",").as_ref(){{/isArray}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}.to_string(){{/isContainer}}{{/isPrimitiveType}}{{/isUuid}}{{/isString}}{{#isString}}){{/isString}}{{/pathParams}});
+    let mut {{{varPrefix}}}req_builder = {{{varPrefix}}}client.request(reqwest::Method::{{{httpMethod}}}, {{{varPrefix}}}uri_str.as_str());
 
     {{#queryParams}}
     {{#required}}
     {{#isArray}}
-    local_var_req_builder = match "{{collectionFormat}}" {
-        "multi" => local_var_req_builder.query(&{{{paramName}}}.into_iter().map(|p| ("{{{baseName}}}".to_owned(), p.to_string())).collect::<Vec<(std::string::String, std::string::String)>>()),
-        _ => local_var_req_builder.query(&[("{{{baseName}}}", &{{{paramName}}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(",").to_string())]),
+    {{{varPrefix}}}req_builder = match "{{collectionFormat}}" {
+        "multi" => {{{varPrefix}}}req_builder.query(&{{{paramName}}}.into_iter().map(|p| ("{{{baseName}}}".to_owned(), p.to_string())).collect::<Vec<(std::string::String, std::string::String)>>()),
+        _ => {{{varPrefix}}}req_builder.query(&[("{{{baseName}}}", &{{{paramName}}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(",").to_string())]),
     };
     {{/isArray}}
     {{^isArray}}
     {{^isNullable}}
-    local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &{{{paramName}}}.to_string())]);
+    {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.query(&[("{{{baseName}}}", &{{{paramName}}}.to_string())]);
     {{/isNullable}}
     {{#isNullable}}
     {{#isDeepObject}}
-    if let Some(ref local_var_str) = {{{paramName}}} {
-        let params = crate::apis::parse_deep_object("{{{baseName}}}", local_var_str);
-        local_var_req_builder = local_var_req_builder.query(&params);
+    if let Some(ref {{{varPrefix}}}str) = {{{paramName}}} {
+        let params = crate::apis::parse_deep_object("{{{baseName}}}", {{{varPrefix}}}str);
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.query(&params);
     };
     {{/isDeepObject}}
     {{^isDeepObject}}
-    if let Some(ref local_var_str) = {{{paramName}}} {
-        local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &local_var_str.to_string())]);
+    if let Some(ref {{{varPrefix}}}str) = {{{paramName}}} {
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.query(&[("{{{baseName}}}", &{{{varPrefix}}}str.to_string())]);
     };
     {{/isDeepObject}}
     {{/isNullable}}
     {{/isArray}}
     {{/required}}
     {{^required}}
-    if let Some(ref local_var_str) = {{{paramName}}} {
+    if let Some(ref {{{varPrefix}}}str) = {{{paramName}}} {
         {{#isArray}}
-        local_var_req_builder = match "{{collectionFormat}}" {
-            "multi" => local_var_req_builder.query(&local_var_str.into_iter().map(|p| ("{{{baseName}}}".to_owned(), p.to_string())).collect::<Vec<(std::string::String, std::string::String)>>()),
-            _ => local_var_req_builder.query(&[("{{{baseName}}}", &local_var_str.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(",").to_string())]),
+        {{{varPrefix}}}req_builder = match "{{collectionFormat}}" {
+            "multi" => {{{varPrefix}}}req_builder.query(&{{{varPrefix}}}str.into_iter().map(|p| ("{{{baseName}}}".to_owned(), p.to_string())).collect::<Vec<(std::string::String, std::string::String)>>()),
+            _ => {{{varPrefix}}}req_builder.query(&[("{{{baseName}}}", &{{{varPrefix}}}str.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(",").to_string())]),
         };
         {{/isArray}}
         {{^isArray}}
         {{#isDeepObject}}
-        let params = crate::apis::parse_deep_object("{{{baseName}}}", local_var_str);
-        local_var_req_builder = local_var_req_builder.query(&params);
+        let params = crate::apis::parse_deep_object("{{{baseName}}}", {{{varPrefix}}}str);
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.query(&params);
         {{/isDeepObject}}
         {{^isDeepObject}}
-        local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &local_var_str.to_string())]);
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.query(&[("{{{baseName}}}", &{{{varPrefix}}}str.to_string())]);
         {{/isDeepObject}}
         {{/isArray}}
     }
@@ -150,13 +150,13 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
     {{#authMethods}}
     {{#isApiKey}}
     {{#isKeyInQuery}}
-    if let Some(ref local_var_apikey) = local_var_configuration.api_key {
-        let local_var_key = local_var_apikey.key.clone();
-        let local_var_value = match local_var_apikey.prefix {
-            Some(ref local_var_prefix) => format!("{} {}", local_var_prefix, local_var_key),
-            None => local_var_key,
+    if let Some(ref {{{varPrefix}}}apikey) = {{{varPrefix}}}configuration.api_key {
+        let {{{varPrefix}}}key = {{{varPrefix}}}apikey.key.clone();
+        let {{{varPrefix}}}value = match {{{varPrefix}}}apikey.prefix {
+            Some(ref {{{varPrefix}}}prefix) => format!("{} {}", {{{varPrefix}}}prefix, {{{varPrefix}}}key),
+            None => {{{varPrefix}}}key,
         };
-        local_var_req_builder = local_var_req_builder.query(&[("{{{keyParamName}}}", local_var_value)]);
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.query(&[("{{{keyParamName}}}", {{{varPrefix}}}value)]);
     }
     {{/isKeyInQuery}}
     {{/isApiKey}}
@@ -164,9 +164,9 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
     {{/hasAuthMethods}}
     {{#hasAuthMethods}}
     {{#withAWSV4Signature}}
-    if let Some(ref local_var_aws_v4_key) = local_var_configuration.aws_v4_key {
-        let local_var_new_headers = match local_var_aws_v4_key.sign(
-	    &local_var_uri_str,
+    if let Some(ref {{{varPrefix}}}aws_v4_key) = {{{varPrefix}}}configuration.aws_v4_key {
+        let {{{varPrefix}}}new_headers = match {{{varPrefix}}}aws_v4_key.sign(
+	    &{{{varPrefix}}}uri_str,
 	    "{{{httpMethod}}}",
 	    {{#hasBodyParam}}
 	    {{#bodyParams}}
@@ -180,31 +180,31 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
 	      Ok(new_headers) => new_headers,
 	      Err(err) => return Err(Error::AWSV4SignatureError(err)),
 	    };
-	for (local_var_name, local_var_value) in local_var_new_headers.iter() {
-	    local_var_req_builder = local_var_req_builder.header(local_var_name.as_str(), local_var_value.as_str());
+	for ({{{varPrefix}}}name, {{{varPrefix}}}value) in {{{varPrefix}}}new_headers.iter() {
+	    {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header({{{varPrefix}}}name.as_str(), {{{varPrefix}}}value.as_str());
 	}
     }
     {{/withAWSV4Signature}}
     {{/hasAuthMethods}}
-    if let Some(ref local_var_user_agent) = local_var_configuration.user_agent {
-        local_var_req_builder = local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
+    if let Some(ref {{{varPrefix}}}user_agent) = {{{varPrefix}}}configuration.user_agent {
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header(reqwest::header::USER_AGENT, {{{varPrefix}}}user_agent.clone());
     }
     {{#hasHeaderParams}}
     {{#headerParams}}
     {{#required}}
     {{^isNullable}}
-    local_var_req_builder = local_var_req_builder.header("{{{baseName}}}", {{{paramName}}}{{#isArray}}.join(","){{/isArray}}.to_string());
+    {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header("{{{baseName}}}", {{{paramName}}}{{#isArray}}.join(","){{/isArray}}.to_string());
     {{/isNullable}}
     {{#isNullable}}
     match {{{paramName}}} {
-        Some(local_var_param_value) => { local_var_req_builder = local_var_req_builder.header("{{{baseName}}}", local_var_param_value{{#isArray}}.join(","){{/isArray}}.to_string()); },
-        None => { local_var_req_builder = local_var_req_builder.header("{{{baseName}}}", ""); },
+        Some({{{varPrefix}}}param_value) => { {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header("{{{baseName}}}", {{{varPrefix}}}param_value{{#isArray}}.join(","){{/isArray}}.to_string()); },
+        None => { {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header("{{{baseName}}}", ""); },
     }
     {{/isNullable}}
     {{/required}}
     {{^required}}
-    if let Some(local_var_param_value) = {{{paramName}}} {
-        local_var_req_builder = local_var_req_builder.header("{{{baseName}}}", local_var_param_value{{#isArray}}.join(","){{/isArray}}.to_string());
+    if let Some({{{varPrefix}}}param_value) = {{{paramName}}} {
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header("{{{baseName}}}", {{{varPrefix}}}param_value{{#isArray}}.join(","){{/isArray}}.to_string());
     }
     {{/required}}
     {{/headerParams}}
@@ -214,38 +214,38 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
     {{#supportTokenSource}}
     // Obtain a token from source provider.
     // Tokens can be Id or access tokens depending on the provider type and configuration.
-    let token = local_var_configuration.token_source.token().await.map_err(Error::TokenSource)?;
+    let token = {{{varPrefix}}}configuration.token_source.token().await.map_err(Error::TokenSource)?;
     // The token format is the responsibility of the provider, thus we just set the authorization header with whatever is given.
-    local_var_req_builder = local_var_req_builder.header(reqwest::header::AUTHORIZATION, token);
+    {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header(reqwest::header::AUTHORIZATION, token);
     {{/supportTokenSource}}
     {{^supportTokenSource}}
     {{#isApiKey}}
     {{#isKeyInHeader}}
-    if let Some(ref local_var_apikey) = local_var_configuration.api_key {
-        let local_var_key = local_var_apikey.key.clone();
-        let local_var_value = match local_var_apikey.prefix {
-            Some(ref local_var_prefix) => format!("{} {}", local_var_prefix, local_var_key),
-            None => local_var_key,
+    if let Some(ref {{{varPrefix}}}apikey) = {{{varPrefix}}}configuration.api_key {
+        let {{{varPrefix}}}key = {{{varPrefix}}}apikey.key.clone();
+        let {{{varPrefix}}}value = match {{{varPrefix}}}apikey.prefix {
+            Some(ref {{{varPrefix}}}prefix) => format!("{} {}", {{{varPrefix}}}prefix, {{{varPrefix}}}key),
+            None => {{{varPrefix}}}key,
         };
-        local_var_req_builder = local_var_req_builder.header("{{{keyParamName}}}", local_var_value);
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.header("{{{keyParamName}}}", {{{varPrefix}}}value);
     };
     {{/isKeyInHeader}}
     {{/isApiKey}}
     {{#isBasic}}
     {{#isBasicBasic}}
-    if let Some(ref local_var_auth_conf) = local_var_configuration.basic_auth {
-        local_var_req_builder = local_var_req_builder.basic_auth(local_var_auth_conf.0.to_owned(), local_var_auth_conf.1.to_owned());
+    if let Some(ref {{{varPrefix}}}auth_conf) = {{{varPrefix}}}configuration.basic_auth {
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.basic_auth({{{varPrefix}}}auth_conf.0.to_owned(), {{{varPrefix}}}auth_conf.1.to_owned());
     };
     {{/isBasicBasic}}
     {{#isBasicBearer}}
-    if let Some(ref local_var_token) = local_var_configuration.bearer_access_token {
-        local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
+    if let Some(ref {{{varPrefix}}}token) = {{{varPrefix}}}configuration.bearer_access_token {
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.bearer_auth({{{varPrefix}}}token.to_owned());
     };
     {{/isBasicBearer}}
     {{/isBasic}}
     {{#isOAuth}}
-    if let Some(ref local_var_token) = local_var_configuration.oauth_access_token {
-        local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
+    if let Some(ref {{{varPrefix}}}token) = {{{varPrefix}}}configuration.oauth_access_token {
+        {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.bearer_auth({{{varPrefix}}}token.to_owned());
     };
     {{/isOAuth}}
     {{/supportTokenSource}}
@@ -253,24 +253,24 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
     {{/hasAuthMethods}}
     {{#isMultipart}}
     {{#hasFormParams}}
-    let mut local_var_form = reqwest{{^supportAsync}}::blocking{{/supportAsync}}::multipart::Form::new();
+    let mut {{{varPrefix}}}form = reqwest{{^supportAsync}}::blocking{{/supportAsync}}::multipart::Form::new();
     {{#formParams}}
     {{#isFile}}
     {{^supportAsync}}
     {{#required}}
     {{^isNullable}}
-    local_var_form = local_var_form.file("{{{baseName}}}", {{{paramName}}})?;
+    {{{varPrefix}}}form = {{{varPrefix}}}form.file("{{{baseName}}}", {{{paramName}}})?;
     {{/isNullable}}
     {{#isNullable}}
     match {{{paramName}}} {
-        Some(local_var_param_value) => { local_var_form = local_var_form.file("{{{baseName}}}", local_var_param_value)?; },
+        Some({{{varPrefix}}}param_value) => { {{{varPrefix}}}form = {{{varPrefix}}}form.file("{{{baseName}}}", {{{varPrefix}}}param_value)?; },
         None => { unimplemented!("Required nullable form file param not supported"); },
     }
     {{/isNullable}}
     {{/required}}
     {{^required}}
-    if let Some(local_var_param_value) = {{{paramName}}} {
-        local_var_form = local_var_form.file("{{{baseName}}}", local_var_param_value)?;
+    if let Some({{{varPrefix}}}param_value) = {{{paramName}}} {
+        {{{varPrefix}}}form = {{{varPrefix}}}form.file("{{{baseName}}}", {{{varPrefix}}}param_value)?;
     }
     {{/required}}
     {{/supportAsync}}
@@ -281,116 +281,116 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
     {{^isFile}}
     {{#required}}
     {{^isNullable}}
-    local_var_form = local_var_form.text("{{{baseName}}}", {{{paramName}}}{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+    {{{varPrefix}}}form = {{{varPrefix}}}form.text("{{{baseName}}}", {{{paramName}}}{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
     {{/isNullable}}
     {{#isNullable}}
     match {{{paramName}}} {
-        Some(local_var_param_value) => { local_var_form = local_var_form.text("{{{baseName}}}", local_var_param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string()); },
-        None => { local_var_form = local_var_form.text("{{{baseName}}}", ""); },
+        Some({{{varPrefix}}}param_value) => { {{{varPrefix}}}form = {{{varPrefix}}}form.text("{{{baseName}}}", {{{varPrefix}}}param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string()); },
+        None => { {{{varPrefix}}}form = {{{varPrefix}}}form.text("{{{baseName}}}", ""); },
     }
     {{/isNullable}}
     {{/required}}
     {{^required}}
-    if let Some(local_var_param_value) = {{{paramName}}} {
-        local_var_form = local_var_form.text("{{{baseName}}}", local_var_param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+    if let Some({{{varPrefix}}}param_value) = {{{paramName}}} {
+        {{{varPrefix}}}form = {{{varPrefix}}}form.text("{{{baseName}}}", {{{varPrefix}}}param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
     }
     {{/required}}
     {{/isFile}}
     {{/formParams}}
-    local_var_req_builder = local_var_req_builder.multipart(local_var_form);
+    {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.multipart({{{varPrefix}}}form);
     {{/hasFormParams}}
     {{/isMultipart}}
     {{^isMultipart}}
     {{#hasFormParams}}
-    let mut local_var_form_params = std::collections::HashMap::new();
+    let mut {{{varPrefix}}}form_params = std::collections::HashMap::new();
     {{#formParams}}
     {{#isFile}}
     {{#required}}
     {{^isNullable}}
-    local_var_form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content"));
+    {{{varPrefix}}}form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content"));
     {{/isNullable}}
     {{#isNullable}}
     match {{{paramName}}} {
-        Some(local_var_param_value) => { local_var_form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content")); },
+        Some({{{varPrefix}}}param_value) => { {{{varPrefix}}}form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content")); },
         None => { unimplemented!("Required nullable file form param not supported with x-www-form-urlencoded content"); },
     }
     {{/isNullable}}
     {{/required}}
     {{^required}}
-    if let Some(local_var_param_value) = {{{paramName}}} {
-        local_var_form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content"));
+    if let Some({{{varPrefix}}}param_value) = {{{paramName}}} {
+        {{{varPrefix}}}form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content"));
     }
     {{/required}}
     {{/isFile}}
     {{^isFile}}
     {{#required}}
     {{^isNullable}}
-    local_var_form_params.insert("{{{baseName}}}", {{{paramName}}}{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+    {{{varPrefix}}}form_params.insert("{{{baseName}}}", {{{paramName}}}{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
     {{/isNullable}}
     {{#isNullable}}
     match {{{paramName}}} {
-        Some(local_var_param_value) => { local_var_form_params.insert("{{{baseName}}}", local_var_param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string()); },
-        None => { local_var_form_params.insert("{{{baseName}}}", ""); },
+        Some({{{varPrefix}}}param_value) => { {{{varPrefix}}}form_params.insert("{{{baseName}}}", {{{varPrefix}}}param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string()); },
+        None => { {{{varPrefix}}}form_params.insert("{{{baseName}}}", ""); },
     }
     {{/isNullable}}
     {{/required}}
     {{^required}}
-    if let Some(local_var_param_value) = {{{paramName}}} {
-        local_var_form_params.insert("{{{baseName}}}", local_var_param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+    if let Some({{{varPrefix}}}param_value) = {{{paramName}}} {
+        {{{varPrefix}}}form_params.insert("{{{baseName}}}", {{{varPrefix}}}param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
     }
     {{/required}}
     {{/isFile}}
     {{/formParams}}
-    local_var_req_builder = local_var_req_builder.form(&local_var_form_params);
+    {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.form(&{{{varPrefix}}}form_params);
     {{/hasFormParams}}
     {{/isMultipart}}
     {{#hasBodyParam}}
     {{#bodyParams}}
     {{#isFile}}
-    local_var_req_builder = local_var_req_builder.body({{{paramName}}});
+    {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.body({{{paramName}}});
     {{/isFile}}
     {{^isFile}}
-    local_var_req_builder = local_var_req_builder.json(&{{{paramName}}});
+    {{{varPrefix}}}req_builder = {{{varPrefix}}}req_builder.json(&{{{paramName}}});
     {{/isFile}}
     {{/bodyParams}}
     {{/hasBodyParam}}
 
-    let local_var_req = local_var_req_builder.build()?;
-    let local_var_resp = local_var_client.execute(local_var_req){{#supportAsync}}.await{{/supportAsync}}?;
+    let {{{varPrefix}}}req = {{{varPrefix}}}req_builder.build()?;
+    let {{{varPrefix}}}resp = {{{varPrefix}}}client.execute({{{varPrefix}}}req){{#supportAsync}}.await{{/supportAsync}}?;
 
-    let local_var_status = local_var_resp.status();
+    let {{{varPrefix}}}status = {{{varPrefix}}}resp.status();
 
-    if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
+    if !{{{varPrefix}}}status.is_client_error() && !{{{varPrefix}}}status.is_server_error() {
         {{^supportMultipleResponses}}
         {{#isResponseFile}}
-        Ok(local_var_resp)
+        Ok({{{varPrefix}}}resp)
         {{/isResponseFile}}
         {{^isResponseFile}}
         {{^returnType}}
         Ok(())
         {{/returnType}}
         {{#returnType}}
-        let local_var_content = local_var_resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
-        serde_json::from_str(&local_var_content).map_err(Error::from)
+        let {{{varPrefix}}}content = {{{varPrefix}}}resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
+        serde_json::from_str(&{{{varPrefix}}}content).map_err(Error::from)
         {{/returnType}}
         {{/isResponseFile}}
         {{/supportMultipleResponses}}
         {{#supportMultipleResponses}}
         {{#isResponseFile}}
-        Ok(local_var_resp)
+        Ok({{{varPrefix}}}resp)
         {{/isResponseFile}}
         {{^isResponseFile}}
-        let local_var_content = local_var_resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
-        let local_var_entity: Option<{{{operationIdCamelCase}}}Success> = serde_json::from_str(&local_var_content).ok();
-        let local_var_result = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
-        Ok(local_var_result)
+        let {{{varPrefix}}}content = {{{varPrefix}}}resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
+        let {{{varPrefix}}}entity: Option<{{{operationIdCamelCase}}}Success> = serde_json::from_str(&{{{varPrefix}}}content).ok();
+        let {{{varPrefix}}}result = ResponseContent { status: {{{varPrefix}}}status, content: {{{varPrefix}}}content, entity: {{{varPrefix}}}entity };
+        Ok({{{varPrefix}}}result)
         {{/isResponseFile}}
         {{/supportMultipleResponses}}
     } else {
-        let local_var_content = local_var_resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
-        let local_var_entity: Option<{{{operationIdCamelCase}}}Error> = serde_json::from_str(&local_var_content).ok();
-        let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
-        Err(Error::ResponseError(local_var_error))
+        let {{{varPrefix}}}content = {{{varPrefix}}}resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
+        let {{{varPrefix}}}entity: Option<{{{operationIdCamelCase}}}Error> = serde_json::from_str(&{{{varPrefix}}}content).ok();
+        let {{{varPrefix}}}error = ResponseContent { status: {{{varPrefix}}}status, content: {{{varPrefix}}}content, entity: {{{varPrefix}}}entity };
+        Err(Error::ResponseError({{{varPrefix}}}error))
     }
 }
 

--- a/samples/client/petstore/rust/reqwest/name-mapping/src/apis/fake_api.rs
+++ b/samples/client/petstore/rust/reqwest/name-mapping/src/apis/fake_api.rs
@@ -24,34 +24,34 @@ pub enum GetParameterNameMappingError {
 
 
 pub fn get_parameter_name_mapping(configuration: &configuration::Configuration, underscore_type: i64, r#type: &str, type_with_underscore: &str, dash_type: &str, http_debug_option: &str) -> Result<(), Error<GetParameterNameMappingError>> {
-    let local_var_configuration = configuration;
+    let configuration = configuration;
 
-    let local_var_client = &local_var_configuration.client;
+    let client = &configuration.client;
 
-    let local_var_uri_str = format!("{}/fake/parameter-name-mapping", local_var_configuration.base_path);
-    let mut local_var_req_builder = local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
+    let uri_str = format!("{}/fake/parameter-name-mapping", configuration.base_path);
+    let mut req_builder = client.request(reqwest::Method::GET, uri_str.as_str());
 
-    local_var_req_builder = local_var_req_builder.query(&[("type", &r#type.to_string())]);
-    local_var_req_builder = local_var_req_builder.query(&[("http_debug_option", &http_debug_option.to_string())]);
-    if let Some(ref local_var_user_agent) = local_var_configuration.user_agent {
-        local_var_req_builder = local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
+    req_builder = req_builder.query(&[("type", &r#type.to_string())]);
+    req_builder = req_builder.query(&[("http_debug_option", &http_debug_option.to_string())]);
+    if let Some(ref user_agent) = configuration.user_agent {
+        req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
     }
-    local_var_req_builder = local_var_req_builder.header("_type", underscore_type.to_string());
-    local_var_req_builder = local_var_req_builder.header("type_", type_with_underscore.to_string());
-    local_var_req_builder = local_var_req_builder.header("-type", dash_type.to_string());
+    req_builder = req_builder.header("_type", underscore_type.to_string());
+    req_builder = req_builder.header("type_", type_with_underscore.to_string());
+    req_builder = req_builder.header("-type", dash_type.to_string());
 
-    let local_var_req = local_var_req_builder.build()?;
-    let local_var_resp = local_var_client.execute(local_var_req)?;
+    let req = req_builder.build()?;
+    let resp = client.execute(req)?;
 
-    let local_var_status = local_var_resp.status();
+    let status = resp.status();
 
-    if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
+    if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
-        let local_var_content = local_var_resp.text()?;
-        let local_var_entity: Option<GetParameterNameMappingError> = serde_json::from_str(&local_var_content).ok();
-        let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
-        Err(Error::ResponseError(local_var_error))
+        let content = resp.text()?;
+        let entity: Option<GetParameterNameMappingError> = serde_json::from_str(&content).ok();
+        let error = ResponseContent { status: status, content: content, entity: entity };
+        Err(Error::ResponseError(error))
     }
 }
 


### PR DESCRIPTION
set the local variable prefix (default: `local_var_`) in the template file

e.g. in CLI, add `--additional-properties varPrefix=""` to clear the prefix.

cc 
@frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

