### PR TITLE
add test showcasing ref property siblings being lost in OpenAPI 3.1

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1976,6 +1976,20 @@ public class DefaultCodegenTest {
         final Map testProperties = Collections.unmodifiableMap(openAPI.getComponents().getSchemas().get("ModelWithTitledProperties").getProperties());
 
         Assertions.assertEquals("Simple-Property-Title", codegen.fromProperty("simpleProperty", (Schema) testProperties.get("simpleProperty")).title);
+        Assertions.assertEquals("All-Of-Ref-Property-Title", codegen.fromProperty("refProperty", (Schema) testProperties.get("allOfRefProperty")).title);
+    }
+
+    @Test
+    public void testTitlePropertyOAS31refSibling() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_1/property-title.yaml");
+        new InlineModelResolver().flatten(openAPI);
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        final Map testProperties = Collections.unmodifiableMap(openAPI.getComponents().getSchemas().get("ModelWithTitledProperties").getProperties());
+
+        Assertions.assertEquals("Simple-Property-Title", codegen.fromProperty("simpleProperty", (Schema) testProperties.get("simpleProperty")).title);
+        Assertions.assertEquals("All-Of-Ref-Property-Title", codegen.fromProperty("refProperty", (Schema) testProperties.get("allOfRefProperty")).title);
         Assertions.assertEquals("Ref-Property-Title", codegen.fromProperty("refProperty", (Schema) testProperties.get("refProperty")).title);
     }
 
@@ -5008,5 +5022,26 @@ public class DefaultCodegenTest {
 
         // When & Then
         assertThat(codegenOperation.hasSingleParam).isTrue();
+    }
+
+    /**
+     * Starting with OpenAPI 3.1, it is legal to have a $ref be a sibling to other properties.
+     * This test ensures that any sibling properties, "title" in this case, do not get lost while resolving the ref.
+     */
+    @Test
+    public void testSiblingPropertyWithRefInOAS31() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_1/property-title.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+        Map<String, Schema> properties = openAPI.getComponents().getSchemas().get("ModelWithTitledProperties").getProperties();
+
+        // These always worked
+        Assert.assertEquals("Simple-Property-Title",
+                codegen.fromModel("dummy", properties.get("simpleProperty")).getTitle());
+        Assert.assertEquals("All-Of-Ref-Property-Title",
+                codegen.fromModel("dummy", properties.get("allOfRefProperty")).getTitle());
+        // This is new in OpenAPI 3.1, and should work now: "title" is a sibling to the "$ref" and should not be lost
+        Assert.assertEquals("Ref-Property-Title",
+                codegen.fromModel("dummy", properties.get("refProperty")).getTitle());
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_1/property-title.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/property-title.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.1.0
 paths:
   /foo:
     get:
@@ -19,6 +19,10 @@ components:
         simpleProperty:
           type: string
           title: Simple-Property-Title
+        refProperty:
+          type: string
+          title: Ref-Property-Title
+          $ref: '#/components/schemas/RefObject'
         allOfRefProperty:
           type: string
           title: All-Of-Ref-Property-Title


### PR DESCRIPTION
This is a complimentary pull request for issue #TODO to showcase the bug.