### PR TITLE
Improve handling of pekko versions in scala-akka-http-server generator

### DIFF
--- a/docs/generators/scala-akka-http-server.md
+++ b/docs/generators/scala-akka-http-server.md
@@ -33,6 +33,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |modelPackage|package for generated models| |null|
 |modelPropertyNaming|Naming convention for the property: 'camelCase', 'PascalCase', 'snake_case' and 'original', which keeps the original name| |camelCase|
+|pekkoHttpVersion|The version of pekko-http| |1.0.0|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|

--- a/docs/generators/scala-akka-http-server.md
+++ b/docs/generators/scala-akka-http-server.md
@@ -33,7 +33,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |modelPackage|package for generated models| |null|
 |modelPropertyNaming|Naming convention for the property: 'camelCase', 'PascalCase', 'snake_case' and 'original', which keeps the original name| |camelCase|
-|pekkoHttpVersion|The version of pekko-http| |1.0.0|
+|pekkoHttpVersion|The version of pekko-http| |1.1.0|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaHttpServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaHttpServerCodegen.java
@@ -52,7 +52,7 @@ public class ScalaAkkaHttpServerCodegen extends AbstractScalaCodegen implements 
     public static final String PEKKO_HTTP_VERSION = "pekkoHttpVersion";
     public static final String PEKKO_HTTP_VERSION_DESC = "The version of pekko-http";
     public static final String DEFAULT_AKKA_HTTP_VERSION = "10.1.10";
-    public static final String DEFAULT_PEKKO_HTTP_VERSION = "1.0.0";
+    public static final String DEFAULT_PEKKO_HTTP_VERSION = "1.1.0";
 
     public static final String GENERATE_AS_MANAGED_SOURCES = "asManagedSources";
     public static final String GENERATE_AS_MANAGED_SOURCES_DESC = "Resulting files cab be used as managed resources. No build files or default controllers will be generated";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaHttpServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaHttpServerCodegen.java
@@ -45,9 +45,12 @@ public class ScalaAkkaHttpServerCodegen extends AbstractScalaCodegen implements 
     protected String akkaHttpVersion;
     protected boolean generateAsManagedSources;
     protected boolean useApachePekko;
+    protected String pekkoHttpVersion;
 
     public static final String AKKA_HTTP_VERSION = "akkaHttpVersion";
     public static final String AKKA_HTTP_VERSION_DESC = "The version of akka-http";
+    public static final String PEKKO_HTTP_VERSION = "pekkoHttpVersion";
+    public static final String PEKKO_HTTP_VERSION_DESC = "The version of pekko-http";
     public static final String DEFAULT_AKKA_HTTP_VERSION = "10.1.10";
     public static final String DEFAULT_PEKKO_HTTP_VERSION = "1.0.0";
 
@@ -124,6 +127,7 @@ public class ScalaAkkaHttpServerCodegen extends AbstractScalaCodegen implements 
         akkaHttpVersion = DEFAULT_AKKA_HTTP_VERSION;
         generateAsManagedSources = DEFAULT_GENERATE_AS_MANAGED_SOURCES;
         useApachePekko = DEFAULT_USE_APACHE_PEKKO;
+        pekkoHttpVersion = DEFAULT_PEKKO_HTTP_VERSION;
 
         setReservedWordsLowerCase(
                 Arrays.asList(
@@ -141,6 +145,7 @@ public class ScalaAkkaHttpServerCodegen extends AbstractScalaCodegen implements 
         cliOptions.add(CliOption.newString(AKKA_HTTP_VERSION, AKKA_HTTP_VERSION_DESC).defaultValue(akkaHttpVersion));
         cliOptions.add(CliOption.newBoolean(GENERATE_AS_MANAGED_SOURCES, GENERATE_AS_MANAGED_SOURCES_DESC).defaultValue(Boolean.valueOf(DEFAULT_GENERATE_AS_MANAGED_SOURCES).toString()));
         cliOptions.add(CliOption.newBoolean(USE_APACHE_PEKKO, USE_APACHE_PEKKO_DESC).defaultValue(Boolean.valueOf(DEFAULT_USE_APACHE_PEKKO).toString()));
+        cliOptions.add(CliOption.newString(PEKKO_HTTP_VERSION, PEKKO_HTTP_VERSION_DESC).defaultValue(pekkoHttpVersion));
 
         importMapping.remove("Seq");
         importMapping.remove("List");
@@ -204,11 +209,16 @@ public class ScalaAkkaHttpServerCodegen extends AbstractScalaCodegen implements 
             additionalProperties.put(USE_APACHE_PEKKO, useApachePekko);
         }
 
+        if (additionalProperties.containsKey(PEKKO_HTTP_VERSION)) {
+            pekkoHttpVersion = (String) additionalProperties.get(PEKKO_HTTP_VERSION);
+        } else {
+            additionalProperties.put(PEKKO_HTTP_VERSION, DEFAULT_PEKKO_HTTP_VERSION);
+        }
+
         if (additionalProperties.containsKey(AKKA_HTTP_VERSION)) {
             akkaHttpVersion = (String) additionalProperties.get(AKKA_HTTP_VERSION);
         } else {
-            String version = useApachePekko ? DEFAULT_PEKKO_HTTP_VERSION : DEFAULT_AKKA_HTTP_VERSION;
-            additionalProperties.put(AKKA_HTTP_VERSION, version);
+            additionalProperties.put(AKKA_HTTP_VERSION, akkaHttpVersion);
         }
 
         if (useApachePekko) {

--- a/modules/openapi-generator/src/main/resources/scala-akka-http-server/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-http-server/build.sbt.mustache
@@ -4,8 +4,8 @@ organization := "{{groupId}}"
 scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq({{#useApachePekko}}
-  "org.apache.pekko" %% "pekko-stream" % "{{akkaHttpVersion}}",
-  "org.apache.pekko" %% "pekko-http" % "{{akkaHttpVersion}}"{{/useApachePekko}}{{^useApachePekko}}
+  "org.apache.pekko" %% "pekko-stream" % "1.0.3",
+  "org.apache.pekko" %% "pekko-http" % "{{pekkoHttpVersion}}"{{/useApachePekko}}{{^useApachePekko}}
   "com.typesafe.akka" %% "akka-stream" % "2.5.21",
   "com.typesafe.akka" %% "akka-http" % "{{akkaHttpVersion}}"{{/useApachePekko}}
 )

--- a/samples/server/petstore/scala-pekko-http-server/build.sbt
+++ b/samples/server/petstore/scala-pekko-http-server/build.sbt
@@ -5,5 +5,5 @@ scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
   "org.apache.pekko" %% "pekko-stream" % "1.0.3",
-  "org.apache.pekko" %% "pekko-http" % "1.0.0"
+  "org.apache.pekko" %% "pekko-http" % "1.1.0"
 )

--- a/samples/server/petstore/scala-pekko-http-server/build.sbt
+++ b/samples/server/petstore/scala-pekko-http-server/build.sbt
@@ -4,6 +4,6 @@ organization := "org.openapitools"
 scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
-  "org.apache.pekko" %% "pekko-stream" % "1.0.0",
+  "org.apache.pekko" %% "pekko-stream" % "1.0.3",
   "org.apache.pekko" %% "pekko-http" % "1.0.0"
 )


### PR DESCRIPTION
This change is a fix for Issue 20225 - Improve handling of pekko versions
https://github.com/OpenAPITools/openapi-generator/issues/20275

This change adds a new parameter for the `scala-akka-http-server` generator. The parameter is called `pekkoHttpVersion` and lets a user control the version of the `pekko-http` package in the same way you do for `akka-http` versions.

The change also increases the version of `pekko-stream` to `1.0.3`.

To validate the work in this PR, run the `scala-akka-http-generator`:
* Not using the `usePekkoHttp` flag should have the same bahavior as before
* `usePekkoHttp=true` should add pekko packages instead of akka packages just as before, but the `pekko-stream` package should now have version `1.0.3`. The version of `pekko-http` should still be `1.0.0` as long as the `pekkoHttpVersion` parameter is not provided.
* `usePekkoHttp=true` and `pekkoHttpVersion=someVersion` should result in pekko packages being used instead of akka and the version of `pekko-http` should be whatever was provided in the `pekkoHttpVersion` paramater.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@clasnake , @shijinkui , @ramzimaalej , @chameleon82 , @Bouillie , @fish86
