### PR TITLE
[PHP][php-nextgen] List all possible return types (fix #17113)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
@@ -189,14 +189,35 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
         objs = super.postProcessOperationsWithModels(objs, allModels);
         OperationMap operations = objs.getOperations();
         for (CodegenOperation operation : operations.getOperation()) {
-            if (operation.returnType == null) {
-                operation.vendorExtensions.putIfAbsent("x-php-return-type", "void");
-            } else {
-                if (operation.returnProperty.isContainer) { // array or map
-                    operation.vendorExtensions.putIfAbsent("x-php-return-type", "array");
-                } else {
-                    operation.vendorExtensions.putIfAbsent("x-php-return-type", operation.returnType);
+            // Once we upgrade to java 21 we can use SequencedSet instead
+            List<String> phpReturnTypeOptions = new ArrayList<>();
+            List<String> docReturnTypeOptions = new ArrayList<>();
+
+            for (CodegenResponse response : operation.responses) {
+                if (response.dataType != null) {
+                    String returnType = response.dataType;
+                    if (response.isArray || response.isMap) {
+                        // PHP does not understand array type hinting so we strip it
+                        // The phpdoc will still contain the array type hinting
+                        returnType = "array";
+                    }
+
+                    if (!phpReturnTypeOptions.contains(returnType)) {
+                        phpReturnTypeOptions.add(returnType);
+                    }
+
+                    if (!docReturnTypeOptions.contains(response.dataType)) {
+                        docReturnTypeOptions.add(response.dataType);
+                    }
                 }
+            }
+
+            if (phpReturnTypeOptions.isEmpty()) {
+                operation.vendorExtensions.putIfAbsent("x-php-return-type", "void");
+                operation.vendorExtensions.putIfAbsent("x-php-doc-return-type", "void");
+            } else {
+                operation.vendorExtensions.putIfAbsent("x-php-return-type", String.join("|", phpReturnTypeOptions));
+                operation.vendorExtensions.putIfAbsent("x-php-doc-return-type", String.join("|", docReturnTypeOptions));
             }
 
             for (CodegenParameter param : operation.allParams) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
@@ -34,11 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
     @SuppressWarnings("hiding")
@@ -189,9 +185,8 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
         objs = super.postProcessOperationsWithModels(objs, allModels);
         OperationMap operations = objs.getOperations();
         for (CodegenOperation operation : operations.getOperation()) {
-            // Once we upgrade to java 21 we can use SequencedSet instead
-            List<String> phpReturnTypeOptions = new ArrayList<>();
-            List<String> docReturnTypeOptions = new ArrayList<>();
+            Set<String> phpReturnTypeOptions = new LinkedHashSet<>();
+            Set<String> docReturnTypeOptions = new LinkedHashSet<>();
 
             for (CodegenResponse response : operation.responses) {
                 if (response.dataType != null) {
@@ -202,13 +197,8 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
                         returnType = "array";
                     }
 
-                    if (!phpReturnTypeOptions.contains(returnType)) {
-                        phpReturnTypeOptions.add(returnType);
-                    }
-
-                    if (!docReturnTypeOptions.contains(response.dataType)) {
-                        docReturnTypeOptions.add(response.dataType);
-                    }
+                    phpReturnTypeOptions.add(returnType);
+                    docReturnTypeOptions.add(response.dataType);
                 }
             }
 

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -164,7 +164,7 @@ use {{invokerPackage}}\ObjectSerializer;
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
      * @throws InvalidArgumentException
-     * @return {{#returnType}}{{#responses}}{{#dataType}}{{^-first}}|{{/-first}}{{/dataType}}{{{dataType}}}{{/responses}}{{/returnType}}{{^returnType}}void{{/returnType}}
+     * @return {{{vendorExtensions.x-php-doc-return-type}}}
     {{#isDeprecated}}
      * @deprecated
     {{/isDeprecated}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
API Endpoints sometimes return different datatypes with different status codes. In the php-nextgen generator on the first such type was used as the return type which would cause fatal errors if any other type was returned.
This PR fixes that by returning an intersection type with all possible return types.

For a [minimal spec example](https://gist.github.com/JulianVennen/71e28763cee1329d93645fb19d29d319) the change looks like this.

Before:
```php
    /**
     * ...
     * @return \OpenAPI\Client\Model\A|\OpenAPI\Client\Model\B|\OpenAPI\Client\Model\C
     */
    public function testGet(
        string $contentType = self::contentTypes['testGet'][0]
    ): \OpenAPI\Client\Model\A
```
After:
```php
    /**
     * ...
     * @return \OpenAPI\Client\Model\A|\OpenAPI\Client\Model\B|\OpenAPI\Client\Model\C
     */
    public function testGet(
        string $contentType = self::contentTypes['testGet'][0]
    ): \OpenAPI\Client\Model\A|\OpenAPI\Client\Model\B|\OpenAPI\Client\Model\C
```

As @individual-it described in #17113 intersection types may not have the same type repeated.
This is prevented by checking if the list of known types already contains the type, before it is added.
Using a Set for this would cause the types to be ordered by the hash function instead of the order in the openapi spec.
Java 21 would make this easier using SequencedSet, but the current solution works as well.

The deduplication of return types is also applied to phpdoc comments. Since they support type hints for the contents of arrays, they are calculated independently.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon 