### PR TITLE
[CSHARP] Default headers overwritten instead of duplicated | Body par…

### DIFF
--- a/docs/generators/fsharp-functions.md
+++ b/docs/generators/fsharp-functions.md
@@ -34,7 +34,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|sourceFolder|source folder for generated code| |OpenAPI/src|
+|sourceFolder|source folder for generated code| |OpenAPI\src|
 
 ## IMPORT MAPPING
 

--- a/docs/generators/fsharp-giraffe-server.md
+++ b/docs/generators/fsharp-giraffe-server.md
@@ -30,7 +30,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |packageVersion|F# package version.| |1.0.0|
 |returnICollection|Return ICollection&lt;T&gt; instead of the concrete type.| |false|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|sourceFolder|source folder for generated code| |OpenAPI/src|
+|sourceFolder|source folder for generated code| |OpenAPI\src|
 |useCollection|Deserialize array types to Collection&lt;T&gt; instead of List&lt;T&gt;.| |false|
 |useDateTimeOffset|Use DateTimeOffset to model date-time properties| |false|
 |useSwashbuckle|Uses the Swashbuckle.AspNetCore NuGet package for documentation.| |false|

--- a/docs/generators/java-inflector.md
+++ b/docs/generators/java-inflector.md
@@ -66,7 +66,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshotVersion|Uses a SNAPSHOT version.|<dl><dt>**true**</dt><dd>Use a SnapShot Version</dd><dt>**false**</dt><dd>Use a Release Version</dd></dl>|null|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|sourceFolder|source folder for generated code| |src/gen/java|
+|sourceFolder|source folder for generated code| |src\gen\java|
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |useJakartaEe|whether to use Jakarta EE namespace instead of javax| |false|
 |useOneOfInterfaces|whether to use a java interface to describe a set of oneOf options, where each option is a class that implements the interface| |false|

--- a/docs/generators/jaxrs-cxf-client.md
+++ b/docs/generators/jaxrs-cxf-client.md
@@ -66,7 +66,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshotVersion|Uses a SNAPSHOT version.|<dl><dt>**true**</dt><dd>Use a SnapShot Version</dd><dt>**false**</dt><dd>Use a Release Version</dd></dl>|null|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|sourceFolder|source folder for generated code| |src/gen/java|
+|sourceFolder|source folder for generated code| |src\gen\java|
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |useAbstractionForFiles|Use alternative types instead of java.io.File to allow passing bytes without a file on disk.| |false|
 |useBeanValidation|Use BeanValidation API annotations| |false|

--- a/docs/generators/swift5.md
+++ b/docs/generators/swift5.md
@@ -49,13 +49,13 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |responseAs|Optionally use libraries to manage response.  Currently PromiseKit, RxSwift, Result, Combine, AsyncAwait are available.| |null|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|swiftPackagePath|Set a custom source path instead of OpenAPIClient/Classes/OpenAPIs.| |null|
+|swiftPackagePath|Set a custom source path instead of OpenAPIClient\Classes\OpenAPIs.| |null|
 |swiftUseApiNamespace|Flag to make all the API classes inner-class of {{projectName}}API| |null|
 |useBacktickEscapes|Escape reserved words using backticks (default: false)| |false|
 |useClasses|Use final classes for models instead of structs (default: false)| |false|
 |useCustomDateWithoutTime|Uses a custom type to decode and encode dates without time information to support OpenAPIs date format (default: false)| |false|
 |useJsonEncodable|Make models conform to JSONEncodable protocol (default: true)| |true|
-|useSPMFileStructure|Use SPM file structure and set the source path to Sources/{{projectName}} (default: false).| |null|
+|useSPMFileStructure|Use SPM file structure and set the source path to Sources\{{projectName}} (default: false).| |null|
 |validatable|Make validation rules and validator for model properies (default: true)| |true|
 
 ## IMPORT MAPPING

--- a/docs/generators/swift6.md
+++ b/docs/generators/swift6.md
@@ -51,13 +51,13 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |responseAs|Optionally use libraries to manage response.  Currently AsyncAwait, Combine, Result, RxSwift, ObjcBlock, PromiseKit are available.| |null|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|swiftPackagePath|Set a custom source path instead of Sources/{{projectName}}.| |null|
+|swiftPackagePath|Set a custom source path instead of Sources\{{projectName}}.| |null|
 |swiftUseApiNamespace|Flag to make all the API classes inner-class of {{projectName}}API| |null|
 |useBacktickEscapes|Escape reserved words using backticks (default: false)| |false|
 |useClasses|Use final classes for models instead of structs (default: false)| |false|
 |useCustomDateWithoutTime|Uses a custom type to decode and encode dates without time information to support OpenAPIs date format (default: false)| |false|
 |useJsonEncodable|Make models conform to JSONEncodable protocol (default: true)| |true|
-|useSPMFileStructure|Use SPM file structure and set the source path to Sources/{{projectName}} (default: true).| |null|
+|useSPMFileStructure|Use SPM file structure and set the source path to Sources\{{projectName}} (default: true).| |null|
 |validatable|Make validation rules and validator for model properies (default: true)| |true|
 
 ## IMPORT MAPPING

--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -317,7 +317,7 @@ namespace {{packageName}}.Client
                 {
                     foreach (var value in headerParam.Value)
                     {
-                        request.AddHeader(headerParam.Key, value);
+                        request.AddOrUpdateHeader(headerParam.Key, value);
                     }
                 }
             }

--- a/modules/openapi-generator/src/main/resources/csharp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/api.mustache
@@ -403,7 +403,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{/required}}
             {{/formParams}}
             {{#bodyParam}}
-            localVarRequestOptions.Data = {{paramName}};
+            localVarRequestOptions.Data = {{packageName}}.Client.ClientUtils.Serialize({{paramName}});
             {{/bodyParam}}
 
             localVarRequestOptions.Operation = "{{classname}}.{{operationId}}";
@@ -693,7 +693,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{/required}}
             {{/formParams}}
             {{#bodyParam}}
-            localVarRequestOptions.Data = {{paramName}};
+            localVarRequestOptions.Data = {{packageName}}.Client.ClientUtils.Serialize({{paramName}});
             {{/bodyParam}}
 
             localVarRequestOptions.Operation = "{{classname}}.{{operationId}}";

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/BodyApi.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/BodyApi.cs
@@ -803,7 +803,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "BodyApi.TestBodyApplicationOctetstreamBinary";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -871,7 +871,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "BodyApi.TestBodyApplicationOctetstreamBinary";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1229,7 +1229,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "BodyApi.TestEchoBodyAllOfPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1297,7 +1297,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "BodyApi.TestEchoBodyAllOfPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1363,7 +1363,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "BodyApi.TestEchoBodyFreeFormObjectResponseString";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1431,7 +1431,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "BodyApi.TestEchoBodyFreeFormObjectResponseString";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1497,7 +1497,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "BodyApi.TestEchoBodyPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1565,7 +1565,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "BodyApi.TestEchoBodyPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1631,7 +1631,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "BodyApi.TestEchoBodyPetResponseString";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1699,7 +1699,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "BodyApi.TestEchoBodyPetResponseString";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1765,7 +1765,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "BodyApi.TestEchoBodyStringEnum";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1833,7 +1833,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "BodyApi.TestEchoBodyStringEnum";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1899,7 +1899,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = tag;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(tag);
 
             localVarRequestOptions.Operation = "BodyApi.TestEchoBodyTagResponseString";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1967,7 +1967,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = tag;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(tag);
 
             localVarRequestOptions.Operation = "BodyApi.TestEchoBodyTagResponseString";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -317,7 +317,7 @@ namespace Org.OpenAPITools.Client
                 {
                     foreach (var value in headerParam.Value)
                     {
-                        request.AddHeader(headerParam.Key, value);
+                        request.AddOrUpdateHeader(headerParam.Key, value);
                     }
                 }
             }

--- a/samples/client/echo_api/php-nextgen-streaming/phpunit.xml.dist
+++ b/samples/client/echo_api/php-nextgen-streaming/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage processUncoveredFiles="true">
     <include>
-      <directory suffix=".php">./src/Api</directory>
-      <directory suffix=".php">./src/Model</directory>
+      <directory suffix=".php">./src\/Api</directory>
+      <directory suffix=".php">./src\/Model</directory>
     </include>
   </coverage>
   <testsuites>

--- a/samples/client/echo_api/php-nextgen/phpunit.xml.dist
+++ b/samples/client/echo_api/php-nextgen/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage processUncoveredFiles="true">
     <include>
-      <directory suffix=".php">./src/Api</directory>
-      <directory suffix=".php">./src/Model</directory>
+      <directory suffix=".php">./src\/Api</directory>
+      <directory suffix=".php">./src\/Model</directory>
     </include>
   </coverage>
   <testsuites>

--- a/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -317,7 +317,7 @@ namespace Org.OpenAPITools.Client
                 {
                     foreach (var value in headerParam.Value)
                     {
-                        request.AddHeader(headerParam.Key, value);
+                        request.AddOrUpdateHeader(headerParam.Key, value);
                     }
                 }
             }

--- a/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Api/PetApi.cs
@@ -602,7 +602,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -694,7 +694,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1460,7 +1460,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1552,7 +1552,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -803,7 +803,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -878,7 +878,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Api/UserApi.cs
@@ -578,7 +578,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -655,7 +655,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -730,7 +730,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -807,7 +807,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -882,7 +882,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -959,7 +959,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1635,7 +1635,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1721,7 +1721,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -318,7 +318,7 @@ namespace Org.OpenAPITools.Client
                 {
                     foreach (var value in headerParam.Value)
                     {
-                        request.AddHeader(headerParam.Key, value);
+                        request.AddOrUpdateHeader(headerParam.Key, value);
                     }
                 }
             }

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "AnotherFakeApi.Call123TestSpecialTags";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -329,7 +329,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "AnotherFakeApi.Call123TestSpecialTags";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -1385,7 +1385,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterBooleanSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1453,7 +1453,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterBooleanSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1519,7 +1519,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = outerComposite;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(outerComposite);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterCompositeSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1587,7 +1587,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = outerComposite;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(outerComposite);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterCompositeSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1653,7 +1653,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterNumberSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1721,7 +1721,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterNumberSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1790,7 +1790,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_uuid", requiredStringUuid));
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterStringSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1861,7 +1861,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_uuid", requiredStringUuid));
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterStringSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2309,7 +2309,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestAdditionalPropertiesReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2381,7 +2381,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestAdditionalPropertiesReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2451,7 +2451,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = fileSchemaTestClass;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(fileSchemaTestClass);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithFileSchema";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2523,7 +2523,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = fileSchemaTestClass;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(fileSchemaTestClass);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithFileSchema";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2602,7 +2602,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "query", query));
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithQueryParams";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2683,7 +2683,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "query", query));
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithQueryParams";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2755,7 +2755,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeApi.TestClientModel";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2829,7 +2829,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeApi.TestClientModel";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3611,7 +3611,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3683,7 +3683,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3753,7 +3753,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = testInlineFreeformAdditionalPropertiesRequest;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(testInlineFreeformAdditionalPropertiesRequest);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineFreeformAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3825,7 +3825,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = testInlineFreeformAdditionalPropertiesRequest;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(testInlineFreeformAdditionalPropertiesRequest);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineFreeformAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -4327,7 +4327,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestStringMapReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -4399,7 +4399,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestStringMapReference";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeClassnameTags123Api.TestClassname";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -334,7 +334,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeClassnameTags123Api.TestClassname";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Api/PetApi.cs
@@ -652,7 +652,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -757,7 +757,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1610,7 +1610,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1715,7 +1715,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -803,7 +803,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -878,7 +878,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
@@ -578,7 +578,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -650,7 +650,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -720,7 +720,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -792,7 +792,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -862,7 +862,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -934,7 +934,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1585,7 +1585,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1666,7 +1666,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -318,7 +318,7 @@ namespace Org.OpenAPITools.Client
                 {
                     foreach (var value in headerParam.Value)
                     {
-                        request.AddHeader(headerParam.Key, value);
+                        request.AddOrUpdateHeader(headerParam.Key, value);
                     }
                 }
             }

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "AnotherFakeApi.Call123TestSpecialTags";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -329,7 +329,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "AnotherFakeApi.Call123TestSpecialTags";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -1385,7 +1385,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterBooleanSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1453,7 +1453,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterBooleanSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1519,7 +1519,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = outerComposite;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(outerComposite);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterCompositeSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1587,7 +1587,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = outerComposite;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(outerComposite);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterCompositeSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1653,7 +1653,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterNumberSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1721,7 +1721,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterNumberSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1790,7 +1790,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_uuid", requiredStringUuid));
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterStringSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1861,7 +1861,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_uuid", requiredStringUuid));
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterStringSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2309,7 +2309,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestAdditionalPropertiesReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2381,7 +2381,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestAdditionalPropertiesReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2451,7 +2451,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = fileSchemaTestClass;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(fileSchemaTestClass);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithFileSchema";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2523,7 +2523,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = fileSchemaTestClass;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(fileSchemaTestClass);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithFileSchema";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2602,7 +2602,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "query", query));
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithQueryParams";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2683,7 +2683,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "query", query));
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithQueryParams";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2755,7 +2755,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeApi.TestClientModel";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2829,7 +2829,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeApi.TestClientModel";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3611,7 +3611,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3683,7 +3683,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3753,7 +3753,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = testInlineFreeformAdditionalPropertiesRequest;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(testInlineFreeformAdditionalPropertiesRequest);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineFreeformAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3825,7 +3825,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = testInlineFreeformAdditionalPropertiesRequest;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(testInlineFreeformAdditionalPropertiesRequest);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineFreeformAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -4327,7 +4327,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestStringMapReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -4399,7 +4399,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestStringMapReference";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeClassnameTags123Api.TestClassname";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -334,7 +334,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeClassnameTags123Api.TestClassname";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Api/PetApi.cs
@@ -652,7 +652,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -757,7 +757,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1610,7 +1610,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1715,7 +1715,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -803,7 +803,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -878,7 +878,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
@@ -578,7 +578,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -650,7 +650,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -720,7 +720,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -792,7 +792,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -862,7 +862,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -934,7 +934,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1585,7 +1585,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1666,7 +1666,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -318,7 +318,7 @@ namespace Org.OpenAPITools.Client
                 {
                     foreach (var value in headerParam.Value)
                     {
-                        request.AddHeader(headerParam.Key, value);
+                        request.AddOrUpdateHeader(headerParam.Key, value);
                     }
                 }
             }

--- a/samples/client/petstore/csharp/restsharp/net6/ParameterMappings/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net6/ParameterMappings/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -316,7 +316,7 @@ namespace Org.OpenAPITools.Client
                 {
                     foreach (var value in headerParam.Value)
                     {
-                        request.AddHeader(headerParam.Key, value);
+                        request.AddOrUpdateHeader(headerParam.Key, value);
                     }
                 }
             }

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "AnotherFakeApi.Call123TestSpecialTags";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -329,7 +329,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "AnotherFakeApi.Call123TestSpecialTags";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -1385,7 +1385,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterBooleanSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1453,7 +1453,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterBooleanSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1519,7 +1519,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = outerComposite;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(outerComposite);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterCompositeSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1587,7 +1587,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = outerComposite;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(outerComposite);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterCompositeSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1653,7 +1653,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterNumberSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1721,7 +1721,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterNumberSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1790,7 +1790,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_uuid", requiredStringUuid));
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterStringSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1861,7 +1861,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_uuid", requiredStringUuid));
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterStringSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2309,7 +2309,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestAdditionalPropertiesReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2381,7 +2381,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestAdditionalPropertiesReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2451,7 +2451,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = fileSchemaTestClass;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(fileSchemaTestClass);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithFileSchema";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2523,7 +2523,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = fileSchemaTestClass;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(fileSchemaTestClass);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithFileSchema";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2602,7 +2602,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "query", query));
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithQueryParams";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2683,7 +2683,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "query", query));
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithQueryParams";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2755,7 +2755,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeApi.TestClientModel";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2829,7 +2829,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeApi.TestClientModel";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3611,7 +3611,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3683,7 +3683,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3753,7 +3753,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = testInlineFreeformAdditionalPropertiesRequest;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(testInlineFreeformAdditionalPropertiesRequest);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineFreeformAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3825,7 +3825,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = testInlineFreeformAdditionalPropertiesRequest;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(testInlineFreeformAdditionalPropertiesRequest);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineFreeformAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -4327,7 +4327,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestStringMapReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -4399,7 +4399,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestStringMapReference";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeClassnameTags123Api.TestClassname";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -334,7 +334,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeClassnameTags123Api.TestClassname";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Api/PetApi.cs
@@ -652,7 +652,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -757,7 +757,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1610,7 +1610,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1715,7 +1715,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -803,7 +803,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -878,7 +878,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Api/UserApi.cs
@@ -578,7 +578,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -650,7 +650,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -720,7 +720,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -792,7 +792,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -862,7 +862,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -934,7 +934,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1585,7 +1585,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1666,7 +1666,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -317,7 +317,7 @@ namespace Org.OpenAPITools.Client
                 {
                     foreach (var value in headerParam.Value)
                     {
-                        request.AddHeader(headerParam.Key, value);
+                        request.AddOrUpdateHeader(headerParam.Key, value);
                     }
                 }
             }

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "AnotherFakeApi.Call123TestSpecialTags";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -329,7 +329,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "AnotherFakeApi.Call123TestSpecialTags";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -1385,7 +1385,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterBooleanSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1453,7 +1453,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterBooleanSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1519,7 +1519,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = outerComposite;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(outerComposite);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterCompositeSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1587,7 +1587,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = outerComposite;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(outerComposite);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterCompositeSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1653,7 +1653,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterNumberSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1721,7 +1721,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterNumberSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1790,7 +1790,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_uuid", requiredStringUuid));
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterStringSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1861,7 +1861,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_uuid", requiredStringUuid));
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterStringSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2309,7 +2309,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestAdditionalPropertiesReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2381,7 +2381,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestAdditionalPropertiesReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2451,7 +2451,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = fileSchemaTestClass;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(fileSchemaTestClass);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithFileSchema";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2523,7 +2523,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = fileSchemaTestClass;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(fileSchemaTestClass);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithFileSchema";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2602,7 +2602,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "query", query));
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithQueryParams";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2683,7 +2683,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "query", query));
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithQueryParams";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2755,7 +2755,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeApi.TestClientModel";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2829,7 +2829,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeApi.TestClientModel";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3611,7 +3611,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3683,7 +3683,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3753,7 +3753,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = testInlineFreeformAdditionalPropertiesRequest;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(testInlineFreeformAdditionalPropertiesRequest);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineFreeformAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3825,7 +3825,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = testInlineFreeformAdditionalPropertiesRequest;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(testInlineFreeformAdditionalPropertiesRequest);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineFreeformAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -4327,7 +4327,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestStringMapReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -4399,7 +4399,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestStringMapReference";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeClassnameTags123Api.TestClassname";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -334,7 +334,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeClassnameTags123Api.TestClassname";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Api/PetApi.cs
@@ -652,7 +652,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -757,7 +757,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1610,7 +1610,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1715,7 +1715,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -803,7 +803,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -878,7 +878,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
@@ -578,7 +578,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -650,7 +650,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -720,7 +720,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -792,7 +792,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -862,7 +862,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -934,7 +934,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1585,7 +1585,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1666,7 +1666,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -317,7 +317,7 @@ namespace Org.OpenAPITools.Client
                 {
                     foreach (var value in headerParam.Value)
                     {
-                        request.AddHeader(headerParam.Key, value);
+                        request.AddOrUpdateHeader(headerParam.Key, value);
                     }
                 }
             }

--- a/samples/client/petstore/csharp/restsharp/net7/UseDateTimeForDate/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net7/UseDateTimeForDate/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -316,7 +316,7 @@ namespace Org.OpenAPITools.Client
                 {
                     foreach (var value in headerParam.Value)
                     {
-                        request.AddHeader(headerParam.Key, value);
+                        request.AddOrUpdateHeader(headerParam.Key, value);
                     }
                 }
             }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "AnotherFakeApi.Call123TestSpecialTags";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -329,7 +329,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "AnotherFakeApi.Call123TestSpecialTags";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -1385,7 +1385,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterBooleanSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1453,7 +1453,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterBooleanSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1519,7 +1519,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = outerComposite;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(outerComposite);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterCompositeSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1587,7 +1587,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = outerComposite;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(outerComposite);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterCompositeSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1653,7 +1653,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterNumberSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1721,7 +1721,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterNumberSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1790,7 +1790,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_uuid", requiredStringUuid));
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterStringSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1861,7 +1861,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_uuid", requiredStringUuid));
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterStringSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2309,7 +2309,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestAdditionalPropertiesReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2381,7 +2381,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestAdditionalPropertiesReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2451,7 +2451,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = fileSchemaTestClass;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(fileSchemaTestClass);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithFileSchema";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2523,7 +2523,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = fileSchemaTestClass;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(fileSchemaTestClass);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithFileSchema";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2602,7 +2602,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "query", query));
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithQueryParams";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2683,7 +2683,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "query", query));
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithQueryParams";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2755,7 +2755,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeApi.TestClientModel";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2829,7 +2829,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeApi.TestClientModel";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3611,7 +3611,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3683,7 +3683,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3753,7 +3753,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = testInlineFreeformAdditionalPropertiesRequest;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(testInlineFreeformAdditionalPropertiesRequest);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineFreeformAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3825,7 +3825,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = testInlineFreeformAdditionalPropertiesRequest;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(testInlineFreeformAdditionalPropertiesRequest);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineFreeformAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -4327,7 +4327,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestStringMapReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -4399,7 +4399,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestStringMapReference";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeClassnameTags123Api.TestClassname";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -334,7 +334,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeClassnameTags123Api.TestClassname";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/PetApi.cs
@@ -652,7 +652,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -757,7 +757,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1610,7 +1610,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1715,7 +1715,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -803,7 +803,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -878,7 +878,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/UserApi.cs
@@ -578,7 +578,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -650,7 +650,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -720,7 +720,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -792,7 +792,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -862,7 +862,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -934,7 +934,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1585,7 +1585,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1666,7 +1666,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -318,7 +318,7 @@ namespace Org.OpenAPITools.Client
                 {
                     foreach (var value in headerParam.Value)
                     {
-                        request.AddHeader(headerParam.Key, value);
+                        request.AddOrUpdateHeader(headerParam.Key, value);
                     }
                 }
             }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "AnotherFakeApi.Call123TestSpecialTags";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -329,7 +329,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "AnotherFakeApi.Call123TestSpecialTags";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -1385,7 +1385,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterBooleanSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1453,7 +1453,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterBooleanSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1519,7 +1519,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = outerComposite;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(outerComposite);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterCompositeSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1587,7 +1587,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = outerComposite;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(outerComposite);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterCompositeSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1653,7 +1653,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterNumberSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1721,7 +1721,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterNumberSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1790,7 +1790,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_uuid", requiredStringUuid));
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterStringSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1861,7 +1861,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_uuid", requiredStringUuid));
-            localVarRequestOptions.Data = body;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(body);
 
             localVarRequestOptions.Operation = "FakeApi.FakeOuterStringSerialize";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2309,7 +2309,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestAdditionalPropertiesReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2381,7 +2381,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestAdditionalPropertiesReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2451,7 +2451,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = fileSchemaTestClass;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(fileSchemaTestClass);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithFileSchema";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2523,7 +2523,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = fileSchemaTestClass;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(fileSchemaTestClass);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithFileSchema";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2602,7 +2602,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "query", query));
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithQueryParams";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2683,7 +2683,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "query", query));
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "FakeApi.TestBodyWithQueryParams";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2755,7 +2755,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeApi.TestClientModel";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2829,7 +2829,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeApi.TestClientModel";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3611,7 +3611,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3683,7 +3683,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3753,7 +3753,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = testInlineFreeformAdditionalPropertiesRequest;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(testInlineFreeformAdditionalPropertiesRequest);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineFreeformAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -3825,7 +3825,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = testInlineFreeformAdditionalPropertiesRequest;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(testInlineFreeformAdditionalPropertiesRequest);
 
             localVarRequestOptions.Operation = "FakeApi.TestInlineFreeformAdditionalProperties";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -4327,7 +4327,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestStringMapReference";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -4399,7 +4399,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = requestBody;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(requestBody);
 
             localVarRequestOptions.Operation = "FakeApi.TestStringMapReference";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeClassnameTags123Api.TestClassname";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -334,7 +334,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = modelClient;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(modelClient);
 
             localVarRequestOptions.Operation = "FakeClassnameTags123Api.TestClassname";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Api/PetApi.cs
@@ -652,7 +652,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -757,7 +757,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.AddPet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1610,7 +1610,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1715,7 +1715,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = pet;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(pet);
 
             localVarRequestOptions.Operation = "PetApi.UpdatePet";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -803,7 +803,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -878,7 +878,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = order;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(order);
 
             localVarRequestOptions.Operation = "StoreApi.PlaceOrder";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Api/UserApi.cs
@@ -578,7 +578,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -650,7 +650,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -720,7 +720,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -792,7 +792,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithArrayInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -862,7 +862,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -934,7 +934,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.CreateUsersWithListInput";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1585,7 +1585,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1666,7 +1666,7 @@ namespace Org.OpenAPITools.Api
             }
 
             localVarRequestOptions.PathParameters.Add("username", Org.OpenAPITools.Client.ClientUtils.ParameterToString(username)); // path parameter
-            localVarRequestOptions.Data = user;
+            localVarRequestOptions.Data = Org.OpenAPITools.Client.ClientUtils.Serialize(user);
 
             localVarRequestOptions.Operation = "UserApi.UpdateUser";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -318,7 +318,7 @@ namespace Org.OpenAPITools.Client
                 {
                     foreach (var value in headerParam.Value)
                     {
-                        request.AddHeader(headerParam.Key, value);
+                        request.AddOrUpdateHeader(headerParam.Key, value);
                     }
                 }
             }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/phpunit.xml.dist
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage processUncoveredFiles="true">
     <include>
-      <directory suffix=".php">./src/Api</directory>
-      <directory suffix=".php">./src/Model</directory>
+      <directory suffix=".php">./src\/Api</directory>
+      <directory suffix=".php">./src\/Model</directory>
     </include>
   </coverage>
   <testsuites>

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/FakeApi.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/FakeApi.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(TestNullable));
             string exampleJson = null;
-            exampleJson = "{\n  \"nullableName\" : \"nullableName\",\n  \"name\" : \"name\"\n}";
+            exampleJson = "{\r\n  \"nullableName\" : \"nullableName\",\r\n  \"name\" : \"name\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<TestNullable>(exampleJson)

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/FakeApi.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/FakeApi.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(TestNullable));
             string exampleJson = null;
-            exampleJson = "{\n  \"nullableName\" : \"nullableName\",\n  \"name\" : \"name\"\n}";
+            exampleJson = "{\r\n  \"nullableName\" : \"nullableName\",\r\n  \"name\" : \"name\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<TestNullable>(exampleJson)

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/FakeApi.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/FakeApi.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(TestNullable));
             string exampleJson = null;
-            exampleJson = "{\n  \"nullableName\" : \"nullableName\",\n  \"name\" : \"name\"\n}";
+            exampleJson = "{\r\n  \"nullableName\" : \"nullableName\",\r\n  \"name\" : \"name\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<TestNullable>(exampleJson)

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-6.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/FakeApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/FakeApi.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(TestNullable));
             string exampleJson = null;
-            exampleJson = "{\n  \"nullableName\" : \"nullableName\",\n  \"name\" : \"name\"\n}";
+            exampleJson = "{\r\n  \"nullableName\" : \"nullableName\",\r\n  \"name\" : \"name\"\r\n}";
             
             var example = exampleJson != null
             ? JsonSerializer.Deserialize<TestNullable>(exampleJson)

--- a/samples/server/petstore/aspnetcore-6.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonSerializer.Deserialize<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-6.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-6.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-6.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/FakeApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/FakeApi.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(TestNullable));
             string exampleJson = null;
-            exampleJson = "{\n  \"nullableName\" : \"nullableName\",\n  \"name\" : \"name\"\n}";
+            exampleJson = "{\r\n  \"nullableName\" : \"nullableName\",\r\n  \"name\" : \"name\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<TestNullable>(exampleJson)

--- a/samples/server/petstore/aspnetcore-6.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-6.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-6.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-6.0-pocoModels/src/Org.OpenAPITools/Controllers/FakeApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-pocoModels/src/Org.OpenAPITools/Controllers/FakeApi.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(TestNullable));
             string exampleJson = null;
-            exampleJson = "{\n  \"nullableName\" : \"nullableName\",\n  \"name\" : \"name\"\n}";
+            exampleJson = "{\r\n  \"nullableName\" : \"nullableName\",\r\n  \"name\" : \"name\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<TestNullable>(exampleJson)

--- a/samples/server/petstore/aspnetcore-6.0-pocoModels/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-pocoModels/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-6.0-pocoModels/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-pocoModels/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-6.0-pocoModels/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-pocoModels/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-6.0-project4Models/src/Org.OpenAPITools/Controllers/FakeApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-project4Models/src/Org.OpenAPITools/Controllers/FakeApi.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(TestNullable));
             string exampleJson = null;
-            exampleJson = "{\n  \"nullableName\" : \"nullableName\",\n  \"name\" : \"name\"\n}";
+            exampleJson = "{\r\n  \"nullableName\" : \"nullableName\",\r\n  \"name\" : \"name\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<TestNullable>(exampleJson)

--- a/samples/server/petstore/aspnetcore-6.0-project4Models/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-project4Models/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-6.0-project4Models/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-project4Models/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-6.0-project4Models/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0-project4Models/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Controllers/FakeApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Controllers/FakeApi.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(TestNullable));
             string exampleJson = null;
-            exampleJson = "{\n  \"nullableName\" : \"nullableName\",\n  \"name\" : \"name\"\n}";
+            exampleJson = "{\r\n  \"nullableName\" : \"nullableName\",\r\n  \"name\" : \"name\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<TestNullable>(exampleJson)

--- a/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-8.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/FakeApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/FakeApi.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(TestNullable));
             string exampleJson = null;
-            exampleJson = "{\n  \"nullableName\" : \"nullableName\",\n  \"name\" : \"name\"\n}";
+            exampleJson = "{\r\n  \"nullableName\" : \"nullableName\",\r\n  \"name\" : \"name\"\r\n}";
             
             var example = exampleJson != null
             ? JsonSerializer.Deserialize<TestNullable>(exampleJson)

--- a/samples/server/petstore/aspnetcore-8.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonSerializer.Deserialize<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-8.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-8.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-NewtonsoftFalse/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-8.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/FakeApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/FakeApi.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(TestNullable));
             string exampleJson = null;
-            exampleJson = "{\n  \"nullableName\" : \"nullableName\",\n  \"name\" : \"name\"\n}";
+            exampleJson = "{\r\n  \"nullableName\" : \"nullableName\",\r\n  \"name\" : \"name\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<TestNullable>(exampleJson)

--- a/samples/server/petstore/aspnetcore-8.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-8.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-8.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-nullableReferenceTypes/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-8.0-pocoModels/src/Org.OpenAPITools/Controllers/FakeApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-pocoModels/src/Org.OpenAPITools/Controllers/FakeApi.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(TestNullable));
             string exampleJson = null;
-            exampleJson = "{\n  \"nullableName\" : \"nullableName\",\n  \"name\" : \"name\"\n}";
+            exampleJson = "{\r\n  \"nullableName\" : \"nullableName\",\r\n  \"name\" : \"name\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<TestNullable>(exampleJson)

--- a/samples/server/petstore/aspnetcore-8.0-pocoModels/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-pocoModels/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-8.0-pocoModels/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-pocoModels/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-8.0-pocoModels/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-pocoModels/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-8.0-project4Models/src/Org.OpenAPITools/Controllers/FakeApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-project4Models/src/Org.OpenAPITools/Controllers/FakeApi.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(TestNullable));
             string exampleJson = null;
-            exampleJson = "{\n  \"nullableName\" : \"nullableName\",\n  \"name\" : \"name\"\n}";
+            exampleJson = "{\r\n  \"nullableName\" : \"nullableName\",\r\n  \"name\" : \"name\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<TestNullable>(exampleJson)

--- a/samples/server/petstore/aspnetcore-8.0-project4Models/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-project4Models/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-8.0-project4Models/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-project4Models/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-8.0-project4Models/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0-project4Models/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-8.0/src/Org.OpenAPITools/Controllers/FakeApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0/src/Org.OpenAPITools/Controllers/FakeApi.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(TestNullable));
             string exampleJson = null;
-            exampleJson = "{\n  \"nullableName\" : \"nullableName\",\n  \"name\" : \"name\"\n}";
+            exampleJson = "{\r\n  \"nullableName\" : \"nullableName\",\r\n  \"name\" : \"name\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<TestNullable>(exampleJson)

--- a/samples/server/petstore/aspnetcore-8.0/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-8.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-8.0/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-8.0/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -117,7 +117,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "[ {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}, {\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n} ]";
+            exampleJson = "[ {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}, {\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n} ]";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <Category>\n    <id>123456789</id>\n    <name>aeiou</name>\n  </Category>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n    <Tag>\n      <id>123456789</id>\n      <name>aeiou</name>\n    </Tag>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -226,7 +226,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null


### PR DESCRIPTION
@mandrean @shibayan @Blackclaws 

Hello,

I fixed two issues I ran into recently.

First, when both the default configuration and the request options added the same header (like Authorization), the header was duplicated. Now, the request options override the default headers so that the header only appears once.

Second, there was a problem with how POST request bodies were being serialized. They were missing quotes and other formatting details, causing errors on the server. I’ve updated the serialization process to ensure the body is formatted correctly.

Please let me know if you need any changes.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
