### PR TITLE
Fix bug in common path prefix calculation in Helidon generators

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
@@ -37,6 +37,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.TreeMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.prefs.BackingStoreException;
@@ -352,7 +353,7 @@ public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
         Scan the paths of all the operations, computing the longest common prefix. Then compute and set the path suffix
         for each operation.
          */
-        String commonPathPrefixForApi = StringUtils.getCommonPrefix(objs.getOperations().getOperation()
+        String commonPathPrefixForApi = commonPathPrefix(objs.getOperations().getOperation()
                                                                   .stream()
                                                                   .map(op -> op.path)
                                                                   .map(path -> path.charAt(0) != '/' ? "/" + path : path )
@@ -448,6 +449,46 @@ public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
 
     protected String rootJavaEEPackage() {
         return rootJavaEEPackage;
+    }
+
+    static String commonPathPrefix(String[] paths) {
+
+        if (paths.length == 0) {
+            return "/";
+        }
+
+        // Start out with the first path as the longest common prefix. The eventual longest common
+        // prefix can be no longer than the first path, so as we check other paths we simply
+        // revise the number of matching segments we have.
+        String[] commonSegments = stripAnyLeadingSlash(paths[0]).split("/");
+        int commonSegmentsCount = commonSegments.length;
+
+        // Examine the remaining paths.
+        for (int i = 1; i < paths.length; i++) {
+            String[] segments = stripAnyLeadingSlash(paths[i]).split("/");
+
+            // Check each segment of this next path against the common segments we have so far.
+            int segmentIndex = 0;
+            while (segmentIndex < Math.min(commonSegmentsCount, segments.length)
+                    && commonSegments[segmentIndex].equals(segments[segmentIndex])) {
+                segmentIndex++;
+            }
+            commonSegmentsCount = segmentIndex;
+            if (commonSegmentsCount == 0) {
+                break;
+            }
+        }
+        StringJoiner commonPath = new StringJoiner("/", "/", "");
+        commonPath.setEmptyValue("/");
+
+        for (int i = 0; i < commonSegmentsCount; i++) {
+            commonPath.add(commonSegments[i]);
+        }
+        return commonPath.toString();
+    }
+
+    private static String stripAnyLeadingSlash(String path) {
+        return path.startsWith("/") ? path.substring(1) : path;
     }
 
     /**
@@ -716,9 +757,9 @@ public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
 
         private static final String DEFAULT_VERSIONS = "<data>\n" +
                                                        "  <archetypes>\n" +
-                                                       "    <version>2.6.5</version>\n" +
-                                                       "    <version>3.2.7</version>\n" +
-                                                       "    <version>4.0.9</version>\n" +
+                                                       "    <version>2.6.10</version>\n" +
+                                                       "    <version>3.2.11</version>\n" +
+                                                       "    <version>4.1.4</version>\n" +
                                                        "  </archetypes>\n" +
                                                        "</data>";
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/HelidonCommonCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/HelidonCommonCodegenTest.java
@@ -54,4 +54,56 @@ public class HelidonCommonCodegenTest {
                                                      List.of("4.0.10", "3.2.1", "3.2.0", "2.0.4", "1.2.3", "1.2.2", "1.1.0")))
                 .isEqualTo("4.0.11-SNAPSHOT");
     }
+
+    @Test
+    void checkCommonPathWithPathParams() {
+        String[] paths = List.of("/users/{userId}/profile",
+                                 "/users/{userId}/problems",
+                                 "/users/{userEmail}",
+                                 "/users/{username}")
+                .toArray(new String[0]);
+
+        String commonPrefix = JavaHelidonCommonCodegen.commonPathPrefix(paths);
+        assertThat(commonPrefix).isEqualTo("/users");
+    }
+
+    @Test
+    void checkCommonPathWithMultipleCommonLevels() {
+        String[] paths = List.of("/users/a/x",
+                                 "/users/a/y",
+                                 "/users/a/z")
+                .toArray(new String[0]);
+
+        String commonPrefix = JavaHelidonCommonCodegen.commonPathPrefix(paths);
+        assertThat(commonPrefix).isEqualTo("/users/a");
+    }
+
+    @Test
+    void checkNoCommonSegments() {
+        String[] paths = List.of("/a/x",
+                                 "/b/y",
+                                 "/c")
+                .toArray(new String[0]);
+
+        String commonPrefix = JavaHelidonCommonCodegen.commonPathPrefix(paths);
+        assertThat(commonPrefix).isEqualTo("/");
+    }
+
+    @Test
+    void checkSinglePathCommonSegments() {
+        String commonPrefix = JavaHelidonCommonCodegen.commonPathPrefix(new String[0]);
+        assertThat(commonPrefix).isEqualTo("/");
+    }
+
+    @Test
+    void checkMixedWithPathParam() {
+        String[] paths = List.of("/store/order/{order_id}",
+                                 "/store/inventory",
+                                 "/store/order/{order_id}",
+                                 "/store/order")
+                .toArray(new String[0]);
+
+        String commonPrefix = JavaHelidonCommonCodegen.commonPathPrefix(paths);
+        assertThat(commonPrefix).isEqualTo("/store");
+    }
 }


### PR DESCRIPTION
Resolves #20298 

The Helidon generator contains code to calculate the longest common prefix among paths to help optimize the grouping of operations into services.

As described in the bug, the original implementation essentially compared character-by-character which led to problems if paths agreed partway through a segment. For example, given the paths "/a/part-one" and "/a/part-two" the code would incorrectly yield a common prefix of "a/part-" when it should have been "/a".

The PR revises the calculation so it examines corresponding _segments_ rather than corresponding _characters_ of the paths. 

The PR includes additional tests to more thoroughly check the implementation.

(Also, the PR updates the hard-coded current latest releases of Helidon used by the generator if the user does not specify a Helidon version and if the available versions are not available on the network.)

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
