### PR TITLE
[PHP][php-nextgen] Fix usage of enums in parameters (Fix #20086)

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -711,7 +711,7 @@ use {{invokerPackage}}\ObjectSerializer;
         {{#queryParams}}
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
-            ${{paramName}},
+            ${{paramName}}{{#isEnumRef}}->value{{/isEnumRef}},
             '{{baseName}}', // param base name
             '{{#schema}}{{openApiType}}{{/schema}}', // openApiType
             '{{style}}', // style
@@ -728,7 +728,7 @@ use {{invokerPackage}}\ObjectSerializer;
         }
         {{/collectionFormat}}
         if (${{paramName}} !== null) {
-            $headerParams['{{baseName}}'] = ObjectSerializer::toHeaderValue(${{paramName}});
+            $headerParams['{{baseName}}'] = ObjectSerializer::toHeaderValue(${{paramName}}{{#isEnumRef}}->value{{/isEnumRef}});
         }
         {{/headerParams}}
 
@@ -742,7 +742,7 @@ use {{invokerPackage}}\ObjectSerializer;
         if (${{paramName}} !== null) {
             $resourcePath = str_replace(
                 '{' . '{{baseName}}' . '}',
-                ObjectSerializer::toPathValue(${{paramName}}),
+                ObjectSerializer::toPathValue(${{paramName}}{{#isEnumRef}}->value{{/isEnumRef}}),
                 $resourcePath
             );
         }

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
@@ -438,7 +438,7 @@ class HeaderApi
         }
         // header params
         if ($enum_ref_string_header !== null) {
-            $headerParams['enum_ref_string_header'] = ObjectSerializer::toHeaderValue($enum_ref_string_header);
+            $headerParams['enum_ref_string_header'] = ObjectSerializer::toHeaderValue($enum_ref_string_header->value);
         }
 
 

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
@@ -462,7 +462,7 @@ class PathApi
         if ($enum_ref_string_path !== null) {
             $resourcePath = str_replace(
                 '{' . 'enum_ref_string_path' . '}',
-                ObjectSerializer::toPathValue($enum_ref_string_path),
+                ObjectSerializer::toPathValue($enum_ref_string_path->value),
                 $resourcePath
             );
         }

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -424,7 +424,7 @@ class QueryApi
         ) ?? []);
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
-            $enum_ref_string_query,
+            $enum_ref_string_query->value,
             'enum_ref_string_query', // param base name
             'StringEnumRef', // openApiType
             'form', // style

--- a/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
@@ -438,7 +438,7 @@ class HeaderApi
         }
         // header params
         if ($enum_ref_string_header !== null) {
-            $headerParams['enum_ref_string_header'] = ObjectSerializer::toHeaderValue($enum_ref_string_header);
+            $headerParams['enum_ref_string_header'] = ObjectSerializer::toHeaderValue($enum_ref_string_header->value);
         }
 
 

--- a/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
@@ -462,7 +462,7 @@ class PathApi
         if ($enum_ref_string_path !== null) {
             $resourcePath = str_replace(
                 '{' . 'enum_ref_string_path' . '}',
-                ObjectSerializer::toPathValue($enum_ref_string_path),
+                ObjectSerializer::toPathValue($enum_ref_string_path->value),
                 $resourcePath
             );
         }

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -424,7 +424,7 @@ class QueryApi
         ) ?? []);
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
-            $enum_ref_string_query,
+            $enum_ref_string_query->value,
             'enum_ref_string_query', // param base name
             'StringEnumRef', // openApiType
             'form', // style

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -773,7 +773,7 @@ class FakeApi
 
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
-            $enum_class,
+            $enum_class->value,
             'enum-class', // param base name
             'EnumClass', // openApiType
             'form', // style


### PR DESCRIPTION
Using enums in path, header or query parameters with the php-nextgen generator currently causes type errors like the following:
```
PHP Fatal error:  Uncaught TypeError: OpenAPI\Client\ObjectSerializer::toPathValue(): Argument #1 ($value) must be of type string, OpenAPI\Client\Model\IntEnum given, called in /tmp/openapi-tests/src/Api/DefaultApi.php on line 1183 and defined in /tmp/openapi-tests/src/ObjectSerializer.php:165
Stack trace:
#0 /tmp/openapi-tests/src/Api/DefaultApi.php(1183): OpenAPI\Client\ObjectSerializer::toPathValue()
#1 /tmp/openapi-tests/src/Api/DefaultApi.php(1051): OpenAPI\Client\Api\DefaultApi->pathIntPGetRequest()
#2 /tmp/openapi-tests/src/Api/DefaultApi.php(1033): OpenAPI\Client\Api\DefaultApi->pathIntPGetWithHttpInfo()
#3 /tmp/openapi-tests/dev.php(11): OpenAPI\Client\Api\DefaultApi->pathIntPGet()
#4 {main}
  thrown in /tmp/openapi-tests/src/ObjectSerializer.php on line 165
```
Example spec: https://gist.github.com/JulianVennen/237b96487d45bbe24b3b174e0e7a758c

This PR fixes those errors by passing the value to these functions instead.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jebentier @dkarlovi  @mandrean @jfastnacht @ybelenko @renepardon