### PR TITLE
fix (DefaultGenerator): Handle "$ref" parameter reference to identify parameter ID (#20239)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -1619,7 +1619,7 @@ public class DefaultGenerator implements Generator {
     }
 
     private static String generateParameterId(Parameter parameter) {
-        return parameter.getName() + ":" + parameter.getIn();
+        return null == parameter.get$ref() ? parameter.getName() + ":" + parameter.getIn() : parameter.get$ref() ;    
     }
 
     private OperationsMap processOperations(CodegenConfig config, String tag, List<CodegenOperation> ops, List<ModelMap> allModels) {


### PR DESCRIPTION
Fix proposal for https://github.com/OpenAPITools/openapi-generator/issues/20239

Use `ref` field when filled in place of missing `name`:`in` to avoid collision onto generated id (when $ref is present, it generate systemically `null:null` ID)

So, with fix, in place of generating a missing parameter onto function prototype:
```java
  public void get(Integer queryParameter) throws ApiException {
```

It now generated the correct list:
```java
  public void get(String pathParameter, Integer queryParameter) throws ApiException {
```

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean install
  ``` 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
