### PR TITLE
Fix a few issues with the C generator (part 5)

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -447,8 +447,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
                     curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
                 }
             } else {
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 1L);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
             }
         }
 

--- a/samples/client/others/c/bearerAuth/src/apiClient.c
+++ b/samples/client/others/c/bearerAuth/src/apiClient.c
@@ -363,8 +363,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
                     curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
                 }
             } else {
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 1L);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
             }
         }
 

--- a/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
+++ b/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
@@ -390,8 +390,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
                     curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
                 }
             } else {
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 1L);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
             }
         }
 

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -390,8 +390,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
                     curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
                 }
             } else {
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 1L);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
             }
         }
 


### PR DESCRIPTION
One more patch from the original pull request at https://github.com/OpenAPITools/openapi-generator/pull/14379. I'm sending this one on its own because it was controversial the last time (@ityuhui). At my company we need the C api to verify ssl certificates by default. We already apply this patch ourselves, but I think a safer default like this should be better for everyone. Of course I'll appreciate any feedback on the matter.

@wing328 @ityuhui @zhemant @michelealbano