### PR TITLE
Fix a few issues with the C generator (part 4)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
@@ -347,6 +347,7 @@ public class CLibcurlClientCodegen extends DefaultCodegen implements CodegenConf
         // root folder
         supportingFiles.add(new SupportingFile("CMakeLists.txt.mustache", "", "CMakeLists.txt"));
         supportingFiles.add(new SupportingFile("Packing.cmake.mustache", "", "Packing.cmake"));
+        supportingFiles.add(new SupportingFile("cmake-config.mustache", "", "Config.cmake.in"));
         supportingFiles.add(new SupportingFile("libcurl.licence.mustache", "", "libcurl.licence"));
         supportingFiles.add(new SupportingFile("uncrustify-rules.cfg.mustache", "", "uncrustify-rules.cfg"));
         supportingFiles.add(new SupportingFile("README.md.mustache", "", "README.md"));

--- a/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
@@ -1,10 +1,9 @@
 cmake_minimum_required (VERSION 2.6...3.10.2)
-project (CGenerator)
+project (CGenerator C)
 
 cmake_policy(SET CMP0063 NEW)
 
 set(CMAKE_C_VISIBILITY_PRESET default)
-set(CMAKE_CXX_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -131,7 +131,7 @@ end:
     {{#pathParams}}
 
     // Path Params
-    long sizeOfPathParams_{{{paramName}}} = {{#pathParams}}{{#isLong}}sizeof({{paramName}})+3{{/isLong}}{{#isString}}strlen({{paramName}})+3{{/isString}}{{^-last}} + {{/-last}}{{/pathParams}} + strlen("{ {{baseName}} }");
+    long sizeOfPathParams_{{{paramName}}} = {{#pathParams}}{{#isLong}}sizeof({{paramName}})+3{{/isLong}}{{#isString}}strlen({{^isEnum}}{{paramName}}{{/isEnum}}{{#isEnum}}{{{operationId}}}_{{enumName}}_ToString({{paramName}}){{/isEnum}})+3{{/isString}}{{^-last}} + {{/-last}}{{/pathParams}} + strlen("{ {{baseName}} }");
     {{#isNumeric}}
     if({{paramName}} == 0){
         goto end;
@@ -185,13 +185,13 @@ end:
 
     {{/isLong}}
     {{#isString}}
-    if({{paramName}} == NULL) {
+    if({{paramName}} == {{#isEnum}}0{{/isEnum}}{{^isEnum}}NULL{{/isEnum}}) {
         goto end;
     }
     char* localVarToReplace_{{paramName}} = malloc(sizeOfPathParams_{{paramName}});
     sprintf(localVarToReplace_{{paramName}}, "{%s}", "{{baseName}}");
 
-    localVarPath = strReplace(localVarPath, localVarToReplace_{{paramName}}, {{paramName}});
+    localVarPath = strReplace(localVarPath, localVarToReplace_{{paramName}}, {{^isEnum}}{{paramName}}{{/isEnum}}{{#isEnum}}{{{operationId}}}_{{enumName}}_ToString({{paramName}}){{/isEnum}});
     {{/isString}}
     {{#isUuid}}
     if({{paramName}} == NULL) {

--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -107,6 +107,7 @@ end:
     list_t *localVarHeaderType = {{#hasProduces}}list_createList();{{/hasProduces}}{{^hasProduces}}NULL;{{/hasProduces}}
     list_t *localVarContentType = {{#hasConsumes}}list_createList();{{/hasConsumes}}{{^hasConsumes}}NULL;{{/hasConsumes}}
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -121,6 +122,10 @@ end:
     if(!{{paramName}})
         goto end;
     {{/isString}}
+    {{#isBinary}}
+    if(!{{paramName}})
+        goto end;
+    {{/isBinary}}
     {{/pathParams}}
 
     {{#pathParams}}
@@ -331,20 +336,30 @@ end:
         }
         cJSON_AddItemToArray(localVarSingleItemJSON_{{paramName}}, localVar_{{paramName}});
         localVarBodyParameters = {{{cJSONPrint}}}(localVarItemJSON_{{paramName}});
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     {{/isArray}}
     {{^isArray}}
     {{#isString}}
     localVarBodyParameters = strdup({{paramName}});
+    localVarBodyLength = strlen(localVarBodyParameters);
     {{/isString}}
     {{^isString}}
+    {{#isBinary}}
+    localVarBodyParameters = malloc({{paramName}}->len);
+    memcpy(localVarBodyParameters, {{paramName}}->data, {{paramName}}->len);
+    localVarBodyLength = {{paramName}}->len;
+    {{/isBinary}}
+    {{^isBinary}}
     cJSON *localVarSingleItemJSON_{{paramName}} = NULL;
     if ({{paramName}} != NULL)
     {
-        //string
+        //not string, not binary
         localVarSingleItemJSON_{{paramName}} = {{dataType}}_convertToJSON({{paramName}});
         localVarBodyParameters = {{{cJSONPrint}}}(localVarSingleItemJSON_{{paramName}});
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
+    {{/isBinary}}
     {{/isString}}
     {{/isArray}}
     {{/bodyParam}}
@@ -362,6 +377,7 @@ end:
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "{{{httpMethod}}}");
 
     {{#responses}}
@@ -503,10 +519,12 @@ end:
     {{/isArray}}
     {{^isArray}}
     {{^isString}}
+    {{^isBinary}}
     if (localVarSingleItemJSON_{{paramName}}) {
         cJSON_Delete(localVarSingleItemJSON_{{paramName}});
         localVarSingleItemJSON_{{paramName}} = NULL;
     }
+    {{/isBinary}}
     {{/isString}}
     free(localVarBodyParameters);
     {{/isArray}}
@@ -644,10 +662,12 @@ end:
     free(localVarBodyParameters);
     {{/isArray}}
     {{^isArray}}
+    {{^isBinary}}
     if (localVarSingleItemJSON_{{paramName}}) {
         cJSON_Delete(localVarSingleItemJSON_{{paramName}});
         localVarSingleItemJSON_{{paramName}} = NULL;
     }
+    {{/isBinary}}
     free(localVarBodyParameters);
     {{/isArray}}
     {{/bodyParams}}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -244,10 +244,10 @@ char *assembleHeaderField(char *key, char *value) {
     return header;
 }
 
-void postData(CURL *handle, const char *bodyParameters) {
+void postData(CURL *handle, const char *bodyParameters, size_t bodyParametersLength) {
     curl_easy_setopt(handle, CURLOPT_POSTFIELDS, bodyParameters);
     curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE,
-                     (curl_off_t)strlen(bodyParameters));
+                     (curl_off_t)bodyParametersLength);
 }
 
 int lengthOfKeyPair(keyValuePair_t *keyPair) {
@@ -270,7 +270,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
                       list_t        *headerType,
                       list_t        *contentType,
                       const char    *bodyParameters,
-                      const char    *requestType) {
+                      size_t       bodyParametersLength,
+                      const char   *requestType) {
     CURL *handle = curl_easy_init();
     CURLcode res;
 
@@ -550,7 +551,7 @@ void apiClient_invoke(apiClient_t    *apiClient,
         {{/hasAuthMethods}}
 
         if(bodyParameters != NULL) {
-            postData(handle, bodyParameters);
+            postData(handle, bodyParameters, bodyParametersLength);
         }
 
         res = curl_easy_perform(handle);

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
@@ -62,7 +62,7 @@ apiClient_t* apiClient_create_with_base_path(const char *basePath
 
 void apiClient_free(apiClient_t *apiClient);
 
-void apiClient_invoke(apiClient_t *apiClient,const char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, const char *bodyParameters, const char *requestType);
+void apiClient_invoke(apiClient_t *apiClient,const char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, const char *bodyParameters, size_t bodyParametersLength, const char *requestType);
 
 sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify);
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/cmake-config.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/cmake-config.mustache
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
+
+check_required_components("@PROJECT_NAME@")

--- a/modules/openapi-generator/src/test/resources/2_0/c/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/c/petstore.yaml
@@ -280,6 +280,7 @@ paths:
           required: true
           schema:
             type: string
+            format: binary
       responses:
         '200':
           description: successful operation
@@ -348,6 +349,52 @@ paths:
         - petstore_auth:
             - 'write:pets'
             - 'read:pets'
+  /store/feedback:
+    post:
+      tags:
+        - store
+      summary: Send us a feedback message
+      description: ''
+      operationId: sendFeedback
+      parameters:
+        - in: body
+          name: feedback
+          description: The feedback message to send
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: string
+            description: Thank you message
+  '/store/rating/{rating}':
+    post:
+      tags:
+        - store
+      summary: How would you rate our service?
+      description: ''
+      operationId: sendRating
+      parameters:
+        - in: path
+          name: rating
+          description: The rating to submit
+          required: true
+          type: string
+          enum:
+            - Excellent
+            - Great
+            - Good
+            - Regular
+            - Bad
+            - Awful
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: string
+            description: Thank you message
   /store/daysWithoutIncident:
     get:
       tags:

--- a/samples/client/others/c/bearerAuth/.openapi-generator/FILES
+++ b/samples/client/others/c/bearerAuth/.openapi-generator/FILES
@@ -1,4 +1,5 @@
 CMakeLists.txt
+Config.cmake.in
 Packing.cmake
 README.md
 api/DefaultAPI.c

--- a/samples/client/others/c/bearerAuth/CMakeLists.txt
+++ b/samples/client/others/c/bearerAuth/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required (VERSION 2.6...3.10.2)
-project (CGenerator)
+project (CGenerator C)
 
 cmake_policy(SET CMP0063 NEW)
 
 set(CMAKE_C_VISIBILITY_PRESET default)
-set(CMAKE_CXX_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 

--- a/samples/client/others/c/bearerAuth/Config.cmake.in
+++ b/samples/client/others/c/bearerAuth/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
+
+check_required_components("@PROJECT_NAME@")

--- a/samples/client/others/c/bearerAuth/api/DefaultAPI.c
+++ b/samples/client/others/c/bearerAuth/api/DefaultAPI.c
@@ -25,6 +25,7 @@ DefaultAPI_privateGet(apiClient_t *apiClient)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -46,6 +47,7 @@ DefaultAPI_privateGet(apiClient_t *apiClient)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -95,6 +97,7 @@ DefaultAPI_publicGet(apiClient_t *apiClient)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -116,6 +119,7 @@ DefaultAPI_publicGet(apiClient_t *apiClient)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -165,6 +169,7 @@ DefaultAPI_usersGet(apiClient_t *apiClient)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -186,6 +191,7 @@ DefaultAPI_usersGet(apiClient_t *apiClient)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response

--- a/samples/client/others/c/bearerAuth/include/apiClient.h
+++ b/samples/client/others/c/bearerAuth/include/apiClient.h
@@ -39,7 +39,7 @@ apiClient_t* apiClient_create_with_base_path(const char *basePath
 
 void apiClient_free(apiClient_t *apiClient);
 
-void apiClient_invoke(apiClient_t *apiClient,const char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, const char *bodyParameters, const char *requestType);
+void apiClient_invoke(apiClient_t *apiClient,const char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, const char *bodyParameters, size_t bodyParametersLength, const char *requestType);
 
 sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify);
 

--- a/samples/client/others/c/bearerAuth/src/apiClient.c
+++ b/samples/client/others/c/bearerAuth/src/apiClient.c
@@ -160,10 +160,10 @@ char *assembleHeaderField(char *key, char *value) {
     return header;
 }
 
-void postData(CURL *handle, const char *bodyParameters) {
+void postData(CURL *handle, const char *bodyParameters, size_t bodyParametersLength) {
     curl_easy_setopt(handle, CURLOPT_POSTFIELDS, bodyParameters);
     curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE,
-                     (curl_off_t)strlen(bodyParameters));
+                     (curl_off_t)bodyParametersLength);
 }
 
 int lengthOfKeyPair(keyValuePair_t *keyPair) {
@@ -186,7 +186,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
                       list_t        *headerType,
                       list_t        *contentType,
                       const char    *bodyParameters,
-                      const char    *requestType) {
+                      size_t       bodyParametersLength,
+                      const char   *requestType) {
     CURL *handle = curl_easy_init();
     CURLcode res;
 
@@ -405,7 +406,7 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
 
         if(bodyParameters != NULL) {
-            postData(handle, bodyParameters);
+            postData(handle, bodyParameters, bodyParametersLength);
         }
 
         res = curl_easy_perform(handle);

--- a/samples/client/petstore/c-useJsonUnformatted/.openapi-generator/FILES
+++ b/samples/client/petstore/c-useJsonUnformatted/.openapi-generator/FILES
@@ -1,4 +1,5 @@
 CMakeLists.txt
+Config.cmake.in
 Packing.cmake
 README.md
 api/PetAPI.c

--- a/samples/client/petstore/c-useJsonUnformatted/CMakeLists.txt
+++ b/samples/client/petstore/c-useJsonUnformatted/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required (VERSION 2.6...3.10.2)
-project (CGenerator)
+project (CGenerator C)
 
 cmake_policy(SET CMP0063 NEW)
 
 set(CMAKE_C_VISIBILITY_PRESET default)
-set(CMAKE_CXX_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 

--- a/samples/client/petstore/c-useJsonUnformatted/Config.cmake.in
+++ b/samples/client/petstore/c-useJsonUnformatted/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
+
+check_required_components("@PROJECT_NAME@")

--- a/samples/client/petstore/c-useJsonUnformatted/README.md
+++ b/samples/client/petstore/c-useJsonUnformatted/README.md
@@ -82,6 +82,8 @@ Category | Method | HTTP request | Description
 *StoreAPI* | [**StoreAPI_getInventory**](docs/StoreAPI.md#StoreAPI_getInventory) | **GET** /store/inventory | Returns pet inventories by status
 *StoreAPI* | [**StoreAPI_getOrderById**](docs/StoreAPI.md#StoreAPI_getOrderById) | **GET** /store/order/{orderId} | Find purchase order by ID
 *StoreAPI* | [**StoreAPI_placeOrder**](docs/StoreAPI.md#StoreAPI_placeOrder) | **POST** /store/order | Place an order for a pet
+*StoreAPI* | [**StoreAPI_sendFeedback**](docs/StoreAPI.md#StoreAPI_sendFeedback) | **POST** /store/feedback | Send us a feedback message
+*StoreAPI* | [**StoreAPI_sendRating**](docs/StoreAPI.md#StoreAPI_sendRating) | **POST** /store/rating/{rating} | How would you rate our service?
 *UserAPI* | [**UserAPI_createUser**](docs/UserAPI.md#UserAPI_createUser) | **POST** /user | Create user
 *UserAPI* | [**UserAPI_createUsersWithArrayInput**](docs/UserAPI.md#UserAPI_createUsersWithArrayInput) | **POST** /user/createWithArray | Creates list of users with given input array
 *UserAPI* | [**UserAPI_createUsersWithListInput**](docs/UserAPI.md#UserAPI_createUsersWithListInput) | **POST** /user/createWithList | Creates list of users with given input array

--- a/samples/client/petstore/c-useJsonUnformatted/api/PetAPI.c
+++ b/samples/client/petstore/c-useJsonUnformatted/api/PetAPI.c
@@ -66,6 +66,7 @@ PetAPI_addPet(apiClient_t *apiClient, pet_t *body)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = list_createList();
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -83,9 +84,10 @@ PetAPI_addPet(apiClient_t *apiClient, pet_t *body)
     cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
-        //string
+        //not string, not binary
         localVarSingleItemJSON_body = pet_convertToJSON(body);
         localVarBodyParameters = cJSON_PrintUnformatted(localVarSingleItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     list_addElement(localVarContentType,"application/json"); //consumes
     list_addElement(localVarContentType,"application/xml"); //consumes
@@ -97,6 +99,7 @@ PetAPI_addPet(apiClient_t *apiClient, pet_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -135,6 +138,7 @@ PetAPI_deletePet(apiClient_t *apiClient, long petId, char *api_key)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -181,6 +185,7 @@ PetAPI_deletePet(apiClient_t *apiClient, long petId, char *api_key)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "DELETE");
 
     // uncomment below to debug the error response
@@ -226,6 +231,7 @@ PetAPI_findPetsByStatus(apiClient_t *apiClient, list_t *status)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -254,6 +260,7 @@ PetAPI_findPetsByStatus(apiClient_t *apiClient, list_t *status)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -317,6 +324,7 @@ PetAPI_findPetsByTags(apiClient_t *apiClient, list_t *tags)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -345,6 +353,7 @@ PetAPI_findPetsByTags(apiClient_t *apiClient, list_t *tags)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -406,6 +415,7 @@ PetAPI_getDaysWithoutIncident(apiClient_t *apiClient)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -427,6 +437,7 @@ PetAPI_getDaysWithoutIncident(apiClient_t *apiClient)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -469,6 +480,7 @@ PetAPI_getPetById(apiClient_t *apiClient, long petId)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -505,6 +517,7 @@ PetAPI_getPetById(apiClient_t *apiClient, long petId)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -561,6 +574,7 @@ PetAPI_getPicture(apiClient_t *apiClient)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -582,6 +596,7 @@ PetAPI_getPicture(apiClient_t *apiClient)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -622,6 +637,7 @@ PetAPI_isPetAvailable(apiClient_t *apiClient, long petId)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -657,6 +673,7 @@ PetAPI_isPetAvailable(apiClient_t *apiClient, long petId)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -697,7 +714,7 @@ end:
 // Send a picture of your happy pet
 //
 char*
-PetAPI_sharePicture(apiClient_t *apiClient, char *picture)
+PetAPI_sharePicture(apiClient_t *apiClient, binary_t* picture)
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -705,6 +722,7 @@ PetAPI_sharePicture(apiClient_t *apiClient, char *picture)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -719,7 +737,9 @@ PetAPI_sharePicture(apiClient_t *apiClient, char *picture)
 
 
     // Body Param
-    localVarBodyParameters = strdup(picture);
+    localVarBodyParameters = malloc(picture->len);
+    memcpy(localVarBodyParameters, picture->data, picture->len);
+    localVarBodyLength = picture->len;
     list_addElement(localVarHeaderType,"*/*"); //produces
     apiClient_invoke(apiClient,
                     localVarPath,
@@ -729,6 +749,7 @@ PetAPI_sharePicture(apiClient_t *apiClient, char *picture)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -772,6 +793,7 @@ PetAPI_specialtyPet(apiClient_t *apiClient)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -794,6 +816,7 @@ PetAPI_specialtyPet(apiClient_t *apiClient)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -841,6 +864,7 @@ PetAPI_updatePet(apiClient_t *apiClient, pet_t *body)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = list_createList();
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -858,9 +882,10 @@ PetAPI_updatePet(apiClient_t *apiClient, pet_t *body)
     cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
-        //string
+        //not string, not binary
         localVarSingleItemJSON_body = pet_convertToJSON(body);
         localVarBodyParameters = cJSON_PrintUnformatted(localVarSingleItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     list_addElement(localVarContentType,"application/json"); //consumes
     list_addElement(localVarContentType,"application/xml"); //consumes
@@ -872,6 +897,7 @@ PetAPI_updatePet(apiClient_t *apiClient, pet_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "PUT");
 
     // uncomment below to debug the error response
@@ -918,6 +944,7 @@ PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char *name, char *s
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = list_createList();
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -977,6 +1004,7 @@ PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char *name, char *s
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -1029,6 +1057,7 @@ PetAPI_uploadFile(apiClient_t *apiClient, long petId, char *additionalMetadata, 
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = list_createList();
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -1089,6 +1118,7 @@ PetAPI_uploadFile(apiClient_t *apiClient, long petId, char *additionalMetadata, 
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response

--- a/samples/client/petstore/c-useJsonUnformatted/api/PetAPI.h
+++ b/samples/client/petstore/c-useJsonUnformatted/api/PetAPI.h
@@ -71,7 +71,7 @@ PetAPI_isPetAvailable(apiClient_t *apiClient, long petId);
 // Send a picture of your happy pet
 //
 char*
-PetAPI_sharePicture(apiClient_t *apiClient, char *picture);
+PetAPI_sharePicture(apiClient_t *apiClient, binary_t* picture);
 
 
 // Specialty of the shop

--- a/samples/client/petstore/c-useJsonUnformatted/api/StoreAPI.c
+++ b/samples/client/petstore/c-useJsonUnformatted/api/StoreAPI.c
@@ -11,6 +11,58 @@
     snprintf(dst, 256, "%ld", (long int)(src));\
 }while(0)
 
+// Functions for enum RATING for StoreAPI_sendRating
+
+static char* sendRating_RATING_ToString(openapi_petstore_sendRating_rating_e RATING){
+    char *RATINGArray[] =  { "NULL", "Excellent", "Great", "Good", "Regular", "Bad", "Awful" };
+    return RATINGArray[RATING];
+}
+
+static openapi_petstore_sendRating_rating_e sendRating_RATING_FromString(char* RATING){
+    int stringToReturn = 0;
+    char *RATINGArray[] =  { "NULL", "Excellent", "Great", "Good", "Regular", "Bad", "Awful" };
+    size_t sizeofArray = sizeof(RATINGArray) / sizeof(RATINGArray[0]);
+    while(stringToReturn < sizeofArray) {
+        if(strcmp(RATING, RATINGArray[stringToReturn]) == 0) {
+            return stringToReturn;
+        }
+        stringToReturn++;
+    }
+    return 0;
+}
+
+/*
+// Function sendRating_RATING_convertToJSON is not currently used,
+// since conversion to JSON passes through the conversion of the model, and ToString. The function is kept for future reference.
+//
+static cJSON *sendRating_RATING_convertToJSON(openapi_petstore_sendRating_rating_e RATING) {
+    cJSON *item = cJSON_CreateObject();
+    if(cJSON_AddStringToObject(item, "rating", sendRating_RATING_ToString(RATING)) == NULL) {
+        goto fail;
+    }
+    return item;
+    fail:
+    cJSON_Delete(item);
+    return NULL;
+}
+
+// Function sendRating_RATING_parseFromJSON is not currently used,
+// since conversion from JSON passes through the conversion of the model, and FromString. The function is kept for future reference.
+//
+static openapi_petstore_sendRating_rating_e sendRating_RATING_parseFromJSON(cJSON* RATINGJSON) {
+    openapi_petstore_sendRating_rating_e RATINGVariable = 0;
+    cJSON *RATINGVar = cJSON_GetObjectItemCaseSensitive(RATINGJSON, "rating");
+    if(!cJSON_IsString(RATINGVar) || (RATINGVar->valuestring == NULL))
+    {
+        goto end;
+    }
+    RATINGVariable = sendRating_RATING_FromString(RATINGVar->valuestring);
+    return RATINGVariable;
+end:
+    return 0;
+}
+*/
+
 
 // Delete purchase order by ID
 //
@@ -25,6 +77,7 @@ StoreAPI_deleteOrder(apiClient_t *apiClient, char *orderId)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -57,6 +110,7 @@ StoreAPI_deleteOrder(apiClient_t *apiClient, char *orderId)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "DELETE");
 
     // uncomment below to debug the error response
@@ -97,6 +151,7 @@ StoreAPI_getInventory(apiClient_t *apiClient)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -118,6 +173,7 @@ StoreAPI_getInventory(apiClient_t *apiClient)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -168,6 +224,7 @@ StoreAPI_getOrderById(apiClient_t *apiClient, long orderId)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -204,6 +261,7 @@ StoreAPI_getOrderById(apiClient_t *apiClient, long orderId)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -260,6 +318,7 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t *body)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -277,9 +336,10 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t *body)
     cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
-        //string
+        //not string, not binary
         localVarSingleItemJSON_body = order_convertToJSON(body);
         localVarBodyParameters = cJSON_PrintUnformatted(localVarSingleItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     list_addElement(localVarHeaderType,"application/xml"); //produces
     list_addElement(localVarHeaderType,"application/json"); //produces
@@ -291,6 +351,7 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -329,6 +390,150 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t *body)
         localVarSingleItemJSON_body = NULL;
     }
     free(localVarBodyParameters);
+    return elementToReturn;
+end:
+    free(localVarPath);
+    return NULL;
+
+}
+
+// Send us a feedback message
+//
+char*
+StoreAPI_sendFeedback(apiClient_t *apiClient, char *feedback)
+{
+    list_t    *localVarQueryParameters = NULL;
+    list_t    *localVarHeaderParameters = NULL;
+    list_t    *localVarFormParameters = NULL;
+    list_t *localVarHeaderType = list_createList();
+    list_t *localVarContentType = NULL;
+    char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
+
+    // clear the error code from the previous api call
+    apiClient->response_code = 0;
+
+    // create the path
+    long sizeOfPath = strlen("/store/feedback")+1;
+    char *localVarPath = malloc(sizeOfPath);
+    snprintf(localVarPath, sizeOfPath, "/store/feedback");
+
+
+
+
+
+    // Body Param
+    localVarBodyParameters = strdup(feedback);
+    localVarBodyLength = strlen(localVarBodyParameters);
+    list_addElement(localVarHeaderType,"*/*"); //produces
+    apiClient_invoke(apiClient,
+                    localVarPath,
+                    localVarQueryParameters,
+                    localVarHeaderParameters,
+                    localVarFormParameters,
+                    localVarHeaderType,
+                    localVarContentType,
+                    localVarBodyParameters,
+                    localVarBodyLength,
+                    "POST");
+
+    // uncomment below to debug the error response
+    //if (apiClient->response_code == 200) {
+    //    printf("%s\n","successful operation");
+    //}
+    //primitive return type simple string
+    char* elementToReturn = NULL;
+    if(apiClient->response_code >= 200 && apiClient->response_code < 300)
+        elementToReturn = strdup((char*)apiClient->dataReceived);
+
+    if (apiClient->dataReceived) {
+        free(apiClient->dataReceived);
+        apiClient->dataReceived = NULL;
+        apiClient->dataReceivedLen = 0;
+    }
+    
+    
+    
+    list_freeList(localVarHeaderType);
+    
+    free(localVarPath);
+    free(localVarBodyParameters);
+    return elementToReturn;
+end:
+    free(localVarPath);
+    return NULL;
+
+}
+
+// How would you rate our service?
+//
+char*
+StoreAPI_sendRating(apiClient_t *apiClient, openapi_petstore_sendRating_rating_e rating)
+{
+    list_t    *localVarQueryParameters = NULL;
+    list_t    *localVarHeaderParameters = NULL;
+    list_t    *localVarFormParameters = NULL;
+    list_t *localVarHeaderType = list_createList();
+    list_t *localVarContentType = NULL;
+    char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
+
+    // clear the error code from the previous api call
+    apiClient->response_code = 0;
+
+    // create the path
+    long sizeOfPath = strlen("/store/rating/{rating}")+1;
+    char *localVarPath = malloc(sizeOfPath);
+    snprintf(localVarPath, sizeOfPath, "/store/rating/{rating}");
+
+    if(!rating)
+        goto end;
+
+
+    // Path Params
+    long sizeOfPathParams_rating = strlen(sendRating_RATING_ToString(rating))+3 + strlen("{ rating }");
+    if(rating == 0) {
+        goto end;
+    }
+    char* localVarToReplace_rating = malloc(sizeOfPathParams_rating);
+    sprintf(localVarToReplace_rating, "{%s}", "rating");
+
+    localVarPath = strReplace(localVarPath, localVarToReplace_rating, sendRating_RATING_ToString(rating));
+
+
+    list_addElement(localVarHeaderType,"*/*"); //produces
+    apiClient_invoke(apiClient,
+                    localVarPath,
+                    localVarQueryParameters,
+                    localVarHeaderParameters,
+                    localVarFormParameters,
+                    localVarHeaderType,
+                    localVarContentType,
+                    localVarBodyParameters,
+                    localVarBodyLength,
+                    "POST");
+
+    // uncomment below to debug the error response
+    //if (apiClient->response_code == 200) {
+    //    printf("%s\n","successful operation");
+    //}
+    //primitive return type simple string
+    char* elementToReturn = NULL;
+    if(apiClient->response_code >= 200 && apiClient->response_code < 300)
+        elementToReturn = strdup((char*)apiClient->dataReceived);
+
+    if (apiClient->dataReceived) {
+        free(apiClient->dataReceived);
+        apiClient->dataReceived = NULL;
+        apiClient->dataReceivedLen = 0;
+    }
+    
+    
+    
+    list_freeList(localVarHeaderType);
+    
+    free(localVarPath);
+    free(localVarToReplace_rating);
     return elementToReturn;
 end:
     free(localVarPath);

--- a/samples/client/petstore/c-useJsonUnformatted/api/StoreAPI.h
+++ b/samples/client/petstore/c-useJsonUnformatted/api/StoreAPI.h
@@ -7,6 +7,9 @@
 #include "../include/binary.h"
 #include "../model/order.h"
 
+// Enum RATING for StoreAPI_sendRating
+typedef enum  { openapi_petstore_sendRating_RATING_NULL = 0, openapi_petstore_sendRating_RATING_Excellent, openapi_petstore_sendRating_RATING_Great, openapi_petstore_sendRating_RATING_Good, openapi_petstore_sendRating_RATING_Regular, openapi_petstore_sendRating_RATING_Bad, openapi_petstore_sendRating_RATING_Awful } openapi_petstore_sendRating_rating_e;
+
 
 // Delete purchase order by ID
 //
@@ -36,5 +39,17 @@ StoreAPI_getOrderById(apiClient_t *apiClient, long orderId);
 //
 order_t*
 StoreAPI_placeOrder(apiClient_t *apiClient, order_t *body);
+
+
+// Send us a feedback message
+//
+char*
+StoreAPI_sendFeedback(apiClient_t *apiClient, char *feedback);
+
+
+// How would you rate our service?
+//
+char*
+StoreAPI_sendRating(apiClient_t *apiClient, openapi_petstore_sendRating_rating_e rating);
 
 

--- a/samples/client/petstore/c-useJsonUnformatted/api/UserAPI.c
+++ b/samples/client/petstore/c-useJsonUnformatted/api/UserAPI.c
@@ -25,6 +25,7 @@ UserAPI_createUser(apiClient_t *apiClient, user_t *body)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -42,9 +43,10 @@ UserAPI_createUser(apiClient_t *apiClient, user_t *body)
     cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
-        //string
+        //not string, not binary
         localVarSingleItemJSON_body = user_convertToJSON(body);
         localVarBodyParameters = cJSON_PrintUnformatted(localVarSingleItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     apiClient_invoke(apiClient,
                     localVarPath,
@@ -54,6 +56,7 @@ UserAPI_createUser(apiClient_t *apiClient, user_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -92,6 +95,7 @@ UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t *body)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -132,6 +136,7 @@ UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t *body)
         }
         cJSON_AddItemToArray(localVarSingleItemJSON_body, localVar_body);
         localVarBodyParameters = cJSON_PrintUnformatted(localVarItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     apiClient_invoke(apiClient,
                     localVarPath,
@@ -141,6 +146,7 @@ UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -187,6 +193,7 @@ UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t *body)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -227,6 +234,7 @@ UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t *body)
         }
         cJSON_AddItemToArray(localVarSingleItemJSON_body, localVar_body);
         localVarBodyParameters = cJSON_PrintUnformatted(localVarItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     apiClient_invoke(apiClient,
                     localVarPath,
@@ -236,6 +244,7 @@ UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -284,6 +293,7 @@ UserAPI_deleteUser(apiClient_t *apiClient, char *username)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -316,6 +326,7 @@ UserAPI_deleteUser(apiClient_t *apiClient, char *username)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "DELETE");
 
     // uncomment below to debug the error response
@@ -354,6 +365,7 @@ UserAPI_getUserByName(apiClient_t *apiClient, char *username)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -388,6 +400,7 @@ UserAPI_getUserByName(apiClient_t *apiClient, char *username)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -444,6 +457,7 @@ UserAPI_loginUser(apiClient_t *apiClient, char *username, char *password)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -490,6 +504,7 @@ UserAPI_loginUser(apiClient_t *apiClient, char *username, char *password)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -558,6 +573,7 @@ UserAPI_logoutUser(apiClient_t *apiClient)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -578,6 +594,7 @@ UserAPI_logoutUser(apiClient_t *apiClient)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -613,6 +630,7 @@ UserAPI_testIntAndBool(apiClient_t *apiClient, int *keep, int *keepDay)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -659,6 +677,7 @@ UserAPI_testIntAndBool(apiClient_t *apiClient, int *keep, int *keepDay)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -694,6 +713,7 @@ UserAPI_updateUser(apiClient_t *apiClient, char *username, user_t *body)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -723,9 +743,10 @@ UserAPI_updateUser(apiClient_t *apiClient, char *username, user_t *body)
     cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
-        //string
+        //not string, not binary
         localVarSingleItemJSON_body = user_convertToJSON(body);
         localVarBodyParameters = cJSON_PrintUnformatted(localVarSingleItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     apiClient_invoke(apiClient,
                     localVarPath,
@@ -735,6 +756,7 @@ UserAPI_updateUser(apiClient_t *apiClient, char *username, user_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "PUT");
 
     // uncomment below to debug the error response

--- a/samples/client/petstore/c-useJsonUnformatted/docs/PetAPI.md
+++ b/samples/client/petstore/c-useJsonUnformatted/docs/PetAPI.md
@@ -260,14 +260,14 @@ Name | Type | Description  | Notes
 ```c
 // Send a picture of your happy pet
 //
-char* PetAPI_sharePicture(apiClient_t *apiClient, char *picture);
+char* PetAPI_sharePicture(apiClient_t *apiClient, binary_t* picture);
 ```
 
 ### Parameters
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **apiClient** | **apiClient_t \*** | context containing the client configuration |
-**picture** | **char \*** | A picture you want to share | 
+**picture** | **binary_t*** | A picture you want to share | 
 
 ### Return type
 

--- a/samples/client/petstore/c-useJsonUnformatted/docs/StoreAPI.md
+++ b/samples/client/petstore/c-useJsonUnformatted/docs/StoreAPI.md
@@ -8,6 +8,8 @@ Method | HTTP request | Description
 [**StoreAPI_getInventory**](StoreAPI.md#StoreAPI_getInventory) | **GET** /store/inventory | Returns pet inventories by status
 [**StoreAPI_getOrderById**](StoreAPI.md#StoreAPI_getOrderById) | **GET** /store/order/{orderId} | Find purchase order by ID
 [**StoreAPI_placeOrder**](StoreAPI.md#StoreAPI_placeOrder) | **POST** /store/order | Place an order for a pet
+[**StoreAPI_sendFeedback**](StoreAPI.md#StoreAPI_sendFeedback) | **POST** /store/feedback | Send us a feedback message
+[**StoreAPI_sendRating**](StoreAPI.md#StoreAPI_sendRating) | **POST** /store/rating/{rating} | How would you rate our service?
 
 
 # **StoreAPI_deleteOrder**
@@ -130,6 +132,66 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: application/xml, application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **StoreAPI_sendFeedback**
+```c
+// Send us a feedback message
+//
+char* StoreAPI_sendFeedback(apiClient_t *apiClient, char *feedback);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration |
+**feedback** | **char \*** | The feedback message to send | 
+
+### Return type
+
+char*
+
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: */*
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **StoreAPI_sendRating**
+```c
+// How would you rate our service?
+//
+char* StoreAPI_sendRating(apiClient_t *apiClient, openapi_petstore_sendRating_rating_e rating);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration |
+**rating** | **openapi_petstore_sendRating_rating_e** | The rating to submit | 
+
+### Return type
+
+char*
+
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: */*
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/c-useJsonUnformatted/include/apiClient.h
+++ b/samples/client/petstore/c-useJsonUnformatted/include/apiClient.h
@@ -41,7 +41,7 @@ apiClient_t* apiClient_create_with_base_path(const char *basePath
 
 void apiClient_free(apiClient_t *apiClient);
 
-void apiClient_invoke(apiClient_t *apiClient,const char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, const char *bodyParameters, const char *requestType);
+void apiClient_invoke(apiClient_t *apiClient,const char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, const char *bodyParameters, size_t bodyParametersLength, const char *requestType);
 
 sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify);
 

--- a/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
+++ b/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
@@ -187,10 +187,10 @@ char *assembleHeaderField(char *key, char *value) {
     return header;
 }
 
-void postData(CURL *handle, const char *bodyParameters) {
+void postData(CURL *handle, const char *bodyParameters, size_t bodyParametersLength) {
     curl_easy_setopt(handle, CURLOPT_POSTFIELDS, bodyParameters);
     curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE,
-                     (curl_off_t)strlen(bodyParameters));
+                     (curl_off_t)bodyParametersLength);
 }
 
 int lengthOfKeyPair(keyValuePair_t *keyPair) {
@@ -213,7 +213,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
                       list_t        *headerType,
                       list_t        *contentType,
                       const char    *bodyParameters,
-                      const char    *requestType) {
+                      size_t       bodyParametersLength,
+                      const char   *requestType) {
     CURL *handle = curl_easy_init();
     CURLcode res;
 
@@ -442,7 +443,7 @@ void apiClient_invoke(apiClient_t    *apiClient,
         }
 
         if(bodyParameters != NULL) {
-            postData(handle, bodyParameters);
+            postData(handle, bodyParameters, bodyParametersLength);
         }
 
         res = curl_easy_perform(handle);

--- a/samples/client/petstore/c/.openapi-generator/FILES
+++ b/samples/client/petstore/c/.openapi-generator/FILES
@@ -1,3 +1,4 @@
+Config.cmake.in
 Packing.cmake
 README.md
 api/PetAPI.c

--- a/samples/client/petstore/c/Config.cmake.in
+++ b/samples/client/petstore/c/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
+
+check_required_components("@PROJECT_NAME@")

--- a/samples/client/petstore/c/README.md
+++ b/samples/client/petstore/c/README.md
@@ -82,6 +82,8 @@ Category | Method | HTTP request | Description
 *StoreAPI* | [**StoreAPI_getInventory**](docs/StoreAPI.md#StoreAPI_getInventory) | **GET** /store/inventory | Returns pet inventories by status
 *StoreAPI* | [**StoreAPI_getOrderById**](docs/StoreAPI.md#StoreAPI_getOrderById) | **GET** /store/order/{orderId} | Find purchase order by ID
 *StoreAPI* | [**StoreAPI_placeOrder**](docs/StoreAPI.md#StoreAPI_placeOrder) | **POST** /store/order | Place an order for a pet
+*StoreAPI* | [**StoreAPI_sendFeedback**](docs/StoreAPI.md#StoreAPI_sendFeedback) | **POST** /store/feedback | Send us a feedback message
+*StoreAPI* | [**StoreAPI_sendRating**](docs/StoreAPI.md#StoreAPI_sendRating) | **POST** /store/rating/{rating} | How would you rate our service?
 *UserAPI* | [**UserAPI_createUser**](docs/UserAPI.md#UserAPI_createUser) | **POST** /user | Create user
 *UserAPI* | [**UserAPI_createUsersWithArrayInput**](docs/UserAPI.md#UserAPI_createUsersWithArrayInput) | **POST** /user/createWithArray | Creates list of users with given input array
 *UserAPI* | [**UserAPI_createUsersWithListInput**](docs/UserAPI.md#UserAPI_createUsersWithListInput) | **POST** /user/createWithList | Creates list of users with given input array

--- a/samples/client/petstore/c/api/PetAPI.c
+++ b/samples/client/petstore/c/api/PetAPI.c
@@ -66,6 +66,7 @@ PetAPI_addPet(apiClient_t *apiClient, pet_t *body)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = list_createList();
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -83,9 +84,10 @@ PetAPI_addPet(apiClient_t *apiClient, pet_t *body)
     cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
-        //string
+        //not string, not binary
         localVarSingleItemJSON_body = pet_convertToJSON(body);
         localVarBodyParameters = cJSON_Print(localVarSingleItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     list_addElement(localVarContentType,"application/json"); //consumes
     list_addElement(localVarContentType,"application/xml"); //consumes
@@ -97,6 +99,7 @@ PetAPI_addPet(apiClient_t *apiClient, pet_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -135,6 +138,7 @@ PetAPI_deletePet(apiClient_t *apiClient, long petId, char *api_key)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -181,6 +185,7 @@ PetAPI_deletePet(apiClient_t *apiClient, long petId, char *api_key)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "DELETE");
 
     // uncomment below to debug the error response
@@ -226,6 +231,7 @@ PetAPI_findPetsByStatus(apiClient_t *apiClient, list_t *status)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -254,6 +260,7 @@ PetAPI_findPetsByStatus(apiClient_t *apiClient, list_t *status)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -317,6 +324,7 @@ PetAPI_findPetsByTags(apiClient_t *apiClient, list_t *tags)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -345,6 +353,7 @@ PetAPI_findPetsByTags(apiClient_t *apiClient, list_t *tags)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -406,6 +415,7 @@ PetAPI_getDaysWithoutIncident(apiClient_t *apiClient)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -427,6 +437,7 @@ PetAPI_getDaysWithoutIncident(apiClient_t *apiClient)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -469,6 +480,7 @@ PetAPI_getPetById(apiClient_t *apiClient, long petId)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -505,6 +517,7 @@ PetAPI_getPetById(apiClient_t *apiClient, long petId)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -561,6 +574,7 @@ PetAPI_getPicture(apiClient_t *apiClient)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -582,6 +596,7 @@ PetAPI_getPicture(apiClient_t *apiClient)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -622,6 +637,7 @@ PetAPI_isPetAvailable(apiClient_t *apiClient, long petId)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -657,6 +673,7 @@ PetAPI_isPetAvailable(apiClient_t *apiClient, long petId)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -697,7 +714,7 @@ end:
 // Send a picture of your happy pet
 //
 char*
-PetAPI_sharePicture(apiClient_t *apiClient, char *picture)
+PetAPI_sharePicture(apiClient_t *apiClient, binary_t* picture)
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -705,6 +722,7 @@ PetAPI_sharePicture(apiClient_t *apiClient, char *picture)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -719,7 +737,9 @@ PetAPI_sharePicture(apiClient_t *apiClient, char *picture)
 
 
     // Body Param
-    localVarBodyParameters = strdup(picture);
+    localVarBodyParameters = malloc(picture->len);
+    memcpy(localVarBodyParameters, picture->data, picture->len);
+    localVarBodyLength = picture->len;
     list_addElement(localVarHeaderType,"*/*"); //produces
     apiClient_invoke(apiClient,
                     localVarPath,
@@ -729,6 +749,7 @@ PetAPI_sharePicture(apiClient_t *apiClient, char *picture)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -772,6 +793,7 @@ PetAPI_specialtyPet(apiClient_t *apiClient)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -794,6 +816,7 @@ PetAPI_specialtyPet(apiClient_t *apiClient)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -841,6 +864,7 @@ PetAPI_updatePet(apiClient_t *apiClient, pet_t *body)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = list_createList();
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -858,9 +882,10 @@ PetAPI_updatePet(apiClient_t *apiClient, pet_t *body)
     cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
-        //string
+        //not string, not binary
         localVarSingleItemJSON_body = pet_convertToJSON(body);
         localVarBodyParameters = cJSON_Print(localVarSingleItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     list_addElement(localVarContentType,"application/json"); //consumes
     list_addElement(localVarContentType,"application/xml"); //consumes
@@ -872,6 +897,7 @@ PetAPI_updatePet(apiClient_t *apiClient, pet_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "PUT");
 
     // uncomment below to debug the error response
@@ -918,6 +944,7 @@ PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char *name, char *s
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = list_createList();
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -977,6 +1004,7 @@ PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char *name, char *s
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -1029,6 +1057,7 @@ PetAPI_uploadFile(apiClient_t *apiClient, long petId, char *additionalMetadata, 
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = list_createList();
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -1089,6 +1118,7 @@ PetAPI_uploadFile(apiClient_t *apiClient, long petId, char *additionalMetadata, 
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response

--- a/samples/client/petstore/c/api/PetAPI.h
+++ b/samples/client/petstore/c/api/PetAPI.h
@@ -71,7 +71,7 @@ PetAPI_isPetAvailable(apiClient_t *apiClient, long petId);
 // Send a picture of your happy pet
 //
 char*
-PetAPI_sharePicture(apiClient_t *apiClient, char *picture);
+PetAPI_sharePicture(apiClient_t *apiClient, binary_t* picture);
 
 
 // Specialty of the shop

--- a/samples/client/petstore/c/api/StoreAPI.c
+++ b/samples/client/petstore/c/api/StoreAPI.c
@@ -11,6 +11,58 @@
     snprintf(dst, 256, "%ld", (long int)(src));\
 }while(0)
 
+// Functions for enum RATING for StoreAPI_sendRating
+
+static char* sendRating_RATING_ToString(openapi_petstore_sendRating_rating_e RATING){
+    char *RATINGArray[] =  { "NULL", "Excellent", "Great", "Good", "Regular", "Bad", "Awful" };
+    return RATINGArray[RATING];
+}
+
+static openapi_petstore_sendRating_rating_e sendRating_RATING_FromString(char* RATING){
+    int stringToReturn = 0;
+    char *RATINGArray[] =  { "NULL", "Excellent", "Great", "Good", "Regular", "Bad", "Awful" };
+    size_t sizeofArray = sizeof(RATINGArray) / sizeof(RATINGArray[0]);
+    while(stringToReturn < sizeofArray) {
+        if(strcmp(RATING, RATINGArray[stringToReturn]) == 0) {
+            return stringToReturn;
+        }
+        stringToReturn++;
+    }
+    return 0;
+}
+
+/*
+// Function sendRating_RATING_convertToJSON is not currently used,
+// since conversion to JSON passes through the conversion of the model, and ToString. The function is kept for future reference.
+//
+static cJSON *sendRating_RATING_convertToJSON(openapi_petstore_sendRating_rating_e RATING) {
+    cJSON *item = cJSON_CreateObject();
+    if(cJSON_AddStringToObject(item, "rating", sendRating_RATING_ToString(RATING)) == NULL) {
+        goto fail;
+    }
+    return item;
+    fail:
+    cJSON_Delete(item);
+    return NULL;
+}
+
+// Function sendRating_RATING_parseFromJSON is not currently used,
+// since conversion from JSON passes through the conversion of the model, and FromString. The function is kept for future reference.
+//
+static openapi_petstore_sendRating_rating_e sendRating_RATING_parseFromJSON(cJSON* RATINGJSON) {
+    openapi_petstore_sendRating_rating_e RATINGVariable = 0;
+    cJSON *RATINGVar = cJSON_GetObjectItemCaseSensitive(RATINGJSON, "rating");
+    if(!cJSON_IsString(RATINGVar) || (RATINGVar->valuestring == NULL))
+    {
+        goto end;
+    }
+    RATINGVariable = sendRating_RATING_FromString(RATINGVar->valuestring);
+    return RATINGVariable;
+end:
+    return 0;
+}
+*/
+
 
 // Delete purchase order by ID
 //
@@ -25,6 +77,7 @@ StoreAPI_deleteOrder(apiClient_t *apiClient, char *orderId)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -57,6 +110,7 @@ StoreAPI_deleteOrder(apiClient_t *apiClient, char *orderId)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "DELETE");
 
     // uncomment below to debug the error response
@@ -97,6 +151,7 @@ StoreAPI_getInventory(apiClient_t *apiClient)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -118,6 +173,7 @@ StoreAPI_getInventory(apiClient_t *apiClient)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -168,6 +224,7 @@ StoreAPI_getOrderById(apiClient_t *apiClient, long orderId)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -204,6 +261,7 @@ StoreAPI_getOrderById(apiClient_t *apiClient, long orderId)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -260,6 +318,7 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t *body)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -277,9 +336,10 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t *body)
     cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
-        //string
+        //not string, not binary
         localVarSingleItemJSON_body = order_convertToJSON(body);
         localVarBodyParameters = cJSON_Print(localVarSingleItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     list_addElement(localVarHeaderType,"application/xml"); //produces
     list_addElement(localVarHeaderType,"application/json"); //produces
@@ -291,6 +351,7 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -329,6 +390,150 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t *body)
         localVarSingleItemJSON_body = NULL;
     }
     free(localVarBodyParameters);
+    return elementToReturn;
+end:
+    free(localVarPath);
+    return NULL;
+
+}
+
+// Send us a feedback message
+//
+char*
+StoreAPI_sendFeedback(apiClient_t *apiClient, char *feedback)
+{
+    list_t    *localVarQueryParameters = NULL;
+    list_t    *localVarHeaderParameters = NULL;
+    list_t    *localVarFormParameters = NULL;
+    list_t *localVarHeaderType = list_createList();
+    list_t *localVarContentType = NULL;
+    char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
+
+    // clear the error code from the previous api call
+    apiClient->response_code = 0;
+
+    // create the path
+    long sizeOfPath = strlen("/store/feedback")+1;
+    char *localVarPath = malloc(sizeOfPath);
+    snprintf(localVarPath, sizeOfPath, "/store/feedback");
+
+
+
+
+
+    // Body Param
+    localVarBodyParameters = strdup(feedback);
+    localVarBodyLength = strlen(localVarBodyParameters);
+    list_addElement(localVarHeaderType,"*/*"); //produces
+    apiClient_invoke(apiClient,
+                    localVarPath,
+                    localVarQueryParameters,
+                    localVarHeaderParameters,
+                    localVarFormParameters,
+                    localVarHeaderType,
+                    localVarContentType,
+                    localVarBodyParameters,
+                    localVarBodyLength,
+                    "POST");
+
+    // uncomment below to debug the error response
+    //if (apiClient->response_code == 200) {
+    //    printf("%s\n","successful operation");
+    //}
+    //primitive return type simple string
+    char* elementToReturn = NULL;
+    if(apiClient->response_code >= 200 && apiClient->response_code < 300)
+        elementToReturn = strdup((char*)apiClient->dataReceived);
+
+    if (apiClient->dataReceived) {
+        free(apiClient->dataReceived);
+        apiClient->dataReceived = NULL;
+        apiClient->dataReceivedLen = 0;
+    }
+    
+    
+    
+    list_freeList(localVarHeaderType);
+    
+    free(localVarPath);
+    free(localVarBodyParameters);
+    return elementToReturn;
+end:
+    free(localVarPath);
+    return NULL;
+
+}
+
+// How would you rate our service?
+//
+char*
+StoreAPI_sendRating(apiClient_t *apiClient, openapi_petstore_sendRating_rating_e rating)
+{
+    list_t    *localVarQueryParameters = NULL;
+    list_t    *localVarHeaderParameters = NULL;
+    list_t    *localVarFormParameters = NULL;
+    list_t *localVarHeaderType = list_createList();
+    list_t *localVarContentType = NULL;
+    char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
+
+    // clear the error code from the previous api call
+    apiClient->response_code = 0;
+
+    // create the path
+    long sizeOfPath = strlen("/store/rating/{rating}")+1;
+    char *localVarPath = malloc(sizeOfPath);
+    snprintf(localVarPath, sizeOfPath, "/store/rating/{rating}");
+
+    if(!rating)
+        goto end;
+
+
+    // Path Params
+    long sizeOfPathParams_rating = strlen(sendRating_RATING_ToString(rating))+3 + strlen("{ rating }");
+    if(rating == 0) {
+        goto end;
+    }
+    char* localVarToReplace_rating = malloc(sizeOfPathParams_rating);
+    sprintf(localVarToReplace_rating, "{%s}", "rating");
+
+    localVarPath = strReplace(localVarPath, localVarToReplace_rating, sendRating_RATING_ToString(rating));
+
+
+    list_addElement(localVarHeaderType,"*/*"); //produces
+    apiClient_invoke(apiClient,
+                    localVarPath,
+                    localVarQueryParameters,
+                    localVarHeaderParameters,
+                    localVarFormParameters,
+                    localVarHeaderType,
+                    localVarContentType,
+                    localVarBodyParameters,
+                    localVarBodyLength,
+                    "POST");
+
+    // uncomment below to debug the error response
+    //if (apiClient->response_code == 200) {
+    //    printf("%s\n","successful operation");
+    //}
+    //primitive return type simple string
+    char* elementToReturn = NULL;
+    if(apiClient->response_code >= 200 && apiClient->response_code < 300)
+        elementToReturn = strdup((char*)apiClient->dataReceived);
+
+    if (apiClient->dataReceived) {
+        free(apiClient->dataReceived);
+        apiClient->dataReceived = NULL;
+        apiClient->dataReceivedLen = 0;
+    }
+    
+    
+    
+    list_freeList(localVarHeaderType);
+    
+    free(localVarPath);
+    free(localVarToReplace_rating);
     return elementToReturn;
 end:
     free(localVarPath);

--- a/samples/client/petstore/c/api/StoreAPI.h
+++ b/samples/client/petstore/c/api/StoreAPI.h
@@ -7,6 +7,9 @@
 #include "../include/binary.h"
 #include "../model/order.h"
 
+// Enum RATING for StoreAPI_sendRating
+typedef enum  { openapi_petstore_sendRating_RATING_NULL = 0, openapi_petstore_sendRating_RATING_Excellent, openapi_petstore_sendRating_RATING_Great, openapi_petstore_sendRating_RATING_Good, openapi_petstore_sendRating_RATING_Regular, openapi_petstore_sendRating_RATING_Bad, openapi_petstore_sendRating_RATING_Awful } openapi_petstore_sendRating_rating_e;
+
 
 // Delete purchase order by ID
 //
@@ -36,5 +39,17 @@ StoreAPI_getOrderById(apiClient_t *apiClient, long orderId);
 //
 order_t*
 StoreAPI_placeOrder(apiClient_t *apiClient, order_t *body);
+
+
+// Send us a feedback message
+//
+char*
+StoreAPI_sendFeedback(apiClient_t *apiClient, char *feedback);
+
+
+// How would you rate our service?
+//
+char*
+StoreAPI_sendRating(apiClient_t *apiClient, openapi_petstore_sendRating_rating_e rating);
 
 

--- a/samples/client/petstore/c/api/UserAPI.c
+++ b/samples/client/petstore/c/api/UserAPI.c
@@ -25,6 +25,7 @@ UserAPI_createUser(apiClient_t *apiClient, user_t *body)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -42,9 +43,10 @@ UserAPI_createUser(apiClient_t *apiClient, user_t *body)
     cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
-        //string
+        //not string, not binary
         localVarSingleItemJSON_body = user_convertToJSON(body);
         localVarBodyParameters = cJSON_Print(localVarSingleItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     apiClient_invoke(apiClient,
                     localVarPath,
@@ -54,6 +56,7 @@ UserAPI_createUser(apiClient_t *apiClient, user_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -92,6 +95,7 @@ UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t *body)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -132,6 +136,7 @@ UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t *body)
         }
         cJSON_AddItemToArray(localVarSingleItemJSON_body, localVar_body);
         localVarBodyParameters = cJSON_Print(localVarItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     apiClient_invoke(apiClient,
                     localVarPath,
@@ -141,6 +146,7 @@ UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -187,6 +193,7 @@ UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t *body)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -227,6 +234,7 @@ UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t *body)
         }
         cJSON_AddItemToArray(localVarSingleItemJSON_body, localVar_body);
         localVarBodyParameters = cJSON_Print(localVarItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     apiClient_invoke(apiClient,
                     localVarPath,
@@ -236,6 +244,7 @@ UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "POST");
 
     // uncomment below to debug the error response
@@ -284,6 +293,7 @@ UserAPI_deleteUser(apiClient_t *apiClient, char *username)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -316,6 +326,7 @@ UserAPI_deleteUser(apiClient_t *apiClient, char *username)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "DELETE");
 
     // uncomment below to debug the error response
@@ -354,6 +365,7 @@ UserAPI_getUserByName(apiClient_t *apiClient, char *username)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -388,6 +400,7 @@ UserAPI_getUserByName(apiClient_t *apiClient, char *username)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -444,6 +457,7 @@ UserAPI_loginUser(apiClient_t *apiClient, char *username, char *password)
     list_t *localVarHeaderType = list_createList();
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -490,6 +504,7 @@ UserAPI_loginUser(apiClient_t *apiClient, char *username, char *password)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -558,6 +573,7 @@ UserAPI_logoutUser(apiClient_t *apiClient)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -578,6 +594,7 @@ UserAPI_logoutUser(apiClient_t *apiClient)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -613,6 +630,7 @@ UserAPI_testIntAndBool(apiClient_t *apiClient, int *keep, int *keepDay)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -659,6 +677,7 @@ UserAPI_testIntAndBool(apiClient_t *apiClient, int *keep, int *keepDay)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "GET");
 
     // uncomment below to debug the error response
@@ -694,6 +713,7 @@ UserAPI_updateUser(apiClient_t *apiClient, char *username, user_t *body)
     list_t *localVarHeaderType = NULL;
     list_t *localVarContentType = NULL;
     char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
 
     // clear the error code from the previous api call
     apiClient->response_code = 0;
@@ -723,9 +743,10 @@ UserAPI_updateUser(apiClient_t *apiClient, char *username, user_t *body)
     cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
-        //string
+        //not string, not binary
         localVarSingleItemJSON_body = user_convertToJSON(body);
         localVarBodyParameters = cJSON_Print(localVarSingleItemJSON_body);
+        localVarBodyLength = strlen(localVarBodyParameters);
     }
     apiClient_invoke(apiClient,
                     localVarPath,
@@ -735,6 +756,7 @@ UserAPI_updateUser(apiClient_t *apiClient, char *username, user_t *body)
                     localVarHeaderType,
                     localVarContentType,
                     localVarBodyParameters,
+                    localVarBodyLength,
                     "PUT");
 
     // uncomment below to debug the error response

--- a/samples/client/petstore/c/docs/PetAPI.md
+++ b/samples/client/petstore/c/docs/PetAPI.md
@@ -260,14 +260,14 @@ Name | Type | Description  | Notes
 ```c
 // Send a picture of your happy pet
 //
-char* PetAPI_sharePicture(apiClient_t *apiClient, char *picture);
+char* PetAPI_sharePicture(apiClient_t *apiClient, binary_t* picture);
 ```
 
 ### Parameters
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **apiClient** | **apiClient_t \*** | context containing the client configuration |
-**picture** | **char \*** | A picture you want to share | 
+**picture** | **binary_t*** | A picture you want to share | 
 
 ### Return type
 

--- a/samples/client/petstore/c/docs/StoreAPI.md
+++ b/samples/client/petstore/c/docs/StoreAPI.md
@@ -8,6 +8,8 @@ Method | HTTP request | Description
 [**StoreAPI_getInventory**](StoreAPI.md#StoreAPI_getInventory) | **GET** /store/inventory | Returns pet inventories by status
 [**StoreAPI_getOrderById**](StoreAPI.md#StoreAPI_getOrderById) | **GET** /store/order/{orderId} | Find purchase order by ID
 [**StoreAPI_placeOrder**](StoreAPI.md#StoreAPI_placeOrder) | **POST** /store/order | Place an order for a pet
+[**StoreAPI_sendFeedback**](StoreAPI.md#StoreAPI_sendFeedback) | **POST** /store/feedback | Send us a feedback message
+[**StoreAPI_sendRating**](StoreAPI.md#StoreAPI_sendRating) | **POST** /store/rating/{rating} | How would you rate our service?
 
 
 # **StoreAPI_deleteOrder**
@@ -130,6 +132,66 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: application/xml, application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **StoreAPI_sendFeedback**
+```c
+// Send us a feedback message
+//
+char* StoreAPI_sendFeedback(apiClient_t *apiClient, char *feedback);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration |
+**feedback** | **char \*** | The feedback message to send | 
+
+### Return type
+
+char*
+
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: */*
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **StoreAPI_sendRating**
+```c
+// How would you rate our service?
+//
+char* StoreAPI_sendRating(apiClient_t *apiClient, openapi_petstore_sendRating_rating_e rating);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration |
+**rating** | **openapi_petstore_sendRating_rating_e** | The rating to submit | 
+
+### Return type
+
+char*
+
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: */*
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/c/include/apiClient.h
+++ b/samples/client/petstore/c/include/apiClient.h
@@ -41,7 +41,7 @@ apiClient_t* apiClient_create_with_base_path(const char *basePath
 
 void apiClient_free(apiClient_t *apiClient);
 
-void apiClient_invoke(apiClient_t *apiClient,const char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, const char *bodyParameters, const char *requestType);
+void apiClient_invoke(apiClient_t *apiClient,const char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, const char *bodyParameters, size_t bodyParametersLength, const char *requestType);
 
 sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify);
 

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -187,10 +187,10 @@ char *assembleHeaderField(char *key, char *value) {
     return header;
 }
 
-void postData(CURL *handle, const char *bodyParameters) {
+void postData(CURL *handle, const char *bodyParameters, size_t bodyParametersLength) {
     curl_easy_setopt(handle, CURLOPT_POSTFIELDS, bodyParameters);
     curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE,
-                     (curl_off_t)strlen(bodyParameters));
+                     (curl_off_t)bodyParametersLength);
 }
 
 int lengthOfKeyPair(keyValuePair_t *keyPair) {
@@ -213,7 +213,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
                       list_t        *headerType,
                       list_t        *contentType,
                       const char    *bodyParameters,
-                      const char    *requestType) {
+                      size_t       bodyParametersLength,
+                      const char   *requestType) {
     CURL *handle = curl_easy_init();
     CURLcode res;
 
@@ -442,7 +443,7 @@ void apiClient_invoke(apiClient_t    *apiClient,
         }
 
         if(bodyParameters != NULL) {
-            postData(handle, bodyParameters);
+            postData(handle, bodyParameters, bodyParametersLength);
         }
 
         res = curl_easy_perform(handle);


### PR DESCRIPTION
Four more patches from the original pull request at https://github.com/OpenAPITools/openapi-generator/pull/14379. I reordered the patches this time because the last remaining two are somewhat harder to explain.

@wing328 @ityuhui @zhemant @michelealbano

I ran `generate-samples.sh` as usual, but I see something off with the results for `petstore/c/`. Not all of the cmake files are getting updated. I retried multiple times but I can't tell what I'm doing wrong.