### PR TITLE
fix: the referenced name (extras) isn't visible in scope

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/api.mustache
@@ -24,7 +24,7 @@ class {{classname}} {
   {{/allParams}}
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress

--- a/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/api/default_api.dart
@@ -24,7 +24,7 @@ class DefaultApi {
   /// Parameters:
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/api/bar_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/api/bar_api.dart
@@ -20,20 +20,20 @@ class BarApi {
   const BarApi(this._dio, this._serializers);
 
   /// Create a Bar
-  /// 
+  ///
   ///
   /// Parameters:
-  /// * [barCreate] 
+  /// * [barCreate]
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [Bar] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<Bar>> createBar({ 
+  Future<Response<Bar>> createBar({
     required BarCreate barCreate,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/api/foo_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/api/foo_api.dart
@@ -21,20 +21,20 @@ class FooApi {
   const FooApi(this._dio, this._serializers);
 
   /// Create a Foo
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [foo] - The Foo to be created
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [FooRefOrValue] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<FooRefOrValue>> createFoo({ 
+  Future<Response<FooRefOrValue>> createFoo({
     Foo? foo,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -116,19 +116,19 @@ class FooApi {
   }
 
   /// GET all Foos
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [BuiltList<FooRefOrValue>] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<BuiltList<FooRefOrValue>>> getAllFoos({ 
+  Future<Response<BuiltList<FooRefOrValue>>> getAllFoos({
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,

--- a/samples/openapi3/client/petstore/dart-dio/oneof_primitive/lib/src/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_primitive/lib/src/api/default_api.dart
@@ -24,7 +24,7 @@ class DefaultApi {
   /// Parameters:
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/another_fake_api.dart
@@ -24,14 +24,14 @@ class AnotherFakeApi {
   /// * [modelClient] - client model
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [ModelClient] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<ModelClient>> call123testSpecialTags({ 
+  Future<Response<ModelClient>> call123testSpecialTags({
     required ModelClient modelClient,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/default_api.dart
@@ -18,19 +18,19 @@ class DefaultApi {
   const DefaultApi(this._dio);
 
   /// fooGet
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [FooGetDefaultResponse] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<FooGetDefaultResponse>> fooGet({ 
+  Future<Response<FooGetDefaultResponse>> fooGet({
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_api.dart
@@ -33,14 +33,14 @@ class FakeApi {
   /// Parameters:
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [FakeBigDecimalMap200Response] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<FakeBigDecimalMap200Response>> fakeBigDecimalMap({ 
+  Future<Response<FakeBigDecimalMap200Response>> fakeBigDecimalMap({
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,
@@ -97,19 +97,19 @@ _responseData = rawData == null ? null : deserialize<FakeBigDecimalMap200Respons
   }
 
   /// Health check endpoint
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [HealthCheckResult] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<HealthCheckResult>> fakeHealthGet({ 
+  Future<Response<HealthCheckResult>> fakeHealthGet({
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,
@@ -166,7 +166,7 @@ _responseData = rawData == null ? null : deserialize<HealthCheckResult, HealthCh
   }
 
   /// test http signature authentication
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [pet] - Pet object that needs to be added to the store
@@ -174,14 +174,14 @@ _responseData = rawData == null ? null : deserialize<HealthCheckResult, HealthCh
   /// * [header1] - header parameter
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> fakeHttpSignatureTest({ 
+  Future<Response<void>> fakeHttpSignatureTest({
     required Pet pet,
     String? query1,
     String? header1,
@@ -254,14 +254,14 @@ _bodyData=jsonEncode(pet);
   /// * [body] - Input boolean as post body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [bool] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<bool>> fakeOuterBooleanSerialize({ 
+  Future<Response<bool>> fakeOuterBooleanSerialize({
     bool? body,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -343,14 +343,14 @@ _responseData = rawData == null ? null : deserialize<bool, bool>(rawData, 'bool'
   /// * [outerComposite] - Input composite as post body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [OuterComposite] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<OuterComposite>> fakeOuterCompositeSerialize({ 
+  Future<Response<OuterComposite>> fakeOuterCompositeSerialize({
     OuterComposite? outerComposite,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -432,14 +432,14 @@ _responseData = rawData == null ? null : deserialize<OuterComposite, OuterCompos
   /// * [body] - Input number as post body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [num] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<num>> fakeOuterNumberSerialize({ 
+  Future<Response<num>> fakeOuterNumberSerialize({
     num? body,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -521,14 +521,14 @@ _responseData = rawData == null ? null : deserialize<num, num>(rawData, 'num', g
   /// * [body] - Input string as post body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [String] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<String>> fakeOuterStringSerialize({ 
+  Future<Response<String>> fakeOuterStringSerialize({
     String? body,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -610,14 +610,14 @@ _responseData = rawData == null ? null : deserialize<String, String>(rawData, 'S
   /// * [outerObjectWithEnumProperty] - Input enum (int) as post body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [OuterObjectWithEnumProperty] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<OuterObjectWithEnumProperty>> fakePropertyEnumIntegerSerialize({ 
+  Future<Response<OuterObjectWithEnumProperty>> fakePropertyEnumIntegerSerialize({
     required OuterObjectWithEnumProperty outerObjectWithEnumProperty,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -693,20 +693,20 @@ _responseData = rawData == null ? null : deserialize<OuterObjectWithEnumProperty
   }
 
   /// test referenced additionalProperties
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [requestBody] - request body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testAdditionalPropertiesReference({ 
+  Future<Response<void>> testAdditionalPropertiesReference({
     required Map<String, Object> requestBody,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -764,14 +764,14 @@ _bodyData=jsonEncode(requestBody);
   /// * [body] - image to upload
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testBodyWithBinary({ 
+  Future<Response<void>> testBodyWithBinary({
     MultipartFile? body,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -826,17 +826,17 @@ _bodyData=jsonEncode(body);
   /// For this test, the body for this request must reference a schema named &#x60;File&#x60;.
   ///
   /// Parameters:
-  /// * [fileSchemaTestClass] 
+  /// * [fileSchemaTestClass]
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testBodyWithFileSchema({ 
+  Future<Response<void>> testBodyWithFileSchema({
     required FileSchemaTestClass fileSchemaTestClass,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -888,21 +888,21 @@ _bodyData=jsonEncode(fileSchemaTestClass);
   }
 
   /// testBodyWithQueryParams
-  /// 
+  ///
   ///
   /// Parameters:
-  /// * [query] 
-  /// * [user] 
+  /// * [query]
+  /// * [user]
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testBodyWithQueryParams({ 
+  Future<Response<void>> testBodyWithQueryParams({
     required String query,
     required User user,
     CancelToken? cancelToken,
@@ -967,14 +967,14 @@ _bodyData=jsonEncode(user);
   /// * [modelClient] - client model
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [ModelClient] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<ModelClient>> testClientModel({ 
+  Future<Response<ModelClient>> testClientModel({
     required ModelClient modelClient,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -1049,8 +1049,8 @@ _responseData = rawData == null ? null : deserialize<ModelClient, ModelClient>(r
     );
   }
 
-  /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-  /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+  /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트
+  /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트
   ///
   /// Parameters:
   /// * [number] - None
@@ -1069,14 +1069,14 @@ _responseData = rawData == null ? null : deserialize<ModelClient, ModelClient>(r
   /// * [callback] - None
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testEndpointParameters({ 
+  Future<Response<void>> testEndpointParameters({
     required num number,
     required double double_,
     required String patternWithoutDelimiter,
@@ -1156,19 +1156,19 @@ _responseData = rawData == null ? null : deserialize<ModelClient, ModelClient>(r
   /// * [enumQueryString] - Query parameter enum test (string)
   /// * [enumQueryInteger] - Query parameter enum test (double)
   /// * [enumQueryDouble] - Query parameter enum test (double)
-  /// * [enumQueryModelArray] 
+  /// * [enumQueryModelArray]
   /// * [enumFormStringArray] - Form parameter enum test (string array)
   /// * [enumFormString] - Form parameter enum test (string)
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testEnumParameters({ 
+  Future<Response<void>> testEnumParameters({
     List<String>? enumHeaderStringArray,
     String? enumHeaderString = '-efg',
     List<String>? enumQueryStringArray,
@@ -1251,14 +1251,14 @@ _responseData = rawData == null ? null : deserialize<ModelClient, ModelClient>(r
   /// * [int64Group] - Integer in group parameters
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testGroupParameters({ 
+  Future<Response<void>> testGroupParameters({
     required int requiredStringGroup,
     required bool requiredBooleanGroup,
     required int requiredInt64Group,
@@ -1313,20 +1313,20 @@ _responseData = rawData == null ? null : deserialize<ModelClient, ModelClient>(r
   }
 
   /// test inline additionalProperties
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [requestBody] - request body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testInlineAdditionalProperties({ 
+  Future<Response<void>> testInlineAdditionalProperties({
     required Map<String, String> requestBody,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -1378,20 +1378,20 @@ _bodyData=jsonEncode(requestBody);
   }
 
   /// test inline free-form additionalProperties
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [testInlineFreeformAdditionalPropertiesRequest] - request body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testInlineFreeformAdditionalProperties({ 
+  Future<Response<void>> testInlineFreeformAdditionalProperties({
     required TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -1443,21 +1443,21 @@ _bodyData=jsonEncode(testInlineFreeformAdditionalPropertiesRequest);
   }
 
   /// test json serialization of form data
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [param] - field1
   /// * [param2] - field2
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testJsonFormData({ 
+  Future<Response<void>> testJsonFormData({
     required String param,
     required String param2,
     CancelToken? cancelToken,
@@ -1510,20 +1510,20 @@ _bodyData=jsonEncode(testInlineFreeformAdditionalPropertiesRequest);
   }
 
   /// test nullable parent property
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [childWithNullable] - request body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testNullable({ 
+  Future<Response<void>> testNullable({
     required ChildWithNullable childWithNullable,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -1578,23 +1578,23 @@ _bodyData=jsonEncode(childWithNullable);
   /// To test the collection format in query parameters
   ///
   /// Parameters:
-  /// * [pipe] 
-  /// * [ioutil] 
-  /// * [http] 
-  /// * [url] 
-  /// * [context] 
-  /// * [allowEmpty] 
-  /// * [language] 
+  /// * [pipe]
+  /// * [ioutil]
+  /// * [http]
+  /// * [url]
+  /// * [context]
+  /// * [allowEmpty]
+  /// * [language]
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testQueryParameterCollectionFormat({ 
+  Future<Response<void>> testQueryParameterCollectionFormat({
     required List<String> pipe,
     required List<String> ioutil,
     required List<String> http,
@@ -1645,20 +1645,20 @@ _bodyData=jsonEncode(childWithNullable);
   }
 
   /// test referenced string map
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [requestBody] - request body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testStringMapReference({ 
+  Future<Response<void>> testStringMapReference({
     required Map<String, String> requestBody,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_classname_tags123_api.dart
@@ -24,14 +24,14 @@ class FakeClassnameTags123Api {
   /// * [modelClient] - client model
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [ModelClient] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<ModelClient>> testClassname({ 
+  Future<Response<ModelClient>> testClassname({
     required ModelClient modelClient,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/pet_api.dart
@@ -19,20 +19,20 @@ class PetApi {
   const PetApi(this._dio);
 
   /// Add a new pet to the store
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [pet] - Pet object that needs to be added to the store
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> addPet({ 
+  Future<Response<void>> addPet({
     required Pet pet,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -89,21 +89,21 @@ _bodyData=jsonEncode(pet);
   }
 
   /// Deletes a pet
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [petId] - Pet id to delete
-  /// * [apiKey] 
+  /// * [apiKey]
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> deletePet({ 
+  Future<Response<void>> deletePet({
     required int petId,
     String? apiKey,
     CancelToken? cancelToken,
@@ -150,14 +150,14 @@ _bodyData=jsonEncode(pet);
   /// * [status] - Status values that need to be considered for filter
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [List<Pet>] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<List<Pet>>> findPetsByStatus({ 
+  Future<Response<List<Pet>>> findPetsByStatus({
     @Deprecated('status is deprecated') required List<String> status,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -231,7 +231,7 @@ _responseData = rawData == null ? null : deserialize<List<Pet>, Pet>(rawData, 'L
   /// * [tags] - Tags to filter by
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
@@ -239,7 +239,7 @@ _responseData = rawData == null ? null : deserialize<List<Pet>, Pet>(rawData, 'L
   /// Returns a [Future] containing a [Response] with a [Set<Pet>] as data
   /// Throws [DioException] if API call or serialization fails
   @Deprecated('This operation has been deprecated')
-  Future<Response<Set<Pet>>> findPetsByTags({ 
+  Future<Response<Set<Pet>>> findPetsByTags({
     required Set<String> tags,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -313,14 +313,14 @@ _responseData = rawData == null ? null : deserialize<Set<Pet>, Pet>(rawData, 'Se
   /// * [petId] - ID of pet to return
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [Pet] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<Pet>> getPetById({ 
+  Future<Response<Pet>> getPetById({
     required int petId,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -385,20 +385,20 @@ _responseData = rawData == null ? null : deserialize<Pet, Pet>(rawData, 'Pet', g
   }
 
   /// Update an existing pet
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [pet] - Pet object that needs to be added to the store
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> updatePet({ 
+  Future<Response<void>> updatePet({
     required Pet pet,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -455,7 +455,7 @@ _bodyData=jsonEncode(pet);
   }
 
   /// Updates a pet in the store with form data
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [petId] - ID of pet that needs to be updated
@@ -463,14 +463,14 @@ _bodyData=jsonEncode(pet);
   /// * [status] - Updated status of the pet
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> updatePetWithForm({ 
+  Future<Response<void>> updatePetWithForm({
     required int petId,
     String? name,
     String? status,
@@ -529,7 +529,7 @@ _bodyData=jsonEncode(pet);
   }
 
   /// uploads an image
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [petId] - ID of pet to update
@@ -537,14 +537,14 @@ _bodyData=jsonEncode(pet);
   /// * [file] - file to upload
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [ApiResponse] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<ApiResponse>> uploadFile({ 
+  Future<Response<ApiResponse>> uploadFile({
     required int petId,
     String? additionalMetadata,
     MultipartFile? file,
@@ -627,7 +627,7 @@ _responseData = rawData == null ? null : deserialize<ApiResponse, ApiResponse>(r
   }
 
   /// uploads an image (required)
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [petId] - ID of pet to update
@@ -635,14 +635,14 @@ _responseData = rawData == null ? null : deserialize<ApiResponse, ApiResponse>(r
   /// * [additionalMetadata] - Additional data to pass to server
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [ApiResponse] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<ApiResponse>> uploadFileWithRequiredFile({ 
+  Future<Response<ApiResponse>> uploadFileWithRequiredFile({
     required int petId,
     required MultipartFile requiredFile,
     String? additionalMetadata,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/store_api.dart
@@ -24,14 +24,14 @@ class StoreApi {
   /// * [orderId] - ID of the order that needs to be deleted
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> deleteOrder({ 
+  Future<Response<void>> deleteOrder({
     required String orderId,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -70,14 +70,14 @@ class StoreApi {
   /// Parameters:
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [Map<String, int>] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<Map<String, int>>> getInventory({ 
+  Future<Response<Map<String, int>>> getInventory({
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,
@@ -147,14 +147,14 @@ _responseData = rawData == null ? null : deserialize<Map<String, int>, int>(rawD
   /// * [orderId] - ID of pet that needs to be fetched
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [Order] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<Order>> getOrderById({ 
+  Future<Response<Order>> getOrderById({
     required int orderId,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -212,20 +212,20 @@ _responseData = rawData == null ? null : deserialize<Order, Order>(rawData, 'Ord
   }
 
   /// Place an order for a pet
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [order] - order placed for purchasing the pet
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [Order] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<Order>> placeOrder({ 
+  Future<Response<Order>> placeOrder({
     required Order order,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/user_api.dart
@@ -24,14 +24,14 @@ class UserApi {
   /// * [user] - Created user object
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> createUser({ 
+  Future<Response<void>> createUser({
     required User user,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -83,20 +83,20 @@ _bodyData=jsonEncode(user);
   }
 
   /// Creates list of users with given input array
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [user] - List of user object
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> createUsersWithArrayInput({ 
+  Future<Response<void>> createUsersWithArrayInput({
     required List<User> user,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -148,20 +148,20 @@ _bodyData=jsonEncode(user);
   }
 
   /// Creates list of users with given input array
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [user] - List of user object
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> createUsersWithListInput({ 
+  Future<Response<void>> createUsersWithListInput({
     required List<User> user,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -219,14 +219,14 @@ _bodyData=jsonEncode(user);
   /// * [username] - The name that needs to be deleted
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> deleteUser({ 
+  Future<Response<void>> deleteUser({
     required String username,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -260,20 +260,20 @@ _bodyData=jsonEncode(user);
   }
 
   /// Get user by user name
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [username] - The name that needs to be fetched. Use user1 for testing.
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [User] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<User>> getUserByName({ 
+  Future<Response<User>> getUserByName({
     required String username,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -331,21 +331,21 @@ _responseData = rawData == null ? null : deserialize<User, User>(rawData, 'User'
   }
 
   /// Logs user into the system
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [username] - The user name for login
   /// * [password] - The password for login in clear text
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [String] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<String>> loginUser({ 
+  Future<Response<String>> loginUser({
     required String username,
     required String password,
     CancelToken? cancelToken,
@@ -410,19 +410,19 @@ _responseData = rawData == null ? null : deserialize<String, String>(rawData, 'S
   }
 
   /// Logs out current logged in user session
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> logoutUser({ 
+  Future<Response<void>> logoutUser({
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,
@@ -462,14 +462,14 @@ _responseData = rawData == null ? null : deserialize<String, String>(rawData, 'S
   /// * [user] - Updated user object
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> updateUser({ 
+  Future<Response<void>> updateUser({
     required String username,
     required User user,
     CancelToken? cancelToken,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/another_fake_api.dart
@@ -25,14 +25,14 @@ class AnotherFakeApi {
   /// * [modelClient] - client model
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [ModelClient] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<ModelClient>> call123testSpecialTags({ 
+  Future<Response<ModelClient>> call123testSpecialTags({
     required ModelClient modelClient,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/default_api.dart
@@ -19,19 +19,19 @@ class DefaultApi {
   const DefaultApi(this._dio, this._serializers);
 
   /// fooGet
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [FooGetDefaultResponse] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<FooGetDefaultResponse>> fooGet({ 
+  Future<Response<FooGetDefaultResponse>> fooGet({
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/fake_api.dart
@@ -39,14 +39,14 @@ class FakeApi {
   /// Parameters:
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [FakeBigDecimalMap200Response] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<FakeBigDecimalMap200Response>> fakeBigDecimalMap({ 
+  Future<Response<FakeBigDecimalMap200Response>> fakeBigDecimalMap({
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,
@@ -107,19 +107,19 @@ class FakeApi {
   }
 
   /// Health check endpoint
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [HealthCheckResult] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<HealthCheckResult>> fakeHealthGet({ 
+  Future<Response<HealthCheckResult>> fakeHealthGet({
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,
@@ -180,7 +180,7 @@ class FakeApi {
   }
 
   /// test http signature authentication
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [pet] - Pet object that needs to be added to the store
@@ -188,14 +188,14 @@ class FakeApi {
   /// * [header1] - header parameter
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> fakeHttpSignatureTest({ 
+  Future<Response<void>> fakeHttpSignatureTest({
     required Pet pet,
     String? query1,
     String? header1,
@@ -270,14 +270,14 @@ class FakeApi {
   /// * [body] - Input boolean as post body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [bool] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<bool>> fakeOuterBooleanSerialize({ 
+  Future<Response<bool>> fakeOuterBooleanSerialize({
     bool? body,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -361,14 +361,14 @@ class FakeApi {
   /// * [outerComposite] - Input composite as post body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [OuterComposite] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<OuterComposite>> fakeOuterCompositeSerialize({ 
+  Future<Response<OuterComposite>> fakeOuterCompositeSerialize({
     OuterComposite? outerComposite,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -456,14 +456,14 @@ class FakeApi {
   /// * [body] - Input number as post body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [num] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<num>> fakeOuterNumberSerialize({ 
+  Future<Response<num>> fakeOuterNumberSerialize({
     num? body,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -547,14 +547,14 @@ class FakeApi {
   /// * [body] - Input string as post body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [String] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<String>> fakeOuterStringSerialize({ 
+  Future<Response<String>> fakeOuterStringSerialize({
     String? body,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -638,14 +638,14 @@ class FakeApi {
   /// * [outerObjectWithEnumProperty] - Input enum (int) as post body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [OuterObjectWithEnumProperty] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<OuterObjectWithEnumProperty>> fakePropertyEnumIntegerSerialize({ 
+  Future<Response<OuterObjectWithEnumProperty>> fakePropertyEnumIntegerSerialize({
     required OuterObjectWithEnumProperty outerObjectWithEnumProperty,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -727,20 +727,20 @@ class FakeApi {
   }
 
   /// test referenced additionalProperties
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [requestBody] - request body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testAdditionalPropertiesReference({ 
+  Future<Response<void>> testAdditionalPropertiesReference({
     required BuiltMap<String, JsonObject> requestBody,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -800,14 +800,14 @@ class FakeApi {
   /// * [body] - image to upload
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testBodyWithBinary({ 
+  Future<Response<void>> testBodyWithBinary({
     MultipartFile? body,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -863,17 +863,17 @@ class FakeApi {
   /// For this test, the body for this request must reference a schema named &#x60;File&#x60;.
   ///
   /// Parameters:
-  /// * [fileSchemaTestClass] 
+  /// * [fileSchemaTestClass]
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testBodyWithFileSchema({ 
+  Future<Response<void>> testBodyWithFileSchema({
     required FileSchemaTestClass fileSchemaTestClass,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -927,21 +927,21 @@ class FakeApi {
   }
 
   /// testBodyWithQueryParams
-  /// 
+  ///
   ///
   /// Parameters:
-  /// * [query] 
-  /// * [user] 
+  /// * [query]
+  /// * [user]
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testBodyWithQueryParams({ 
+  Future<Response<void>> testBodyWithQueryParams({
     required String query,
     required User user,
     CancelToken? cancelToken,
@@ -1008,14 +1008,14 @@ class FakeApi {
   /// * [modelClient] - client model
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [ModelClient] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<ModelClient>> testClientModel({ 
+  Future<Response<ModelClient>> testClientModel({
     required ModelClient modelClient,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -1096,8 +1096,8 @@ class FakeApi {
     );
   }
 
-  /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-  /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+  /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트
+  /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트
   ///
   /// Parameters:
   /// * [number] - None
@@ -1116,14 +1116,14 @@ class FakeApi {
   /// * [callback] - None
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testEndpointParameters({ 
+  Future<Response<void>> testEndpointParameters({
     required num number,
     required double double_,
     required String patternWithoutDelimiter,
@@ -1219,19 +1219,19 @@ class FakeApi {
   /// * [enumQueryString] - Query parameter enum test (string)
   /// * [enumQueryInteger] - Query parameter enum test (double)
   /// * [enumQueryDouble] - Query parameter enum test (double)
-  /// * [enumQueryModelArray] 
+  /// * [enumQueryModelArray]
   /// * [enumFormStringArray] - Form parameter enum test (string array)
   /// * [enumFormString] - Form parameter enum test (string)
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testEnumParameters({ 
+  Future<Response<void>> testEnumParameters({
     BuiltList<String>? enumHeaderStringArray,
     String? enumHeaderString = '-efg',
     BuiltList<String>? enumQueryStringArray,
@@ -1318,14 +1318,14 @@ class FakeApi {
   /// * [int64Group] - Integer in group parameters
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testGroupParameters({ 
+  Future<Response<void>> testGroupParameters({
     required int requiredStringGroup,
     required bool requiredBooleanGroup,
     required int requiredInt64Group,
@@ -1380,20 +1380,20 @@ class FakeApi {
   }
 
   /// test inline additionalProperties
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [requestBody] - request body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testInlineAdditionalProperties({ 
+  Future<Response<void>> testInlineAdditionalProperties({
     required BuiltMap<String, String> requestBody,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -1447,20 +1447,20 @@ class FakeApi {
   }
 
   /// test inline free-form additionalProperties
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [testInlineFreeformAdditionalPropertiesRequest] - request body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testInlineFreeformAdditionalProperties({ 
+  Future<Response<void>> testInlineFreeformAdditionalProperties({
     required TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -1514,21 +1514,21 @@ class FakeApi {
   }
 
   /// test json serialization of form data
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [param] - field1
   /// * [param2] - field2
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testJsonFormData({ 
+  Future<Response<void>> testJsonFormData({
     required String param,
     required String param2,
     CancelToken? cancelToken,
@@ -1585,20 +1585,20 @@ class FakeApi {
   }
 
   /// test nullable parent property
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [childWithNullable] - request body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testNullable({ 
+  Future<Response<void>> testNullable({
     required ChildWithNullable childWithNullable,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -1655,23 +1655,23 @@ class FakeApi {
   /// To test the collection format in query parameters
   ///
   /// Parameters:
-  /// * [pipe] 
-  /// * [ioutil] 
-  /// * [http] 
-  /// * [url] 
-  /// * [context] 
-  /// * [allowEmpty] 
-  /// * [language] 
+  /// * [pipe]
+  /// * [ioutil]
+  /// * [http]
+  /// * [url]
+  /// * [context]
+  /// * [allowEmpty]
+  /// * [language]
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testQueryParameterCollectionFormat({ 
+  Future<Response<void>> testQueryParameterCollectionFormat({
     required BuiltList<String> pipe,
     required BuiltList<String> ioutil,
     required BuiltList<String> http,
@@ -1722,20 +1722,20 @@ class FakeApi {
   }
 
   /// test referenced string map
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [requestBody] - request body
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> testStringMapReference({ 
+  Future<Response<void>> testStringMapReference({
     required BuiltMap<String, String> requestBody,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/fake_classname_tags123_api.dart
@@ -25,14 +25,14 @@ class FakeClassnameTags123Api {
   /// * [modelClient] - client model
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [ModelClient] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<ModelClient>> testClassname({ 
+  Future<Response<ModelClient>> testClassname({
     required ModelClient modelClient,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/pet_api.dart
@@ -22,20 +22,20 @@ class PetApi {
   const PetApi(this._dio, this._serializers);
 
   /// Add a new pet to the store
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [pet] - Pet object that needs to be added to the store
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> addPet({ 
+  Future<Response<void>> addPet({
     required Pet pet,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -94,21 +94,21 @@ class PetApi {
   }
 
   /// Deletes a pet
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [petId] - Pet id to delete
-  /// * [apiKey] 
+  /// * [apiKey]
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> deletePet({ 
+  Future<Response<void>> deletePet({
     required int petId,
     String? apiKey,
     CancelToken? cancelToken,
@@ -155,14 +155,14 @@ class PetApi {
   /// * [status] - Status values that need to be considered for filter
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [BuiltList<Pet>] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<BuiltList<Pet>>> findPetsByStatus({ 
+  Future<Response<BuiltList<Pet>>> findPetsByStatus({
     @Deprecated('status is deprecated') required BuiltList<String> status,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -240,7 +240,7 @@ class PetApi {
   /// * [tags] - Tags to filter by
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
@@ -248,7 +248,7 @@ class PetApi {
   /// Returns a [Future] containing a [Response] with a [BuiltSet<Pet>] as data
   /// Throws [DioException] if API call or serialization fails
   @Deprecated('This operation has been deprecated')
-  Future<Response<BuiltSet<Pet>>> findPetsByTags({ 
+  Future<Response<BuiltSet<Pet>>> findPetsByTags({
     required BuiltSet<String> tags,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -326,14 +326,14 @@ class PetApi {
   /// * [petId] - ID of pet to return
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [Pet] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<Pet>> getPetById({ 
+  Future<Response<Pet>> getPetById({
     required int petId,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -402,20 +402,20 @@ class PetApi {
   }
 
   /// Update an existing pet
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [pet] - Pet object that needs to be added to the store
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> updatePet({ 
+  Future<Response<void>> updatePet({
     required Pet pet,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -474,7 +474,7 @@ class PetApi {
   }
 
   /// Updates a pet in the store with form data
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [petId] - ID of pet that needs to be updated
@@ -482,14 +482,14 @@ class PetApi {
   /// * [status] - Updated status of the pet
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> updatePetWithForm({ 
+  Future<Response<void>> updatePetWithForm({
     required int petId,
     String? name,
     String? status,
@@ -552,7 +552,7 @@ class PetApi {
   }
 
   /// uploads an image
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [petId] - ID of pet to update
@@ -560,14 +560,14 @@ class PetApi {
   /// * [file] - file to upload
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [ApiResponse] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<ApiResponse>> uploadFile({ 
+  Future<Response<ApiResponse>> uploadFile({
     required int petId,
     String? additionalMetadata,
     MultipartFile? file,
@@ -658,7 +658,7 @@ class PetApi {
   }
 
   /// uploads an image (required)
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [petId] - ID of pet to update
@@ -666,14 +666,14 @@ class PetApi {
   /// * [additionalMetadata] - Additional data to pass to server
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [ApiResponse] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<ApiResponse>> uploadFileWithRequiredFile({ 
+  Future<Response<ApiResponse>> uploadFileWithRequiredFile({
     required int petId,
     required MultipartFile requiredFile,
     String? additionalMetadata,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/store_api.dart
@@ -27,14 +27,14 @@ class StoreApi {
   /// * [orderId] - ID of the order that needs to be deleted
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> deleteOrder({ 
+  Future<Response<void>> deleteOrder({
     required String orderId,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -73,14 +73,14 @@ class StoreApi {
   /// Parameters:
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [BuiltMap<String, int>] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<BuiltMap<String, int>>> getInventory({ 
+  Future<Response<BuiltMap<String, int>>> getInventory({
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,
@@ -154,14 +154,14 @@ class StoreApi {
   /// * [orderId] - ID of pet that needs to be fetched
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [Order] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<Order>> getOrderById({ 
+  Future<Response<Order>> getOrderById({
     required int orderId,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -223,20 +223,20 @@ class StoreApi {
   }
 
   /// Place an order for a pet
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [order] - order placed for purchasing the pet
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [Order] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<Order>> placeOrder({ 
+  Future<Response<Order>> placeOrder({
     required Order order,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/user_api.dart
@@ -27,14 +27,14 @@ class UserApi {
   /// * [user] - Created user object
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> createUser({ 
+  Future<Response<void>> createUser({
     required User user,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -88,20 +88,20 @@ class UserApi {
   }
 
   /// Creates list of users with given input array
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [user] - List of user object
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> createUsersWithArrayInput({ 
+  Future<Response<void>> createUsersWithArrayInput({
     required BuiltList<User> user,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -155,20 +155,20 @@ class UserApi {
   }
 
   /// Creates list of users with given input array
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [user] - List of user object
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> createUsersWithListInput({ 
+  Future<Response<void>> createUsersWithListInput({
     required BuiltList<User> user,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -228,14 +228,14 @@ class UserApi {
   /// * [username] - The name that needs to be deleted
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> deleteUser({ 
+  Future<Response<void>> deleteUser({
     required String username,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -269,20 +269,20 @@ class UserApi {
   }
 
   /// Get user by user name
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [username] - The name that needs to be fetched. Use user1 for testing.
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [User] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<User>> getUserByName({ 
+  Future<Response<User>> getUserByName({
     required String username,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -344,21 +344,21 @@ class UserApi {
   }
 
   /// Logs user into the system
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [username] - The user name for login
   /// * [password] - The password for login in clear text
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future] containing a [Response] with a [String] as data
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<String>> loginUser({ 
+  Future<Response<String>> loginUser({
     required String username,
     required String password,
     CancelToken? cancelToken,
@@ -424,19 +424,19 @@ class UserApi {
   }
 
   /// Logs out current logged in user session
-  /// 
+  ///
   ///
   /// Parameters:
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> logoutUser({ 
+  Future<Response<void>> logoutUser({
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,
@@ -476,14 +476,14 @@ class UserApi {
   /// * [user] - Updated user object
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extras] - Can be used to add flags to the request
+  /// * [extra] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
   ///
   /// Returns a [Future]
   /// Throws [DioException] if API call or serialization fails
-  Future<Response<void>> updateUser({ 
+  Future<Response<void>> updateUser({
     required String username,
     required User user,
     CancelToken? cancelToken,


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This pull request removes incorrect references to the `extras` property within the Dart-Dio code generator templates. Currently, the generated code attempts to use a non-existent `extras` field on `dio.Options`, leading to compilation errors. By removing these references, the generated code will correctly compile against the current `dio` version.

**What was done**:

- Updated the Dart-Dio client code generation templates to no longer output `extras` references.
- Verified that generated code compiles and runs without reference errors.
- Regenerated and tested sample outputs to ensure compatibility.

**Why this is needed**:

- Prevents compilation errors due to non-existent fields.
- Ensures generated Dart-Dio clients are fully compatible with `dio`'s current API.

**Issue reference (if any)**:

- (If there's an open issue related to this, reference it here. Otherwise, remove this line.)

---

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:

```sh
./mvnw clean package || exit
./bin/generate-samples.sh ./bin/configs/\*.yaml || exit
./bin/utils/export_docs_generators.sh || exit
```

(For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
Commit all changed files.
- [ ] Ensure all generated samples match expected outputs to pass CI checks.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/OpenAPITools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
```
