### PR TITLE
[BUG][Python-fastapi] Fix to update number parameter to float rather than StrictFloat

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -5135,6 +5135,15 @@ public class DefaultCodegen implements CodegenConfig {
         }
     }
 
+    protected void updateParameterForNumber(CodegenParameter codegenParameter, Schema parameterSchema) {
+        codegenParameter.isPrimitiveType = true;
+        if (ModelUtils.isFloatSchema(parameterSchema)) { // float
+            codegenParameter.isFloat = true;
+        } else if (ModelUtils.isDoubleSchema(parameterSchema)) { // double
+            codegenParameter.isDouble = true;
+        }
+    }
+
     /**
      * Convert OAS Parameter object to Codegen Parameter object
      *
@@ -5265,12 +5274,7 @@ public class DefaultCodegen implements CodegenConfig {
         } else if (ModelUtils.isBooleanSchema(parameterSchema)) {
             codegenParameter.isPrimitiveType = true;
         } else if (ModelUtils.isNumberSchema(parameterSchema)) {
-            codegenParameter.isPrimitiveType = true;
-            if (ModelUtils.isFloatSchema(parameterSchema)) { // float
-                codegenParameter.isFloat = true;
-            } else if (ModelUtils.isDoubleSchema(parameterSchema)) { // double
-                codegenParameter.isDouble = true;
-            }
+            updateParameterForNumber(codegenParameter, parameterSchema);
         } else if (ModelUtils.isIntegerSchema(parameterSchema)) { // integer type
             codegenParameter.isPrimitiveType = true;
             if (ModelUtils.isLongSchema(parameterSchema)) { // int64/long format

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
@@ -334,4 +334,14 @@ public class PythonFastAPIServerCodegen extends AbstractPythonCodegen {
         }
         return "var_" + name;
     }
+
+    @Override
+    protected void updateParameterForNumber(CodegenParameter codegenParameter, Schema parameterSchema) {
+        mapNumberTo = "float";
+        if (ModelUtils.isNumberSchema(parameterSchema) || (ModelUtils.isFloatSchema(parameterSchema))) { // Number or float is a float
+            codegenParameter.isFloat = true;
+        } else if (ModelUtils.isDoubleSchema(parameterSchema)) { // double
+            codegenParameter.isDouble = true;
+        }
+    }
 }


### PR DESCRIPTION
Related Issue: https://github.com/OpenAPITools/openapi-generator/issues/20315
- Created method to set number values in DefaultCodegen
- Implemented this method in PythonFastAPIServerCodegen to set the number mapping variable and set it type Float

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.§

@krjakbrjak
