### PR TITLE
[Java][okhttp-gson][retrofit2] Avoid ambiguous references for date and time classes (#18416)

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/JSON.mustache
@@ -31,9 +31,11 @@ import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
+{{#jsr310}}
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+{{/jsr310}}
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -47,9 +47,11 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.text.DateFormat;
+{{#jsr310}}
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+{{/jsr310}}
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/JSON.mustache
@@ -28,9 +28,11 @@ import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
+{{#jsr310}}
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+{{/jsr310}}
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
@@ -46,7 +46,9 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.text.DateFormat;
+{{#jsr310}}
 import java.time.format.DateTimeFormatter;
+{{/jsr310}}
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.HashMap;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/JSON.mustache
@@ -30,9 +30,11 @@ import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
+{{#jsr310}}
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+{{/jsr310}}
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This change adds some missing guards in Mustache templates to avoid having imports of conflicting date/time classes when using the Joda library. These guards were on the methods that used the differing date/time classes, but were not on the corresponding imports. Of the various Java library templates, only those for okhttp-gson and retrofit2 had these date/time class import patterns. It looks like these guards were once there but got accidentally removed as part of #11547.

I used the following command line to reproduce the issue on master using the Petstore API spec:
```
~/work/openapi-generator [master] $ java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
            -g java \
            --library okhttp-gson \
            --additional-properties=dateLibrary=joda \
            -i modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-okhttp-gson.yaml \
            -o ~/tmp/openapi-generator-master/
```
```
~/tmp/openapi-generator-master  $ mvn compile
...
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /Users/johnbrugge/tmp/openapi-generator-master/src/main/java/org/openapitools/client/ApiClient.java:[465,39] error: reference to DateTimeFormatter is ambiguous
  both class org.joda.time.format.DateTimeFormatter in org.joda.time.format and class java.time.format.DateTimeFormatter in java.time.format match
[ERROR] /Users/johnbrugge/tmp/openapi-generator-master/src/main/java/org/openapitools/client/ApiClient.java:[470,40] error: reference to DateTimeFormatter is ambiguous
  both class org.joda.time.format.DateTimeFormatter in org.joda.time.format and class java.time.format.DateTimeFormatter in java.time.format match
[ERROR] /Users/johnbrugge/tmp/openapi-generator-master/src/main/java/org/openapitools/client/JSON.java:[484,65] error: reference to LocalDate is ambiguous
  both class org.joda.time.LocalDate in org.joda.time and class java.time.LocalDate in java.time match
[ERROR] /Users/johnbrugge/tmp/openapi-generator-master/src/main/java/org/openapitools/client/JSON.java:[522,41] error: reference to DateTimeFormatter is ambiguous
 #...
```

When I ran the same commands against the PR branch, the ambiguous class reference issues went away.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
