### PR TITLE
Fix a few issues with the C generator (part 6)

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration")
+set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
@@ -6,6 +6,7 @@ cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
@@ -14,7 +15,7 @@ find_package(OpenSSL)
 if (OPENSSL_FOUND)
     message (STATUS "OPENSSL found")
 
-    set(CMAKE_C_FLAGS "-DOPENSSL")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DOPENSSL")
     if(CMAKE_VERSION VERSION_LESS 3.4)
         include_directories(${OPENSSL_INCLUDE_DIR})
         include_directories(${OPENSSL_INCLUDE_DIRS})

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -173,7 +173,7 @@ void sslConfig_free(sslConfig_t *sslConfig) {
     free(sslConfig);
 }
 
-void replaceSpaceWithPlus(char *stringToProcess) {
+static void replaceSpaceWithPlus(char *stringToProcess) {
     for(int i = 0; i < strlen(stringToProcess); i++) {
         if(stringToProcess[i] == ' ') {
             stringToProcess[i] = '+';
@@ -181,9 +181,9 @@ void replaceSpaceWithPlus(char *stringToProcess) {
     }
 }
 
-char *assembleTargetUrl(const char  *basePath,
-                        const char  *operationParameter,
-                        list_t    *queryParameters) {
+static char *assembleTargetUrl(const char  *basePath,
+                               const char  *operationParameter,
+                               list_t    *queryParameters) {
     int neededBufferSizeForQueryParameters = 0;
     listEntry_t *listEntry;
 
@@ -234,7 +234,7 @@ char *assembleTargetUrl(const char  *basePath,
     return targetUrl;
 }
 
-char *assembleHeaderField(char *key, char *value) {
+static char *assembleHeaderField(char *key, char *value) {
     char *header = malloc(strlen(key) + strlen(value) + 3);
 
     strcpy(header, key),
@@ -244,13 +244,13 @@ char *assembleHeaderField(char *key, char *value) {
     return header;
 }
 
-void postData(CURL *handle, const char *bodyParameters, size_t bodyParametersLength) {
+static void postData(CURL *handle, const char *bodyParameters, size_t bodyParametersLength) {
     curl_easy_setopt(handle, CURLOPT_POSTFIELDS, bodyParameters);
     curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE,
                      (curl_off_t)bodyParametersLength);
 }
 
-int lengthOfKeyPair(keyValuePair_t *keyPair) {
+static int lengthOfKeyPair(keyValuePair_t *keyPair) {
     long length = 0;
     if((keyPair->key != NULL) &&
        (keyPair->value != NULL) )

--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -376,7 +376,7 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     {{/isBoolean}}
     {{#isEnum}}
     {{#isString}}
-    if(cJSON_AddStringToObject(item, "{{{baseName}}}", {{{name}}}{{classname}}_ToString({{{classname}}}->{{{name}}})) == NULL)
+    if(cJSON_AddStringToObject(item, "{{{baseName}}}", {{classname}}_{{name}}_ToString({{{classname}}}->{{{name}}})) == NULL)
     {
     goto fail; //Enum
     }

--- a/samples/client/others/c/bearerAuth/CMakeLists.txt
+++ b/samples/client/others/c/bearerAuth/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration")
+set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 

--- a/samples/client/others/c/bearerAuth/CMakeLists.txt
+++ b/samples/client/others/c/bearerAuth/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
@@ -14,7 +15,7 @@ find_package(OpenSSL)
 if (OPENSSL_FOUND)
     message (STATUS "OPENSSL found")
 
-    set(CMAKE_C_FLAGS "-DOPENSSL")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DOPENSSL")
     if(CMAKE_VERSION VERSION_LESS 3.4)
         include_directories(${OPENSSL_INCLUDE_DIR})
         include_directories(${OPENSSL_INCLUDE_DIRS})

--- a/samples/client/others/c/bearerAuth/src/apiClient.c
+++ b/samples/client/others/c/bearerAuth/src/apiClient.c
@@ -89,7 +89,7 @@ void sslConfig_free(sslConfig_t *sslConfig) {
     free(sslConfig);
 }
 
-void replaceSpaceWithPlus(char *stringToProcess) {
+static void replaceSpaceWithPlus(char *stringToProcess) {
     for(int i = 0; i < strlen(stringToProcess); i++) {
         if(stringToProcess[i] == ' ') {
             stringToProcess[i] = '+';
@@ -97,9 +97,9 @@ void replaceSpaceWithPlus(char *stringToProcess) {
     }
 }
 
-char *assembleTargetUrl(const char  *basePath,
-                        const char  *operationParameter,
-                        list_t    *queryParameters) {
+static char *assembleTargetUrl(const char  *basePath,
+                               const char  *operationParameter,
+                               list_t    *queryParameters) {
     int neededBufferSizeForQueryParameters = 0;
     listEntry_t *listEntry;
 
@@ -150,7 +150,7 @@ char *assembleTargetUrl(const char  *basePath,
     return targetUrl;
 }
 
-char *assembleHeaderField(char *key, char *value) {
+static char *assembleHeaderField(char *key, char *value) {
     char *header = malloc(strlen(key) + strlen(value) + 3);
 
     strcpy(header, key),
@@ -160,13 +160,13 @@ char *assembleHeaderField(char *key, char *value) {
     return header;
 }
 
-void postData(CURL *handle, const char *bodyParameters, size_t bodyParametersLength) {
+static void postData(CURL *handle, const char *bodyParameters, size_t bodyParametersLength) {
     curl_easy_setopt(handle, CURLOPT_POSTFIELDS, bodyParameters);
     curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE,
                      (curl_off_t)bodyParametersLength);
 }
 
-int lengthOfKeyPair(keyValuePair_t *keyPair) {
+static int lengthOfKeyPair(keyValuePair_t *keyPair) {
     long length = 0;
     if((keyPair->key != NULL) &&
        (keyPair->value != NULL) )

--- a/samples/client/petstore/c-useJsonUnformatted/CMakeLists.txt
+++ b/samples/client/petstore/c-useJsonUnformatted/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration")
+set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 

--- a/samples/client/petstore/c-useJsonUnformatted/CMakeLists.txt
+++ b/samples/client/petstore/c-useJsonUnformatted/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
@@ -14,7 +15,7 @@ find_package(OpenSSL)
 if (OPENSSL_FOUND)
     message (STATUS "OPENSSL found")
 
-    set(CMAKE_C_FLAGS "-DOPENSSL")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DOPENSSL")
     if(CMAKE_VERSION VERSION_LESS 3.4)
         include_directories(${OPENSSL_INCLUDE_DIR})
         include_directories(${OPENSSL_INCLUDE_DIRS})

--- a/samples/client/petstore/c-useJsonUnformatted/model/order.c
+++ b/samples/client/petstore/c-useJsonUnformatted/model/order.c
@@ -94,7 +94,7 @@ cJSON *order_convertToJSON(order_t *order) {
 
     // order->status
     if(order->status != openapi_petstore_order_STATUS_NULL) {
-    if(cJSON_AddStringToObject(item, "status", statusorder_ToString(order->status)) == NULL)
+    if(cJSON_AddStringToObject(item, "status", order_status_ToString(order->status)) == NULL)
     {
     goto fail; //Enum
     }

--- a/samples/client/petstore/c-useJsonUnformatted/model/pet.c
+++ b/samples/client/petstore/c-useJsonUnformatted/model/pet.c
@@ -148,7 +148,7 @@ cJSON *pet_convertToJSON(pet_t *pet) {
 
     // pet->status
     if(pet->status != openapi_petstore_pet_STATUS_NULL) {
-    if(cJSON_AddStringToObject(item, "status", statuspet_ToString(pet->status)) == NULL)
+    if(cJSON_AddStringToObject(item, "status", pet_status_ToString(pet->status)) == NULL)
     {
     goto fail; //Enum
     }

--- a/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
+++ b/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
@@ -116,7 +116,7 @@ void sslConfig_free(sslConfig_t *sslConfig) {
     free(sslConfig);
 }
 
-void replaceSpaceWithPlus(char *stringToProcess) {
+static void replaceSpaceWithPlus(char *stringToProcess) {
     for(int i = 0; i < strlen(stringToProcess); i++) {
         if(stringToProcess[i] == ' ') {
             stringToProcess[i] = '+';
@@ -124,9 +124,9 @@ void replaceSpaceWithPlus(char *stringToProcess) {
     }
 }
 
-char *assembleTargetUrl(const char  *basePath,
-                        const char  *operationParameter,
-                        list_t    *queryParameters) {
+static char *assembleTargetUrl(const char  *basePath,
+                               const char  *operationParameter,
+                               list_t    *queryParameters) {
     int neededBufferSizeForQueryParameters = 0;
     listEntry_t *listEntry;
 
@@ -177,7 +177,7 @@ char *assembleTargetUrl(const char  *basePath,
     return targetUrl;
 }
 
-char *assembleHeaderField(char *key, char *value) {
+static char *assembleHeaderField(char *key, char *value) {
     char *header = malloc(strlen(key) + strlen(value) + 3);
 
     strcpy(header, key),
@@ -187,13 +187,13 @@ char *assembleHeaderField(char *key, char *value) {
     return header;
 }
 
-void postData(CURL *handle, const char *bodyParameters, size_t bodyParametersLength) {
+static void postData(CURL *handle, const char *bodyParameters, size_t bodyParametersLength) {
     curl_easy_setopt(handle, CURLOPT_POSTFIELDS, bodyParameters);
     curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE,
                      (curl_off_t)bodyParametersLength);
 }
 
-int lengthOfKeyPair(keyValuePair_t *keyPair) {
+static int lengthOfKeyPair(keyValuePair_t *keyPair) {
     long length = 0;
     if((keyPair->key != NULL) &&
        (keyPair->value != NULL) )

--- a/samples/client/petstore/c/model/order.c
+++ b/samples/client/petstore/c/model/order.c
@@ -94,7 +94,7 @@ cJSON *order_convertToJSON(order_t *order) {
 
     // order->status
     if(order->status != openapi_petstore_order_STATUS_NULL) {
-    if(cJSON_AddStringToObject(item, "status", statusorder_ToString(order->status)) == NULL)
+    if(cJSON_AddStringToObject(item, "status", order_status_ToString(order->status)) == NULL)
     {
     goto fail; //Enum
     }

--- a/samples/client/petstore/c/model/pet.c
+++ b/samples/client/petstore/c/model/pet.c
@@ -148,7 +148,7 @@ cJSON *pet_convertToJSON(pet_t *pet) {
 
     // pet->status
     if(pet->status != openapi_petstore_pet_STATUS_NULL) {
-    if(cJSON_AddStringToObject(item, "status", statuspet_ToString(pet->status)) == NULL)
+    if(cJSON_AddStringToObject(item, "status", pet_status_ToString(pet->status)) == NULL)
     {
     goto fail; //Enum
     }

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -116,7 +116,7 @@ void sslConfig_free(sslConfig_t *sslConfig) {
     free(sslConfig);
 }
 
-void replaceSpaceWithPlus(char *stringToProcess) {
+static void replaceSpaceWithPlus(char *stringToProcess) {
     for(int i = 0; i < strlen(stringToProcess); i++) {
         if(stringToProcess[i] == ' ') {
             stringToProcess[i] = '+';
@@ -124,9 +124,9 @@ void replaceSpaceWithPlus(char *stringToProcess) {
     }
 }
 
-char *assembleTargetUrl(const char  *basePath,
-                        const char  *operationParameter,
-                        list_t    *queryParameters) {
+static char *assembleTargetUrl(const char  *basePath,
+                               const char  *operationParameter,
+                               list_t    *queryParameters) {
     int neededBufferSizeForQueryParameters = 0;
     listEntry_t *listEntry;
 
@@ -177,7 +177,7 @@ char *assembleTargetUrl(const char  *basePath,
     return targetUrl;
 }
 
-char *assembleHeaderField(char *key, char *value) {
+static char *assembleHeaderField(char *key, char *value) {
     char *header = malloc(strlen(key) + strlen(value) + 3);
 
     strcpy(header, key),
@@ -187,13 +187,13 @@ char *assembleHeaderField(char *key, char *value) {
     return header;
 }
 
-void postData(CURL *handle, const char *bodyParameters, size_t bodyParametersLength) {
+static void postData(CURL *handle, const char *bodyParameters, size_t bodyParametersLength) {
     curl_easy_setopt(handle, CURLOPT_POSTFIELDS, bodyParameters);
     curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE,
                      (curl_off_t)bodyParametersLength);
 }
 
-int lengthOfKeyPair(keyValuePair_t *keyPair) {
+static int lengthOfKeyPair(keyValuePair_t *keyPair) {
     long length = 0;
     if((keyPair->key != NULL) &&
        (keyPair->value != NULL) )


### PR DESCRIPTION
Before completing the pull request at https://github.com/OpenAPITools/openapi-generator/pull/14379, I want to draw attention to a newer issue I've recently noticed. Building the petstore sample results in the following warnings:

```
/home/runner/work/openapi-generator/openapi-generator/samples/client/petstore/c/model/order.c: In function ‘order_convertToJSON’:
/home/runner/work/openapi-generator/openapi-generator/samples/client/petstore/c/model/order.c:97:48: warning: implicit declaration of function ‘statusorder_ToString’ [-Wimplicit-function-declaration]
   97 |     if(cJSON_AddStringToObject(item, "status", statusorder_ToString(order->status)) == NULL)
      |                                                ^~~~~~~~~~~~~~~~~~~~
/home/runner/work/openapi-generator/openapi-generator/samples/client/petstore/c/model/order.c:97:48: warning: passing argument 3 of ‘cJSON_AddStringToObject’ makes pointer from integer without a cast [-Wint-conversion]
   97 |     if(cJSON_AddStringToObject(item, "status", statusorder_ToString(order->status)) == NULL)
      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                |
      |                                                int
In file included from /home/runner/work/openapi-generator/openapi-generator/samples/client/petstore/c/model/order.h:11,
                 from /home/runner/work/openapi-generator/openapi-generator/samples/client/petstore/c/model/order.c:4:
/home/runner/work/openapi-generator/openapi-generator/samples/client/petstore/c/model/../external/cJSON.h:255:112: note: expected ‘const char * const’ but argument is of type ‘int’
  255 | CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
      |                                                                                             ~~~~~~~~~~~~~~~~~~~^~~~~~
[ 60%] Building C object CMakeFiles/openapi_petstore.dir/model/pet.c.o
/home/runner/work/openapi-generator/openapi-generator/samples/client/petstore/c/model/pet.c: In function ‘pet_convertToJSON’:
/home/runner/work/openapi-generator/openapi-generator/samples/client/petstore/c/model/pet.c:151:[48](https://github.com/OpenAPITools/openapi-generator/actions/runs/12053425233/job/33609057818?pr=20200#step:4:49): warning: implicit declaration of function ‘statuspet_ToString’ [-Wimplicit-function-declaration]
  151 |     if(cJSON_AddStringToObject(item, "status", statuspet_ToString(pet->status)) == NULL)
      |                                                ^~~~~~~~~~~~~~~~~~
/home/runner/work/openapi-generator/openapi-generator/samples/client/petstore/c/model/pet.c:1[51](https://github.com/OpenAPITools/openapi-generator/actions/runs/12053425233/job/33609057818?pr=20200#step:4:52):48: warning: passing argument 3 of ‘cJSON_AddStringToObject’ makes pointer from integer without a cast [-Wint-conversion]
  151 |     if(cJSON_AddStringToObject(item, "status", statuspet_ToString(pet->status)) == NULL)
      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                |
      |                                                int
In file included from /home/runner/work/openapi-generator/openapi-generator/samples/client/petstore/c/model/pet.h:11,
                 from /home/runner/work/openapi-generator/openapi-generator/samples/client/petstore/c/model/pet.c:4:
/home/runner/work/openapi-generator/openapi-generator/samples/client/petstore/c/model/../external/cJSON.h:2[55](https://github.com/OpenAPITools/openapi-generator/actions/runs/12053425233/job/33609057818?pr=20200#step:4:56):112: note: expected ‘const char * const’ but argument is of type ‘int’
  255 | CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
      |                                                                                             ~~~~~~~~~~~~~~~~~~~^~~~~~
```

These warnings are serious because they indicate that there is no definition anywhere for functions like statusorder_ToString(). It's a regression caused by commit `34c3f8c7aa84 ("[C][Client] Fix enum function names not matching headers in the model template (#17512)")` (https://github.com/OpenAPITools/openapi-generator/pull/17512, @bookerdj). The petstore schema covers this case, but the tests still pass because the warnings don't break the build.

So I propose here:

1. Change the compiler flags so that implicit function declarations result in build failure. This will make it harder for similar regressions to happen again in the future.
2. Revert the patch that caused the regression. I haven't looked into it in depth and I appreciate that it was probably a bugfix for another serious issue, but I think regressions are more important, especially for things that are covered by the existing test schemas.

Of course I'll appreciate any feedback on the matter.

@wing328 @ityuhui @zhemant @michelealbano