### PR TITLE
[Rust-Axum][Breaking Change] Improve the `oneOf` model generator.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -1083,8 +1083,8 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         sb.append(", items='").append(items).append('\'');
         sb.append(", additionalProperties='").append(additionalProperties).append('\'');
         sb.append(", isModel='").append(isModel).append('\'');
-        sb.append(", isNull='").append(isNull);
-        sb.append(", hasValidation='").append(hasValidation);
+        sb.append(", isNull='").append(isNull).append('\'');
+        sb.append(", hasValidation='").append(hasValidation).append('\'');
         sb.append(", getAdditionalPropertiesIsAnyType=").append(getAdditionalPropertiesIsAnyType());
         sb.append(", getHasDiscriminatorWithNonEmptyMapping=").append(hasDiscriminatorWithNonEmptyMapping);
         sb.append(", getIsAnyType=").append(getIsAnyType());

--- a/modules/openapi-generator/src/main/resources/rust-axum/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/models.mustache
@@ -573,21 +573,70 @@ impl PartialEq for {{{classname}}} {
         self.0.get() == other.0.get()
     }
 }
+
 {{/anyOf.size}}
 {{#oneOf.size}}
-/// One of:
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+{{#discriminator}}
+#[serde(tag = "{{{propertyBaseName}}}")]
+{{/discriminator}}
+{{^discriminator}}
+#[serde(untagged)]
+{{/discriminator}}
+pub enum {{{classname}}} {
 {{#oneOf}}
-/// - {{{.}}}
+    {{{.}}}(Box<{{{.}}}>),
 {{/oneOf}}
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct {{{classname}}}(Box<serde_json::value::RawValue>);
+}
 
 impl validator::Validate for {{{classname}}}
 {
     fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
-        std::result::Result::Ok(())
+        match self {
+            {{#oneOf}}
+            Self::{{{.}}}(x) => x.validate(),
+            {{/oneOf}}
+        }
     }
 }
+
+{{#discriminator}}
+impl serde::Serialize for {{{classname}}} {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer {
+            match self {
+                {{#oneOf}}
+                Self::{{{.}}}(x) => {{{.}}}::serialize(x, serializer),
+                {{/oneOf}}
+            }
+    }
+}
+
+{{#oneOf}}
+impl {{{.}}} {
+    fn __name_for_{{{propertyBaseName}}}() -> String {
+        String::from("{{{.}}}")
+    }
+
+    fn __serialize_{{{propertyBaseName}}}<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        s.serialize_str(&Self::__name_for_{{{propertyBaseName}}}())
+    }
+}
+{{/oneOf}}
+{{/discriminator}}
+
+
+
+{{#oneOf}}
+impl From<{{{.}}}> for {{{classname}}} {
+    fn from(value: {{{.}}}) -> Self {
+        Self::{{{.}}}(Box::new(value))
+    }
+}
+{{/oneOf}}
 
 /// Converts Query Parameters representation (style=form, explode=false) to a {{{classname}}} value
 /// as specified in https://swagger.io/docs/specification/serialization/
@@ -600,11 +649,6 @@ impl std::str::FromStr for {{{classname}}} {
     }
 }
 
-impl PartialEq for {{{classname}}} {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.get() == other.0.get()
-    }
-}
 {{/oneOf.size}}
 {{^anyOf.size}}
 {{^oneOf.size}}
@@ -613,10 +657,14 @@ impl PartialEq for {{{classname}}} {
 pub struct {{{classname}}} {
 {{#vars}}
 {{#description}}    
-/// {{{.}}}
+    /// {{{.}}}
 {{/description}}
+{{#isDiscriminator}}
+    #[serde(default = "{{{classname}}}::__name_for_{{{name}}}")]
+    #[serde(serialize_with = "{{{classname}}}::__serialize_{{{name}}}")]
+{{/isDiscriminator}}
 {{#isEnum}}
-/// Note: inline enums are not fully supported by openapi-generator
+    /// Note: inline enums are not fully supported by openapi-generator
 {{/isEnum}}
     #[serde(rename = "{{{baseName}}}")]
 {{#hasValidation}}

--- a/modules/openapi-generator/src/main/resources/rust-axum/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/models.mustache
@@ -576,26 +576,32 @@ impl PartialEq for {{{classname}}} {
 
 {{/anyOf.size}}
 {{#oneOf.size}}
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
 {{#discriminator}}
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
 #[serde(tag = "{{{propertyBaseName}}}")]
 {{/discriminator}}
 {{^discriminator}}
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 {{/discriminator}}
+#[allow(non_camel_case_types)]
 pub enum {{{classname}}} {
-{{#oneOf}}
-    {{{.}}}(Box<{{{.}}}>),
-{{/oneOf}}
+    {{#composedSchemas}}
+    {{#oneOf}}
+    {{{datatypeWithEnum}}}(Box<{{{dataType}}}>),
+    {{/oneOf}}
+    {{/composedSchemas}}
 }
 
 impl validator::Validate for {{{classname}}}
 {
     fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
         match self {
+            {{#composedSchemas}}
             {{#oneOf}}
-            Self::{{{.}}}(x) => x.validate(),
+            Self::{{{datatypeWithEnum}}}(x) => x.validate(),
             {{/oneOf}}
+            {{/composedSchemas}}
         }
     }
 }
@@ -605,38 +611,27 @@ impl serde::Serialize for {{{classname}}} {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: serde::Serializer {
             match self {
+                {{#composedSchemas}}
                 {{#oneOf}}
-                Self::{{{.}}}(x) => {{{.}}}::serialize(x, serializer),
+                Self::{{{datatypeWithEnum}}}(x) => x.serialize(serializer),
                 {{/oneOf}}
+                {{/composedSchemas}}
             }
     }
 }
-
-{{#oneOf}}
-impl {{{.}}} {
-    fn __name_for_{{{propertyBaseName}}}() -> String {
-        String::from("{{{.}}}")
-    }
-
-    fn __serialize_{{{propertyBaseName}}}<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        s.serialize_str(&Self::__name_for_{{{propertyBaseName}}}())
-    }
-}
-{{/oneOf}}
 {{/discriminator}}
 
 
 
+{{#composedSchemas}}
 {{#oneOf}}
-impl From<{{{.}}}> for {{{classname}}} {
-    fn from(value: {{{.}}}) -> Self {
-        Self::{{{.}}}(Box::new(value))
+impl From<{{{dataType}}}> for {{{classname}}} {
+    fn from(value: {{{dataType}}}) -> Self {
+        Self::{{{datatypeWithEnum}}}(Box::new(value))
     }
 }
 {{/oneOf}}
+{{/composedSchemas}}
 
 /// Converts Query Parameters representation (style=form, explode=false) to a {{{classname}}} value
 /// as specified in https://swagger.io/docs/specification/serialization/
@@ -659,13 +654,13 @@ pub struct {{{classname}}} {
 {{#description}}    
     /// {{{.}}}
 {{/description}}
+{{#isEnum}}
+        /// Note: inline enums are not fully supported by openapi-generator
+{{/isEnum}}
 {{#isDiscriminator}}
     #[serde(default = "{{{classname}}}::__name_for_{{{name}}}")]
     #[serde(serialize_with = "{{{classname}}}::__serialize_{{{name}}}")]
 {{/isDiscriminator}}
-{{#isEnum}}
-    /// Note: inline enums are not fully supported by openapi-generator
-{{/isEnum}}
     #[serde(rename = "{{{baseName}}}")]
 {{#hasValidation}}
     #[validate(
@@ -732,6 +727,25 @@ pub struct {{{classname}}} {
 
 {{/vars}}
 }
+
+
+{{#vars}}
+{{#isDiscriminator}}
+impl {{{classname}}} {
+    fn __name_for_{{{name}}}() -> String {
+        String::from("{{{classname}}}")
+    }
+
+    fn __serialize_{{{name}}}<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        s.serialize_str(&Self::__name_for_{{{name}}}())
+    }
+}
+{{/isDiscriminator}}
+{{/vars}}
+
 
 {{#vars}}
 {{#hasValidation}}

--- a/samples/server/petstore/rust-axum/output/multipart-v3/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/src/lib.rs
@@ -6,7 +6,7 @@
     unused_extern_crates,
     non_camel_case_types,
     unused_imports,
-    unused_attributes
+    unused_attributes,
 )]
 #![allow(
     clippy::derive_partial_eq_without_eq,
@@ -20,9 +20,9 @@ pub const API_VERSION: &str = "1.0.7";
 #[cfg(feature = "server")]
 pub mod server;
 
-pub mod apis;
 pub mod models;
 pub mod types;
+pub mod apis;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;

--- a/samples/server/petstore/rust-axum/output/multipart-v3/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/src/models.rs
@@ -7,24 +7,73 @@ use validator::Validate;
 use crate::header;
 use crate::{models, types::*};
 
+      
+      
+      
+
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct MultipartRelatedRequest {
     #[serde(rename = "object_field")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub object_field: Option<models::MultipartRequestObjectField>,
 
     #[serde(rename = "optional_binary_field")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub optional_binary_field: Option<ByteArray>,
 
     #[serde(rename = "required_binary_field")]
     pub required_binary_field: ByteArray,
+
 }
 
 impl MultipartRelatedRequest {
+    fn __name_for_object_field() -> String {
+        String::from("CodegenProperty{openApiType='multipart_request_object_field', baseName='object_field', complexType='multipart_request_object_field', getter='getObjectField', setter='setObjectField', description='null', dataType='models::MultipartRequestObjectField', datatypeWithEnum='models::MultipartRequestObjectField', dataFormat='null', name='object_field', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.object_field;', baseType='multipart_request_object_field', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/multipart_request_object_field"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='objectField', nameInPascalCase='ObjectField', nameInSnakeCase='OBJECT_FIELD', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/multipart_request_object_field, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_object_field<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_object_field())
+        }
+}
+impl MultipartRelatedRequest {
+    fn __name_for_optional_binary_field() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='optional_binary_field', complexType='file', getter='getOptionalBinaryField', setter='setOptionalBinaryField', description='null', dataType='ByteArray', datatypeWithEnum='ByteArray', dataFormat='binary', name='optional_binary_field', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.optional_binary_field;', baseType='file', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "binary",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=true, isFile=true, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='optionalBinaryField', nameInPascalCase='OptionalBinaryField', nameInSnakeCase='OPTIONAL_BINARY_FIELD', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=binary, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_optional_binary_field<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_optional_binary_field())
+        }
+}
+impl MultipartRelatedRequest {
+    fn __name_for_required_binary_field() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='required_binary_field', complexType='file', getter='getRequiredBinaryField', setter='setRequiredBinaryField', description='null', dataType='ByteArray', datatypeWithEnum='ByteArray', dataFormat='binary', name='required_binary_field', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.required_binary_field;', baseType='file', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "binary",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=true, isFile=true, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='requiredBinaryField', nameInPascalCase='RequiredBinaryField', nameInSnakeCase='REQUIRED_BINARY_FIELD', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=binary, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_required_binary_field<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_required_binary_field())
+        }
+}
+
+
+impl MultipartRelatedRequest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(required_binary_field: ByteArray) -> MultipartRelatedRequest {
+    pub fn new(required_binary_field: ByteArray, ) -> MultipartRelatedRequest {
         MultipartRelatedRequest {
             object_field: None,
             optional_binary_field: None,
@@ -49,11 +98,7 @@ impl std::fmt::Display for MultipartRelatedRequest {
 
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -82,11 +127,7 @@ impl std::str::FromStr for MultipartRelatedRequest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing MultipartRelatedRequest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing MultipartRelatedRequest".to_string())
             };
 
             if let Some(key) = key_result {
@@ -108,13 +149,7 @@ impl std::str::FromStr for MultipartRelatedRequest {
         std::result::Result::Ok(MultipartRelatedRequest {
             object_field: intermediate_rep.object_field.into_iter().next(),
             optional_binary_field: intermediate_rep.optional_binary_field.into_iter().next(),
-            required_binary_field: intermediate_rep
-                .required_binary_field
-                .into_iter()
-                .next()
-                .ok_or_else(|| {
-                    "required_binary_field missing in MultipartRelatedRequest".to_string()
-                })?,
+            required_binary_field: intermediate_rep.required_binary_field.into_iter().next().ok_or_else(|| "required_binary_field missing in MultipartRelatedRequest".to_string())?,
         })
     }
 }
@@ -125,16 +160,13 @@ impl std::str::FromStr for MultipartRelatedRequest {
 impl std::convert::TryFrom<header::IntoHeaderValue<MultipartRelatedRequest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<MultipartRelatedRequest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MultipartRelatedRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for MultipartRelatedRequest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for MultipartRelatedRequest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -145,24 +177,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<MultipartRel
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <MultipartRelatedRequest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <MultipartRelatedRequest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into MultipartRelatedRequest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into MultipartRelatedRequest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -171,20 +202,76 @@ pub struct MultipartRequest {
     pub string_field: String,
 
     #[serde(rename = "optional_string_field")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub optional_string_field: Option<String>,
 
     #[serde(rename = "object_field")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub object_field: Option<models::MultipartRequestObjectField>,
 
     #[serde(rename = "binary_field")]
     pub binary_field: ByteArray,
+
 }
 
 impl MultipartRequest {
+    fn __name_for_string_field() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='string_field', complexType='string', getter='getStringField', setter='setStringField', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='string_field', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.string_field;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='stringField', nameInPascalCase='StringField', nameInSnakeCase='STRING_FIELD', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_string_field<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_string_field())
+        }
+}
+impl MultipartRequest {
+    fn __name_for_optional_string_field() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='optional_string_field', complexType='string', getter='getOptionalStringField', setter='setOptionalStringField', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='optional_string_field', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.optional_string_field;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='optionalStringField', nameInPascalCase='OptionalStringField', nameInSnakeCase='OPTIONAL_STRING_FIELD', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_optional_string_field<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_optional_string_field())
+        }
+}
+impl MultipartRequest {
+    fn __name_for_object_field() -> String {
+        String::from("CodegenProperty{openApiType='multipart_request_object_field', baseName='object_field', complexType='multipart_request_object_field', getter='getObjectField', setter='setObjectField', description='null', dataType='models::MultipartRequestObjectField', datatypeWithEnum='models::MultipartRequestObjectField', dataFormat='null', name='object_field', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.object_field;', baseType='multipart_request_object_field', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/multipart_request_object_field"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='objectField', nameInPascalCase='ObjectField', nameInSnakeCase='OBJECT_FIELD', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/multipart_request_object_field, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_object_field<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_object_field())
+        }
+}
+impl MultipartRequest {
+    fn __name_for_binary_field() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='binary_field', complexType='ByteArray', getter='getBinaryField', setter='setBinaryField', description='null', dataType='ByteArray', datatypeWithEnum='ByteArray', dataFormat='byte', name='binary_field', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.binary_field;', baseType='ByteArray', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "byte",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=true, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='binaryField', nameInPascalCase='BinaryField', nameInSnakeCase='BINARY_FIELD', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=byte, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_binary_field<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_binary_field())
+        }
+}
+
+
+impl MultipartRequest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(string_field: String, binary_field: ByteArray) -> MultipartRequest {
+    pub fn new(string_field: String, binary_field: ByteArray, ) -> MultipartRequest {
         MultipartRequest {
             string_field,
             optional_string_field: None,
@@ -200,28 +287,26 @@ impl MultipartRequest {
 impl std::fmt::Display for MultipartRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             Some("string_field".to_string()),
             Some(self.string_field.to_string()),
-            self.optional_string_field
-                .as_ref()
-                .map(|optional_string_field| {
-                    [
-                        "optional_string_field".to_string(),
-                        optional_string_field.to_string(),
-                    ]
-                    .join(",")
-                }),
+
+
+            self.optional_string_field.as_ref().map(|optional_string_field| {
+                [
+                    "optional_string_field".to_string(),
+                    optional_string_field.to_string(),
+                ].join(",")
+            }),
+
             // Skipping object_field in query parameter serialization
 
             // Skipping binary_field in query parameter serialization
             // Skipping binary_field in query parameter serialization
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -251,38 +336,20 @@ impl std::str::FromStr for MultipartRequest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing MultipartRequest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing MultipartRequest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "string_field" => intermediate_rep.string_field.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "string_field" => intermediate_rep.string_field.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "optional_string_field" => intermediate_rep.optional_string_field.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "optional_string_field" => intermediate_rep.optional_string_field.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "object_field" => intermediate_rep.object_field.push(
-                        <models::MultipartRequestObjectField as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
-                    ),
-                    "binary_field" => return std::result::Result::Err(
-                        "Parsing binary data in this style is not supported in MultipartRequest"
-                            .to_string(),
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing MultipartRequest".to_string(),
-                        )
-                    }
+                    "object_field" => intermediate_rep.object_field.push(<models::MultipartRequestObjectField as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "binary_field" => return std::result::Result::Err("Parsing binary data in this style is not supported in MultipartRequest".to_string()),
+                    _ => return std::result::Result::Err("Unexpected key while parsing MultipartRequest".to_string())
                 }
             }
 
@@ -292,18 +359,10 @@ impl std::str::FromStr for MultipartRequest {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(MultipartRequest {
-            string_field: intermediate_rep
-                .string_field
-                .into_iter()
-                .next()
-                .ok_or_else(|| "string_field missing in MultipartRequest".to_string())?,
+            string_field: intermediate_rep.string_field.into_iter().next().ok_or_else(|| "string_field missing in MultipartRequest".to_string())?,
             optional_string_field: intermediate_rep.optional_string_field.into_iter().next(),
             object_field: intermediate_rep.object_field.into_iter().next(),
-            binary_field: intermediate_rep
-                .binary_field
-                .into_iter()
-                .next()
-                .ok_or_else(|| "binary_field missing in MultipartRequest".to_string())?,
+            binary_field: intermediate_rep.binary_field.into_iter().next().ok_or_else(|| "binary_field missing in MultipartRequest".to_string())?,
         })
     }
 }
@@ -314,16 +373,13 @@ impl std::str::FromStr for MultipartRequest {
 impl std::convert::TryFrom<header::IntoHeaderValue<MultipartRequest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<MultipartRequest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MultipartRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for MultipartRequest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for MultipartRequest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -334,24 +390,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<MultipartReq
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <MultipartRequest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <MultipartRequest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into MultipartRequest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into MultipartRequest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -360,13 +415,49 @@ pub struct MultipartRequestObjectField {
     pub field_a: String,
 
     #[serde(rename = "field_b")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub field_b: Option<Vec<String>>,
+
 }
 
 impl MultipartRequestObjectField {
+    fn __name_for_field_a() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='field_a', complexType='string', getter='getFieldA', setter='setFieldA', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='field_a', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.field_a;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='fieldA', nameInPascalCase='FieldA', nameInSnakeCase='FIELD_A', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_field_a<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_field_a())
+        }
+}
+impl MultipartRequestObjectField {
+    fn __name_for_field_b() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='field_b', complexType='string', getter='getFieldB', setter='setFieldB', description='null', dataType='Vec<String>', datatypeWithEnum='Vec<String>', dataFormat='null', name='field_b', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.field_b;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "string"
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='string', baseName='field_b', complexType='string', getter='getFieldB', setter='setFieldB', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='field_b', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.field_b;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='fieldB', nameInPascalCase='FieldB', nameInSnakeCase='FIELD_B', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='field_b', complexType='string', getter='getFieldB', setter='setFieldB', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='field_b', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.field_b;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='fieldB', nameInPascalCase='FieldB', nameInSnakeCase='FIELD_B', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='fieldB', nameInPascalCase='FieldB', nameInSnakeCase='FIELD_B', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_field_b<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_field_b())
+        }
+}
+
+
+impl MultipartRequestObjectField {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(field_a: String) -> MultipartRequestObjectField {
+    pub fn new(field_a: String, ) -> MultipartRequestObjectField {
         MultipartRequestObjectField {
             field_a,
             field_b: None,
@@ -380,26 +471,21 @@ impl MultipartRequestObjectField {
 impl std::fmt::Display for MultipartRequestObjectField {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             Some("field_a".to_string()),
             Some(self.field_a.to_string()),
+
+
             self.field_b.as_ref().map(|field_b| {
                 [
                     "field_b".to_string(),
-                    field_b
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<_>>()
-                        .join(","),
-                ]
-                .join(",")
+                    field_b.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","),
+                ].join(",")
             }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -427,11 +513,7 @@ impl std::str::FromStr for MultipartRequestObjectField {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing MultipartRequestObjectField".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing MultipartRequestObjectField".to_string())
             };
 
             if let Some(key) = key_result {
@@ -450,11 +532,7 @@ impl std::str::FromStr for MultipartRequestObjectField {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(MultipartRequestObjectField {
-            field_a: intermediate_rep
-                .field_a
-                .into_iter()
-                .next()
-                .ok_or_else(|| "field_a missing in MultipartRequestObjectField".to_string())?,
+            field_a: intermediate_rep.field_a.into_iter().next().ok_or_else(|| "field_a missing in MultipartRequestObjectField".to_string())?,
             field_b: intermediate_rep.field_b.into_iter().next(),
         })
     }
@@ -466,16 +544,13 @@ impl std::str::FromStr for MultipartRequestObjectField {
 impl std::convert::TryFrom<header::IntoHeaderValue<MultipartRequestObjectField>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<MultipartRequestObjectField>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MultipartRequestObjectField>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for MultipartRequestObjectField - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for MultipartRequestObjectField - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -486,36 +561,66 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<MultipartReq
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <MultipartRequestObjectField as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <MultipartRequestObjectField as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into MultipartRequestObjectField - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into MultipartRequestObjectField - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct MultipleIdenticalMimeTypesPostRequest {
     #[serde(rename = "binary1")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub binary1: Option<ByteArray>,
 
     #[serde(rename = "binary2")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub binary2: Option<ByteArray>,
+
 }
+
+impl MultipleIdenticalMimeTypesPostRequest {
+    fn __name_for_binary1() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='binary1', complexType='file', getter='getBinary1', setter='setBinary1', description='null', dataType='ByteArray', datatypeWithEnum='ByteArray', dataFormat='binary', name='binary1', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.binary1;', baseType='file', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "binary",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=true, isFile=true, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='binary1', nameInPascalCase='Binary1', nameInSnakeCase='BINARY1', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=binary, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_binary1<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_binary1())
+        }
+}
+impl MultipleIdenticalMimeTypesPostRequest {
+    fn __name_for_binary2() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='binary2', complexType='file', getter='getBinary2', setter='setBinary2', description='null', dataType='ByteArray', datatypeWithEnum='ByteArray', dataFormat='binary', name='binary2', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.binary2;', baseType='file', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "binary",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=true, isFile=true, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='binary2', nameInPascalCase='Binary2', nameInSnakeCase='BINARY2', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=binary, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_binary2<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_binary2())
+        }
+}
+
 
 impl MultipleIdenticalMimeTypesPostRequest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -541,11 +646,7 @@ impl std::fmt::Display for MultipleIdenticalMimeTypesPostRequest {
 
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -573,12 +674,7 @@ impl std::str::FromStr for MultipleIdenticalMimeTypesPostRequest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing MultipleIdenticalMimeTypesPostRequest"
-                            .to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing MultipleIdenticalMimeTypesPostRequest".to_string())
             };
 
             if let Some(key) = key_result {
@@ -605,14 +701,10 @@ impl std::str::FromStr for MultipleIdenticalMimeTypesPostRequest {
 // Methods for converting between header::IntoHeaderValue<MultipleIdenticalMimeTypesPostRequest> and HeaderValue
 
 #[cfg(feature = "server")]
-impl std::convert::TryFrom<header::IntoHeaderValue<MultipleIdenticalMimeTypesPostRequest>>
-    for HeaderValue
-{
+impl std::convert::TryFrom<header::IntoHeaderValue<MultipleIdenticalMimeTypesPostRequest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<MultipleIdenticalMimeTypesPostRequest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MultipleIdenticalMimeTypesPostRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
              std::result::Result::Ok(value) => std::result::Result::Ok(value),
@@ -624,9 +716,7 @@ impl std::convert::TryFrom<header::IntoHeaderValue<MultipleIdenticalMimeTypesPos
 }
 
 #[cfg(feature = "server")]
-impl std::convert::TryFrom<HeaderValue>
-    for header::IntoHeaderValue<MultipleIdenticalMimeTypesPostRequest>
-{
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<MultipleIdenticalMimeTypesPostRequest> {
     type Error = String;
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
@@ -645,3 +735,6 @@ impl std::convert::TryFrom<HeaderValue>
         }
     }
 }
+
+
+

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/lib.rs
@@ -6,7 +6,7 @@
     unused_extern_crates,
     non_camel_case_types,
     unused_imports,
-    unused_attributes
+    unused_attributes,
 )]
 #![allow(
     clippy::derive_partial_eq_without_eq,
@@ -20,9 +20,9 @@ pub const API_VERSION: &str = "1.0.7";
 #[cfg(feature = "server")]
 pub mod server;
 
-pub mod apis;
 pub mod models;
 pub mod types;
+pub mod apis;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/models.rs
@@ -7,109 +7,146 @@ use validator::Validate;
 use crate::header;
 use crate::{models, types::*};
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct AnyOfGetQueryParams {
-    /// list of any of objects
-    #[serde(rename = "any-of")]
-    #[validate(length(min = 1))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub any_of: Option<Vec<models::AnyOfObject>>,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct AnyOfGetQueryParams {
+            /// list of any of objects
+                #[serde(rename = "any-of")]
+                #[validate(
+                        length(min = 1),
+                    )]
+                #[serde(skip_serializing_if="Option::is_none")]
+                pub any_of: Option<Vec<models::AnyOfObject>>,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct CallbackWithHeaderPostQueryParams {
-    #[serde(rename = "url")]
-    pub url: String,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct CallbackWithHeaderPostQueryParams {
+                #[serde(rename = "url")]
+                pub url: String,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct ComplexQueryParamGetQueryParams {
-    #[serde(rename = "list-of-strings")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub list_of_strings: Option<Vec<models::StringObject>>,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct ComplexQueryParamGetQueryParams {
+                #[serde(rename = "list-of-strings")]
+                #[serde(skip_serializing_if="Option::is_none")]
+                pub list_of_strings: Option<Vec<models::StringObject>>,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct EnumInPathPathParamGetPathParams {
-    pub path_param: models::StringEnum,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct EnumInPathPathParamGetPathParams {
+                pub path_param: models::StringEnum,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct GetWithBooleanParameterQueryParams {
-    /// Let's check apostrophes get encoded properly!
-    #[serde(rename = "iambool")]
-    pub iambool: bool,
-}
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct JsonComplexQueryParamGetQueryParams {
-    #[serde(rename = "list-of-strings")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub list_of_strings: Option<Vec<models::StringObject>>,
-}
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct GetWithBooleanParameterQueryParams {
+            /// Let's check apostrophes get encoded properly!
+                #[serde(rename = "iambool")]
+                pub iambool: bool,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct MandatoryRequestHeaderGetHeaderParams {
-    pub x_header: String,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct JsonComplexQueryParamGetQueryParams {
+                #[serde(rename = "list-of-strings")]
+                #[serde(skip_serializing_if="Option::is_none")]
+                pub list_of_strings: Option<Vec<models::StringObject>>,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGetPathParams {
-    pub path_param_a: String,
-    pub path_param_b: String,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+    pub struct MandatoryRequestHeaderGetHeaderParams {
+        pub x_header: String,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct ParamgetGetQueryParams {
-    /// The stuff to get
-    #[serde(rename = "uuid")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub uuid: Option<uuid::Uuid>,
-    /// Some object to pass as query parameter
-    #[serde(rename = "someObject")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub some_object: Option<crate::types::Object>,
-    /// Some list to pass as query parameter
-    #[serde(rename = "someList")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub some_list: Option<Vec<models::MyId>>,
-}
+            
+      
+      
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGetPathParams {
+                pub path_param_a: String,
+                pub path_param_b: String,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct RegisterCallbackPostQueryParams {
-    #[serde(rename = "url")]
-    pub url: String,
-}
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct TwoFirstLetterHeadersHeaderParams {
-    pub x_header_one: Option<bool>,
-    pub x_header_two: Option<bool>,
-}
+      
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct ParamgetGetQueryParams {
+            /// The stuff to get
+                #[serde(rename = "uuid")]
+                #[serde(skip_serializing_if="Option::is_none")]
+                pub uuid: Option<uuid::Uuid>,
+            /// Some object to pass as query parameter
+                #[serde(rename = "someObject")]
+                #[serde(skip_serializing_if="Option::is_none")]
+                pub some_object: Option<crate::types::Object>,
+            /// Some list to pass as query parameter
+                #[serde(rename = "someList")]
+                #[serde(skip_serializing_if="Option::is_none")]
+                pub some_list: Option<Vec<models::MyId>>,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct GetRepoInfoPathParams {
-    pub repo_id: String,
-}
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct RegisterCallbackPostQueryParams {
+                #[serde(rename = "url")]
+                pub url: String,
+    }
+
+      
+      
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+    pub struct TwoFirstLetterHeadersHeaderParams {
+        pub x_header_one: Option<bool>,
+        pub x_header_two: Option<bool>,
+    }
+
+            
+      
+      
+      
+      
+      
+      
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct GetRepoInfoPathParams {
+                pub repo_id: String,
+    }
+
+
+      
+
 
 /// Check that an object with only additional properties that references another object (e.g. an anyOf object) isn't treated as freeForm
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct AdditionalPropertiesReferencedAnyOfObject(
-    std::collections::HashMap<String, models::AnyOfProperty>,
-);
+pub struct AdditionalPropertiesReferencedAnyOfObject(std::collections::HashMap<String, models::AnyOfProperty>);
 
 impl validator::Validate for AdditionalPropertiesReferencedAnyOfObject {
     fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
@@ -117,17 +154,13 @@ impl validator::Validate for AdditionalPropertiesReferencedAnyOfObject {
     }
 }
 
-impl std::convert::From<std::collections::HashMap<String, models::AnyOfProperty>>
-    for AdditionalPropertiesReferencedAnyOfObject
-{
+impl std::convert::From<std::collections::HashMap<String, models::AnyOfProperty>> for AdditionalPropertiesReferencedAnyOfObject {
     fn from(x: std::collections::HashMap<String, models::AnyOfProperty>) -> Self {
         AdditionalPropertiesReferencedAnyOfObject(x)
     }
 }
 
-impl std::convert::From<AdditionalPropertiesReferencedAnyOfObject>
-    for std::collections::HashMap<String, models::AnyOfProperty>
-{
+impl std::convert::From<AdditionalPropertiesReferencedAnyOfObject> for std::collections::HashMap<String, models::AnyOfProperty> {
     fn from(x: AdditionalPropertiesReferencedAnyOfObject) -> Self {
         x.0
     }
@@ -167,6 +200,7 @@ impl ::std::str::FromStr for AdditionalPropertiesReferencedAnyOfObject {
     }
 }
 
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct AdditionalPropertiesWithList(std::collections::HashMap<String, Vec<String>>);
@@ -177,17 +211,13 @@ impl validator::Validate for AdditionalPropertiesWithList {
     }
 }
 
-impl std::convert::From<std::collections::HashMap<String, Vec<String>>>
-    for AdditionalPropertiesWithList
-{
+impl std::convert::From<std::collections::HashMap<String, Vec<String>>> for AdditionalPropertiesWithList {
     fn from(x: std::collections::HashMap<String, Vec<String>>) -> Self {
         AdditionalPropertiesWithList(x)
     }
 }
 
-impl std::convert::From<AdditionalPropertiesWithList>
-    for std::collections::HashMap<String, Vec<String>>
-{
+impl std::convert::From<AdditionalPropertiesWithList> for std::collections::HashMap<String, Vec<String>> {
     fn from(x: AdditionalPropertiesWithList) -> Self {
         x.0
     }
@@ -223,11 +253,10 @@ impl ::std::str::FromStr for AdditionalPropertiesWithList {
     type Err = &'static str;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        std::result::Result::Err(
-            "Parsing additionalProperties for AdditionalPropertiesWithList is not supported",
-        )
+        std::result::Result::Err("Parsing additionalProperties for AdditionalPropertiesWithList is not supported")
     }
 }
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -235,13 +264,55 @@ pub struct AdditionalPropertiesWithNullable {
     #[serde(rename = "nullableString")]
     #[serde(deserialize_with = "deserialize_optional_nullable")]
     #[serde(default = "default_optional_nullable")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_string: Option<Nullable<String>>,
 
     #[serde(rename = "nullableMap")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_map: Option<std::collections::HashMap<String, models::NullableObject>>,
+
 }
+
+impl AdditionalPropertiesWithNullable {
+    fn __name_for_nullable_string() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='nullableString', complexType='string', getter='getNullableString', setter='setNullableString', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='nullable_string', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.nullableString;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "nullable" : true,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=true, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='nullableString', nameInPascalCase='NullableString', nameInSnakeCase='NULLABLE_STRING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_nullable_string<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_nullable_string())
+        }
+}
+impl AdditionalPropertiesWithNullable {
+    fn __name_for_nullable_map() -> String {
+        String::from("CodegenProperty{openApiType='object', baseName='nullableMap', complexType='string', getter='getNullableMap', setter='setNullableMap', description='null', dataType='std::collections::HashMap<String, models::NullableObject>', datatypeWithEnum='std::collections::HashMap<String, models::NullableObject>', dataFormat='null', name='nullable_map', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.nullableMap;', baseType='map', containerType='map', containerTypeMapped='std::collections::HashMap', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "additionalProperties" : {
+    "$ref" : "#/components/schemas/NullableObject"
+  },
+  "type" : "object"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=true, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "nullable" : true,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=true, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=CodegenProperty{openApiType='string', baseName='additional_properties', complexType='string', getter='getAdditionalProperties', setter='setAdditionalProperties', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='additional_properties', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.additional_properties;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "nullable" : true,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=true, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalProperties', nameInPascalCase='AdditionalProperties', nameInSnakeCase='ADDITIONAL_PROPERTIES', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "nullable" : true,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=true, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='nullableMap', nameInPascalCase='NullableMap', nameInSnakeCase='NULLABLE_MAP', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=true, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_nullable_map<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_nullable_map())
+        }
+}
+
 
 impl AdditionalPropertiesWithNullable {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -259,23 +330,19 @@ impl AdditionalPropertiesWithNullable {
 impl std::fmt::Display for AdditionalPropertiesWithNullable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             self.nullable_string.as_ref().map(|nullable_string| {
                 [
                     "nullableString".to_string(),
-                    nullable_string
-                        .as_ref()
-                        .map_or("null".to_string(), |x| x.to_string()),
-                ]
-                .join(",")
+                    nullable_string.as_ref().map_or("null".to_string(), |x| x.to_string()),
+                ].join(",")
             }),
+
             // Skipping nullableMap in query parameter serialization
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -303,11 +370,7 @@ impl std::str::FromStr for AdditionalPropertiesWithNullable {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing AdditionalPropertiesWithNullable".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing AdditionalPropertiesWithNullable".to_string())
             };
 
             if let Some(key) = key_result {
@@ -325,9 +388,7 @@ impl std::str::FromStr for AdditionalPropertiesWithNullable {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(AdditionalPropertiesWithNullable {
-            nullable_string: std::result::Result::Err(
-                "Nullable types not supported in AdditionalPropertiesWithNullable".to_string(),
-            )?,
+            nullable_string: std::result::Result::Err("Nullable types not supported in AdditionalPropertiesWithNullable".to_string())?,
             nullable_map: intermediate_rep.nullable_map.into_iter().next(),
         })
     }
@@ -336,14 +397,10 @@ impl std::str::FromStr for AdditionalPropertiesWithNullable {
 // Methods for converting between header::IntoHeaderValue<AdditionalPropertiesWithNullable> and HeaderValue
 
 #[cfg(feature = "server")]
-impl std::convert::TryFrom<header::IntoHeaderValue<AdditionalPropertiesWithNullable>>
-    for HeaderValue
-{
+impl std::convert::TryFrom<header::IntoHeaderValue<AdditionalPropertiesWithNullable>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<AdditionalPropertiesWithNullable>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<AdditionalPropertiesWithNullable>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
              std::result::Result::Ok(value) => std::result::Result::Ok(value),
@@ -355,9 +412,7 @@ impl std::convert::TryFrom<header::IntoHeaderValue<AdditionalPropertiesWithNulla
 }
 
 #[cfg(feature = "server")]
-impl std::convert::TryFrom<HeaderValue>
-    for header::IntoHeaderValue<AdditionalPropertiesWithNullable>
-{
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AdditionalPropertiesWithNullable> {
     type Error = String;
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
@@ -376,6 +431,9 @@ impl std::convert::TryFrom<HeaderValue>
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -400,7 +458,7 @@ impl std::convert::From<AnotherXmlArray> for Vec<String> {
 }
 
 impl std::iter::FromIterator<String> for AnotherXmlArray {
-    fn from_iter<U: IntoIterator<Item = String>>(u: U) -> Self {
+    fn from_iter<U: IntoIterator<Item=String>>(u: U) -> Self {
         AnotherXmlArray(Vec::<String>::from_iter(u))
     }
 }
@@ -449,15 +507,8 @@ impl std::ops::DerefMut for AnotherXmlArray {
 /// specified in https://swagger.io/docs/specification/serialization/
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for AnotherXmlArray {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            self.iter()
-                .map(|x| x.to_string())
-                .collect::<Vec<_>>()
-                .join(",")
-        )
+   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+       write!(f, "{}", self.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","))
     }
 }
 
@@ -469,12 +520,14 @@ impl std::str::FromStr for AnotherXmlArray {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let mut items = vec![];
-        for item in s.split(',') {
+        for item in s.split(',')
+        {
             items.push(item.parse()?);
         }
         std::result::Result::Ok(AnotherXmlArray(items))
     }
 }
+
 
 // Methods for converting between header::IntoHeaderValue<AnotherXmlArray> and HeaderValue
 
@@ -482,16 +535,13 @@ impl std::str::FromStr for AnotherXmlArray {
 impl std::convert::TryFrom<header::IntoHeaderValue<AnotherXmlArray>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<AnotherXmlArray>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<AnotherXmlArray>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for AnotherXmlArray - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for AnotherXmlArray - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -502,24 +552,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AnotherXmlAr
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <AnotherXmlArray as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <AnotherXmlArray as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into AnotherXmlArray - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into AnotherXmlArray - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -539,7 +588,7 @@ impl std::convert::From<String> for AnotherXmlInner {
 
 impl std::fmt::Display for AnotherXmlInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.0)
+       write!(f, "{:?}", self.0)
     }
 }
 
@@ -569,19 +618,39 @@ impl std::ops::DerefMut for AnotherXmlInner {
     }
 }
 
+
+
 /// An XML object
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct AnotherXmlObject {
     #[serde(rename = "inner_string")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub inner_string: Option<String>,
+
 }
+
+impl AnotherXmlObject {
+    fn __name_for_inner_string() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='inner_string', complexType='string', getter='getInnerString', setter='setInnerString', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner_string', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.inner_string;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='innerString', nameInPascalCase='InnerString', nameInSnakeCase='INNER_STRING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_inner_string<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_inner_string())
+        }
+}
+
 
 impl AnotherXmlObject {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new() -> AnotherXmlObject {
-        AnotherXmlObject { inner_string: None }
+        AnotherXmlObject {
+            inner_string: None,
+        }
     }
 }
 
@@ -590,16 +659,18 @@ impl AnotherXmlObject {
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for AnotherXmlObject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> = vec![self
-            .inner_string
-            .as_ref()
-            .map(|inner_string| ["inner_string".to_string(), inner_string.to_string()].join(","))];
+        let params: Vec<Option<String>> = vec![
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+            self.inner_string.as_ref().map(|inner_string| {
+                [
+                    "inner_string".to_string(),
+                    inner_string.to_string(),
+                ].join(",")
+            }),
+
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -626,25 +697,15 @@ impl std::str::FromStr for AnotherXmlObject {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing AnotherXmlObject".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing AnotherXmlObject".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "inner_string" => intermediate_rep.inner_string.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing AnotherXmlObject".to_string(),
-                        )
-                    }
+                    "inner_string" => intermediate_rep.inner_string.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing AnotherXmlObject".to_string())
                 }
             }
 
@@ -665,16 +726,13 @@ impl std::str::FromStr for AnotherXmlObject {
 impl std::convert::TryFrom<header::IntoHeaderValue<AnotherXmlObject>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<AnotherXmlObject>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<AnotherXmlObject>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for AnotherXmlObject - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for AnotherXmlObject - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -685,24 +743,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AnotherXmlOb
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <AnotherXmlObject as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <AnotherXmlObject as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into AnotherXmlObject - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into AnotherXmlObject - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// Any of:
 /// - String
@@ -710,7 +767,8 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AnotherXmlOb
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AnyOfGet202Response(Box<serde_json::value::RawValue>);
 
-impl validator::Validate for AnyOfGet202Response {
+impl validator::Validate for AnyOfGet202Response
+{
     fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
         std::result::Result::Ok(())
     }
@@ -733,6 +791,10 @@ impl PartialEq for AnyOfGet202Response {
     }
 }
 
+
+
+
+
 /// Test a model containing an anyOf of a hash map
 /// Any of:
 /// - String
@@ -740,7 +802,8 @@ impl PartialEq for AnyOfGet202Response {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AnyOfHashMapObject(Box<serde_json::value::RawValue>);
 
-impl validator::Validate for AnyOfHashMapObject {
+impl validator::Validate for AnyOfHashMapObject
+{
     fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
         std::result::Result::Ok(())
     }
@@ -763,13 +826,18 @@ impl PartialEq for AnyOfHashMapObject {
     }
 }
 
+
+
+
+
 /// Test a model containing an anyOf
 /// Any of:
 /// - String
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AnyOfObject(Box<serde_json::value::RawValue>);
 
-impl validator::Validate for AnyOfObject {
+impl validator::Validate for AnyOfObject
+{
     fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
         std::result::Result::Ok(())
     }
@@ -792,6 +860,10 @@ impl PartialEq for AnyOfObject {
     }
 }
 
+
+
+
+
 /// Test containing an anyOf object
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -800,13 +872,42 @@ pub struct AnyOfProperty {
     pub required_any_of: models::AnyOfObject,
 
     #[serde(rename = "optionalAnyOf")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub optional_any_of: Option<models::Model12345AnyOfObject>,
+
 }
 
 impl AnyOfProperty {
+    fn __name_for_required_any_of() -> String {
+        String::from("CodegenProperty{openApiType='AnyOfObject', baseName='requiredAnyOf', complexType='AnyOfObject', getter='getRequiredAnyOf', setter='setRequiredAnyOf', description='null', dataType='models::AnyOfObject', datatypeWithEnum='models::AnyOfObject', dataFormat='null', name='required_any_of', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.requiredAnyOf;', baseType='AnyOfObject', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/AnyOfObject"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='requiredAnyOf', nameInPascalCase='RequiredAnyOf', nameInSnakeCase='REQUIRED_ANY_OF', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=#/components/schemas/AnyOfObject, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_required_any_of<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_required_any_of())
+        }
+}
+impl AnyOfProperty {
+    fn __name_for_optional_any_of() -> String {
+        String::from("CodegenProperty{openApiType='12345AnyOfObject', baseName='optionalAnyOf', complexType='12345AnyOfObject', getter='getOptionalAnyOf', setter='setOptionalAnyOf', description='null', dataType='models::Model12345AnyOfObject', datatypeWithEnum='models::Model12345AnyOfObject', dataFormat='null', name='optional_any_of', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.optionalAnyOf;', baseType='12345AnyOfObject', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/12345AnyOfObject"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='optionalAnyOf', nameInPascalCase='OptionalAnyOf', nameInSnakeCase='OPTIONAL_ANY_OF', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=#/components/schemas/12345AnyOfObject, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_optional_any_of<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_optional_any_of())
+        }
+}
+
+
+impl AnyOfProperty {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(required_any_of: models::AnyOfObject) -> AnyOfProperty {
+    pub fn new(required_any_of: models::AnyOfObject, ) -> AnyOfProperty {
         AnyOfProperty {
             required_any_of,
             optional_any_of: None,
@@ -826,11 +927,7 @@ impl std::fmt::Display for AnyOfProperty {
 
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -858,31 +955,17 @@ impl std::str::FromStr for AnyOfProperty {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing AnyOfProperty".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing AnyOfProperty".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "requiredAnyOf" => intermediate_rep.required_any_of.push(
-                        <models::AnyOfObject as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
-                    ),
+                    "requiredAnyOf" => intermediate_rep.required_any_of.push(<models::AnyOfObject as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "optionalAnyOf" => intermediate_rep.optional_any_of.push(
-                        <models::Model12345AnyOfObject as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing AnyOfProperty".to_string(),
-                        )
-                    }
+                    "optionalAnyOf" => intermediate_rep.optional_any_of.push(<models::Model12345AnyOfObject as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing AnyOfProperty".to_string())
                 }
             }
 
@@ -892,11 +975,7 @@ impl std::str::FromStr for AnyOfProperty {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(AnyOfProperty {
-            required_any_of: intermediate_rep
-                .required_any_of
-                .into_iter()
-                .next()
-                .ok_or_else(|| "requiredAnyOf missing in AnyOfProperty".to_string())?,
+            required_any_of: intermediate_rep.required_any_of.into_iter().next().ok_or_else(|| "requiredAnyOf missing in AnyOfProperty".to_string())?,
             optional_any_of: intermediate_rep.optional_any_of.into_iter().next(),
         })
     }
@@ -908,16 +987,13 @@ impl std::str::FromStr for AnyOfProperty {
 impl std::convert::TryFrom<header::IntoHeaderValue<AnyOfProperty>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<AnyOfProperty>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<AnyOfProperty>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for AnyOfProperty - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for AnyOfProperty - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -928,40 +1004,68 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AnyOfPropert
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <AnyOfProperty as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <AnyOfProperty as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into AnyOfProperty - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into AnyOfProperty - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// An XML object
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct DuplicateXmlObject {
     #[serde(rename = "inner_string")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub inner_string: Option<String>,
 
     #[serde(rename = "inner_array")]
     pub inner_array: models::XmlArray,
+
 }
 
 impl DuplicateXmlObject {
+    fn __name_for_inner_string() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='inner_string', complexType='string', getter='getInnerString', setter='setInnerString', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner_string', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.inner_string;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='innerString', nameInPascalCase='InnerString', nameInSnakeCase='INNER_STRING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_inner_string<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_inner_string())
+        }
+}
+impl DuplicateXmlObject {
+    fn __name_for_inner_array() -> String {
+        String::from("CodegenProperty{openApiType='xml_array', baseName='inner_array', complexType='xml_array', getter='getInnerArray', setter='setInnerArray', description='null', dataType='models::XmlArray', datatypeWithEnum='models::XmlArray', dataFormat='null', name='inner_array', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner_array;', baseType='xml_array', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/xml_array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='innerArray', nameInPascalCase='InnerArray', nameInSnakeCase='INNER_ARRAY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='CamelXmlArray', xmlNamespace='null', isXmlWrapped=true, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/xml_array, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_inner_array<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_inner_array())
+        }
+}
+
+
+impl DuplicateXmlObject {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(inner_array: models::XmlArray) -> DuplicateXmlObject {
+    pub fn new(inner_array: models::XmlArray, ) -> DuplicateXmlObject {
         DuplicateXmlObject {
             inner_string: None,
             inner_array,
@@ -975,17 +1079,19 @@ impl DuplicateXmlObject {
 impl std::fmt::Display for DuplicateXmlObject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             self.inner_string.as_ref().map(|inner_string| {
-                ["inner_string".to_string(), inner_string.to_string()].join(",")
+                [
+                    "inner_string".to_string(),
+                    inner_string.to_string(),
+                ].join(",")
             }),
+
             // Skipping inner_array in query parameter serialization
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1013,30 +1119,17 @@ impl std::str::FromStr for DuplicateXmlObject {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing DuplicateXmlObject".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing DuplicateXmlObject".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "inner_string" => intermediate_rep.inner_string.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "inner_string" => intermediate_rep.inner_string.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "inner_array" => intermediate_rep.inner_array.push(
-                        <models::XmlArray as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing DuplicateXmlObject".to_string(),
-                        )
-                    }
+                    "inner_array" => intermediate_rep.inner_array.push(<models::XmlArray as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing DuplicateXmlObject".to_string())
                 }
             }
 
@@ -1047,11 +1140,7 @@ impl std::str::FromStr for DuplicateXmlObject {
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(DuplicateXmlObject {
             inner_string: intermediate_rep.inner_string.into_iter().next(),
-            inner_array: intermediate_rep
-                .inner_array
-                .into_iter()
-                .next()
-                .ok_or_else(|| "inner_array missing in DuplicateXmlObject".to_string())?,
+            inner_array: intermediate_rep.inner_array.into_iter().next().ok_or_else(|| "inner_array missing in DuplicateXmlObject".to_string())?,
         })
     }
 }
@@ -1062,16 +1151,13 @@ impl std::str::FromStr for DuplicateXmlObject {
 impl std::convert::TryFrom<header::IntoHeaderValue<DuplicateXmlObject>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<DuplicateXmlObject>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<DuplicateXmlObject>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for DuplicateXmlObject - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for DuplicateXmlObject - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1082,24 +1168,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<DuplicateXml
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <DuplicateXmlObject as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <DuplicateXmlObject as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into DuplicateXmlObject - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into DuplicateXmlObject - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// Test a model containing a special character in the enum
 /// Enumeration of values.
@@ -1107,9 +1192,7 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<DuplicateXml
 /// which helps with FFI.
 #[allow(non_camel_case_types)]
 #[repr(C)]
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum EnumWithStarObject {
     #[serde(rename = "FOO")]
@@ -1143,6 +1226,7 @@ impl std::str::FromStr for EnumWithStarObject {
     }
 }
 
+
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Err(String);
@@ -1161,7 +1245,7 @@ impl std::convert::From<String> for Err {
 
 impl std::fmt::Display for Err {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.0)
+       write!(f, "{:?}", self.0)
     }
 }
 
@@ -1191,6 +1275,8 @@ impl std::ops::DerefMut for Err {
     }
 }
 
+
+
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Error(String);
@@ -1209,7 +1295,7 @@ impl std::convert::From<String> for Error {
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.0)
+       write!(f, "{:?}", self.0)
     }
 }
 
@@ -1239,13 +1325,38 @@ impl std::ops::DerefMut for Error {
     }
 }
 
+
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct FormTestRequest {
     #[serde(rename = "requiredArray")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub required_array: Option<Vec<String>>,
+
 }
+
+impl FormTestRequest {
+    fn __name_for_required_array() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='requiredArray', complexType='string', getter='getRequiredArray', setter='setRequiredArray', description='null', dataType='Vec<String>', datatypeWithEnum='Vec<String>', dataFormat='null', name='required_array', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.requiredArray;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "string"
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='string', baseName='required_array', complexType='string', getter='getRequiredArray', setter='setRequiredArray', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='required_array', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.required_array;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='requiredArray', nameInPascalCase='RequiredArray', nameInSnakeCase='REQUIRED_ARRAY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='required_array', complexType='string', getter='getRequiredArray', setter='setRequiredArray', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='required_array', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.required_array;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='requiredArray', nameInPascalCase='RequiredArray', nameInSnakeCase='REQUIRED_ARRAY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='requiredArray', nameInPascalCase='RequiredArray', nameInSnakeCase='REQUIRED_ARRAY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_required_array<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_required_array())
+        }
+}
+
 
 impl FormTestRequest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -1261,24 +1372,18 @@ impl FormTestRequest {
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for FormTestRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> =
-            vec![self.required_array.as_ref().map(|required_array| {
+        let params: Vec<Option<String>> = vec![
+
+            self.required_array.as_ref().map(|required_array| {
                 [
                     "requiredArray".to_string(),
-                    required_array
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<_>>()
-                        .join(","),
-                ]
-                .join(",")
-            })];
+                    required_array.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","),
+                ].join(",")
+            }),
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1305,27 +1410,14 @@ impl std::str::FromStr for FormTestRequest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing FormTestRequest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing FormTestRequest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
-                    "requiredArray" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in FormTestRequest"
-                                .to_string(),
-                        )
-                    }
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing FormTestRequest".to_string(),
-                        )
-                    }
+                    "requiredArray" => return std::result::Result::Err("Parsing a container in this style is not supported in FormTestRequest".to_string()),
+                    _ => return std::result::Result::Err("Unexpected key while parsing FormTestRequest".to_string())
                 }
             }
 
@@ -1346,16 +1438,13 @@ impl std::str::FromStr for FormTestRequest {
 impl std::convert::TryFrom<header::IntoHeaderValue<FormTestRequest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<FormTestRequest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<FormTestRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for FormTestRequest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for FormTestRequest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1366,24 +1455,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<FormTestRequ
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <FormTestRequest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <FormTestRequest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into FormTestRequest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into FormTestRequest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// Test a model containing an anyOf that starts with a number
 /// Any of:
@@ -1391,7 +1479,8 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<FormTestRequ
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Model12345AnyOfObject(Box<serde_json::value::RawValue>);
 
-impl validator::Validate for Model12345AnyOfObject {
+impl validator::Validate for Model12345AnyOfObject
+{
     fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
         std::result::Result::Ok(())
     }
@@ -1414,18 +1503,40 @@ impl PartialEq for Model12345AnyOfObject {
     }
 }
 
+
+
+
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct MultigetGet201Response {
     #[serde(rename = "foo")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub foo: Option<String>,
+
 }
+
+impl MultigetGet201Response {
+    fn __name_for_foo() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='foo', complexType='string', getter='getFoo', setter='setFoo', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='foo', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.foo;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='foo', nameInPascalCase='Foo', nameInSnakeCase='FOO', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_foo<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_foo())
+        }
+}
+
 
 impl MultigetGet201Response {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new() -> MultigetGet201Response {
-        MultigetGet201Response { foo: None }
+        MultigetGet201Response {
+            foo: None,
+        }
     }
 }
 
@@ -1434,16 +1545,18 @@ impl MultigetGet201Response {
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for MultigetGet201Response {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> = vec![self
-            .foo
-            .as_ref()
-            .map(|foo| ["foo".to_string(), foo.to_string()].join(","))];
+        let params: Vec<Option<String>> = vec![
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+            self.foo.as_ref().map(|foo| {
+                [
+                    "foo".to_string(),
+                    foo.to_string(),
+                ].join(",")
+            }),
+
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1470,25 +1583,15 @@ impl std::str::FromStr for MultigetGet201Response {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing MultigetGet201Response".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing MultigetGet201Response".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "foo" => intermediate_rep.foo.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing MultigetGet201Response".to_string(),
-                        )
-                    }
+                    "foo" => intermediate_rep.foo.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing MultigetGet201Response".to_string())
                 }
             }
 
@@ -1509,16 +1612,13 @@ impl std::str::FromStr for MultigetGet201Response {
 impl std::convert::TryFrom<header::IntoHeaderValue<MultigetGet201Response>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<MultigetGet201Response>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MultigetGet201Response>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for MultigetGet201Response - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for MultigetGet201Response - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1529,24 +1629,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<MultigetGet2
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <MultigetGet201Response as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <MultigetGet201Response as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into MultigetGet201Response - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into MultigetGet201Response - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -1583,6 +1682,8 @@ impl std::ops::DerefMut for MyId {
     }
 }
 
+
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct MyIdList(Vec<i32>);
@@ -1606,7 +1707,7 @@ impl std::convert::From<MyIdList> for Vec<i32> {
 }
 
 impl std::iter::FromIterator<i32> for MyIdList {
-    fn from_iter<U: IntoIterator<Item = i32>>(u: U) -> Self {
+    fn from_iter<U: IntoIterator<Item=i32>>(u: U) -> Self {
         MyIdList(Vec::<i32>::from_iter(u))
     }
 }
@@ -1655,15 +1756,8 @@ impl std::ops::DerefMut for MyIdList {
 /// specified in https://swagger.io/docs/specification/serialization/
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for MyIdList {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            self.iter()
-                .map(|x| x.to_string())
-                .collect::<Vec<_>>()
-                .join(",")
-        )
+   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+       write!(f, "{}", self.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1675,12 +1769,14 @@ impl std::str::FromStr for MyIdList {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let mut items = vec![];
-        for item in s.split(',') {
+        for item in s.split(',')
+        {
             items.push(item.parse()?);
         }
         std::result::Result::Ok(MyIdList(items))
     }
 }
+
 
 // Methods for converting between header::IntoHeaderValue<MyIdList> and HeaderValue
 
@@ -1688,16 +1784,13 @@ impl std::str::FromStr for MyIdList {
 impl std::convert::TryFrom<header::IntoHeaderValue<MyIdList>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<MyIdList>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MyIdList>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for MyIdList - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for MyIdList - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1708,24 +1801,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<MyIdList> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <MyIdList as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <MyIdList as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into MyIdList - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into MyIdList - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -1745,7 +1837,7 @@ impl std::convert::From<String> for NullableObject {
 
 impl std::fmt::Display for NullableObject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.0)
+       write!(f, "{:?}", self.0)
     }
 }
 
@@ -1775,6 +1867,8 @@ impl std::ops::DerefMut for NullableObject {
     }
 }
 
+
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct NullableTest {
@@ -1784,46 +1878,197 @@ pub struct NullableTest {
     #[serde(rename = "nullableWithNullDefault")]
     #[serde(deserialize_with = "deserialize_optional_nullable")]
     #[serde(default = "default_optional_nullable")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_with_null_default: Option<Nullable<String>>,
 
     #[serde(rename = "nullableWithPresentDefault")]
     #[serde(deserialize_with = "deserialize_optional_nullable")]
     #[serde(default = "default_optional_nullable")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_with_present_default: Option<Nullable<String>>,
 
     #[serde(rename = "nullableWithNoDefault")]
     #[serde(deserialize_with = "deserialize_optional_nullable")]
     #[serde(default = "default_optional_nullable")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_with_no_default: Option<Nullable<String>>,
 
     #[serde(rename = "nullableArray")]
     #[serde(deserialize_with = "deserialize_optional_nullable")]
     #[serde(default = "default_optional_nullable")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_array: Option<Nullable<Vec<String>>>,
 
     #[serde(rename = "min_item_test")]
-    #[validate(length(min = 1))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(
+            length(min = 1),
+        )]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_item_test: Option<Vec<i32>>,
 
     #[serde(rename = "max_item_test")]
-    #[validate(length(max = 2))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(
+            length(max = 2),
+        )]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_item_test: Option<Vec<i32>>,
 
     #[serde(rename = "min_max_item_test")]
-    #[validate(length(min = 1, max = 3))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(
+            length(min = 1, max = 3),
+        )]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_max_item_test: Option<Vec<i32>>,
+
 }
 
 impl NullableTest {
+    fn __name_for_nullable() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='nullable', complexType='string', getter='getNullable', setter='setNullable', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='nullable', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.nullable;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "nullable" : true,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=true, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='nullable', nameInPascalCase='Nullable', nameInSnakeCase='NULLABLE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_nullable<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_nullable())
+        }
+}
+impl NullableTest {
+    fn __name_for_nullable_with_null_default() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='nullableWithNullDefault', complexType='string', getter='getNullableWithNullDefault', setter='setNullableWithNullDefault', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='nullable_with_null_default', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.nullableWithNullDefault;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "nullable" : true,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=true, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='nullableWithNullDefault', nameInPascalCase='NullableWithNullDefault', nameInSnakeCase='NULLABLE_WITH_NULL_DEFAULT', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_nullable_with_null_default<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_nullable_with_null_default())
+        }
+}
+impl NullableTest {
+    fn __name_for_nullable_with_present_default() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='nullableWithPresentDefault', complexType='string', getter='getNullableWithPresentDefault', setter='setNullableWithPresentDefault', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='nullable_with_present_default', min='null', max='null', defaultValue='Some(Nullable::Present(r#"default"#.to_string()))', defaultValueWithParam=' = data.nullableWithPresentDefault;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "default" : "default",
+  "nullable" : true,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=true, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='nullableWithPresentDefault', nameInPascalCase='NullableWithPresentDefault', nameInSnakeCase='NULLABLE_WITH_PRESENT_DEFAULT', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_nullable_with_present_default<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_nullable_with_present_default())
+        }
+}
+impl NullableTest {
+    fn __name_for_nullable_with_no_default() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='nullableWithNoDefault', complexType='string', getter='getNullableWithNoDefault', setter='setNullableWithNoDefault', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='nullable_with_no_default', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.nullableWithNoDefault;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "nullable" : true,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=true, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='nullableWithNoDefault', nameInPascalCase='NullableWithNoDefault', nameInSnakeCase='NULLABLE_WITH_NO_DEFAULT', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_nullable_with_no_default<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_nullable_with_no_default())
+        }
+}
+impl NullableTest {
+    fn __name_for_nullable_array() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='nullableArray', complexType='string', getter='getNullableArray', setter='setNullableArray', description='null', dataType='Vec<String>', datatypeWithEnum='Vec<String>', dataFormat='null', name='nullable_array', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.nullableArray;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "string"
+  },
+  "nullable" : true,
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=true, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='string', baseName='nullable_array', complexType='string', getter='getNullableArray', setter='setNullableArray', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='nullable_array', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.nullable_array;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='nullableArray', nameInPascalCase='NullableArray', nameInSnakeCase='NULLABLE_ARRAY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='nullable_array', complexType='string', getter='getNullableArray', setter='setNullableArray', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='nullable_array', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.nullable_array;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='nullableArray', nameInPascalCase='NullableArray', nameInSnakeCase='NULLABLE_ARRAY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='nullableArray', nameInPascalCase='NullableArray', nameInSnakeCase='NULLABLE_ARRAY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_nullable_array<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_nullable_array())
+        }
+}
+impl NullableTest {
+    fn __name_for_min_item_test() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='min_item_test', complexType='integer', getter='getMinItemTest', setter='setMinItemTest', description='null', dataType='Vec<i32>', datatypeWithEnum='Vec<i32>', dataFormat='null', name='min_item_test', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.min_item_test;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "integer"
+  },
+  "minItems" : 1,
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='integer', baseName='min_item_test', complexType='integer', getter='getMinItemTest', setter='setMinItemTest', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='null', name='min_item_test', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.min_item_test;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=false, isLong=false, isUnboundedInteger=true, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='minItemTest', nameInPascalCase='MinItemTest', nameInSnakeCase='MIN_ITEM_TEST', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='integer', baseName='min_item_test', complexType='integer', getter='getMinItemTest', setter='setMinItemTest', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='null', name='min_item_test', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.min_item_test;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=false, isLong=false, isUnboundedInteger=true, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='minItemTest', nameInPascalCase='MinItemTest', nameInSnakeCase='MIN_ITEM_TEST', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='minItemTest', nameInPascalCase='MinItemTest', nameInSnakeCase='MIN_ITEM_TEST', enumName='null', maxItems=null, minItems=1, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_min_item_test<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_min_item_test())
+        }
+}
+impl NullableTest {
+    fn __name_for_max_item_test() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='max_item_test', complexType='integer', getter='getMaxItemTest', setter='setMaxItemTest', description='null', dataType='Vec<i32>', datatypeWithEnum='Vec<i32>', dataFormat='null', name='max_item_test', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.max_item_test;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "integer"
+  },
+  "maxItems" : 2,
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='integer', baseName='max_item_test', complexType='integer', getter='getMaxItemTest', setter='setMaxItemTest', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='null', name='max_item_test', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.max_item_test;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=false, isLong=false, isUnboundedInteger=true, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='maxItemTest', nameInPascalCase='MaxItemTest', nameInSnakeCase='MAX_ITEM_TEST', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='integer', baseName='max_item_test', complexType='integer', getter='getMaxItemTest', setter='setMaxItemTest', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='null', name='max_item_test', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.max_item_test;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=false, isLong=false, isUnboundedInteger=true, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='maxItemTest', nameInPascalCase='MaxItemTest', nameInSnakeCase='MAX_ITEM_TEST', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='maxItemTest', nameInPascalCase='MaxItemTest', nameInSnakeCase='MAX_ITEM_TEST', enumName='null', maxItems=2, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_max_item_test<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_max_item_test())
+        }
+}
+impl NullableTest {
+    fn __name_for_min_max_item_test() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='min_max_item_test', complexType='integer', getter='getMinMaxItemTest', setter='setMinMaxItemTest', description='null', dataType='Vec<i32>', datatypeWithEnum='Vec<i32>', dataFormat='null', name='min_max_item_test', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.min_max_item_test;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "integer"
+  },
+  "maxItems" : 3,
+  "minItems" : 1,
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='integer', baseName='min_max_item_test', complexType='integer', getter='getMinMaxItemTest', setter='setMinMaxItemTest', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='null', name='min_max_item_test', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.min_max_item_test;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=false, isLong=false, isUnboundedInteger=true, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='minMaxItemTest', nameInPascalCase='MinMaxItemTest', nameInSnakeCase='MIN_MAX_ITEM_TEST', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='integer', baseName='min_max_item_test', complexType='integer', getter='getMinMaxItemTest', setter='setMinMaxItemTest', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='null', name='min_max_item_test', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.min_max_item_test;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=false, isLong=false, isUnboundedInteger=true, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='minMaxItemTest', nameInPascalCase='MinMaxItemTest', nameInSnakeCase='MIN_MAX_ITEM_TEST', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='minMaxItemTest', nameInPascalCase='MinMaxItemTest', nameInSnakeCase='MIN_MAX_ITEM_TEST', enumName='null', maxItems=3, minItems=1, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_min_max_item_test<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_min_max_item_test())
+        }
+}
+
+
+impl NullableTest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(nullable: Nullable<String>) -> NullableTest {
+    pub fn new(nullable: Nullable<String>, ) -> NullableTest {
         NullableTest {
             nullable,
             nullable_with_null_default: None,
@@ -1843,97 +2088,69 @@ impl NullableTest {
 impl std::fmt::Display for NullableTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             Some("nullable".to_string()),
-            Some(
-                self.nullable
-                    .as_ref()
-                    .map_or("null".to_string(), |x| x.to_string()),
-            ),
-            self.nullable_with_null_default
-                .as_ref()
-                .map(|nullable_with_null_default| {
-                    [
-                        "nullableWithNullDefault".to_string(),
-                        nullable_with_null_default
-                            .as_ref()
-                            .map_or("null".to_string(), |x| x.to_string()),
-                    ]
-                    .join(",")
-                }),
-            self.nullable_with_present_default
-                .as_ref()
-                .map(|nullable_with_present_default| {
-                    [
-                        "nullableWithPresentDefault".to_string(),
-                        nullable_with_present_default
-                            .as_ref()
-                            .map_or("null".to_string(), |x| x.to_string()),
-                    ]
-                    .join(",")
-                }),
-            self.nullable_with_no_default
-                .as_ref()
-                .map(|nullable_with_no_default| {
-                    [
-                        "nullableWithNoDefault".to_string(),
-                        nullable_with_no_default
-                            .as_ref()
-                            .map_or("null".to_string(), |x| x.to_string()),
-                    ]
-                    .join(",")
-                }),
+            Some(self.nullable.as_ref().map_or("null".to_string(), |x| x.to_string())),
+
+
+            self.nullable_with_null_default.as_ref().map(|nullable_with_null_default| {
+                [
+                    "nullableWithNullDefault".to_string(),
+                    nullable_with_null_default.as_ref().map_or("null".to_string(), |x| x.to_string()),
+                ].join(",")
+            }),
+
+
+            self.nullable_with_present_default.as_ref().map(|nullable_with_present_default| {
+                [
+                    "nullableWithPresentDefault".to_string(),
+                    nullable_with_present_default.as_ref().map_or("null".to_string(), |x| x.to_string()),
+                ].join(",")
+            }),
+
+
+            self.nullable_with_no_default.as_ref().map(|nullable_with_no_default| {
+                [
+                    "nullableWithNoDefault".to_string(),
+                    nullable_with_no_default.as_ref().map_or("null".to_string(), |x| x.to_string()),
+                ].join(",")
+            }),
+
+
             self.nullable_array.as_ref().map(|nullable_array| {
                 [
                     "nullableArray".to_string(),
-                    nullable_array.as_ref().map_or("null".to_string(), |x| {
-                        x.iter()
-                            .map(|x| x.to_string())
-                            .collect::<Vec<_>>()
-                            .join(",")
-                    }),
-                ]
-                .join(",")
+                    nullable_array.as_ref().map_or("null".to_string(), |x| x.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(",")),
+                ].join(",")
             }),
+
+
             self.min_item_test.as_ref().map(|min_item_test| {
                 [
                     "min_item_test".to_string(),
-                    min_item_test
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<_>>()
-                        .join(","),
-                ]
-                .join(",")
+                    min_item_test.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","),
+                ].join(",")
             }),
+
+
             self.max_item_test.as_ref().map(|max_item_test| {
                 [
                     "max_item_test".to_string(),
-                    max_item_test
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<_>>()
-                        .join(","),
-                ]
-                .join(",")
+                    max_item_test.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","),
+                ].join(",")
             }),
+
+
             self.min_max_item_test.as_ref().map(|min_max_item_test| {
                 [
                     "min_max_item_test".to_string(),
-                    min_max_item_test
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<_>>()
-                        .join(","),
-                ]
-                .join(",")
+                    min_max_item_test.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","),
+                ].join(",")
             }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1967,61 +2184,21 @@ impl std::str::FromStr for NullableTest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing NullableTest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing NullableTest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
-                    "nullable" => return std::result::Result::Err(
-                        "Parsing a nullable type in this style is not supported in NullableTest"
-                            .to_string(),
-                    ),
-                    "nullableWithNullDefault" => return std::result::Result::Err(
-                        "Parsing a nullable type in this style is not supported in NullableTest"
-                            .to_string(),
-                    ),
-                    "nullableWithPresentDefault" => return std::result::Result::Err(
-                        "Parsing a nullable type in this style is not supported in NullableTest"
-                            .to_string(),
-                    ),
-                    "nullableWithNoDefault" => return std::result::Result::Err(
-                        "Parsing a nullable type in this style is not supported in NullableTest"
-                            .to_string(),
-                    ),
-                    "nullableArray" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in NullableTest"
-                                .to_string(),
-                        )
-                    }
-                    "min_item_test" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in NullableTest"
-                                .to_string(),
-                        )
-                    }
-                    "max_item_test" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in NullableTest"
-                                .to_string(),
-                        )
-                    }
-                    "min_max_item_test" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in NullableTest"
-                                .to_string(),
-                        )
-                    }
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing NullableTest".to_string(),
-                        )
-                    }
+                    "nullable" => return std::result::Result::Err("Parsing a nullable type in this style is not supported in NullableTest".to_string()),
+                    "nullableWithNullDefault" => return std::result::Result::Err("Parsing a nullable type in this style is not supported in NullableTest".to_string()),
+                    "nullableWithPresentDefault" => return std::result::Result::Err("Parsing a nullable type in this style is not supported in NullableTest".to_string()),
+                    "nullableWithNoDefault" => return std::result::Result::Err("Parsing a nullable type in this style is not supported in NullableTest".to_string()),
+                    "nullableArray" => return std::result::Result::Err("Parsing a container in this style is not supported in NullableTest".to_string()),
+                    "min_item_test" => return std::result::Result::Err("Parsing a container in this style is not supported in NullableTest".to_string()),
+                    "max_item_test" => return std::result::Result::Err("Parsing a container in this style is not supported in NullableTest".to_string()),
+                    "min_max_item_test" => return std::result::Result::Err("Parsing a container in this style is not supported in NullableTest".to_string()),
+                    _ => return std::result::Result::Err("Unexpected key while parsing NullableTest".to_string())
                 }
             }
 
@@ -2031,21 +2208,11 @@ impl std::str::FromStr for NullableTest {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(NullableTest {
-            nullable: std::result::Result::Err(
-                "Nullable types not supported in NullableTest".to_string(),
-            )?,
-            nullable_with_null_default: std::result::Result::Err(
-                "Nullable types not supported in NullableTest".to_string(),
-            )?,
-            nullable_with_present_default: std::result::Result::Err(
-                "Nullable types not supported in NullableTest".to_string(),
-            )?,
-            nullable_with_no_default: std::result::Result::Err(
-                "Nullable types not supported in NullableTest".to_string(),
-            )?,
-            nullable_array: std::result::Result::Err(
-                "Nullable types not supported in NullableTest".to_string(),
-            )?,
+            nullable: std::result::Result::Err("Nullable types not supported in NullableTest".to_string())?,
+            nullable_with_null_default: std::result::Result::Err("Nullable types not supported in NullableTest".to_string())?,
+            nullable_with_present_default: std::result::Result::Err("Nullable types not supported in NullableTest".to_string())?,
+            nullable_with_no_default: std::result::Result::Err("Nullable types not supported in NullableTest".to_string())?,
+            nullable_array: std::result::Result::Err("Nullable types not supported in NullableTest".to_string())?,
             min_item_test: intermediate_rep.min_item_test.into_iter().next(),
             max_item_test: intermediate_rep.max_item_test.into_iter().next(),
             min_max_item_test: intermediate_rep.min_max_item_test.into_iter().next(),
@@ -2059,16 +2226,13 @@ impl std::str::FromStr for NullableTest {
 impl std::convert::TryFrom<header::IntoHeaderValue<NullableTest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<NullableTest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<NullableTest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for NullableTest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for NullableTest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2079,24 +2243,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<NullableTest
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <NullableTest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <NullableTest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into NullableTest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into NullableTest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -2105,13 +2268,42 @@ pub struct ObjectHeader {
     pub required_object_header: bool,
 
     #[serde(rename = "optionalObjectHeader")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub optional_object_header: Option<i32>,
+
 }
 
 impl ObjectHeader {
+    fn __name_for_required_object_header() -> String {
+        String::from("CodegenProperty{openApiType='boolean', baseName='requiredObjectHeader', complexType='boolean', getter='getRequiredObjectHeader', setter='setRequiredObjectHeader', description='null', dataType='bool', datatypeWithEnum='bool', dataFormat='null', name='required_object_header', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.requiredObjectHeader;', baseType='boolean', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "boolean"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=true, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='requiredObjectHeader', nameInPascalCase='RequiredObjectHeader', nameInSnakeCase='REQUIRED_OBJECT_HEADER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_required_object_header<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_required_object_header())
+        }
+}
+impl ObjectHeader {
+    fn __name_for_optional_object_header() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='optionalObjectHeader', complexType='integer', getter='getOptionalObjectHeader', setter='setOptionalObjectHeader', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='null', name='optional_object_header', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.optionalObjectHeader;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=false, isLong=false, isUnboundedInteger=true, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='optionalObjectHeader', nameInPascalCase='OptionalObjectHeader', nameInSnakeCase='OPTIONAL_OBJECT_HEADER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_optional_object_header<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_optional_object_header())
+        }
+}
+
+
+impl ObjectHeader {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(required_object_header: bool) -> ObjectHeader {
+    pub fn new(required_object_header: bool, ) -> ObjectHeader {
         ObjectHeader {
             required_object_header,
             optional_object_header: None,
@@ -2125,24 +2317,21 @@ impl ObjectHeader {
 impl std::fmt::Display for ObjectHeader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             Some("requiredObjectHeader".to_string()),
             Some(self.required_object_header.to_string()),
-            self.optional_object_header
-                .as_ref()
-                .map(|optional_object_header| {
-                    [
-                        "optionalObjectHeader".to_string(),
-                        optional_object_header.to_string(),
-                    ]
-                    .join(",")
-                }),
+
+
+            self.optional_object_header.as_ref().map(|optional_object_header| {
+                [
+                    "optionalObjectHeader".to_string(),
+                    optional_object_header.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -2170,29 +2359,17 @@ impl std::str::FromStr for ObjectHeader {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing ObjectHeader".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing ObjectHeader".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "requiredObjectHeader" => intermediate_rep.required_object_header.push(
-                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "requiredObjectHeader" => intermediate_rep.required_object_header.push(<bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "optionalObjectHeader" => intermediate_rep.optional_object_header.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing ObjectHeader".to_string(),
-                        )
-                    }
+                    "optionalObjectHeader" => intermediate_rep.optional_object_header.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing ObjectHeader".to_string())
                 }
             }
 
@@ -2202,11 +2379,7 @@ impl std::str::FromStr for ObjectHeader {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(ObjectHeader {
-            required_object_header: intermediate_rep
-                .required_object_header
-                .into_iter()
-                .next()
-                .ok_or_else(|| "requiredObjectHeader missing in ObjectHeader".to_string())?,
+            required_object_header: intermediate_rep.required_object_header.into_iter().next().ok_or_else(|| "requiredObjectHeader missing in ObjectHeader".to_string())?,
             optional_object_header: intermediate_rep.optional_object_header.into_iter().next(),
         })
     }
@@ -2218,16 +2391,13 @@ impl std::str::FromStr for ObjectHeader {
 impl std::convert::TryFrom<header::IntoHeaderValue<ObjectHeader>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<ObjectHeader>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectHeader>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for ObjectHeader - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ObjectHeader - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2238,24 +2408,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ObjectHeader
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <ObjectHeader as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <ObjectHeader as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ObjectHeader - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into ObjectHeader - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -2264,13 +2433,42 @@ pub struct ObjectParam {
     pub required_param: bool,
 
     #[serde(rename = "optionalParam")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub optional_param: Option<i32>,
+
 }
 
 impl ObjectParam {
+    fn __name_for_required_param() -> String {
+        String::from("CodegenProperty{openApiType='boolean', baseName='requiredParam', complexType='boolean', getter='getRequiredParam', setter='setRequiredParam', description='null', dataType='bool', datatypeWithEnum='bool', dataFormat='null', name='required_param', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.requiredParam;', baseType='boolean', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "boolean"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=true, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='requiredParam', nameInPascalCase='RequiredParam', nameInSnakeCase='REQUIRED_PARAM', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_required_param<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_required_param())
+        }
+}
+impl ObjectParam {
+    fn __name_for_optional_param() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='optionalParam', complexType='integer', getter='getOptionalParam', setter='setOptionalParam', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='null', name='optional_param', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.optionalParam;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=false, isLong=false, isUnboundedInteger=true, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='optionalParam', nameInPascalCase='OptionalParam', nameInSnakeCase='OPTIONAL_PARAM', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_optional_param<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_optional_param())
+        }
+}
+
+
+impl ObjectParam {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(required_param: bool) -> ObjectParam {
+    pub fn new(required_param: bool, ) -> ObjectParam {
         ObjectParam {
             required_param,
             optional_param: None,
@@ -2284,18 +2482,21 @@ impl ObjectParam {
 impl std::fmt::Display for ObjectParam {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             Some("requiredParam".to_string()),
             Some(self.required_param.to_string()),
+
+
             self.optional_param.as_ref().map(|optional_param| {
-                ["optionalParam".to_string(), optional_param.to_string()].join(",")
+                [
+                    "optionalParam".to_string(),
+                    optional_param.to_string(),
+                ].join(",")
             }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -2323,29 +2524,17 @@ impl std::str::FromStr for ObjectParam {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing ObjectParam".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing ObjectParam".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "requiredParam" => intermediate_rep.required_param.push(
-                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "requiredParam" => intermediate_rep.required_param.push(<bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "optionalParam" => intermediate_rep.optional_param.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing ObjectParam".to_string(),
-                        )
-                    }
+                    "optionalParam" => intermediate_rep.optional_param.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing ObjectParam".to_string())
                 }
             }
 
@@ -2355,11 +2544,7 @@ impl std::str::FromStr for ObjectParam {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(ObjectParam {
-            required_param: intermediate_rep
-                .required_param
-                .into_iter()
-                .next()
-                .ok_or_else(|| "requiredParam missing in ObjectParam".to_string())?,
+            required_param: intermediate_rep.required_param.into_iter().next().ok_or_else(|| "requiredParam missing in ObjectParam".to_string())?,
             optional_param: intermediate_rep.optional_param.into_iter().next(),
         })
     }
@@ -2371,16 +2556,13 @@ impl std::str::FromStr for ObjectParam {
 impl std::convert::TryFrom<header::IntoHeaderValue<ObjectParam>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<ObjectParam>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectParam>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for ObjectParam - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ObjectParam - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2391,24 +2573,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ObjectParam>
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <ObjectParam as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <ObjectParam as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ObjectParam - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into ObjectParam - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -2420,20 +2601,72 @@ pub struct ObjectUntypedProps {
     pub required_untyped_nullable: Nullable<crate::types::Object>,
 
     #[serde(rename = "not_required_untyped")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub not_required_untyped: Option<crate::types::Object>,
 
     #[serde(rename = "not_required_untyped_nullable")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub not_required_untyped_nullable: Option<crate::types::Object>,
+
 }
 
 impl ObjectUntypedProps {
+    fn __name_for_required_untyped() -> String {
+        String::from("CodegenProperty{openApiType='AnyType', baseName='required_untyped', complexType='null', getter='getRequiredUntyped', setter='setRequiredUntyped', description='null', dataType='crate::types::Object', datatypeWithEnum='crate::types::Object', dataFormat='null', name='required_untyped', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.required_untyped;', baseType='AnyType', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "nullable" : false
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=true, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='requiredUntyped', nameInPascalCase='RequiredUntyped', nameInSnakeCase='REQUIRED_UNTYPED', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_required_untyped<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_required_untyped())
+        }
+}
+impl ObjectUntypedProps {
+    fn __name_for_required_untyped_nullable() -> String {
+        String::from("CodegenProperty{openApiType='AnyType', baseName='required_untyped_nullable', complexType='null', getter='getRequiredUntypedNullable', setter='setRequiredUntypedNullable', description='null', dataType='crate::types::Object', datatypeWithEnum='crate::types::Object', dataFormat='null', name='required_untyped_nullable', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.required_untyped_nullable;', baseType='AnyType', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "nullable" : true
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=true, isReadOnly=false, isWriteOnly=false, isNullable=true, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='requiredUntypedNullable', nameInPascalCase='RequiredUntypedNullable', nameInSnakeCase='REQUIRED_UNTYPED_NULLABLE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_required_untyped_nullable<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_required_untyped_nullable())
+        }
+}
+impl ObjectUntypedProps {
+    fn __name_for_not_required_untyped() -> String {
+        String::from("CodegenProperty{openApiType='AnyType', baseName='not_required_untyped', complexType='null', getter='getNotRequiredUntyped', setter='setNotRequiredUntyped', description='null', dataType='crate::types::Object', datatypeWithEnum='crate::types::Object', dataFormat='null', name='not_required_untyped', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.not_required_untyped;', baseType='AnyType', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "nullable" : false
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=true, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='notRequiredUntyped', nameInPascalCase='NotRequiredUntyped', nameInSnakeCase='NOT_REQUIRED_UNTYPED', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_not_required_untyped<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_not_required_untyped())
+        }
+}
+impl ObjectUntypedProps {
+    fn __name_for_not_required_untyped_nullable() -> String {
+        String::from("CodegenProperty{openApiType='AnyType', baseName='not_required_untyped_nullable', complexType='null', getter='getNotRequiredUntypedNullable', setter='setNotRequiredUntypedNullable', description='null', dataType='crate::types::Object', datatypeWithEnum='crate::types::Object', dataFormat='null', name='not_required_untyped_nullable', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.not_required_untyped_nullable;', baseType='AnyType', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "nullable" : false
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=true, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='notRequiredUntypedNullable', nameInPascalCase='NotRequiredUntypedNullable', nameInSnakeCase='NOT_REQUIRED_UNTYPED_NULLABLE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_not_required_untyped_nullable<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_not_required_untyped_nullable())
+        }
+}
+
+
+impl ObjectUntypedProps {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(
-        required_untyped: crate::types::Object,
-        required_untyped_nullable: Nullable<crate::types::Object>,
-    ) -> ObjectUntypedProps {
+    pub fn new(required_untyped: crate::types::Object, required_untyped_nullable: Nullable<crate::types::Object>, ) -> ObjectUntypedProps {
         ObjectUntypedProps {
             required_untyped,
             required_untyped_nullable,
@@ -2459,11 +2692,7 @@ impl std::fmt::Display for ObjectUntypedProps {
 
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -2493,11 +2722,7 @@ impl std::str::FromStr for ObjectUntypedProps {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing ObjectUntypedProps".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing ObjectUntypedProps".to_string())
             };
 
             if let Some(key) = key_result {
@@ -2520,19 +2745,10 @@ impl std::str::FromStr for ObjectUntypedProps {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(ObjectUntypedProps {
-            required_untyped: intermediate_rep
-                .required_untyped
-                .into_iter()
-                .next()
-                .ok_or_else(|| "required_untyped missing in ObjectUntypedProps".to_string())?,
-            required_untyped_nullable: std::result::Result::Err(
-                "Nullable types not supported in ObjectUntypedProps".to_string(),
-            )?,
+            required_untyped: intermediate_rep.required_untyped.into_iter().next().ok_or_else(|| "required_untyped missing in ObjectUntypedProps".to_string())?,
+            required_untyped_nullable: std::result::Result::Err("Nullable types not supported in ObjectUntypedProps".to_string())?,
             not_required_untyped: intermediate_rep.not_required_untyped.into_iter().next(),
-            not_required_untyped_nullable: intermediate_rep
-                .not_required_untyped_nullable
-                .into_iter()
-                .next(),
+            not_required_untyped_nullable: intermediate_rep.not_required_untyped_nullable.into_iter().next(),
         })
     }
 }
@@ -2543,16 +2759,13 @@ impl std::str::FromStr for ObjectUntypedProps {
 impl std::convert::TryFrom<header::IntoHeaderValue<ObjectUntypedProps>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<ObjectUntypedProps>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectUntypedProps>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for ObjectUntypedProps - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ObjectUntypedProps - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2563,37 +2776,61 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ObjectUntype
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <ObjectUntypedProps as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <ObjectUntypedProps as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ObjectUntypedProps - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into ObjectUntypedProps - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ObjectWithArrayOfObjects {
     #[serde(rename = "objectArray")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub object_array: Option<Vec<models::StringObject>>,
+
 }
+
+impl ObjectWithArrayOfObjects {
+    fn __name_for_object_array() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='objectArray', complexType='string', getter='getObjectArray', setter='setObjectArray', description='null', dataType='Vec<models::StringObject>', datatypeWithEnum='Vec<models::StringObject>', dataFormat='null', name='object_array', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.objectArray;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "$ref" : "#/components/schemas/StringObject"
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='string', baseName='object_array', complexType='string', getter='getObjectArray', setter='setObjectArray', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='object_array', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.object_array;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='objectArray', nameInPascalCase='ObjectArray', nameInSnakeCase='OBJECT_ARRAY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='object_array', complexType='string', getter='getObjectArray', setter='setObjectArray', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='object_array', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.object_array;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='objectArray', nameInPascalCase='ObjectArray', nameInSnakeCase='OBJECT_ARRAY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='objectArray', nameInPascalCase='ObjectArray', nameInSnakeCase='OBJECT_ARRAY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_object_array<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_object_array())
+        }
+}
+
 
 impl ObjectWithArrayOfObjects {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new() -> ObjectWithArrayOfObjects {
-        ObjectWithArrayOfObjects { object_array: None }
+        ObjectWithArrayOfObjects {
+            object_array: None,
+        }
     }
 }
 
@@ -2602,23 +2839,18 @@ impl ObjectWithArrayOfObjects {
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for ObjectWithArrayOfObjects {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> = vec![self.object_array.as_ref().map(|object_array| {
-            [
-                "objectArray".to_string(),
-                object_array
-                    .iter()
-                    .map(|x| x.to_string())
-                    .collect::<Vec<_>>()
-                    .join(","),
-            ]
-            .join(",")
-        })];
+        let params: Vec<Option<String>> = vec![
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+            self.object_array.as_ref().map(|object_array| {
+                [
+                    "objectArray".to_string(),
+                    object_array.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","),
+                ].join(",")
+            }),
+
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -2645,11 +2877,7 @@ impl std::str::FromStr for ObjectWithArrayOfObjects {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing ObjectWithArrayOfObjects".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing ObjectWithArrayOfObjects".to_string())
             };
 
             if let Some(key) = key_result {
@@ -2677,16 +2905,13 @@ impl std::str::FromStr for ObjectWithArrayOfObjects {
 impl std::convert::TryFrom<header::IntoHeaderValue<ObjectWithArrayOfObjects>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<ObjectWithArrayOfObjects>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectWithArrayOfObjects>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for ObjectWithArrayOfObjects - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ObjectWithArrayOfObjects - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2697,24 +2922,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ObjectWithAr
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <ObjectWithArrayOfObjects as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <ObjectWithArrayOfObjects as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ObjectWithArrayOfObjects - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into ObjectWithArrayOfObjects - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -2734,7 +2958,7 @@ impl std::convert::From<String> for Ok {
 
 impl std::fmt::Display for Ok {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.0)
+       write!(f, "{:?}", self.0)
     }
 }
 
@@ -2764,15 +2988,37 @@ impl std::ops::DerefMut for Ok {
     }
 }
 
-/// One of:
-/// - Vec<String>
-/// - i32
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct OneOfGet200Response(Box<serde_json::value::RawValue>);
 
-impl validator::Validate for OneOfGet200Response {
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+#[allow(non_camel_case_types)]
+pub enum OneOfGet200Response {
+    I32(Box<i32>),
+    VecOfString(Box<Vec<String>>),
+}
+
+impl validator::Validate for OneOfGet200Response
+{
     fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
-        std::result::Result::Ok(())
+        match self {
+            Self::I32(x) => x.validate(),
+            Self::VecOfString(x) => x.validate(),
+        }
+    }
+}
+
+
+
+
+impl From<i32> for OneOfGet200Response {
+    fn from(value: i32) -> Self {
+        Self::I32(Box::new(value))
+    }
+}
+impl From<Vec<String>> for OneOfGet200Response {
+    fn from(value: Vec<String>) -> Self {
+        Self::VecOfString(Box::new(value))
     }
 }
 
@@ -2787,11 +3033,9 @@ impl std::str::FromStr for OneOfGet200Response {
     }
 }
 
-impl PartialEq for OneOfGet200Response {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.get() == other.0.get()
-    }
-}
+
+
+
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -2828,6 +3072,8 @@ impl std::ops::DerefMut for OptionalObjectHeader {
     }
 }
 
+
+
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct RequiredObjectHeader(bool);
@@ -2863,6 +3109,8 @@ impl std::ops::DerefMut for RequiredObjectHeader {
     }
 }
 
+
+
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Result(String);
@@ -2881,7 +3129,7 @@ impl std::convert::From<String> for Result {
 
 impl std::fmt::Display for Result {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.0)
+       write!(f, "{:?}", self.0)
     }
 }
 
@@ -2911,14 +3159,14 @@ impl std::ops::DerefMut for Result {
     }
 }
 
+
+
 /// Enumeration of values.
 /// Since this enum's variants do not hold data, we can easily define them as `#[repr(C)]`
 /// which helps with FFI.
 #[allow(non_camel_case_types)]
 #[repr(C)]
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum StringEnum {
     #[serde(rename = "FOO")]
@@ -2948,6 +3196,7 @@ impl std::str::FromStr for StringEnum {
     }
 }
 
+
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct StringObject(String);
@@ -2966,7 +3215,7 @@ impl std::convert::From<String> for StringObject {
 
 impl std::fmt::Display for StringObject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.0)
+       write!(f, "{:?}", self.0)
     }
 }
 
@@ -2995,6 +3244,8 @@ impl std::ops::DerefMut for StringObject {
         &mut self.0
     }
 }
+
+
 
 /// Test a model containing a UUID
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
@@ -3032,6 +3283,8 @@ impl std::ops::DerefMut for UuidObject {
     }
 }
 
+
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct XmlArray(Vec<String>);
@@ -3055,7 +3308,7 @@ impl std::convert::From<XmlArray> for Vec<String> {
 }
 
 impl std::iter::FromIterator<String> for XmlArray {
-    fn from_iter<U: IntoIterator<Item = String>>(u: U) -> Self {
+    fn from_iter<U: IntoIterator<Item=String>>(u: U) -> Self {
         XmlArray(Vec::<String>::from_iter(u))
     }
 }
@@ -3104,15 +3357,8 @@ impl std::ops::DerefMut for XmlArray {
 /// specified in https://swagger.io/docs/specification/serialization/
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for XmlArray {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            self.iter()
-                .map(|x| x.to_string())
-                .collect::<Vec<_>>()
-                .join(",")
-        )
+   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+       write!(f, "{}", self.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","))
     }
 }
 
@@ -3124,12 +3370,14 @@ impl std::str::FromStr for XmlArray {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let mut items = vec![];
-        for item in s.split(',') {
+        for item in s.split(',')
+        {
             items.push(item.parse()?);
         }
         std::result::Result::Ok(XmlArray(items))
     }
 }
+
 
 // Methods for converting between header::IntoHeaderValue<XmlArray> and HeaderValue
 
@@ -3137,16 +3385,13 @@ impl std::str::FromStr for XmlArray {
 impl std::convert::TryFrom<header::IntoHeaderValue<XmlArray>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<XmlArray>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<XmlArray>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for XmlArray - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for XmlArray - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3157,24 +3402,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<XmlArray> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <XmlArray as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <XmlArray as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into XmlArray - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into XmlArray - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -3194,7 +3438,7 @@ impl std::convert::From<String> for XmlInner {
 
 impl std::fmt::Display for XmlInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.0)
+       write!(f, "{:?}", self.0)
     }
 }
 
@@ -3224,18 +3468,49 @@ impl std::ops::DerefMut for XmlInner {
     }
 }
 
+
+
 /// An XML object
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct XmlObject {
     #[serde(rename = "innerString")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub inner_string: Option<String>,
 
     #[serde(rename = "other_inner_rename")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub other_inner_rename: Option<i32>,
+
 }
+
+impl XmlObject {
+    fn __name_for_inner_string() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='innerString', complexType='string', getter='getInnerString', setter='setInnerString', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner_string', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.innerString;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='innerString', nameInPascalCase='InnerString', nameInSnakeCase='INNER_STRING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_inner_string<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_inner_string())
+        }
+}
+impl XmlObject {
+    fn __name_for_other_inner_rename() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='other_inner_rename', complexType='integer', getter='getOtherInnerRename', setter='setOtherInnerRename', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='null', name='other_inner_rename', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.other_inner_rename;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=false, isLong=false, isUnboundedInteger=true, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='otherInnerRename', nameInPascalCase='OtherInnerRename', nameInSnakeCase='OTHER_INNER_RENAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_other_inner_rename<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_other_inner_rename())
+        }
+}
+
 
 impl XmlObject {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -3253,23 +3528,25 @@ impl XmlObject {
 impl std::fmt::Display for XmlObject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             self.inner_string.as_ref().map(|inner_string| {
-                ["innerString".to_string(), inner_string.to_string()].join(",")
+                [
+                    "innerString".to_string(),
+                    inner_string.to_string(),
+                ].join(",")
             }),
+
+
             self.other_inner_rename.as_ref().map(|other_inner_rename| {
                 [
                     "other_inner_rename".to_string(),
                     other_inner_rename.to_string(),
-                ]
-                .join(",")
+                ].join(",")
             }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -3297,29 +3574,17 @@ impl std::str::FromStr for XmlObject {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing XmlObject".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing XmlObject".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "innerString" => intermediate_rep.inner_string.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "innerString" => intermediate_rep.inner_string.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "other_inner_rename" => intermediate_rep.other_inner_rename.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing XmlObject".to_string(),
-                        )
-                    }
+                    "other_inner_rename" => intermediate_rep.other_inner_rename.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing XmlObject".to_string())
                 }
             }
 
@@ -3341,16 +3606,13 @@ impl std::str::FromStr for XmlObject {
 impl std::convert::TryFrom<header::IntoHeaderValue<XmlObject>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<XmlObject>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<XmlObject>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for XmlObject - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for XmlObject - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3361,21 +3623,20 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<XmlObject> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <XmlObject as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <XmlObject as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into XmlObject - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into XmlObject - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -6,7 +6,7 @@
     unused_extern_crates,
     non_camel_case_types,
     unused_imports,
-    unused_attributes
+    unused_attributes,
 )]
 #![allow(
     clippy::derive_partial_eq_without_eq,
@@ -20,9 +20,9 @@ pub const API_VERSION: &str = "1.0.0";
 #[cfg(feature = "server")]
 pub mod server;
 
-pub mod apis;
 pub mod models;
 pub mod types;
+pub mod apis;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
@@ -7,162 +7,280 @@ use validator::Validate;
 use crate::header;
 use crate::{models, types::*};
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct HyphenParamPathParams {
-    /// Parameter with hyphen in name
-    pub hyphen_param: String,
-}
+      
+      
+      
+      
+      
+      
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct HyphenParamPathParams {
+            /// Parameter with hyphen in name
+                pub hyphen_param: String,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct TestBodyWithQueryParamsQueryParams {
-    #[serde(rename = "query")]
-    pub query: String,
-}
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct TestEnumParametersHeaderParams {
-    pub enum_header_string_array: Option<Vec<String>>,
-    pub enum_header_string: Option<String>,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct TestBodyWithQueryParamsQueryParams {
+                #[serde(rename = "query")]
+                pub query: String,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct TestEnumParametersQueryParams {
-    /// Query parameter enum test (string array)
-    /// Note: inline enums are not fully supported by openapi-generator
-    #[serde(rename = "enum_query_string_array")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enum_query_string_array: Option<Vec<String>>,
-    /// Query parameter enum test (string)
-    /// Note: inline enums are not fully supported by openapi-generator
-    #[serde(rename = "enum_query_string")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enum_query_string: Option<String>,
-    /// Query parameter enum test (double)
-    /// Note: inline enums are not fully supported by openapi-generator
-    #[serde(rename = "enum_query_integer")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enum_query_integer: Option<i32>,
-    /// Query parameter enum test (double)
-    /// Note: inline enums are not fully supported by openapi-generator
-    #[serde(rename = "enum_query_double")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enum_query_double: Option<f64>,
-}
+      
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+    pub struct TestEnumParametersHeaderParams {
+        pub enum_header_string_array: Option<Vec<String>>,
+        pub enum_header_string: Option<String>,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct DeletePetHeaderParams {
-    pub api_key: Option<String>,
-}
+            
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct TestEnumParametersQueryParams {
+            /// Query parameter enum test (string array)
+            /// Note: inline enums are not fully supported by openapi-generator
+                #[serde(rename = "enum_query_string_array")]
+                #[serde(skip_serializing_if="Option::is_none")]
+                pub enum_query_string_array: Option<Vec<String>>,
+            /// Query parameter enum test (string)
+            /// Note: inline enums are not fully supported by openapi-generator
+                #[serde(rename = "enum_query_string")]
+                #[serde(skip_serializing_if="Option::is_none")]
+                pub enum_query_string: Option<String>,
+            /// Query parameter enum test (double)
+            /// Note: inline enums are not fully supported by openapi-generator
+                #[serde(rename = "enum_query_integer")]
+                #[serde(skip_serializing_if="Option::is_none")]
+                pub enum_query_integer: Option<i32>,
+            /// Query parameter enum test (double)
+            /// Note: inline enums are not fully supported by openapi-generator
+                #[serde(rename = "enum_query_double")]
+                #[serde(skip_serializing_if="Option::is_none")]
+                pub enum_query_double: Option<f64>,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct DeletePetPathParams {
-    /// Pet id to delete
-    pub pet_id: i64,
-}
+      
+      
+      
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+    pub struct DeletePetHeaderParams {
+        pub api_key: Option<String>,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct FindPetsByStatusQueryParams {
-    /// Status values that need to be considered for filter
-    /// Note: inline enums are not fully supported by openapi-generator
-    #[serde(rename = "status")]
-    pub status: Vec<String>,
-}
+            
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct DeletePetPathParams {
+            /// Pet id to delete
+                pub pet_id: i64,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct FindPetsByTagsQueryParams {
-    /// Tags to filter by
-    #[serde(rename = "tags")]
-    pub tags: Vec<String>,
-}
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct GetPetByIdPathParams {
-    /// ID of pet to return
-    pub pet_id: i64,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct FindPetsByStatusQueryParams {
+            /// Status values that need to be considered for filter
+            /// Note: inline enums are not fully supported by openapi-generator
+                #[serde(rename = "status")]
+                pub status: Vec<String>,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct UpdatePetWithFormPathParams {
-    /// ID of pet that needs to be updated
-    pub pet_id: i64,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct FindPetsByTagsQueryParams {
+            /// Tags to filter by
+                #[serde(rename = "tags")]
+                pub tags: Vec<String>,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct UploadFilePathParams {
-    /// ID of pet to update
-    pub pet_id: i64,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct GetPetByIdPathParams {
+            /// ID of pet to return
+                pub pet_id: i64,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct DeleteOrderPathParams {
-    /// ID of the order that needs to be deleted
-    pub order_id: String,
-}
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct GetOrderByIdPathParams {
-    /// ID of pet that needs to be fetched
-    #[validate(range(min = 1i64, max = 5i64))]
-    pub order_id: i64,
-}
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct UpdatePetWithFormPathParams {
+            /// ID of pet that needs to be updated
+                pub pet_id: i64,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct DeleteUserPathParams {
-    /// The name that needs to be deleted
-    pub username: String,
-}
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct GetUserByNamePathParams {
-    /// The name that needs to be fetched. Use user1 for testing.
-    pub username: String,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct UploadFilePathParams {
+            /// ID of pet to update
+                pub pet_id: i64,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct LoginUserQueryParams {
-    /// The user name for login
-    #[serde(rename = "username")]
-    pub username: String,
-    /// The password for login in clear text
-    #[serde(rename = "password")]
-    pub password: String,
-}
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct UpdateUserPathParams {
-    /// name that need to be deleted
-    pub username: String,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct DeleteOrderPathParams {
+            /// ID of the order that needs to be deleted
+                pub order_id: String,
+    }
+
+
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct GetOrderByIdPathParams {
+            /// ID of pet that needs to be fetched
+                #[validate(
+                        range(min = 1i64, max = 5i64),
+                    )]
+                pub order_id: i64,
+    }
+
+
+      
+      
+      
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct DeleteUserPathParams {
+            /// The name that needs to be deleted
+                pub username: String,
+    }
+
+
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct GetUserByNamePathParams {
+            /// The name that needs to be fetched. Use user1 for testing.
+                pub username: String,
+    }
+
+
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct LoginUserQueryParams {
+            /// The user name for login
+                #[serde(rename = "username")]
+                pub username: String,
+            /// The password for login in clear text
+                #[serde(rename = "password")]
+                pub password: String,
+    }
+
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct UpdateUserPathParams {
+            /// name that need to be deleted
+                pub username: String,
+    }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct AdditionalPropertiesClass {
     #[serde(rename = "map_property")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub map_property: Option<std::collections::HashMap<String, String>>,
 
     #[serde(rename = "map_of_map_property")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub map_of_map_property:
-        Option<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub map_of_map_property: Option<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
+
 }
+
+impl AdditionalPropertiesClass {
+    fn __name_for_map_property() -> String {
+        String::from("CodegenProperty{openApiType='object', baseName='map_property', complexType='string', getter='getMapProperty', setter='setMapProperty', description='null', dataType='std::collections::HashMap<String, String>', datatypeWithEnum='std::collections::HashMap<String, String>', dataFormat='null', name='map_property', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.map_property;', baseType='map', containerType='map', containerTypeMapped='std::collections::HashMap', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "additionalProperties" : {
+    "type" : "string"
+  },
+  "type" : "object"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=true, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=CodegenProperty{openApiType='string', baseName='additional_properties', complexType='string', getter='getAdditionalProperties', setter='setAdditionalProperties', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='additional_properties', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.additional_properties;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalProperties', nameInPascalCase='AdditionalProperties', nameInSnakeCase='ADDITIONAL_PROPERTIES', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='mapProperty', nameInPascalCase='MapProperty', nameInSnakeCase='MAP_PROPERTY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=true, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_map_property<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_map_property())
+        }
+}
+impl AdditionalPropertiesClass {
+    fn __name_for_map_of_map_property() -> String {
+        String::from("CodegenProperty{openApiType='object', baseName='map_of_map_property', complexType='map', getter='getMapOfMapProperty', setter='setMapOfMapProperty', description='null', dataType='std::collections::HashMap<String, std::collections::HashMap<String, String>>', datatypeWithEnum='std::collections::HashMap<String, std::collections::HashMap<String, String>>', dataFormat='null', name='map_of_map_property', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.map_of_map_property;', baseType='map', containerType='map', containerTypeMapped='std::collections::HashMap', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "additionalProperties" : {
+    "type" : "object",
+    "additionalProperties" : {
+      "type" : "string"
+    }
+  },
+  "type" : "object"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=true, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='object', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='std::collections::HashMap<String, String>', datatypeWithEnum='std::collections::HashMap<String, String>', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='map', containerType='map', containerTypeMapped='std::collections::HashMap', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "additionalProperties" : {
+    "type" : "string"
+  },
+  "type" : "object"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=true, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=CodegenProperty{openApiType='string', baseName='additional_properties', complexType='string', getter='getAdditionalProperties', setter='setAdditionalProperties', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='additional_properties', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.additional_properties;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalProperties', nameInPascalCase='AdditionalProperties', nameInSnakeCase='ADDITIONAL_PROPERTIES', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=true, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=CodegenProperty{openApiType='object', baseName='additional_properties', complexType='string', getter='getAdditionalProperties', setter='setAdditionalProperties', description='null', dataType='std::collections::HashMap<String, String>', datatypeWithEnum='std::collections::HashMap<String, String>', dataFormat='null', name='additional_properties', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.additional_properties;', baseType='map', containerType='map', containerTypeMapped='std::collections::HashMap', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "additionalProperties" : {
+    "type" : "string"
+  },
+  "type" : "object"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=true, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=CodegenProperty{openApiType='string', baseName='additional_properties', complexType='string', getter='getAdditionalProperties', setter='setAdditionalProperties', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='additional_properties', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.additional_properties;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalProperties', nameInPascalCase='AdditionalProperties', nameInSnakeCase='ADDITIONAL_PROPERTIES', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalProperties', nameInPascalCase='AdditionalProperties', nameInSnakeCase='ADDITIONAL_PROPERTIES', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=true, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='mapOfMapProperty', nameInPascalCase='MapOfMapProperty', nameInSnakeCase='MAP_OF_MAP_PROPERTY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=true, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_map_of_map_property<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_map_of_map_property())
+        }
+}
+
 
 impl AdditionalPropertiesClass {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -187,11 +305,7 @@ impl std::fmt::Display for AdditionalPropertiesClass {
 
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -207,8 +321,7 @@ impl std::str::FromStr for AdditionalPropertiesClass {
         #[allow(dead_code)]
         struct IntermediateRep {
             pub map_property: Vec<std::collections::HashMap<String, String>>,
-            pub map_of_map_property:
-                Vec<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
+            pub map_of_map_property: Vec<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -220,11 +333,7 @@ impl std::str::FromStr for AdditionalPropertiesClass {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing AdditionalPropertiesClass".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing AdditionalPropertiesClass".to_string())
             };
 
             if let Some(key) = key_result {
@@ -254,16 +363,13 @@ impl std::str::FromStr for AdditionalPropertiesClass {
 impl std::convert::TryFrom<header::IntoHeaderValue<AdditionalPropertiesClass>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<AdditionalPropertiesClass>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<AdditionalPropertiesClass>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for AdditionalPropertiesClass - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for AdditionalPropertiesClass - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -274,39 +380,70 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AdditionalPr
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <AdditionalPropertiesClass as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <AdditionalPropertiesClass as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into AdditionalPropertiesClass - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into AdditionalPropertiesClass - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
 
+
+
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Animal {
+    #[serde(default = "Animal::__name_for_class_name")]
+    #[serde(serialize_with = "Animal::__serialize_class_name")]
     #[serde(rename = "className")]
     pub class_name: String,
 
     #[serde(rename = "color")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub color: Option<String>,
+
 }
 
 impl Animal {
+    fn __name_for_class_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='className', complexType='string', getter='getClassName', setter='setClassName', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='class_name', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.className;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=true, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='className', nameInPascalCase='ClassName', nameInSnakeCase='CLASS_NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_class_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_class_name())
+        }
+}
+impl Animal {
+    fn __name_for_color() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='color', complexType='string', getter='getColor', setter='setColor', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='color', min='null', max='null', defaultValue='Some(r#"red"#.to_string())', defaultValueWithParam=' = data.color;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "default" : "red",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='color', nameInPascalCase='Color', nameInSnakeCase='COLOR', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_color<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_color())
+        }
+}
+
+
+impl Animal {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(class_name: String) -> Animal {
+    pub fn new(class_name: String, ) -> Animal {
         Animal {
             class_name,
             color: Some(r#"red"#.to_string()),
@@ -320,18 +457,21 @@ impl Animal {
 impl std::fmt::Display for Animal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             Some("className".to_string()),
             Some(self.class_name.to_string()),
-            self.color
-                .as_ref()
-                .map(|color| ["color".to_string(), color.to_string()].join(",")),
+
+
+            self.color.as_ref().map(|color| {
+                [
+                    "color".to_string(),
+                    color.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -359,29 +499,17 @@ impl std::str::FromStr for Animal {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing Animal".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing Animal".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "className" => intermediate_rep.class_name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "className" => intermediate_rep.class_name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "color" => intermediate_rep.color.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Animal".to_string(),
-                        )
-                    }
+                    "color" => intermediate_rep.color.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Animal".to_string())
                 }
             }
 
@@ -391,11 +519,7 @@ impl std::str::FromStr for Animal {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(Animal {
-            class_name: intermediate_rep
-                .class_name
-                .into_iter()
-                .next()
-                .ok_or_else(|| "className missing in Animal".to_string())?,
+            class_name: intermediate_rep.class_name.into_iter().next().ok_or_else(|| "className missing in Animal".to_string())?,
             color: intermediate_rep.color.into_iter().next(),
         })
     }
@@ -407,16 +531,13 @@ impl std::str::FromStr for Animal {
 impl std::convert::TryFrom<header::IntoHeaderValue<Animal>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<Animal>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Animal>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Animal - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Animal - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -427,24 +548,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Animal> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <Animal as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <Animal as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Animal - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into Animal - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -469,7 +589,7 @@ impl std::convert::From<AnimalFarm> for Vec<Animal> {
 }
 
 impl std::iter::FromIterator<Animal> for AnimalFarm {
-    fn from_iter<U: IntoIterator<Item = Animal>>(u: U) -> Self {
+    fn from_iter<U: IntoIterator<Item=Animal>>(u: U) -> Self {
         AnimalFarm(Vec::<Animal>::from_iter(u))
     }
 }
@@ -518,15 +638,8 @@ impl std::ops::DerefMut for AnimalFarm {
 /// specified in https://swagger.io/docs/specification/serialization/
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for AnimalFarm {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            self.iter()
-                .map(|x| x.to_string())
-                .collect::<Vec<_>>()
-                .join(",")
-        )
+   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+       write!(f, "{}", self.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","))
     }
 }
 
@@ -538,12 +651,14 @@ impl std::str::FromStr for AnimalFarm {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let mut items = vec![];
-        for item in s.split(',') {
+        for item in s.split(',')
+        {
             items.push(item.parse()?);
         }
         std::result::Result::Ok(AnimalFarm(items))
     }
 }
+
 
 // Methods for converting between header::IntoHeaderValue<AnimalFarm> and HeaderValue
 
@@ -551,16 +666,13 @@ impl std::str::FromStr for AnimalFarm {
 impl std::convert::TryFrom<header::IntoHeaderValue<AnimalFarm>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<AnimalFarm>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<AnimalFarm>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for AnimalFarm - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for AnimalFarm - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -571,40 +683,82 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AnimalFarm> 
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <AnimalFarm as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <AnimalFarm as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into AnimalFarm - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into AnimalFarm - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ApiResponse {
     #[serde(rename = "code")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<i32>,
 
     #[serde(rename = "type")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub r#type: Option<String>,
 
     #[serde(rename = "message")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+
 }
+
+impl ApiResponse {
+    fn __name_for_code() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='code', complexType='integer', getter='getCode', setter='setCode', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='int32', name='code', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.code;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int32",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='code', nameInPascalCase='Code', nameInSnakeCase='CODE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_code<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_code())
+        }
+}
+impl ApiResponse {
+    fn __name_for_r#type() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='type', complexType='string', getter='getR#type', setter='setR#type', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='r#type', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.type;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='r#type', nameInPascalCase='R#type', nameInSnakeCase='R#TYPE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_r#type<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_r#type())
+        }
+}
+impl ApiResponse {
+    fn __name_for_message() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='message', complexType='string', getter='getMessage', setter='setMessage', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='message', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.message;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='message', nameInPascalCase='Message', nameInSnakeCase='MESSAGE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_message<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_message())
+        }
+}
+
 
 impl ApiResponse {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -623,22 +777,33 @@ impl ApiResponse {
 impl std::fmt::Display for ApiResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.code
-                .as_ref()
-                .map(|code| ["code".to_string(), code.to_string()].join(",")),
-            self.r#type
-                .as_ref()
-                .map(|r#type| ["type".to_string(), r#type.to_string()].join(",")),
-            self.message
-                .as_ref()
-                .map(|message| ["message".to_string(), message.to_string()].join(",")),
+
+            self.code.as_ref().map(|code| {
+                [
+                    "code".to_string(),
+                    code.to_string(),
+                ].join(",")
+            }),
+
+
+            self.r#type.as_ref().map(|r#type| {
+                [
+                    "type".to_string(),
+                    r#type.to_string(),
+                ].join(",")
+            }),
+
+
+            self.message.as_ref().map(|message| {
+                [
+                    "message".to_string(),
+                    message.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -667,33 +832,19 @@ impl std::str::FromStr for ApiResponse {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing ApiResponse".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing ApiResponse".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "code" => intermediate_rep.code.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "code" => intermediate_rep.code.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "type" => intermediate_rep.r#type.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "type" => intermediate_rep.r#type.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "message" => intermediate_rep.message.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing ApiResponse".to_string(),
-                        )
-                    }
+                    "message" => intermediate_rep.message.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing ApiResponse".to_string())
                 }
             }
 
@@ -716,16 +867,13 @@ impl std::str::FromStr for ApiResponse {
 impl std::convert::TryFrom<header::IntoHeaderValue<ApiResponse>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<ApiResponse>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ApiResponse>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for ApiResponse - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ApiResponse - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -736,32 +884,64 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ApiResponse>
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <ApiResponse as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <ApiResponse as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ApiResponse - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into ApiResponse - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ArrayOfArrayOfNumberOnly {
     #[serde(rename = "ArrayArrayNumber")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub array_array_number: Option<Vec<Vec<f64>>>,
+
 }
+
+impl ArrayOfArrayOfNumberOnly {
+    fn __name_for_array_array_number() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='ArrayArrayNumber', complexType='array', getter='getArrayArrayNumber', setter='setArrayArrayNumber', description='null', dataType='Vec<Vec<f64>>', datatypeWithEnum='Vec<Vec<f64>>', dataFormat='null', name='array_array_number', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.ArrayArrayNumber;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "array",
+    "items" : {
+      "type" : "number"
+    }
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='array', baseName='array_array_number', complexType='number', getter='getArrayArrayNumber', setter='setArrayArrayNumber', description='null', dataType='Vec<f64>', datatypeWithEnum='Vec<f64>', dataFormat='null', name='array_array_number', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_number;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "number"
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='number', baseName='array_array_number', complexType='number', getter='getArrayArrayNumber', setter='setArrayArrayNumber', description='null', dataType='f64', datatypeWithEnum='f64', dataFormat='null', name='array_array_number', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_number;', baseType='number', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "number"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=true, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayNumber', nameInPascalCase='ArrayArrayNumber', nameInSnakeCase='ARRAY_ARRAY_NUMBER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='number', baseName='array_array_number', complexType='number', getter='getArrayArrayNumber', setter='setArrayArrayNumber', description='null', dataType='f64', datatypeWithEnum='f64', dataFormat='null', name='array_array_number', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_number;', baseType='number', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "number"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=true, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayNumber', nameInPascalCase='ArrayArrayNumber', nameInSnakeCase='ARRAY_ARRAY_NUMBER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayNumber', nameInPascalCase='ArrayArrayNumber', nameInSnakeCase='ARRAY_ARRAY_NUMBER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='number', baseName='array_array_number', complexType='number', getter='getArrayArrayNumber', setter='setArrayArrayNumber', description='null', dataType='f64', datatypeWithEnum='f64', dataFormat='null', name='array_array_number', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_number;', baseType='number', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "number"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=true, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayNumber', nameInPascalCase='ArrayArrayNumber', nameInSnakeCase='ARRAY_ARRAY_NUMBER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayNumber', nameInPascalCase='ArrayArrayNumber', nameInSnakeCase='ARRAY_ARRAY_NUMBER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_array_array_number<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_array_array_number())
+        }
+}
+
 
 impl ArrayOfArrayOfNumberOnly {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -782,11 +962,7 @@ impl std::fmt::Display for ArrayOfArrayOfNumberOnly {
 
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -813,11 +989,7 @@ impl std::str::FromStr for ArrayOfArrayOfNumberOnly {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing ArrayOfArrayOfNumberOnly".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing ArrayOfArrayOfNumberOnly".to_string())
             };
 
             if let Some(key) = key_result {
@@ -845,16 +1017,13 @@ impl std::str::FromStr for ArrayOfArrayOfNumberOnly {
 impl std::convert::TryFrom<header::IntoHeaderValue<ArrayOfArrayOfNumberOnly>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<ArrayOfArrayOfNumberOnly>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ArrayOfArrayOfNumberOnly>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for ArrayOfArrayOfNumberOnly - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ArrayOfArrayOfNumberOnly - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -865,37 +1034,61 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ArrayOfArray
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <ArrayOfArrayOfNumberOnly as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <ArrayOfArrayOfNumberOnly as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ArrayOfArrayOfNumberOnly - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into ArrayOfArrayOfNumberOnly - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ArrayOfNumberOnly {
     #[serde(rename = "ArrayNumber")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub array_number: Option<Vec<f64>>,
+
 }
+
+impl ArrayOfNumberOnly {
+    fn __name_for_array_number() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='ArrayNumber', complexType='number', getter='getArrayNumber', setter='setArrayNumber', description='null', dataType='Vec<f64>', datatypeWithEnum='Vec<f64>', dataFormat='null', name='array_number', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.ArrayNumber;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "number"
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='number', baseName='array_number', complexType='number', getter='getArrayNumber', setter='setArrayNumber', description='null', dataType='f64', datatypeWithEnum='f64', dataFormat='null', name='array_number', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_number;', baseType='number', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "number"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=true, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayNumber', nameInPascalCase='ArrayNumber', nameInSnakeCase='ARRAY_NUMBER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='number', baseName='array_number', complexType='number', getter='getArrayNumber', setter='setArrayNumber', description='null', dataType='f64', datatypeWithEnum='f64', dataFormat='null', name='array_number', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_number;', baseType='number', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "number"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=true, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayNumber', nameInPascalCase='ArrayNumber', nameInSnakeCase='ARRAY_NUMBER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayNumber', nameInPascalCase='ArrayNumber', nameInSnakeCase='ARRAY_NUMBER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_array_number<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_array_number())
+        }
+}
+
 
 impl ArrayOfNumberOnly {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new() -> ArrayOfNumberOnly {
-        ArrayOfNumberOnly { array_number: None }
+        ArrayOfNumberOnly {
+            array_number: None,
+        }
     }
 }
 
@@ -904,23 +1097,18 @@ impl ArrayOfNumberOnly {
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for ArrayOfNumberOnly {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> = vec![self.array_number.as_ref().map(|array_number| {
-            [
-                "ArrayNumber".to_string(),
-                array_number
-                    .iter()
-                    .map(|x| x.to_string())
-                    .collect::<Vec<_>>()
-                    .join(","),
-            ]
-            .join(",")
-        })];
+        let params: Vec<Option<String>> = vec![
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+            self.array_number.as_ref().map(|array_number| {
+                [
+                    "ArrayNumber".to_string(),
+                    array_number.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","),
+                ].join(",")
+            }),
+
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -947,25 +1135,14 @@ impl std::str::FromStr for ArrayOfNumberOnly {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing ArrayOfNumberOnly".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing ArrayOfNumberOnly".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
-                    "ArrayNumber" => return std::result::Result::Err(
-                        "Parsing a container in this style is not supported in ArrayOfNumberOnly"
-                            .to_string(),
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing ArrayOfNumberOnly".to_string(),
-                        )
-                    }
+                    "ArrayNumber" => return std::result::Result::Err("Parsing a container in this style is not supported in ArrayOfNumberOnly".to_string()),
+                    _ => return std::result::Result::Err("Unexpected key while parsing ArrayOfNumberOnly".to_string())
                 }
             }
 
@@ -986,16 +1163,13 @@ impl std::str::FromStr for ArrayOfNumberOnly {
 impl std::convert::TryFrom<header::IntoHeaderValue<ArrayOfNumberOnly>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<ArrayOfNumberOnly>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ArrayOfNumberOnly>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for ArrayOfNumberOnly - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ArrayOfNumberOnly - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1006,45 +1180,155 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ArrayOfNumbe
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <ArrayOfNumberOnly as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <ArrayOfNumberOnly as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ArrayOfNumberOnly - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into ArrayOfNumberOnly - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ArrayTest {
     #[serde(rename = "array_of_string")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub array_of_string: Option<Vec<String>>,
 
     #[serde(rename = "array_array_of_integer")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub array_array_of_integer: Option<Vec<Vec<i64>>>,
 
     #[serde(rename = "array_array_of_model")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub array_array_of_model: Option<Vec<Vec<models::ReadOnlyFirst>>>,
 
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "array_of_enum")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub array_of_enum: Option<Vec<String>>,
+
 }
+
+impl ArrayTest {
+    fn __name_for_array_of_string() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='array_of_string', complexType='string', getter='getArrayOfString', setter='setArrayOfString', description='null', dataType='Vec<String>', datatypeWithEnum='Vec<String>', dataFormat='null', name='array_of_string', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.array_of_string;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "string"
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='string', baseName='array_of_string', complexType='string', getter='getArrayOfString', setter='setArrayOfString', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='array_of_string', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_of_string;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayOfString', nameInPascalCase='ArrayOfString', nameInSnakeCase='ARRAY_OF_STRING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='array_of_string', complexType='string', getter='getArrayOfString', setter='setArrayOfString', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='array_of_string', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_of_string;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayOfString', nameInPascalCase='ArrayOfString', nameInSnakeCase='ARRAY_OF_STRING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayOfString', nameInPascalCase='ArrayOfString', nameInSnakeCase='ARRAY_OF_STRING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_array_of_string<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_array_of_string())
+        }
+}
+impl ArrayTest {
+    fn __name_for_array_array_of_integer() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='array_array_of_integer', complexType='array', getter='getArrayArrayOfInteger', setter='setArrayArrayOfInteger', description='null', dataType='Vec<Vec<i64>>', datatypeWithEnum='Vec<Vec<i64>>', dataFormat='int64', name='array_array_of_integer', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.array_array_of_integer;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "array",
+    "items" : {
+      "type" : "integer",
+      "format" : "int64"
+    }
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='array', baseName='array_array_of_integer', complexType='long', getter='getArrayArrayOfInteger', setter='setArrayArrayOfInteger', description='null', dataType='Vec<i64>', datatypeWithEnum='Vec<i64>', dataFormat='int64', name='array_array_of_integer', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_of_integer;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "integer",
+    "format" : "int64"
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='integer', baseName='array_array_of_integer', complexType='long', getter='getArrayArrayOfInteger', setter='setArrayArrayOfInteger', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='array_array_of_integer', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_of_integer;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayOfInteger', nameInPascalCase='ArrayArrayOfInteger', nameInSnakeCase='ARRAY_ARRAY_OF_INTEGER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='integer', baseName='array_array_of_integer', complexType='long', getter='getArrayArrayOfInteger', setter='setArrayArrayOfInteger', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='array_array_of_integer', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_of_integer;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayOfInteger', nameInPascalCase='ArrayArrayOfInteger', nameInSnakeCase='ARRAY_ARRAY_OF_INTEGER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayOfInteger', nameInPascalCase='ArrayArrayOfInteger', nameInSnakeCase='ARRAY_ARRAY_OF_INTEGER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='integer', baseName='array_array_of_integer', complexType='long', getter='getArrayArrayOfInteger', setter='setArrayArrayOfInteger', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='array_array_of_integer', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_of_integer;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayOfInteger', nameInPascalCase='ArrayArrayOfInteger', nameInSnakeCase='ARRAY_ARRAY_OF_INTEGER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayOfInteger', nameInPascalCase='ArrayArrayOfInteger', nameInSnakeCase='ARRAY_ARRAY_OF_INTEGER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_array_array_of_integer<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_array_array_of_integer())
+        }
+}
+impl ArrayTest {
+    fn __name_for_array_array_of_model() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='array_array_of_model', complexType='array', getter='getArrayArrayOfModel', setter='setArrayArrayOfModel', description='null', dataType='Vec<Vec<models::ReadOnlyFirst>>', datatypeWithEnum='Vec<Vec<models::ReadOnlyFirst>>', dataFormat='null', name='array_array_of_model', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.array_array_of_model;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "array",
+    "items" : {
+      "$ref" : "#/components/schemas/ReadOnlyFirst"
+    }
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='array', baseName='array_array_of_model', complexType='ReadOnlyFirst', getter='getArrayArrayOfModel', setter='setArrayArrayOfModel', description='null', dataType='Vec<models::ReadOnlyFirst>', datatypeWithEnum='Vec<models::ReadOnlyFirst>', dataFormat='null', name='array_array_of_model', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_of_model;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "$ref" : "#/components/schemas/ReadOnlyFirst"
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='ReadOnlyFirst', baseName='array_array_of_model', complexType='ReadOnlyFirst', getter='getArrayArrayOfModel', setter='setArrayArrayOfModel', description='null', dataType='models::ReadOnlyFirst', datatypeWithEnum='models::ReadOnlyFirst', dataFormat='null', name='array_array_of_model', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_of_model;', baseType='ReadOnlyFirst', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/ReadOnlyFirst"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayOfModel', nameInPascalCase='ArrayArrayOfModel', nameInSnakeCase='ARRAY_ARRAY_OF_MODEL', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/ReadOnlyFirst, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='ReadOnlyFirst', baseName='array_array_of_model', complexType='ReadOnlyFirst', getter='getArrayArrayOfModel', setter='setArrayArrayOfModel', description='null', dataType='models::ReadOnlyFirst', datatypeWithEnum='models::ReadOnlyFirst', dataFormat='null', name='array_array_of_model', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_of_model;', baseType='ReadOnlyFirst', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/ReadOnlyFirst"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayOfModel', nameInPascalCase='ArrayArrayOfModel', nameInSnakeCase='ARRAY_ARRAY_OF_MODEL', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/ReadOnlyFirst, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayOfModel', nameInPascalCase='ArrayArrayOfModel', nameInSnakeCase='ARRAY_ARRAY_OF_MODEL', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='ReadOnlyFirst', baseName='array_array_of_model', complexType='ReadOnlyFirst', getter='getArrayArrayOfModel', setter='setArrayArrayOfModel', description='null', dataType='models::ReadOnlyFirst', datatypeWithEnum='models::ReadOnlyFirst', dataFormat='null', name='array_array_of_model', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_of_model;', baseType='ReadOnlyFirst', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/ReadOnlyFirst"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayOfModel', nameInPascalCase='ArrayArrayOfModel', nameInSnakeCase='ARRAY_ARRAY_OF_MODEL', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/ReadOnlyFirst, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayOfModel', nameInPascalCase='ArrayArrayOfModel', nameInSnakeCase='ARRAY_ARRAY_OF_MODEL', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_array_array_of_model<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_array_array_of_model())
+        }
+}
+impl ArrayTest {
+    fn __name_for_array_of_enum() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='array_of_enum', complexType='string', getter='getArrayOfEnum', setter='setArrayOfEnum', description='null', dataType='Vec<String>', datatypeWithEnum='Vec<String>', dataFormat='null', name='array_of_enum', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.array_of_enum;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "string",
+    "enum" : [ "UPPER", "lower" ]
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues={enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}], values=[UPPER, lower]}, items=CodegenProperty{openApiType='string', baseName='array_of_enum', complexType='string', getter='getArrayOfEnum', setter='setArrayOfEnum', description='null', dataType='String', datatypeWithEnum='ArrayOfEnum', dataFormat='null', name='array_of_enum', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_of_enum;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower], allowableValues={values=[UPPER, lower], enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayOfEnum', nameInPascalCase='ArrayOfEnum', nameInSnakeCase='ARRAY_OF_ENUM', enumName='ArrayOfEnum', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='array_of_enum', complexType='string', getter='getArrayOfEnum', setter='setArrayOfEnum', description='null', dataType='String', datatypeWithEnum='ArrayOfEnum', dataFormat='null', name='array_of_enum', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_of_enum;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower], allowableValues={values=[UPPER, lower], enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayOfEnum', nameInPascalCase='ArrayOfEnum', nameInSnakeCase='ARRAY_OF_ENUM', enumName='ArrayOfEnum', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayOfEnum', nameInPascalCase='ArrayOfEnum', nameInSnakeCase='ARRAY_OF_ENUM', enumName='ArrayOfEnum', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_array_of_enum<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_array_of_enum())
+        }
+}
+
 
 impl ArrayTest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -1064,38 +1348,29 @@ impl ArrayTest {
 impl std::fmt::Display for ArrayTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             self.array_of_string.as_ref().map(|array_of_string| {
                 [
                     "array_of_string".to_string(),
-                    array_of_string
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<_>>()
-                        .join(","),
-                ]
-                .join(",")
+                    array_of_string.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","),
+                ].join(",")
             }),
+
             // Skipping array_array_of_integer in query parameter serialization
 
             // Skipping array_array_of_model in query parameter serialization
+
+
             self.array_of_enum.as_ref().map(|array_of_enum| {
                 [
                     "array_of_enum".to_string(),
-                    array_of_enum
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<_>>()
-                        .join(","),
-                ]
-                .join(",")
+                    array_of_enum.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","),
+                ].join(",")
             }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1125,45 +1400,17 @@ impl std::str::FromStr for ArrayTest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing ArrayTest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing ArrayTest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
-                    "array_of_string" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in ArrayTest"
-                                .to_string(),
-                        )
-                    }
-                    "array_array_of_integer" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in ArrayTest"
-                                .to_string(),
-                        )
-                    }
-                    "array_array_of_model" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in ArrayTest"
-                                .to_string(),
-                        )
-                    }
-                    "array_of_enum" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in ArrayTest"
-                                .to_string(),
-                        )
-                    }
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing ArrayTest".to_string(),
-                        )
-                    }
+                    "array_of_string" => return std::result::Result::Err("Parsing a container in this style is not supported in ArrayTest".to_string()),
+                    "array_array_of_integer" => return std::result::Result::Err("Parsing a container in this style is not supported in ArrayTest".to_string()),
+                    "array_array_of_model" => return std::result::Result::Err("Parsing a container in this style is not supported in ArrayTest".to_string()),
+                    "array_of_enum" => return std::result::Result::Err("Parsing a container in this style is not supported in ArrayTest".to_string()),
+                    _ => return std::result::Result::Err("Unexpected key while parsing ArrayTest".to_string())
                 }
             }
 
@@ -1187,16 +1434,13 @@ impl std::str::FromStr for ArrayTest {
 impl std::convert::TryFrom<header::IntoHeaderValue<ArrayTest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<ArrayTest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ArrayTest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for ArrayTest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ArrayTest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1207,53 +1451,135 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ArrayTest> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <ArrayTest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <ArrayTest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ArrayTest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into ArrayTest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Capitalization {
     #[serde(rename = "smallCamel")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub small_camel: Option<String>,
 
     #[serde(rename = "CapitalCamel")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capital_camel: Option<String>,
 
     #[serde(rename = "small_Snake")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub small_snake: Option<String>,
 
     #[serde(rename = "Capital_Snake")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capital_snake: Option<String>,
 
     #[serde(rename = "SCA_ETH_Flow_Points")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sca_eth_flow_points: Option<String>,
 
-    /// Name of the pet
+    /// Name of the pet 
     #[serde(rename = "ATT_NAME")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub att_name: Option<String>,
+
 }
+
+impl Capitalization {
+    fn __name_for_small_camel() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='smallCamel', complexType='string', getter='getSmallCamel', setter='setSmallCamel', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='small_camel', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.smallCamel;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='smallCamel', nameInPascalCase='SmallCamel', nameInSnakeCase='SMALL_CAMEL', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_small_camel<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_small_camel())
+        }
+}
+impl Capitalization {
+    fn __name_for_capital_camel() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='CapitalCamel', complexType='string', getter='getCapitalCamel', setter='setCapitalCamel', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='capital_camel', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.CapitalCamel;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='capitalCamel', nameInPascalCase='CapitalCamel', nameInSnakeCase='CAPITAL_CAMEL', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_capital_camel<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_capital_camel())
+        }
+}
+impl Capitalization {
+    fn __name_for_small_snake() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='small_Snake', complexType='string', getter='getSmallSnake', setter='setSmallSnake', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='small_snake', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.small_Snake;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='smallSnake', nameInPascalCase='SmallSnake', nameInSnakeCase='SMALL_SNAKE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_small_snake<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_small_snake())
+        }
+}
+impl Capitalization {
+    fn __name_for_capital_snake() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='Capital_Snake', complexType='string', getter='getCapitalSnake', setter='setCapitalSnake', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='capital_snake', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.Capital_Snake;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='capitalSnake', nameInPascalCase='CapitalSnake', nameInSnakeCase='CAPITAL_SNAKE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_capital_snake<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_capital_snake())
+        }
+}
+impl Capitalization {
+    fn __name_for_sca_eth_flow_points() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='SCA_ETH_Flow_Points', complexType='string', getter='getScaEthFlowPoints', setter='setScaEthFlowPoints', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='sca_eth_flow_points', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.SCA_ETH_Flow_Points;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='scaEthFlowPoints', nameInPascalCase='ScaEthFlowPoints', nameInSnakeCase='SCA_ETH_FLOW_POINTS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_sca_eth_flow_points<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_sca_eth_flow_points())
+        }
+}
+impl Capitalization {
+    fn __name_for_att_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='ATT_NAME', complexType='string', getter='getAttName', setter='setAttName', description='Name of the pet ', dataType='String', datatypeWithEnum='String', dataFormat='null', name='att_name', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.ATT_NAME;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='Name of the pet
+', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "Name of the pet\n",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='attName', nameInPascalCase='AttName', nameInSnakeCase='ATT_NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_att_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_att_name())
+        }
+}
+
 
 impl Capitalization {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -1275,37 +1601,57 @@ impl Capitalization {
 impl std::fmt::Display for Capitalization {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.small_camel
-                .as_ref()
-                .map(|small_camel| ["smallCamel".to_string(), small_camel.to_string()].join(",")),
+
+            self.small_camel.as_ref().map(|small_camel| {
+                [
+                    "smallCamel".to_string(),
+                    small_camel.to_string(),
+                ].join(",")
+            }),
+
+
             self.capital_camel.as_ref().map(|capital_camel| {
-                ["CapitalCamel".to_string(), capital_camel.to_string()].join(",")
+                [
+                    "CapitalCamel".to_string(),
+                    capital_camel.to_string(),
+                ].join(",")
             }),
-            self.small_snake
-                .as_ref()
-                .map(|small_snake| ["small_Snake".to_string(), small_snake.to_string()].join(",")),
+
+
+            self.small_snake.as_ref().map(|small_snake| {
+                [
+                    "small_Snake".to_string(),
+                    small_snake.to_string(),
+                ].join(",")
+            }),
+
+
             self.capital_snake.as_ref().map(|capital_snake| {
-                ["Capital_Snake".to_string(), capital_snake.to_string()].join(",")
+                [
+                    "Capital_Snake".to_string(),
+                    capital_snake.to_string(),
+                ].join(",")
             }),
-            self.sca_eth_flow_points
-                .as_ref()
-                .map(|sca_eth_flow_points| {
-                    [
-                        "SCA_ETH_Flow_Points".to_string(),
-                        sca_eth_flow_points.to_string(),
-                    ]
-                    .join(",")
-                }),
-            self.att_name
-                .as_ref()
-                .map(|att_name| ["ATT_NAME".to_string(), att_name.to_string()].join(",")),
+
+
+            self.sca_eth_flow_points.as_ref().map(|sca_eth_flow_points| {
+                [
+                    "SCA_ETH_Flow_Points".to_string(),
+                    sca_eth_flow_points.to_string(),
+                ].join(",")
+            }),
+
+
+            self.att_name.as_ref().map(|att_name| {
+                [
+                    "ATT_NAME".to_string(),
+                    att_name.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1337,45 +1683,25 @@ impl std::str::FromStr for Capitalization {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing Capitalization".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing Capitalization".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "smallCamel" => intermediate_rep.small_camel.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "smallCamel" => intermediate_rep.small_camel.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "CapitalCamel" => intermediate_rep.capital_camel.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "CapitalCamel" => intermediate_rep.capital_camel.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "small_Snake" => intermediate_rep.small_snake.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "small_Snake" => intermediate_rep.small_snake.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "Capital_Snake" => intermediate_rep.capital_snake.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "Capital_Snake" => intermediate_rep.capital_snake.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "SCA_ETH_Flow_Points" => intermediate_rep.sca_eth_flow_points.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "SCA_ETH_Flow_Points" => intermediate_rep.sca_eth_flow_points.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "ATT_NAME" => intermediate_rep.att_name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Capitalization".to_string(),
-                        )
-                    }
+                    "ATT_NAME" => intermediate_rep.att_name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Capitalization".to_string())
                 }
             }
 
@@ -1401,16 +1727,13 @@ impl std::str::FromStr for Capitalization {
 impl std::convert::TryFrom<header::IntoHeaderValue<Capitalization>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<Capitalization>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Capitalization>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Capitalization - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Capitalization - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1421,24 +1744,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Capitalizati
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <Capitalization as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <Capitalization as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Capitalization - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into Capitalization - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -1447,17 +1769,60 @@ pub struct Cat {
     pub class_name: String,
 
     #[serde(rename = "color")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub color: Option<String>,
 
     #[serde(rename = "declawed")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub declawed: Option<bool>,
+
 }
 
 impl Cat {
+    fn __name_for_class_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='className', complexType='string', getter='getClassName', setter='setClassName', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='class_name', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.className;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=true, isOverridden=false, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='className', nameInPascalCase='ClassName', nameInSnakeCase='CLASS_NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_class_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_class_name())
+        }
+}
+impl Cat {
+    fn __name_for_color() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='color', complexType='string', getter='getColor', setter='setColor', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='color', min='null', max='null', defaultValue='Some(r#"red"#.to_string())', defaultValueWithParam=' = data.color;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "default" : "red",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=false, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='color', nameInPascalCase='Color', nameInSnakeCase='COLOR', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_color<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_color())
+        }
+}
+impl Cat {
+    fn __name_for_declawed() -> String {
+        String::from("CodegenProperty{openApiType='boolean', baseName='declawed', complexType='boolean', getter='getDeclawed', setter='setDeclawed', description='null', dataType='bool', datatypeWithEnum='bool', dataFormat='null', name='declawed', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.declawed;', baseType='boolean', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "boolean"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=true, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=false, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='declawed', nameInPascalCase='Declawed', nameInSnakeCase='DECLAWED', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_declawed<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_declawed())
+        }
+}
+
+
+impl Cat {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(class_name: String) -> Cat {
+    pub fn new(class_name: String, ) -> Cat {
         Cat {
             class_name,
             color: Some(r#"red"#.to_string()),
@@ -1472,21 +1837,29 @@ impl Cat {
 impl std::fmt::Display for Cat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             Some("className".to_string()),
             Some(self.class_name.to_string()),
-            self.color
-                .as_ref()
-                .map(|color| ["color".to_string(), color.to_string()].join(",")),
-            self.declawed
-                .as_ref()
-                .map(|declawed| ["declawed".to_string(), declawed.to_string()].join(",")),
+
+
+            self.color.as_ref().map(|color| {
+                [
+                    "color".to_string(),
+                    color.to_string(),
+                ].join(",")
+            }),
+
+
+            self.declawed.as_ref().map(|declawed| {
+                [
+                    "declawed".to_string(),
+                    declawed.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1515,31 +1888,19 @@ impl std::str::FromStr for Cat {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err("Missing value while parsing Cat".to_string())
-                }
+                None => return std::result::Result::Err("Missing value while parsing Cat".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "className" => intermediate_rep.class_name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "className" => intermediate_rep.class_name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "color" => intermediate_rep.color.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "color" => intermediate_rep.color.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "declawed" => intermediate_rep.declawed.push(
-                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Cat".to_string(),
-                        )
-                    }
+                    "declawed" => intermediate_rep.declawed.push(<bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Cat".to_string())
                 }
             }
 
@@ -1549,11 +1910,7 @@ impl std::str::FromStr for Cat {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(Cat {
-            class_name: intermediate_rep
-                .class_name
-                .into_iter()
-                .next()
-                .ok_or_else(|| "className missing in Cat".to_string())?,
+            class_name: intermediate_rep.class_name.into_iter().next().ok_or_else(|| "className missing in Cat".to_string())?,
             color: intermediate_rep.color.into_iter().next(),
             declawed: intermediate_rep.declawed.into_iter().next(),
         })
@@ -1569,11 +1926,10 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Cat>> for HeaderValue {
     fn try_from(hdr_value: header::IntoHeaderValue<Cat>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Cat - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Cat - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1584,34 +1940,65 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Cat> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => match <Cat as std::str::FromStr>::from_str(value) {
-                std::result::Result::Ok(value) => {
-                    std::result::Result::Ok(header::IntoHeaderValue(value))
-                }
-                std::result::Result::Err(err) => std::result::Result::Err(format!(
-                    "Unable to convert header value '{}' into Cat - {}",
-                    value, err
-                )),
-            },
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => {
+                    match <Cat as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Cat - {}",
+                                value, err))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Category {
     #[serde(rename = "id")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "name")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
+
 }
+
+impl Category {
+    fn __name_for_id() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='id', complexType='long', getter='getId', setter='setId', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='id', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.id;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='id', nameInPascalCase='Id', nameInSnakeCase='ID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_id<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_id())
+        }
+}
+impl Category {
+    fn __name_for_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='name', complexType='string', getter='getName', setter='setName', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='name', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.name;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='name', nameInPascalCase='Name', nameInSnakeCase='NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_name())
+        }
+}
+
 
 impl Category {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -1629,19 +2016,25 @@ impl Category {
 impl std::fmt::Display for Category {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.id
-                .as_ref()
-                .map(|id| ["id".to_string(), id.to_string()].join(",")),
-            self.name
-                .as_ref()
-                .map(|name| ["name".to_string(), name.to_string()].join(",")),
+
+            self.id.as_ref().map(|id| {
+                [
+                    "id".to_string(),
+                    id.to_string(),
+                ].join(",")
+            }),
+
+
+            self.name.as_ref().map(|name| {
+                [
+                    "name".to_string(),
+                    name.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1669,29 +2062,17 @@ impl std::str::FromStr for Category {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing Category".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing Category".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "id" => intermediate_rep.id.push(
-                        <i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "id" => intermediate_rep.id.push(<i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "name" => intermediate_rep.name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Category".to_string(),
-                        )
-                    }
+                    "name" => intermediate_rep.name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Category".to_string())
                 }
             }
 
@@ -1713,16 +2094,13 @@ impl std::str::FromStr for Category {
 impl std::convert::TryFrom<header::IntoHeaderValue<Category>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<Category>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Category>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Category - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Category - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1733,38 +2111,55 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Category> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <Category as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <Category as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Category - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into Category - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// Model for testing model with \"_class\" property
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ClassModel {
     #[serde(rename = "_class")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub _class: Option<String>,
+
 }
+
+impl ClassModel {
+    fn __name_for__class() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='_class', complexType='string', getter='getClass', setter='setClass', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='_class', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data._class;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='class', nameInPascalCase='Class', nameInSnakeCase='CLASS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize__class<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for__class())
+        }
+}
+
 
 impl ClassModel {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new() -> ClassModel {
-        ClassModel { _class: None }
+        ClassModel {
+            _class: None,
+        }
     }
 }
 
@@ -1773,16 +2168,18 @@ impl ClassModel {
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for ClassModel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> = vec![self
-            ._class
-            .as_ref()
-            .map(|_class| ["_class".to_string(), _class.to_string()].join(","))];
+        let params: Vec<Option<String>> = vec![
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+            self._class.as_ref().map(|_class| {
+                [
+                    "_class".to_string(),
+                    _class.to_string(),
+                ].join(",")
+            }),
+
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1809,25 +2206,15 @@ impl std::str::FromStr for ClassModel {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing ClassModel".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing ClassModel".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "_class" => intermediate_rep._class.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing ClassModel".to_string(),
-                        )
-                    }
+                    "_class" => intermediate_rep._class.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing ClassModel".to_string())
                 }
             }
 
@@ -1848,16 +2235,13 @@ impl std::str::FromStr for ClassModel {
 impl std::convert::TryFrom<header::IntoHeaderValue<ClassModel>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<ClassModel>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ClassModel>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for ClassModel - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ClassModel - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1868,37 +2252,54 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ClassModel> 
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <ClassModel as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <ClassModel as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ClassModel - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into ClassModel - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Client {
     #[serde(rename = "client")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client: Option<String>,
+
 }
+
+impl Client {
+    fn __name_for_client() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='client', complexType='string', getter='getClient', setter='setClient', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='client', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.client;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='client', nameInPascalCase='Client', nameInSnakeCase='CLIENT', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_client<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_client())
+        }
+}
+
 
 impl Client {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new() -> Client {
-        Client { client: None }
+        Client {
+            client: None,
+        }
     }
 }
 
@@ -1907,16 +2308,18 @@ impl Client {
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for Client {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> = vec![self
-            .client
-            .as_ref()
-            .map(|client| ["client".to_string(), client.to_string()].join(","))];
+        let params: Vec<Option<String>> = vec![
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+            self.client.as_ref().map(|client| {
+                [
+                    "client".to_string(),
+                    client.to_string(),
+                ].join(",")
+            }),
+
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1943,25 +2346,15 @@ impl std::str::FromStr for Client {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing Client".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing Client".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "client" => intermediate_rep.client.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Client".to_string(),
-                        )
-                    }
+                    "client" => intermediate_rep.client.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Client".to_string())
                 }
             }
 
@@ -1982,16 +2375,13 @@ impl std::str::FromStr for Client {
 impl std::convert::TryFrom<header::IntoHeaderValue<Client>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<Client>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Client>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Client - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Client - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2002,24 +2392,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Client> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <Client as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <Client as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Client - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into Client - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -2028,17 +2417,60 @@ pub struct Dog {
     pub class_name: String,
 
     #[serde(rename = "color")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub color: Option<String>,
 
     #[serde(rename = "breed")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub breed: Option<String>,
+
 }
 
 impl Dog {
+    fn __name_for_class_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='className', complexType='string', getter='getClassName', setter='setClassName', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='class_name', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.className;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=true, isOverridden=false, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='className', nameInPascalCase='ClassName', nameInSnakeCase='CLASS_NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_class_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_class_name())
+        }
+}
+impl Dog {
+    fn __name_for_color() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='color', complexType='string', getter='getColor', setter='setColor', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='color', min='null', max='null', defaultValue='Some(r#"red"#.to_string())', defaultValueWithParam=' = data.color;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "default" : "red",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=false, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='color', nameInPascalCase='Color', nameInSnakeCase='COLOR', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_color<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_color())
+        }
+}
+impl Dog {
+    fn __name_for_breed() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='breed', complexType='string', getter='getBreed', setter='setBreed', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='breed', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.breed;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=false, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='breed', nameInPascalCase='Breed', nameInSnakeCase='BREED', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_breed<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_breed())
+        }
+}
+
+
+impl Dog {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(class_name: String) -> Dog {
+    pub fn new(class_name: String, ) -> Dog {
         Dog {
             class_name,
             color: Some(r#"red"#.to_string()),
@@ -2053,21 +2485,29 @@ impl Dog {
 impl std::fmt::Display for Dog {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             Some("className".to_string()),
             Some(self.class_name.to_string()),
-            self.color
-                .as_ref()
-                .map(|color| ["color".to_string(), color.to_string()].join(",")),
-            self.breed
-                .as_ref()
-                .map(|breed| ["breed".to_string(), breed.to_string()].join(",")),
+
+
+            self.color.as_ref().map(|color| {
+                [
+                    "color".to_string(),
+                    color.to_string(),
+                ].join(",")
+            }),
+
+
+            self.breed.as_ref().map(|breed| {
+                [
+                    "breed".to_string(),
+                    breed.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -2096,31 +2536,19 @@ impl std::str::FromStr for Dog {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err("Missing value while parsing Dog".to_string())
-                }
+                None => return std::result::Result::Err("Missing value while parsing Dog".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "className" => intermediate_rep.class_name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "className" => intermediate_rep.class_name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "color" => intermediate_rep.color.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "color" => intermediate_rep.color.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "breed" => intermediate_rep.breed.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Dog".to_string(),
-                        )
-                    }
+                    "breed" => intermediate_rep.breed.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Dog".to_string())
                 }
             }
 
@@ -2130,11 +2558,7 @@ impl std::str::FromStr for Dog {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(Dog {
-            class_name: intermediate_rep
-                .class_name
-                .into_iter()
-                .next()
-                .ok_or_else(|| "className missing in Dog".to_string())?,
+            class_name: intermediate_rep.class_name.into_iter().next().ok_or_else(|| "className missing in Dog".to_string())?,
             color: intermediate_rep.color.into_iter().next(),
             breed: intermediate_rep.breed.into_iter().next(),
         })
@@ -2150,11 +2574,10 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Dog>> for HeaderValue {
     fn try_from(hdr_value: header::IntoHeaderValue<Dog>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Dog - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Dog - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2165,30 +2588,48 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Dog> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => match <Dog as std::str::FromStr>::from_str(value) {
-                std::result::Result::Ok(value) => {
-                    std::result::Result::Ok(header::IntoHeaderValue(value))
-                }
-                std::result::Result::Err(err) => std::result::Result::Err(format!(
-                    "Unable to convert header value '{}' into Dog - {}",
-                    value, err
-                )),
-            },
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => {
+                    match <Dog as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Dog - {}",
+                                value, err))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct DollarSpecialLeftSquareBracketModelPeriodNameRightSquareBracket {
     #[serde(rename = "$special[property.name]")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dollar_special_left_square_bracket_property_period_name_right_square_bracket: Option<i64>,
+
 }
+
+impl DollarSpecialLeftSquareBracketModelPeriodNameRightSquareBracket {
+    fn __name_for_dollar_special_left_square_bracket_property_period_name_right_square_bracket() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='$special[property.name]', complexType='long', getter='getDollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket', setter='setDollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='dollar_special_left_square_bracket_property_period_name_right_square_bracket', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.$special[property.name];', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket', nameInPascalCase='DollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket', nameInSnakeCase='DOLLAR_SPECIAL_LEFT_SQUARE_BRACKET_PROPERTY_PERIOD_NAME_RIGHT_SQUARE_BRACKET', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_dollar_special_left_square_bracket_property_period_name_right_square_bracket<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_dollar_special_left_square_bracket_property_period_name_right_square_bracket())
+        }
+}
+
 
 impl DollarSpecialLeftSquareBracketModelPeriodNameRightSquareBracket {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -2215,11 +2656,7 @@ impl std::fmt::Display for DollarSpecialLeftSquareBracketModelPeriodNameRightSqu
 
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -2234,8 +2671,7 @@ impl std::str::FromStr for DollarSpecialLeftSquareBracketModelPeriodNameRightSqu
         #[derive(Default)]
         #[allow(dead_code)]
         struct IntermediateRep {
-            pub dollar_special_left_square_bracket_property_period_name_right_square_bracket:
-                Vec<i64>,
+            pub dollar_special_left_square_bracket_property_period_name_right_square_bracket: Vec<i64>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -2273,18 +2709,10 @@ impl std::str::FromStr for DollarSpecialLeftSquareBracketModelPeriodNameRightSqu
 // Methods for converting between header::IntoHeaderValue<DollarSpecialLeftSquareBracketModelPeriodNameRightSquareBracket> and HeaderValue
 
 #[cfg(feature = "server")]
-impl
-    std::convert::TryFrom<
-        header::IntoHeaderValue<DollarSpecialLeftSquareBracketModelPeriodNameRightSquareBracket>,
-    > for HeaderValue
-{
+impl std::convert::TryFrom<header::IntoHeaderValue<DollarSpecialLeftSquareBracketModelPeriodNameRightSquareBracket>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<
-            DollarSpecialLeftSquareBracketModelPeriodNameRightSquareBracket,
-        >,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<DollarSpecialLeftSquareBracketModelPeriodNameRightSquareBracket>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
              std::result::Result::Ok(value) => std::result::Result::Ok(value),
@@ -2296,9 +2724,7 @@ impl
 }
 
 #[cfg(feature = "server")]
-impl std::convert::TryFrom<HeaderValue>
-    for header::IntoHeaderValue<DollarSpecialLeftSquareBracketModelPeriodNameRightSquareBracket>
-{
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<DollarSpecialLeftSquareBracketModelPeriodNameRightSquareBracket> {
     type Error = String;
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
@@ -2318,24 +2744,102 @@ impl std::convert::TryFrom<HeaderValue>
     }
 }
 
+
+
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct EnumArrays {
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "just_symbol")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub just_symbol: Option<String>,
 
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "array_enum")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub array_enum: Option<Vec<String>>,
 
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "array_array_enum")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub array_array_enum: Option<Vec<Vec<String>>>,
+
 }
+
+impl EnumArrays {
+    fn __name_for_just_symbol() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='just_symbol', complexType='string', getter='getJustSymbol', setter='setJustSymbol', description='null', dataType='String', datatypeWithEnum='JustSymbol', dataFormat='null', name='just_symbol', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.just_symbol;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ ">=", "$" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[>=, $], allowableValues={enumVars=[{name=GreaterThanEqual, isString=true, value=">="}, {name=Dollar, isString=true, value="$"}], values=[>=, $]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='justSymbol', nameInPascalCase='JustSymbol', nameInSnakeCase='JUST_SYMBOL', enumName='JustSymbol', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_just_symbol<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_just_symbol())
+        }
+}
+impl EnumArrays {
+    fn __name_for_array_enum() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='array_enum', complexType='string', getter='getArrayEnum', setter='setArrayEnum', description='null', dataType='Vec<String>', datatypeWithEnum='Vec<String>', dataFormat='null', name='array_enum', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.array_enum;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "string",
+    "enum" : [ "fish", "crab" ]
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues={enumVars=[{name=Fish, isString=true, value="fish"}, {name=Crab, isString=true, value="crab"}], values=[fish, crab]}, items=CodegenProperty{openApiType='string', baseName='array_enum', complexType='string', getter='getArrayEnum', setter='setArrayEnum', description='null', dataType='String', datatypeWithEnum='ArrayEnum', dataFormat='null', name='array_enum', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_enum;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "fish", "crab" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[fish, crab], allowableValues={values=[fish, crab], enumVars=[{name=Fish, isString=true, value="fish"}, {name=Crab, isString=true, value="crab"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayEnum', nameInPascalCase='ArrayEnum', nameInSnakeCase='ARRAY_ENUM', enumName='ArrayEnum', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='array_enum', complexType='string', getter='getArrayEnum', setter='setArrayEnum', description='null', dataType='String', datatypeWithEnum='ArrayEnum', dataFormat='null', name='array_enum', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_enum;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "fish", "crab" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[fish, crab], allowableValues={values=[fish, crab], enumVars=[{name=Fish, isString=true, value="fish"}, {name=Crab, isString=true, value="crab"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayEnum', nameInPascalCase='ArrayEnum', nameInSnakeCase='ARRAY_ENUM', enumName='ArrayEnum', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayEnum', nameInPascalCase='ArrayEnum', nameInSnakeCase='ARRAY_ENUM', enumName='ArrayEnum', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_array_enum<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_array_enum())
+        }
+}
+impl EnumArrays {
+    fn __name_for_array_array_enum() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='array_array_enum', complexType='array', getter='getArrayArrayEnum', setter='setArrayArrayEnum', description='null', dataType='Vec<Vec<String>>', datatypeWithEnum='Vec<Vec<String>>', dataFormat='null', name='array_array_enum', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.array_array_enum;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "array",
+    "items" : {
+      "type" : "string",
+      "enum" : [ "Cat", "Dog" ]
+    }
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues={enumVars=[{name=Cat, isString=true, value="Cat"}, {name=Dog, isString=true, value="Dog"}], values=[Cat, Dog]}, items=CodegenProperty{openApiType='array', baseName='array_array_enum', complexType='string', getter='getArrayArrayEnum', setter='setArrayArrayEnum', description='null', dataType='Vec<String>', datatypeWithEnum='Vec<String>', dataFormat='null', name='array_array_enum', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_enum;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "string",
+    "enum" : [ "Cat", "Dog" ]
+  },
+  "type" : "array"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues={values=[Cat, Dog], enumVars=[{name=Cat, isString=true, value="Cat"}, {name=Dog, isString=true, value="Dog"}]}, items=CodegenProperty{openApiType='string', baseName='array_array_enum', complexType='string', getter='getArrayArrayEnum', setter='setArrayArrayEnum', description='null', dataType='String', datatypeWithEnum='ArrayArrayEnum', dataFormat='null', name='array_array_enum', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_enum;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "Cat", "Dog" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[Cat, Dog], allowableValues={values=[Cat, Dog], enumVars=[{name=Cat, isString=true, value="Cat"}, {name=Dog, isString=true, value="Dog"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayEnum', nameInPascalCase='ArrayArrayEnum', nameInSnakeCase='ARRAY_ARRAY_ENUM', enumName='ArrayArrayEnum', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='array_array_enum', complexType='string', getter='getArrayArrayEnum', setter='setArrayArrayEnum', description='null', dataType='String', datatypeWithEnum='ArrayArrayEnum', dataFormat='null', name='array_array_enum', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_enum;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "Cat", "Dog" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[Cat, Dog], allowableValues={values=[Cat, Dog], enumVars=[{name=Cat, isString=true, value="Cat"}, {name=Dog, isString=true, value="Dog"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayEnum', nameInPascalCase='ArrayArrayEnum', nameInSnakeCase='ARRAY_ARRAY_ENUM', enumName='ArrayArrayEnum', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayEnum', nameInPascalCase='ArrayArrayEnum', nameInSnakeCase='ARRAY_ARRAY_ENUM', enumName='ArrayArrayEnum', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='array_array_enum', complexType='string', getter='getArrayArrayEnum', setter='setArrayArrayEnum', description='null', dataType='String', datatypeWithEnum='ArrayArrayEnum', dataFormat='null', name='array_array_enum', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.array_array_enum;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "Cat", "Dog" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[Cat, Dog], allowableValues={values=[Cat, Dog], enumVars=[{name=Cat, isString=true, value="Cat"}, {name=Dog, isString=true, value="Dog"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayEnum', nameInPascalCase='ArrayArrayEnum', nameInSnakeCase='ARRAY_ARRAY_ENUM', enumName='ArrayArrayEnum', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='arrayArrayEnum', nameInPascalCase='ArrayArrayEnum', nameInSnakeCase='ARRAY_ARRAY_ENUM', enumName='ArrayArrayEnum', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_array_array_enum<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_array_array_enum())
+        }
+}
+
 
 impl EnumArrays {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -2354,28 +2858,27 @@ impl EnumArrays {
 impl std::fmt::Display for EnumArrays {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.just_symbol
-                .as_ref()
-                .map(|just_symbol| ["just_symbol".to_string(), just_symbol.to_string()].join(",")),
+
+            self.just_symbol.as_ref().map(|just_symbol| {
+                [
+                    "just_symbol".to_string(),
+                    just_symbol.to_string(),
+                ].join(",")
+            }),
+
+
             self.array_enum.as_ref().map(|array_enum| {
                 [
                     "array_enum".to_string(),
-                    array_enum
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<_>>()
-                        .join(","),
-                ]
-                .join(",")
+                    array_enum.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(","),
+                ].join(",")
             }),
+
             // Skipping array_array_enum in query parameter serialization
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -2404,37 +2907,17 @@ impl std::str::FromStr for EnumArrays {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing EnumArrays".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing EnumArrays".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "just_symbol" => intermediate_rep.just_symbol.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    "array_enum" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in EnumArrays"
-                                .to_string(),
-                        )
-                    }
-                    "array_array_enum" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in EnumArrays"
-                                .to_string(),
-                        )
-                    }
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing EnumArrays".to_string(),
-                        )
-                    }
+                    "just_symbol" => intermediate_rep.just_symbol.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "array_enum" => return std::result::Result::Err("Parsing a container in this style is not supported in EnumArrays".to_string()),
+                    "array_array_enum" => return std::result::Result::Err("Parsing a container in this style is not supported in EnumArrays".to_string()),
+                    _ => return std::result::Result::Err("Unexpected key while parsing EnumArrays".to_string())
                 }
             }
 
@@ -2457,16 +2940,13 @@ impl std::str::FromStr for EnumArrays {
 impl std::convert::TryFrom<header::IntoHeaderValue<EnumArrays>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<EnumArrays>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<EnumArrays>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for EnumArrays - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for EnumArrays - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2477,33 +2957,30 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<EnumArrays> 
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <EnumArrays as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <EnumArrays as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into EnumArrays - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into EnumArrays - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// Enumeration of values.
 /// Since this enum's variants do not hold data, we can easily define them as `#[repr(C)]`
 /// which helps with FFI.
 #[allow(non_camel_case_types)]
 #[repr(C)]
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum EnumClass {
     #[serde(rename = "_abc")]
@@ -2537,36 +3014,111 @@ impl std::str::FromStr for EnumClass {
     }
 }
 
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct EnumTest {
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "enum_string")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enum_string: Option<String>,
 
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "enum_string_required")]
     pub enum_string_required: String,
 
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "enum_integer")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enum_integer: Option<i32>,
 
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "enum_number")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enum_number: Option<f64>,
 
     #[serde(rename = "outerEnum")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub outer_enum: Option<models::OuterEnum>,
+
 }
 
 impl EnumTest {
+    fn __name_for_enum_string() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='enum_string', complexType='string', getter='getEnumString', setter='setEnumString', description='null', dataType='String', datatypeWithEnum='EnumString', dataFormat='null', name='enum_string', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.enum_string;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower", "" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower, ], allowableValues={enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}, {name=Empty, isString=true, value=""}], values=[UPPER, lower, ]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='enumString', nameInPascalCase='EnumString', nameInSnakeCase='ENUM_STRING', enumName='EnumString', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_enum_string<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_enum_string())
+        }
+}
+impl EnumTest {
+    fn __name_for_enum_string_required() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='enum_string_required', complexType='string', getter='getEnumStringRequired', setter='setEnumStringRequired', description='null', dataType='String', datatypeWithEnum='EnumStringRequired', dataFormat='null', name='enum_string_required', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.enum_string_required;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower", "" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower, ], allowableValues={enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}, {name=Empty, isString=true, value=""}], values=[UPPER, lower, ]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='enumStringRequired', nameInPascalCase='EnumStringRequired', nameInSnakeCase='ENUM_STRING_REQUIRED', enumName='EnumStringRequired', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_enum_string_required<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_enum_string_required())
+        }
+}
+impl EnumTest {
+    fn __name_for_enum_integer() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='enum_integer', complexType='integer', getter='getEnumInteger', setter='setEnumInteger', description='null', dataType='i32', datatypeWithEnum='EnumInteger', dataFormat='int32', name='enum_integer', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.enum_integer;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ 1, -1 ],
+  "format" : "int32",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[1, -1], allowableValues={enumVars=[{name=Variant1, isString=false, value="1"}, {name=Variant12, isString=false, value="-1"}], values=[1, -1]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='enumInteger', nameInPascalCase='EnumInteger', nameInSnakeCase='ENUM_INTEGER', enumName='EnumInteger', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_enum_integer<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_enum_integer())
+        }
+}
+impl EnumTest {
+    fn __name_for_enum_number() -> String {
+        String::from("CodegenProperty{openApiType='number', baseName='enum_number', complexType='double', getter='getEnumNumber', setter='setEnumNumber', description='null', dataType='f64', datatypeWithEnum='EnumNumber', dataFormat='double', name='enum_number', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.enum_number;', baseType='double', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ 1.1, -1.2 ],
+  "format" : "double",
+  "type" : "number"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=true, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[1.1, -1.2], allowableValues={enumVars=[{name=Variant1Period1, isString=false, value="1.1"}, {name=Variant1Period2, isString=false, value="-1.2"}], values=[1.1, -1.2]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='enumNumber', nameInPascalCase='EnumNumber', nameInSnakeCase='ENUM_NUMBER', enumName='EnumNumber', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=double, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_enum_number<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_enum_number())
+        }
+}
+impl EnumTest {
+    fn __name_for_outer_enum() -> String {
+        String::from("CodegenProperty{openApiType='OuterEnum', baseName='outerEnum', complexType='OuterEnum', getter='getOuterEnum', setter='setOuterEnum', description='null', dataType='models::OuterEnum', datatypeWithEnum='models::OuterEnum', dataFormat='null', name='outer_enum', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.outerEnum;', baseType='OuterEnum', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/OuterEnum"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=true, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues={enumVars=[{name=Placed, isString=false, value="placed"}, {name=Approved, isString=false, value="approved"}, {name=Delivered, isString=false, value="delivered"}], values=[placed, approved, delivered]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='outerEnum', nameInPascalCase='OuterEnum', nameInSnakeCase='OUTER_ENUM', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=#/components/schemas/OuterEnum, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_outer_enum<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_outer_enum())
+        }
+}
+
+
+impl EnumTest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(enum_string_required: String) -> EnumTest {
+    pub fn new(enum_string_required: String, ) -> EnumTest {
         EnumTest {
             enum_string: None,
             enum_string_required,
@@ -2583,25 +3135,39 @@ impl EnumTest {
 impl std::fmt::Display for EnumTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.enum_string
-                .as_ref()
-                .map(|enum_string| ["enum_string".to_string(), enum_string.to_string()].join(",")),
+
+            self.enum_string.as_ref().map(|enum_string| {
+                [
+                    "enum_string".to_string(),
+                    enum_string.to_string(),
+                ].join(",")
+            }),
+
+
             Some("enum_string_required".to_string()),
             Some(self.enum_string_required.to_string()),
+
+
             self.enum_integer.as_ref().map(|enum_integer| {
-                ["enum_integer".to_string(), enum_integer.to_string()].join(",")
+                [
+                    "enum_integer".to_string(),
+                    enum_integer.to_string(),
+                ].join(",")
             }),
-            self.enum_number
-                .as_ref()
-                .map(|enum_number| ["enum_number".to_string(), enum_number.to_string()].join(",")),
+
+
+            self.enum_number.as_ref().map(|enum_number| {
+                [
+                    "enum_number".to_string(),
+                    enum_number.to_string(),
+                ].join(",")
+            }),
+
             // Skipping outerEnum in query parameter serialization
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -2632,42 +3198,23 @@ impl std::str::FromStr for EnumTest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing EnumTest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing EnumTest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "enum_string" => intermediate_rep.enum_string.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "enum_string" => intermediate_rep.enum_string.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "enum_string_required" => intermediate_rep.enum_string_required.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "enum_string_required" => intermediate_rep.enum_string_required.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "enum_integer" => intermediate_rep.enum_integer.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "enum_integer" => intermediate_rep.enum_integer.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "enum_number" => intermediate_rep.enum_number.push(
-                        <f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "enum_number" => intermediate_rep.enum_number.push(<f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "outerEnum" => intermediate_rep.outer_enum.push(
-                        <models::OuterEnum as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing EnumTest".to_string(),
-                        )
-                    }
+                    "outerEnum" => intermediate_rep.outer_enum.push(<models::OuterEnum as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing EnumTest".to_string())
                 }
             }
 
@@ -2678,11 +3225,7 @@ impl std::str::FromStr for EnumTest {
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(EnumTest {
             enum_string: intermediate_rep.enum_string.into_iter().next(),
-            enum_string_required: intermediate_rep
-                .enum_string_required
-                .into_iter()
-                .next()
-                .ok_or_else(|| "enum_string_required missing in EnumTest".to_string())?,
+            enum_string_required: intermediate_rep.enum_string_required.into_iter().next().ok_or_else(|| "enum_string_required missing in EnumTest".to_string())?,
             enum_integer: intermediate_rep.enum_integer.into_iter().next(),
             enum_number: intermediate_rep.enum_number.into_iter().next(),
             outer_enum: intermediate_rep.outer_enum.into_iter().next(),
@@ -2696,16 +3239,13 @@ impl std::str::FromStr for EnumTest {
 impl std::convert::TryFrom<header::IntoHeaderValue<EnumTest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<EnumTest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<EnumTest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for EnumTest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for EnumTest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2716,85 +3256,293 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<EnumTest> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <EnumTest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <EnumTest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into EnumTest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into EnumTest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct FormatTest {
     #[serde(rename = "integer")]
-    #[validate(range(min = 10u8, max = 100u8))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(
+            range(min = 10u8, max = 100u8),
+        )]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub integer: Option<u8>,
 
     #[serde(rename = "int32")]
-    #[validate(range(min = 20u8, max = 200u8))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(
+            range(min = 20u8, max = 200u8),
+        )]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub int32: Option<u8>,
 
     #[serde(rename = "int64")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub int64: Option<i64>,
 
     #[serde(rename = "number")]
-    #[validate(range(min = 32.1f64, max = 543.2f64))]
+    #[validate(
+            range(min = 32.1f64, max = 543.2f64),
+        )]
     pub number: f64,
 
     #[serde(rename = "float")]
-    #[validate(range(min = 54.3f32, max = 987.6f32))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(
+            range(min = 54.3f32, max = 987.6f32),
+        )]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub float: Option<f32>,
 
     #[serde(rename = "double")]
-    #[validate(range(min = 67.8f64, max = 123.4f64))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(
+            range(min = 67.8f64, max = 123.4f64),
+        )]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub double: Option<f64>,
 
     #[serde(rename = "string")]
     #[validate(
             regex(path = *RE_FORMATTEST_STRING),
         )]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub string: Option<String>,
 
     #[serde(rename = "byte")]
-    #[validate(custom(function = "validate_byte_formattest_byte"))]
+    #[validate(
+            custom(function = "validate_byte_formattest_byte"),
+        )]
     pub byte: ByteArray,
 
     #[serde(rename = "binary")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub binary: Option<ByteArray>,
 
     #[serde(rename = "date")]
     pub date: chrono::naive::NaiveDate,
 
     #[serde(rename = "dateTime")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub date_time: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub date_time: Option<chrono::DateTime::<chrono::Utc>>,
 
     #[serde(rename = "uuid")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub uuid: Option<uuid::Uuid>,
 
     #[serde(rename = "password")]
-    #[validate(length(min = 10, max = 64))]
+    #[validate(
+            length(min = 10, max = 64),
+        )]
     pub password: String,
+
+}
+
+impl FormatTest {
+    fn __name_for_integer() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='integer', complexType='integer', getter='getInteger', setter='setInteger', description='null', dataType='u8', datatypeWithEnum='i32', dataFormat='null', name='integer', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.integer;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "maximum" : 100,
+  "minimum" : 10,
+  "type" : "integer"
+}', minimum='10', maximum='100', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=false, isLong=false, isUnboundedInteger=true, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='integer', nameInPascalCase='Integer', nameInSnakeCase='INTEGER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_integer<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_integer())
+        }
+}
+impl FormatTest {
+    fn __name_for_int32() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='int32', complexType='integer', getter='getInt32', setter='setInt32', description='null', dataType='u8', datatypeWithEnum='i32', dataFormat='int32', name='int32', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.int32;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int32",
+  "maximum" : 200,
+  "minimum" : 20,
+  "type" : "integer"
+}', minimum='20', maximum='200', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='int32', nameInPascalCase='Int32', nameInSnakeCase='INT32', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_int32<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_int32())
+        }
+}
+impl FormatTest {
+    fn __name_for_int64() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='int64', complexType='long', getter='getInt64', setter='setInt64', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='int64', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.int64;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='int64', nameInPascalCase='Int64', nameInSnakeCase='INT64', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_int64<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_int64())
+        }
+}
+impl FormatTest {
+    fn __name_for_number() -> String {
+        String::from("CodegenProperty{openApiType='number', baseName='number', complexType='number', getter='getNumber', setter='setNumber', description='null', dataType='f64', datatypeWithEnum='f64', dataFormat='null', name='number', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.number;', baseType='number', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "maximum" : 543.2,
+  "minimum" : 32.1,
+  "type" : "number"
+}', minimum='32.1', maximum='543.2', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=true, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='number', nameInPascalCase='Number', nameInSnakeCase='NUMBER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_number<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_number())
+        }
+}
+impl FormatTest {
+    fn __name_for_float() -> String {
+        String::from("CodegenProperty{openApiType='number', baseName='float', complexType='float', getter='getFloat', setter='setFloat', description='null', dataType='f32', datatypeWithEnum='f32', dataFormat='float', name='float', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.float;', baseType='float', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "float",
+  "maximum" : 987.6,
+  "minimum" : 54.3,
+  "type" : "number"
+}', minimum='54.3', maximum='987.6', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=true, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='float', nameInPascalCase='Float', nameInSnakeCase='FLOAT', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=float, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_float<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_float())
+        }
+}
+impl FormatTest {
+    fn __name_for_double() -> String {
+        String::from("CodegenProperty{openApiType='number', baseName='double', complexType='double', getter='getDouble', setter='setDouble', description='null', dataType='f64', datatypeWithEnum='f64', dataFormat='double', name='double', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.double;', baseType='double', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "double",
+  "maximum" : 123.4,
+  "minimum" : 67.8,
+  "type" : "number"
+}', minimum='67.8', maximum='123.4', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=true, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='double', nameInPascalCase='Double', nameInSnakeCase='DOUBLE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=double, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_double<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_double())
+        }
+}
+impl FormatTest {
+    fn __name_for_string() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='string', complexType='string', getter='getString', setter='setString', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='string', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.string;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='/[a-z]/i', example='null', jsonSchema='{
+  "pattern" : "/[a-z]/i",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='string', nameInPascalCase='String', nameInSnakeCase='STRING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_string<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_string())
+        }
+}
+impl FormatTest {
+    fn __name_for_byte() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='byte', complexType='ByteArray', getter='getByte', setter='setByte', description='null', dataType='ByteArray', datatypeWithEnum='ByteArray', dataFormat='byte', name='byte', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.byte;', baseType='ByteArray', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$', example='null', jsonSchema='{
+  "format" : "byte",
+  "pattern" : "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=true, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='byte', nameInPascalCase='Byte', nameInSnakeCase='BYTE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=byte, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_byte<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_byte())
+        }
+}
+impl FormatTest {
+    fn __name_for_binary() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='binary', complexType='file', getter='getBinary', setter='setBinary', description='null', dataType='ByteArray', datatypeWithEnum='ByteArray', dataFormat='binary', name='binary', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.binary;', baseType='file', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "binary",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=true, isFile=true, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='binary', nameInPascalCase='Binary', nameInSnakeCase='BINARY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=binary, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_binary<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_binary())
+        }
+}
+impl FormatTest {
+    fn __name_for_date() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='date', complexType='date', getter='getDate', setter='setDate', description='null', dataType='chrono::naive::NaiveDate', datatypeWithEnum='chrono::naive::NaiveDate', dataFormat='date', name='date', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.date;', baseType='date', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "date",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=true, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='date', nameInPascalCase='Date', nameInSnakeCase='DATE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=date, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_date<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_date())
+        }
+}
+impl FormatTest {
+    fn __name_for_date_time() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='dateTime', complexType='DateTime', getter='getDateTime', setter='setDateTime', description='null', dataType='chrono::DateTime::<chrono::Utc>', datatypeWithEnum='chrono::DateTime::<chrono::Utc>', dataFormat='date-time', name='date_time', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.dateTime;', baseType='DateTime', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "date-time",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=true, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='dateTime', nameInPascalCase='DateTime', nameInSnakeCase='DATE_TIME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=date-time, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_date_time<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_date_time())
+        }
+}
+impl FormatTest {
+    fn __name_for_uuid() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='uuid', complexType='UUID', getter='getUuid', setter='setUuid', description='null', dataType='uuid::Uuid', datatypeWithEnum='uuid::Uuid', dataFormat='uuid', name='uuid', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.uuid;', baseType='UUID', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "uuid",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=true, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='uuid', nameInPascalCase='Uuid', nameInSnakeCase='UUID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=uuid, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_uuid<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_uuid())
+        }
+}
+impl FormatTest {
+    fn __name_for_password() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='password', complexType='password', getter='getPassword', setter='setPassword', description='null', dataType='String', datatypeWithEnum='String', dataFormat='password', name='password', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.password;', baseType='password', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=64, minLength=10, pattern='null', example='null', jsonSchema='{
+  "format" : "password",
+  "maxLength" : 64,
+  "minLength" : 10,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=true, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='password', nameInPascalCase='Password', nameInSnakeCase='PASSWORD', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=password, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_password<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_password())
+        }
 }
 
 lazy_static::lazy_static! {
@@ -2804,7 +3552,7 @@ lazy_static::lazy_static! {
     static ref RE_FORMATTEST_BYTE: regex::bytes::Regex = regex::bytes::Regex::new(r"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}&#x3D;&#x3D;|[A-Za-z0-9+/]{3}&#x3D;)?$").unwrap();
 }
 fn validate_byte_formattest_byte(
-    b: &ByteArray,
+    b: &ByteArray
 ) -> std::result::Result<(), validator::ValidationError> {
     if !RE_FORMATTEST_BYTE.is_match(&b.0) {
         return Err(validator::ValidationError::new("Character not allowed"));
@@ -2814,12 +3562,7 @@ fn validate_byte_formattest_byte(
 
 impl FormatTest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(
-        number: f64,
-        byte: ByteArray,
-        date: chrono::naive::NaiveDate,
-        password: String,
-    ) -> FormatTest {
+    pub fn new(number: f64, byte: ByteArray, date: chrono::naive::NaiveDate, password: String, ) -> FormatTest {
         FormatTest {
             integer: None,
             int32: None,
@@ -2844,26 +3587,58 @@ impl FormatTest {
 impl std::fmt::Display for FormatTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.integer
-                .as_ref()
-                .map(|integer| ["integer".to_string(), integer.to_string()].join(",")),
-            self.int32
-                .as_ref()
-                .map(|int32| ["int32".to_string(), int32.to_string()].join(",")),
-            self.int64
-                .as_ref()
-                .map(|int64| ["int64".to_string(), int64.to_string()].join(",")),
+
+            self.integer.as_ref().map(|integer| {
+                [
+                    "integer".to_string(),
+                    integer.to_string(),
+                ].join(",")
+            }),
+
+
+            self.int32.as_ref().map(|int32| {
+                [
+                    "int32".to_string(),
+                    int32.to_string(),
+                ].join(",")
+            }),
+
+
+            self.int64.as_ref().map(|int64| {
+                [
+                    "int64".to_string(),
+                    int64.to_string(),
+                ].join(",")
+            }),
+
+
             Some("number".to_string()),
             Some(self.number.to_string()),
-            self.float
-                .as_ref()
-                .map(|float| ["float".to_string(), float.to_string()].join(",")),
-            self.double
-                .as_ref()
-                .map(|double| ["double".to_string(), double.to_string()].join(",")),
-            self.string
-                .as_ref()
-                .map(|string| ["string".to_string(), string.to_string()].join(",")),
+
+
+            self.float.as_ref().map(|float| {
+                [
+                    "float".to_string(),
+                    float.to_string(),
+                ].join(",")
+            }),
+
+
+            self.double.as_ref().map(|double| {
+                [
+                    "double".to_string(),
+                    double.to_string(),
+                ].join(",")
+            }),
+
+
+            self.string.as_ref().map(|string| {
+                [
+                    "string".to_string(),
+                    string.to_string(),
+                ].join(",")
+            }),
+
             // Skipping byte in query parameter serialization
             // Skipping byte in query parameter serialization
 
@@ -2875,15 +3650,14 @@ impl std::fmt::Display for FormatTest {
             // Skipping dateTime in query parameter serialization
 
             // Skipping uuid in query parameter serialization
+
+
             Some("password".to_string()),
             Some(self.password.to_string()),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -2908,7 +3682,7 @@ impl std::str::FromStr for FormatTest {
             pub byte: Vec<ByteArray>,
             pub binary: Vec<ByteArray>,
             pub date: Vec<chrono::naive::NaiveDate>,
-            pub date_time: Vec<chrono::DateTime<chrono::Utc>>,
+            pub date_time: Vec<chrono::DateTime::<chrono::Utc>>,
             pub uuid: Vec<uuid::Uuid>,
             pub password: Vec<String>,
         }
@@ -2922,80 +3696,37 @@ impl std::str::FromStr for FormatTest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing FormatTest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing FormatTest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "integer" => intermediate_rep
-                        .integer
-                        .push(<u8 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "integer" => intermediate_rep.integer.push(<u8 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "int32" => intermediate_rep
-                        .int32
-                        .push(<u8 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "int32" => intermediate_rep.int32.push(<u8 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "int64" => intermediate_rep.int64.push(
-                        <i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "int64" => intermediate_rep.int64.push(<i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "number" => intermediate_rep.number.push(
-                        <f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "number" => intermediate_rep.number.push(<f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "float" => intermediate_rep.float.push(
-                        <f32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "float" => intermediate_rep.float.push(<f32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "double" => intermediate_rep.double.push(
-                        <f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "double" => intermediate_rep.double.push(<f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "string" => intermediate_rep.string.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    "byte" => {
-                        return std::result::Result::Err(
-                            "Parsing binary data in this style is not supported in FormatTest"
-                                .to_string(),
-                        )
-                    }
-                    "binary" => {
-                        return std::result::Result::Err(
-                            "Parsing binary data in this style is not supported in FormatTest"
-                                .to_string(),
-                        )
-                    }
+                    "string" => intermediate_rep.string.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "byte" => return std::result::Result::Err("Parsing binary data in this style is not supported in FormatTest".to_string()),
+                    "binary" => return std::result::Result::Err("Parsing binary data in this style is not supported in FormatTest".to_string()),
                     #[allow(clippy::redundant_clone)]
-                    "date" => intermediate_rep.date.push(
-                        <chrono::naive::NaiveDate as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
-                    ),
+                    "date" => intermediate_rep.date.push(<chrono::naive::NaiveDate as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "dateTime" => intermediate_rep.date_time.push(
-                        <chrono::DateTime<chrono::Utc> as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
-                    ),
+                    "dateTime" => intermediate_rep.date_time.push(<chrono::DateTime::<chrono::Utc> as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "uuid" => intermediate_rep.uuid.push(
-                        <uuid::Uuid as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
-                    ),
+                    "uuid" => intermediate_rep.uuid.push(<uuid::Uuid as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "password" => intermediate_rep.password.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing FormatTest".to_string(),
-                        )
-                    }
+                    "password" => intermediate_rep.password.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing FormatTest".to_string())
                 }
             }
 
@@ -3008,32 +3739,16 @@ impl std::str::FromStr for FormatTest {
             integer: intermediate_rep.integer.into_iter().next(),
             int32: intermediate_rep.int32.into_iter().next(),
             int64: intermediate_rep.int64.into_iter().next(),
-            number: intermediate_rep
-                .number
-                .into_iter()
-                .next()
-                .ok_or_else(|| "number missing in FormatTest".to_string())?,
+            number: intermediate_rep.number.into_iter().next().ok_or_else(|| "number missing in FormatTest".to_string())?,
             float: intermediate_rep.float.into_iter().next(),
             double: intermediate_rep.double.into_iter().next(),
             string: intermediate_rep.string.into_iter().next(),
-            byte: intermediate_rep
-                .byte
-                .into_iter()
-                .next()
-                .ok_or_else(|| "byte missing in FormatTest".to_string())?,
+            byte: intermediate_rep.byte.into_iter().next().ok_or_else(|| "byte missing in FormatTest".to_string())?,
             binary: intermediate_rep.binary.into_iter().next(),
-            date: intermediate_rep
-                .date
-                .into_iter()
-                .next()
-                .ok_or_else(|| "date missing in FormatTest".to_string())?,
+            date: intermediate_rep.date.into_iter().next().ok_or_else(|| "date missing in FormatTest".to_string())?,
             date_time: intermediate_rep.date_time.into_iter().next(),
             uuid: intermediate_rep.uuid.into_iter().next(),
-            password: intermediate_rep
-                .password
-                .into_iter()
-                .next()
-                .ok_or_else(|| "password missing in FormatTest".to_string())?,
+            password: intermediate_rep.password.into_iter().next().ok_or_else(|| "password missing in FormatTest".to_string())?,
         })
     }
 }
@@ -3044,16 +3759,13 @@ impl std::str::FromStr for FormatTest {
 impl std::convert::TryFrom<header::IntoHeaderValue<FormatTest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<FormatTest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<FormatTest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for FormatTest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for FormatTest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3064,36 +3776,66 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<FormatTest> 
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <FormatTest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <FormatTest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into FormatTest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into FormatTest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct HasOnlyReadOnly {
     #[serde(rename = "bar")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bar: Option<String>,
 
     #[serde(rename = "foo")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub foo: Option<String>,
+
 }
+
+impl HasOnlyReadOnly {
+    fn __name_for_bar() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='bar', complexType='string', getter='getBar', setter='setBar', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='bar', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.bar;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "readOnly" : true,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=true, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='bar', nameInPascalCase='Bar', nameInSnakeCase='BAR', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_bar<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_bar())
+        }
+}
+impl HasOnlyReadOnly {
+    fn __name_for_foo() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='foo', complexType='string', getter='getFoo', setter='setFoo', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='foo', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.foo;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "readOnly" : true,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=true, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='foo', nameInPascalCase='Foo', nameInSnakeCase='FOO', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_foo<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_foo())
+        }
+}
+
 
 impl HasOnlyReadOnly {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -3111,19 +3853,25 @@ impl HasOnlyReadOnly {
 impl std::fmt::Display for HasOnlyReadOnly {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.bar
-                .as_ref()
-                .map(|bar| ["bar".to_string(), bar.to_string()].join(",")),
-            self.foo
-                .as_ref()
-                .map(|foo| ["foo".to_string(), foo.to_string()].join(",")),
+
+            self.bar.as_ref().map(|bar| {
+                [
+                    "bar".to_string(),
+                    bar.to_string(),
+                ].join(",")
+            }),
+
+
+            self.foo.as_ref().map(|foo| {
+                [
+                    "foo".to_string(),
+                    foo.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -3151,29 +3899,17 @@ impl std::str::FromStr for HasOnlyReadOnly {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing HasOnlyReadOnly".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing HasOnlyReadOnly".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "bar" => intermediate_rep.bar.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "bar" => intermediate_rep.bar.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "foo" => intermediate_rep.foo.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing HasOnlyReadOnly".to_string(),
-                        )
-                    }
+                    "foo" => intermediate_rep.foo.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing HasOnlyReadOnly".to_string())
                 }
             }
 
@@ -3195,16 +3931,13 @@ impl std::str::FromStr for HasOnlyReadOnly {
 impl std::convert::TryFrom<header::IntoHeaderValue<HasOnlyReadOnly>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<HasOnlyReadOnly>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<HasOnlyReadOnly>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for HasOnlyReadOnly - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for HasOnlyReadOnly - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3215,32 +3948,47 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<HasOnlyReadO
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <HasOnlyReadOnly as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <HasOnlyReadOnly as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into HasOnlyReadOnly - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into HasOnlyReadOnly - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct List {
     #[serde(rename = "123-list")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub param_123_list: Option<String>,
+
 }
+
+impl List {
+    fn __name_for_param_123_list() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='123-list', complexType='string', getter='getParam123List', setter='setParam123List', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='param_123_list', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.123-list;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='param123List', nameInPascalCase='Param123List', nameInSnakeCase='PARAM123_LIST', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_param_123_list<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_param_123_list())
+        }
+}
+
 
 impl List {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -3256,16 +4004,18 @@ impl List {
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for List {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> = vec![self
-            .param_123_list
-            .as_ref()
-            .map(|param_123_list| ["123-list".to_string(), param_123_list.to_string()].join(","))];
+        let params: Vec<Option<String>> = vec![
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+            self.param_123_list.as_ref().map(|param_123_list| {
+                [
+                    "123-list".to_string(),
+                    param_123_list.to_string(),
+                ].join(",")
+            }),
+
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -3292,23 +4042,15 @@ impl std::str::FromStr for List {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err("Missing value while parsing List".to_string())
-                }
+                None => return std::result::Result::Err("Missing value while parsing List".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "123-list" => intermediate_rep.param_123_list.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing List".to_string(),
-                        )
-                    }
+                    "123-list" => intermediate_rep.param_123_list.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing List".to_string())
                 }
             }
 
@@ -3329,16 +4071,13 @@ impl std::str::FromStr for List {
 impl std::convert::TryFrom<header::IntoHeaderValue<List>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<List>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<List>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for List - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for List - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3349,42 +4088,166 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<List> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => match <List as std::str::FromStr>::from_str(value) {
-                std::result::Result::Ok(value) => {
-                    std::result::Result::Ok(header::IntoHeaderValue(value))
-                }
-                std::result::Result::Err(err) => std::result::Result::Err(format!(
-                    "Unable to convert header value '{}' into List - {}",
-                    value, err
-                )),
-            },
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => {
+                    match <List as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into List - {}",
+                                value, err))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct MapTest {
     #[serde(rename = "map_map_of_string")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub map_map_of_string:
-        Option<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub map_map_of_string: Option<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
 
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "map_map_of_enum")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub map_map_of_enum:
-        Option<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub map_map_of_enum: Option<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
 
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "map_of_enum_string")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub map_of_enum_string: Option<std::collections::HashMap<String, String>>,
+
 }
+
+impl MapTest {
+    fn __name_for_map_map_of_string() -> String {
+        String::from("CodegenProperty{openApiType='object', baseName='map_map_of_string', complexType='map', getter='getMapMapOfString', setter='setMapMapOfString', description='null', dataType='std::collections::HashMap<String, std::collections::HashMap<String, String>>', datatypeWithEnum='std::collections::HashMap<String, std::collections::HashMap<String, String>>', dataFormat='null', name='map_map_of_string', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.map_map_of_string;', baseType='map', containerType='map', containerTypeMapped='std::collections::HashMap', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "additionalProperties" : {
+    "type" : "object",
+    "additionalProperties" : {
+      "type" : "string"
+    }
+  },
+  "type" : "object"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=true, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='object', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='std::collections::HashMap<String, String>', datatypeWithEnum='std::collections::HashMap<String, String>', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='map', containerType='map', containerTypeMapped='std::collections::HashMap', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "additionalProperties" : {
+    "type" : "string"
+  },
+  "type" : "object"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=true, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=CodegenProperty{openApiType='string', baseName='additional_properties', complexType='string', getter='getAdditionalProperties', setter='setAdditionalProperties', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='additional_properties', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.additional_properties;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalProperties', nameInPascalCase='AdditionalProperties', nameInSnakeCase='ADDITIONAL_PROPERTIES', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=true, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=CodegenProperty{openApiType='object', baseName='additional_properties', complexType='string', getter='getAdditionalProperties', setter='setAdditionalProperties', description='null', dataType='std::collections::HashMap<String, String>', datatypeWithEnum='std::collections::HashMap<String, String>', dataFormat='null', name='additional_properties', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.additional_properties;', baseType='map', containerType='map', containerTypeMapped='std::collections::HashMap', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "additionalProperties" : {
+    "type" : "string"
+  },
+  "type" : "object"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=true, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=CodegenProperty{openApiType='string', baseName='additional_properties', complexType='string', getter='getAdditionalProperties', setter='setAdditionalProperties', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='additional_properties', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.additional_properties;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalProperties', nameInPascalCase='AdditionalProperties', nameInSnakeCase='ADDITIONAL_PROPERTIES', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalProperties', nameInPascalCase='AdditionalProperties', nameInSnakeCase='ADDITIONAL_PROPERTIES', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=true, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='mapMapOfString', nameInPascalCase='MapMapOfString', nameInSnakeCase='MAP_MAP_OF_STRING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=true, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_map_map_of_string<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_map_map_of_string())
+        }
+}
+impl MapTest {
+    fn __name_for_map_map_of_enum() -> String {
+        String::from("CodegenProperty{openApiType='object', baseName='map_map_of_enum', complexType='map', getter='getMapMapOfEnum', setter='setMapMapOfEnum', description='null', dataType='std::collections::HashMap<String, std::collections::HashMap<String, String>>', datatypeWithEnum='std::collections::HashMap<String, std::collections::HashMap<String, String>>', dataFormat='null', name='map_map_of_enum', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.map_map_of_enum;', baseType='map', containerType='map', containerTypeMapped='std::collections::HashMap', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "additionalProperties" : {
+    "type" : "object",
+    "additionalProperties" : {
+      "type" : "string",
+      "enum" : [ "UPPER", "lower" ]
+    }
+  },
+  "type" : "object"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=true, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues={enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}], values=[UPPER, lower]}, items=CodegenProperty{openApiType='object', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='std::collections::HashMap<String, String>', datatypeWithEnum='std::collections::HashMap<String, String>', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='map', containerType='map', containerTypeMapped='std::collections::HashMap', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "additionalProperties" : {
+    "type" : "string",
+    "enum" : [ "UPPER", "lower" ]
+  },
+  "type" : "object"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=true, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues={values=[UPPER, lower], enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}]}, items=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='Inner', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower], allowableValues={values=[UPPER, lower], enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='Inner', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=CodegenProperty{openApiType='string', baseName='additional_properties', complexType='string', getter='getAdditionalProperties', setter='setAdditionalProperties', description='null', dataType='String', datatypeWithEnum='AdditionalProperties', dataFormat='null', name='additional_properties', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.additional_properties;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower], allowableValues={values=[UPPER, lower]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalProperties', nameInPascalCase='AdditionalProperties', nameInSnakeCase='ADDITIONAL_PROPERTIES', enumName='AdditionalProperties', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='Inner', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower], allowableValues={values=[UPPER, lower], enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='Inner', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='Inner', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=true, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=CodegenProperty{openApiType='object', baseName='additional_properties', complexType='string', getter='getAdditionalProperties', setter='setAdditionalProperties', description='null', dataType='std::collections::HashMap<String, String>', datatypeWithEnum='std::collections::HashMap<String, String>', dataFormat='null', name='additional_properties', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.additional_properties;', baseType='map', containerType='map', containerTypeMapped='std::collections::HashMap', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "additionalProperties" : {
+    "type" : "string",
+    "enum" : [ "UPPER", "lower" ]
+  },
+  "type" : "object"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=true, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues={values=[UPPER, lower], enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}]}, items=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='Inner', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower], allowableValues={values=[UPPER, lower], enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='Inner', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=CodegenProperty{openApiType='string', baseName='additional_properties', complexType='string', getter='getAdditionalProperties', setter='setAdditionalProperties', description='null', dataType='String', datatypeWithEnum='AdditionalProperties', dataFormat='null', name='additional_properties', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.additional_properties;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower], allowableValues={values=[UPPER, lower]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalProperties', nameInPascalCase='AdditionalProperties', nameInSnakeCase='ADDITIONAL_PROPERTIES', enumName='AdditionalProperties', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='Inner', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower], allowableValues={values=[UPPER, lower], enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='Inner', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalProperties', nameInPascalCase='AdditionalProperties', nameInSnakeCase='ADDITIONAL_PROPERTIES', enumName='AdditionalProperties', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=true, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='Inner', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower], allowableValues={values=[UPPER, lower], enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='Inner', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='mapMapOfEnum', nameInPascalCase='MapMapOfEnum', nameInSnakeCase='MAP_MAP_OF_ENUM', enumName='MapMapOfEnum', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=true, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_map_map_of_enum<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_map_map_of_enum())
+        }
+}
+impl MapTest {
+    fn __name_for_map_of_enum_string() -> String {
+        String::from("CodegenProperty{openApiType='object', baseName='map_of_enum_string', complexType='string', getter='getMapOfEnumString', setter='setMapOfEnumString', description='null', dataType='std::collections::HashMap<String, String>', datatypeWithEnum='std::collections::HashMap<String, String>', dataFormat='null', name='map_of_enum_string', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.map_of_enum_string;', baseType='map', containerType='map', containerTypeMapped='std::collections::HashMap', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "additionalProperties" : {
+    "type" : "string",
+    "enum" : [ "UPPER", "lower" ]
+  },
+  "type" : "object"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=true, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues={enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}], values=[UPPER, lower]}, items=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='Inner', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower], allowableValues={values=[UPPER, lower], enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='Inner', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=CodegenProperty{openApiType='string', baseName='additional_properties', complexType='string', getter='getAdditionalProperties', setter='setAdditionalProperties', description='null', dataType='String', datatypeWithEnum='AdditionalProperties', dataFormat='null', name='additional_properties', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.additional_properties;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower], allowableValues={values=[UPPER, lower]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalProperties', nameInPascalCase='AdditionalProperties', nameInSnakeCase='ADDITIONAL_PROPERTIES', enumName='AdditionalProperties', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='inner', complexType='string', getter='getInner', setter='setInner', description='null', dataType='String', datatypeWithEnum='Inner', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "enum" : [ "UPPER", "lower" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[UPPER, lower], allowableValues={values=[UPPER, lower], enumVars=[{name=Upper, isString=true, value="UPPER"}, {name=Lower, isString=true, value="lower"}]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='Inner', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='mapOfEnumString', nameInPascalCase='MapOfEnumString', nameInSnakeCase='MAP_OF_ENUM_STRING', enumName='MapOfEnumString', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=true, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_map_of_enum_string<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_map_of_enum_string())
+        }
+}
+
 
 impl MapTest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -3413,11 +4276,7 @@ impl std::fmt::Display for MapTest {
 
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -3432,10 +4291,8 @@ impl std::str::FromStr for MapTest {
         #[derive(Default)]
         #[allow(dead_code)]
         struct IntermediateRep {
-            pub map_map_of_string:
-                Vec<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
-            pub map_map_of_enum:
-                Vec<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
+            pub map_map_of_string: Vec<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
+            pub map_map_of_enum: Vec<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
             pub map_of_enum_string: Vec<std::collections::HashMap<String, String>>,
         }
 
@@ -3448,39 +4305,16 @@ impl std::str::FromStr for MapTest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing MapTest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing MapTest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
-                    "map_map_of_string" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in MapTest"
-                                .to_string(),
-                        )
-                    }
-                    "map_map_of_enum" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in MapTest"
-                                .to_string(),
-                        )
-                    }
-                    "map_of_enum_string" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in MapTest"
-                                .to_string(),
-                        )
-                    }
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing MapTest".to_string(),
-                        )
-                    }
+                    "map_map_of_string" => return std::result::Result::Err("Parsing a container in this style is not supported in MapTest".to_string()),
+                    "map_map_of_enum" => return std::result::Result::Err("Parsing a container in this style is not supported in MapTest".to_string()),
+                    "map_of_enum_string" => return std::result::Result::Err("Parsing a container in this style is not supported in MapTest".to_string()),
+                    _ => return std::result::Result::Err("Unexpected key while parsing MapTest".to_string())
                 }
             }
 
@@ -3503,16 +4337,13 @@ impl std::str::FromStr for MapTest {
 impl std::convert::TryFrom<header::IntoHeaderValue<MapTest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<MapTest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MapTest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for MapTest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for MapTest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3523,40 +4354,92 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<MapTest> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <MapTest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <MapTest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into MapTest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into MapTest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct MixedPropertiesAndAdditionalPropertiesClass {
     #[serde(rename = "uuid")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub uuid: Option<uuid::Uuid>,
 
     #[serde(rename = "dateTime")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub date_time: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub date_time: Option<chrono::DateTime::<chrono::Utc>>,
 
     #[serde(rename = "map")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub map: Option<std::collections::HashMap<String, models::Animal>>,
+
 }
+
+impl MixedPropertiesAndAdditionalPropertiesClass {
+    fn __name_for_uuid() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='uuid', complexType='UUID', getter='getUuid', setter='setUuid', description='null', dataType='uuid::Uuid', datatypeWithEnum='uuid::Uuid', dataFormat='uuid', name='uuid', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.uuid;', baseType='UUID', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "uuid",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=true, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='uuid', nameInPascalCase='Uuid', nameInSnakeCase='UUID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=uuid, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_uuid<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_uuid())
+        }
+}
+impl MixedPropertiesAndAdditionalPropertiesClass {
+    fn __name_for_date_time() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='dateTime', complexType='DateTime', getter='getDateTime', setter='setDateTime', description='null', dataType='chrono::DateTime::<chrono::Utc>', datatypeWithEnum='chrono::DateTime::<chrono::Utc>', dataFormat='date-time', name='date_time', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.dateTime;', baseType='DateTime', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "date-time",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=true, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='dateTime', nameInPascalCase='DateTime', nameInSnakeCase='DATE_TIME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=date-time, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_date_time<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_date_time())
+        }
+}
+impl MixedPropertiesAndAdditionalPropertiesClass {
+    fn __name_for_map() -> String {
+        String::from("CodegenProperty{openApiType='object', baseName='map', complexType='Animal', getter='getMap', setter='setMap', description='null', dataType='std::collections::HashMap<String, models::Animal>', datatypeWithEnum='std::collections::HashMap<String, models::Animal>', dataFormat='null', name='map', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.map;', baseType='map', containerType='map', containerTypeMapped='std::collections::HashMap', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "additionalProperties" : {
+    "$ref" : "#/components/schemas/Animal"
+  },
+  "type" : "object"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=true, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='Animal', baseName='inner', complexType='Animal', getter='getInner', setter='setInner', description='null', dataType='models::Animal', datatypeWithEnum='models::Animal', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='Animal', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/Animal"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/Animal, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=CodegenProperty{openApiType='Animal', baseName='additional_properties', complexType='Animal', getter='getAdditionalProperties', setter='setAdditionalProperties', description='null', dataType='models::Animal', datatypeWithEnum='models::Animal', dataFormat='null', name='additional_properties', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.additional_properties;', baseType='Animal', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/Animal"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalProperties', nameInPascalCase='AdditionalProperties', nameInSnakeCase='ADDITIONAL_PROPERTIES', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/Animal, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='Animal', baseName='inner', complexType='Animal', getter='getInner', setter='setInner', description='null', dataType='models::Animal', datatypeWithEnum='models::Animal', dataFormat='null', name='inner', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.inner;', baseType='Animal', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/Animal"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/Animal, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='map', nameInPascalCase='Map', nameInSnakeCase='MAP', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=true, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_map<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_map())
+        }
+}
+
 
 impl MixedPropertiesAndAdditionalPropertiesClass {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -3584,11 +4467,7 @@ impl std::fmt::Display for MixedPropertiesAndAdditionalPropertiesClass {
 
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -3604,7 +4483,7 @@ impl std::str::FromStr for MixedPropertiesAndAdditionalPropertiesClass {
         #[allow(dead_code)]
         struct IntermediateRep {
             pub uuid: Vec<uuid::Uuid>,
-            pub date_time: Vec<chrono::DateTime<chrono::Utc>>,
+            pub date_time: Vec<chrono::DateTime::<chrono::Utc>>,
             pub map: Vec<std::collections::HashMap<String, models::Animal>>,
         }
 
@@ -3615,14 +4494,10 @@ impl std::str::FromStr for MixedPropertiesAndAdditionalPropertiesClass {
         let mut key_result = string_iter.next();
 
         while key_result.is_some() {
-            let val =
-                match string_iter.next() {
-                    Some(x) => x,
-                    None => return std::result::Result::Err(
-                        "Missing value while parsing MixedPropertiesAndAdditionalPropertiesClass"
-                            .to_string(),
-                    ),
-                };
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => return std::result::Result::Err("Missing value while parsing MixedPropertiesAndAdditionalPropertiesClass".to_string())
+            };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
@@ -3652,14 +4527,10 @@ impl std::str::FromStr for MixedPropertiesAndAdditionalPropertiesClass {
 // Methods for converting between header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass> and HeaderValue
 
 #[cfg(feature = "server")]
-impl std::convert::TryFrom<header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass>>
-    for HeaderValue
-{
+impl std::convert::TryFrom<header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
              std::result::Result::Ok(value) => std::result::Result::Ok(value),
@@ -3671,9 +4542,7 @@ impl std::convert::TryFrom<header::IntoHeaderValue<MixedPropertiesAndAdditionalP
 }
 
 #[cfg(feature = "server")]
-impl std::convert::TryFrom<HeaderValue>
-    for header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass>
-{
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass> {
     type Error = String;
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
@@ -3693,18 +4562,51 @@ impl std::convert::TryFrom<HeaderValue>
     }
 }
 
+
+
+
 /// Model for testing model name starting with number
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Model200Response {
     #[serde(rename = "name")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<i32>,
 
     #[serde(rename = "class")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub class: Option<String>,
+
 }
+
+impl Model200Response {
+    fn __name_for_name() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='name', complexType='integer', getter='getName', setter='setName', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='int32', name='name', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.name;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int32",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='name', nameInPascalCase='Name', nameInSnakeCase='NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_name())
+        }
+}
+impl Model200Response {
+    fn __name_for_class() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='class', complexType='string', getter='getClass', setter='setClass', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='class', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.class;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='class', nameInPascalCase='Class', nameInSnakeCase='CLASS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_class<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_class())
+        }
+}
+
 
 impl Model200Response {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -3722,19 +4624,25 @@ impl Model200Response {
 impl std::fmt::Display for Model200Response {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.name
-                .as_ref()
-                .map(|name| ["name".to_string(), name.to_string()].join(",")),
-            self.class
-                .as_ref()
-                .map(|class| ["class".to_string(), class.to_string()].join(",")),
+
+            self.name.as_ref().map(|name| {
+                [
+                    "name".to_string(),
+                    name.to_string(),
+                ].join(",")
+            }),
+
+
+            self.class.as_ref().map(|class| {
+                [
+                    "class".to_string(),
+                    class.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -3762,29 +4670,17 @@ impl std::str::FromStr for Model200Response {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing Model200Response".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing Model200Response".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "name" => intermediate_rep.name.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "name" => intermediate_rep.name.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "class" => intermediate_rep.class.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Model200Response".to_string(),
-                        )
-                    }
+                    "class" => intermediate_rep.class.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Model200Response".to_string())
                 }
             }
 
@@ -3806,16 +4702,13 @@ impl std::str::FromStr for Model200Response {
 impl std::convert::TryFrom<header::IntoHeaderValue<Model200Response>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<Model200Response>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Model200Response>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Model200Response - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Model200Response - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3826,24 +4719,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Model200Resp
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <Model200Response as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <Model200Response as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Model200Response - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into Model200Response - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// Model for testing model name same as property name
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
@@ -3853,21 +4745,80 @@ pub struct Name {
     pub name: i32,
 
     #[serde(rename = "snake_case")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snake_case: Option<i32>,
 
     #[serde(rename = "property")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub property: Option<String>,
 
     #[serde(rename = "123Number")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub param_123_number: Option<i32>,
+
 }
 
 impl Name {
+    fn __name_for_name() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='name', complexType='integer', getter='getName', setter='setName', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='int32', name='name', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.name;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int32",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='name', nameInPascalCase='Name', nameInSnakeCase='NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_name())
+        }
+}
+impl Name {
+    fn __name_for_snake_case() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='snake_case', complexType='integer', getter='getSnakeCase', setter='setSnakeCase', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='int32', name='snake_case', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.snake_case;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int32",
+  "readOnly" : true,
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=true, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='snakeCase', nameInPascalCase='SnakeCase', nameInSnakeCase='SNAKE_CASE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_snake_case<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_snake_case())
+        }
+}
+impl Name {
+    fn __name_for_property() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='property', complexType='string', getter='getProperty', setter='setProperty', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='property', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.property;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='property', nameInPascalCase='Property', nameInSnakeCase='PROPERTY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_property<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_property())
+        }
+}
+impl Name {
+    fn __name_for_param_123_number() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='123Number', complexType='integer', getter='getParam123Number', setter='setParam123Number', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='null', name='param_123_number', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.123Number;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "readOnly" : true,
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=false, isLong=false, isUnboundedInteger=true, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=true, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='param123Number', nameInPascalCase='Param123Number', nameInSnakeCase='PARAM123_NUMBER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_param_123_number<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_param_123_number())
+        }
+}
+
+
+impl Name {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(name: i32) -> Name {
+    pub fn new(name: i32, ) -> Name {
         Name {
             name,
             snake_case: None,
@@ -3883,24 +4834,37 @@ impl Name {
 impl std::fmt::Display for Name {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             Some("name".to_string()),
             Some(self.name.to_string()),
-            self.snake_case
-                .as_ref()
-                .map(|snake_case| ["snake_case".to_string(), snake_case.to_string()].join(",")),
-            self.property
-                .as_ref()
-                .map(|property| ["property".to_string(), property.to_string()].join(",")),
-            self.param_123_number.as_ref().map(|param_123_number| {
-                ["123Number".to_string(), param_123_number.to_string()].join(",")
+
+
+            self.snake_case.as_ref().map(|snake_case| {
+                [
+                    "snake_case".to_string(),
+                    snake_case.to_string(),
+                ].join(",")
             }),
+
+
+            self.property.as_ref().map(|property| {
+                [
+                    "property".to_string(),
+                    property.to_string(),
+                ].join(",")
+            }),
+
+
+            self.param_123_number.as_ref().map(|param_123_number| {
+                [
+                    "123Number".to_string(),
+                    param_123_number.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -3930,35 +4894,21 @@ impl std::str::FromStr for Name {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err("Missing value while parsing Name".to_string())
-                }
+                None => return std::result::Result::Err("Missing value while parsing Name".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "name" => intermediate_rep.name.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "name" => intermediate_rep.name.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "snake_case" => intermediate_rep.snake_case.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "snake_case" => intermediate_rep.snake_case.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "property" => intermediate_rep.property.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "property" => intermediate_rep.property.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "123Number" => intermediate_rep.param_123_number.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Name".to_string(),
-                        )
-                    }
+                    "123Number" => intermediate_rep.param_123_number.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Name".to_string())
                 }
             }
 
@@ -3968,11 +4918,7 @@ impl std::str::FromStr for Name {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(Name {
-            name: intermediate_rep
-                .name
-                .into_iter()
-                .next()
-                .ok_or_else(|| "name missing in Name".to_string())?,
+            name: intermediate_rep.name.into_iter().next().ok_or_else(|| "name missing in Name".to_string())?,
             snake_case: intermediate_rep.snake_case.into_iter().next(),
             property: intermediate_rep.property.into_iter().next(),
             param_123_number: intermediate_rep.param_123_number.into_iter().next(),
@@ -3986,16 +4932,13 @@ impl std::str::FromStr for Name {
 impl std::convert::TryFrom<header::IntoHeaderValue<Name>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<Name>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Name>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Name - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Name - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4006,35 +4949,54 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Name> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => match <Name as std::str::FromStr>::from_str(value) {
-                std::result::Result::Ok(value) => {
-                    std::result::Result::Ok(header::IntoHeaderValue(value))
-                }
-                std::result::Result::Err(err) => std::result::Result::Err(format!(
-                    "Unable to convert header value '{}' into Name - {}",
-                    value, err
-                )),
-            },
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => {
+                    match <Name as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Name - {}",
+                                value, err))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct NumberOnly {
     #[serde(rename = "JustNumber")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub just_number: Option<f64>,
+
 }
+
+impl NumberOnly {
+    fn __name_for_just_number() -> String {
+        String::from("CodegenProperty{openApiType='number', baseName='JustNumber', complexType='number', getter='getJustNumber', setter='setJustNumber', description='null', dataType='f64', datatypeWithEnum='f64', dataFormat='null', name='just_number', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.JustNumber;', baseType='number', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "number"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=true, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='justNumber', nameInPascalCase='JustNumber', nameInSnakeCase='JUST_NUMBER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_just_number<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_just_number())
+        }
+}
+
 
 impl NumberOnly {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new() -> NumberOnly {
-        NumberOnly { just_number: None }
+        NumberOnly {
+            just_number: None,
+        }
     }
 }
 
@@ -4043,16 +5005,18 @@ impl NumberOnly {
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for NumberOnly {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> = vec![self
-            .just_number
-            .as_ref()
-            .map(|just_number| ["JustNumber".to_string(), just_number.to_string()].join(","))];
+        let params: Vec<Option<String>> = vec![
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+            self.just_number.as_ref().map(|just_number| {
+                [
+                    "JustNumber".to_string(),
+                    just_number.to_string(),
+                ].join(",")
+            }),
+
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -4079,25 +5043,15 @@ impl std::str::FromStr for NumberOnly {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing NumberOnly".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing NumberOnly".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "JustNumber" => intermediate_rep.just_number.push(
-                        <f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing NumberOnly".to_string(),
-                        )
-                    }
+                    "JustNumber" => intermediate_rep.just_number.push(<f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing NumberOnly".to_string())
                 }
             }
 
@@ -4118,16 +5072,13 @@ impl std::str::FromStr for NumberOnly {
 impl std::convert::TryFrom<header::IntoHeaderValue<NumberOnly>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<NumberOnly>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<NumberOnly>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for NumberOnly - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for NumberOnly - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4138,37 +5089,54 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<NumberOnly> 
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <NumberOnly as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <NumberOnly as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into NumberOnly - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into NumberOnly - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ObjectContainingObjectWithOnlyAdditionalProperties {
     #[serde(rename = "inner")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub inner: Option<models::ObjectWithOnlyAdditionalProperties>,
+
 }
+
+impl ObjectContainingObjectWithOnlyAdditionalProperties {
+    fn __name_for_inner() -> String {
+        String::from("CodegenProperty{openApiType='ObjectWithOnlyAdditionalProperties', baseName='inner', complexType='ObjectWithOnlyAdditionalProperties', getter='getInner', setter='setInner', description='null', dataType='models::ObjectWithOnlyAdditionalProperties', datatypeWithEnum='models::ObjectWithOnlyAdditionalProperties', dataFormat='null', name='inner', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.inner;', baseType='ObjectWithOnlyAdditionalProperties', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/ObjectWithOnlyAdditionalProperties"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/ObjectWithOnlyAdditionalProperties, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_inner<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_inner())
+        }
+}
+
 
 impl ObjectContainingObjectWithOnlyAdditionalProperties {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new() -> ObjectContainingObjectWithOnlyAdditionalProperties {
-        ObjectContainingObjectWithOnlyAdditionalProperties { inner: None }
+        ObjectContainingObjectWithOnlyAdditionalProperties {
+            inner: None,
+        }
     }
 }
 
@@ -4182,11 +5150,7 @@ impl std::fmt::Display for ObjectContainingObjectWithOnlyAdditionalProperties {
 
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -4239,16 +5203,10 @@ impl std::str::FromStr for ObjectContainingObjectWithOnlyAdditionalProperties {
 // Methods for converting between header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties> and HeaderValue
 
 #[cfg(feature = "server")]
-impl
-    std::convert::TryFrom<
-        header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties>,
-    > for HeaderValue
-{
+impl std::convert::TryFrom<header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
              std::result::Result::Ok(value) => std::result::Result::Ok(value),
@@ -4260,9 +5218,7 @@ impl
 }
 
 #[cfg(feature = "server")]
-impl std::convert::TryFrom<HeaderValue>
-    for header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties>
-{
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties> {
     type Error = String;
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
@@ -4282,6 +5238,9 @@ impl std::convert::TryFrom<HeaderValue>
     }
 }
 
+
+
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ObjectWithOnlyAdditionalProperties(std::collections::HashMap<String, String>);
@@ -4292,17 +5251,13 @@ impl validator::Validate for ObjectWithOnlyAdditionalProperties {
     }
 }
 
-impl std::convert::From<std::collections::HashMap<String, String>>
-    for ObjectWithOnlyAdditionalProperties
-{
+impl std::convert::From<std::collections::HashMap<String, String>> for ObjectWithOnlyAdditionalProperties {
     fn from(x: std::collections::HashMap<String, String>) -> Self {
         ObjectWithOnlyAdditionalProperties(x)
     }
 }
 
-impl std::convert::From<ObjectWithOnlyAdditionalProperties>
-    for std::collections::HashMap<String, String>
-{
+impl std::convert::From<ObjectWithOnlyAdditionalProperties> for std::collections::HashMap<String, String> {
     fn from(x: ObjectWithOnlyAdditionalProperties) -> Self {
         x.0
     }
@@ -4338,41 +5293,128 @@ impl ::std::str::FromStr for ObjectWithOnlyAdditionalProperties {
     type Err = &'static str;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        std::result::Result::Err(
-            "Parsing additionalProperties for ObjectWithOnlyAdditionalProperties is not supported",
-        )
+        std::result::Result::Err("Parsing additionalProperties for ObjectWithOnlyAdditionalProperties is not supported")
     }
 }
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Order {
     #[serde(rename = "id")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "petId")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pet_id: Option<i64>,
 
     #[serde(rename = "quantity")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub quantity: Option<i32>,
 
     #[serde(rename = "shipDate")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ship_date: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub ship_date: Option<chrono::DateTime::<chrono::Utc>>,
 
     /// Order Status
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "status")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 
     #[serde(rename = "complete")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub complete: Option<bool>,
+
 }
+
+impl Order {
+    fn __name_for_id() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='id', complexType='long', getter='getId', setter='setId', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='id', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.id;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='id', nameInPascalCase='Id', nameInSnakeCase='ID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_id<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_id())
+        }
+}
+impl Order {
+    fn __name_for_pet_id() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='petId', complexType='long', getter='getPetId', setter='setPetId', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='pet_id', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.petId;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='petId', nameInPascalCase='PetId', nameInSnakeCase='PET_ID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_pet_id<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_pet_id())
+        }
+}
+impl Order {
+    fn __name_for_quantity() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='quantity', complexType='integer', getter='getQuantity', setter='setQuantity', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='int32', name='quantity', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.quantity;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int32",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='quantity', nameInPascalCase='Quantity', nameInSnakeCase='QUANTITY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_quantity<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_quantity())
+        }
+}
+impl Order {
+    fn __name_for_ship_date() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='shipDate', complexType='DateTime', getter='getShipDate', setter='setShipDate', description='null', dataType='chrono::DateTime::<chrono::Utc>', datatypeWithEnum='chrono::DateTime::<chrono::Utc>', dataFormat='date-time', name='ship_date', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.shipDate;', baseType='DateTime', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "date-time",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=true, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='shipDate', nameInPascalCase='ShipDate', nameInSnakeCase='SHIP_DATE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=date-time, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_ship_date<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_ship_date())
+        }
+}
+impl Order {
+    fn __name_for_status() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='status', complexType='string', getter='getStatus', setter='setStatus', description='Order Status', dataType='String', datatypeWithEnum='Status', dataFormat='null', name='status', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.status;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='Order Status', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "Order Status",
+  "enum" : [ "placed", "approved", "delivered" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[placed, approved, delivered], allowableValues={enumVars=[{name=Placed, isString=true, value="placed"}, {name=Approved, isString=true, value="approved"}, {name=Delivered, isString=true, value="delivered"}], values=[placed, approved, delivered]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='status', nameInPascalCase='Status', nameInSnakeCase='STATUS', enumName='Status', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_status<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_status())
+        }
+}
+impl Order {
+    fn __name_for_complete() -> String {
+        String::from("CodegenProperty{openApiType='boolean', baseName='complete', complexType='boolean', getter='getComplete', setter='setComplete', description='null', dataType='bool', datatypeWithEnum='bool', dataFormat='null', name='complete', min='null', max='null', defaultValue='Some(false)', defaultValueWithParam=' = data.complete;', baseType='boolean', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "default" : false,
+  "type" : "boolean"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=true, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='complete', nameInPascalCase='Complete', nameInSnakeCase='COMPLETE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_complete<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_complete())
+        }
+}
+
 
 impl Order {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -4394,29 +5436,51 @@ impl Order {
 impl std::fmt::Display for Order {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.id
-                .as_ref()
-                .map(|id| ["id".to_string(), id.to_string()].join(",")),
-            self.pet_id
-                .as_ref()
-                .map(|pet_id| ["petId".to_string(), pet_id.to_string()].join(",")),
-            self.quantity
-                .as_ref()
-                .map(|quantity| ["quantity".to_string(), quantity.to_string()].join(",")),
+
+            self.id.as_ref().map(|id| {
+                [
+                    "id".to_string(),
+                    id.to_string(),
+                ].join(",")
+            }),
+
+
+            self.pet_id.as_ref().map(|pet_id| {
+                [
+                    "petId".to_string(),
+                    pet_id.to_string(),
+                ].join(",")
+            }),
+
+
+            self.quantity.as_ref().map(|quantity| {
+                [
+                    "quantity".to_string(),
+                    quantity.to_string(),
+                ].join(",")
+            }),
+
             // Skipping shipDate in query parameter serialization
-            self.status
-                .as_ref()
-                .map(|status| ["status".to_string(), status.to_string()].join(",")),
-            self.complete
-                .as_ref()
-                .map(|complete| ["complete".to_string(), complete.to_string()].join(",")),
+
+
+            self.status.as_ref().map(|status| {
+                [
+                    "status".to_string(),
+                    status.to_string(),
+                ].join(",")
+            }),
+
+
+            self.complete.as_ref().map(|complete| {
+                [
+                    "complete".to_string(),
+                    complete.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -4434,7 +5498,7 @@ impl std::str::FromStr for Order {
             pub id: Vec<i64>,
             pub pet_id: Vec<i64>,
             pub quantity: Vec<i32>,
-            pub ship_date: Vec<chrono::DateTime<chrono::Utc>>,
+            pub ship_date: Vec<chrono::DateTime::<chrono::Utc>>,
             pub status: Vec<String>,
             pub complete: Vec<bool>,
         }
@@ -4448,46 +5512,25 @@ impl std::str::FromStr for Order {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing Order".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing Order".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "id" => intermediate_rep.id.push(
-                        <i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "id" => intermediate_rep.id.push(<i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "petId" => intermediate_rep.pet_id.push(
-                        <i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "petId" => intermediate_rep.pet_id.push(<i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "quantity" => intermediate_rep.quantity.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "quantity" => intermediate_rep.quantity.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "shipDate" => intermediate_rep.ship_date.push(
-                        <chrono::DateTime<chrono::Utc> as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
-                    ),
+                    "shipDate" => intermediate_rep.ship_date.push(<chrono::DateTime::<chrono::Utc> as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "status" => intermediate_rep.status.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "status" => intermediate_rep.status.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "complete" => intermediate_rep.complete.push(
-                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Order".to_string(),
-                        )
-                    }
+                    "complete" => intermediate_rep.complete.push(<bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Order".to_string())
                 }
             }
 
@@ -4513,16 +5556,13 @@ impl std::str::FromStr for Order {
 impl std::convert::TryFrom<header::IntoHeaderValue<Order>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<Order>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Order>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Order - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Order - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4533,22 +5573,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Order> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => match <Order as std::str::FromStr>::from_str(value) {
-                std::result::Result::Ok(value) => {
-                    std::result::Result::Ok(header::IntoHeaderValue(value))
-                }
-                std::result::Result::Err(err) => std::result::Result::Err(format!(
-                    "Unable to convert header value '{}' into Order - {}",
-                    value, err
-                )),
-            },
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => {
+                    match <Order as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Order - {}",
+                                value, err))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -4585,21 +5626,66 @@ impl std::ops::DerefMut for OuterBoolean {
     }
 }
 
+
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct OuterComposite {
     #[serde(rename = "my_number")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub my_number: Option<f64>,
 
     #[serde(rename = "my_string")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub my_string: Option<String>,
 
     #[serde(rename = "my_boolean")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub my_boolean: Option<bool>,
+
 }
+
+impl OuterComposite {
+    fn __name_for_my_number() -> String {
+        String::from("CodegenProperty{openApiType='number', baseName='my_number', complexType='number', getter='getMyNumber', setter='setMyNumber', description='null', dataType='f64', datatypeWithEnum='f64', dataFormat='null', name='my_number', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.my_number;', baseType='number', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "number"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=true, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='myNumber', nameInPascalCase='MyNumber', nameInSnakeCase='MY_NUMBER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_my_number<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_my_number())
+        }
+}
+impl OuterComposite {
+    fn __name_for_my_string() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='my_string', complexType='string', getter='getMyString', setter='setMyString', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='my_string', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.my_string;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='myString', nameInPascalCase='MyString', nameInSnakeCase='MY_STRING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_my_string<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_my_string())
+        }
+}
+impl OuterComposite {
+    fn __name_for_my_boolean() -> String {
+        String::from("CodegenProperty{openApiType='boolean', baseName='my_boolean', complexType='boolean', getter='getMyBoolean', setter='setMyBoolean', description='null', dataType='bool', datatypeWithEnum='bool', dataFormat='null', name='my_boolean', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.my_boolean;', baseType='boolean', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "boolean",
+  "x-codegen-body-parameter-name" : "boolean_post_body"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=true, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={x-codegen-body-parameter-name=boolean_post_body}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='myBoolean', nameInPascalCase='MyBoolean', nameInSnakeCase='MY_BOOLEAN', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_my_boolean<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_my_boolean())
+        }
+}
+
 
 impl OuterComposite {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -4618,22 +5704,33 @@ impl OuterComposite {
 impl std::fmt::Display for OuterComposite {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.my_number
-                .as_ref()
-                .map(|my_number| ["my_number".to_string(), my_number.to_string()].join(",")),
-            self.my_string
-                .as_ref()
-                .map(|my_string| ["my_string".to_string(), my_string.to_string()].join(",")),
-            self.my_boolean
-                .as_ref()
-                .map(|my_boolean| ["my_boolean".to_string(), my_boolean.to_string()].join(",")),
+
+            self.my_number.as_ref().map(|my_number| {
+                [
+                    "my_number".to_string(),
+                    my_number.to_string(),
+                ].join(",")
+            }),
+
+
+            self.my_string.as_ref().map(|my_string| {
+                [
+                    "my_string".to_string(),
+                    my_string.to_string(),
+                ].join(",")
+            }),
+
+
+            self.my_boolean.as_ref().map(|my_boolean| {
+                [
+                    "my_boolean".to_string(),
+                    my_boolean.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -4662,33 +5759,19 @@ impl std::str::FromStr for OuterComposite {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing OuterComposite".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing OuterComposite".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "my_number" => intermediate_rep.my_number.push(
-                        <f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "my_number" => intermediate_rep.my_number.push(<f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "my_string" => intermediate_rep.my_string.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "my_string" => intermediate_rep.my_string.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "my_boolean" => intermediate_rep.my_boolean.push(
-                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing OuterComposite".to_string(),
-                        )
-                    }
+                    "my_boolean" => intermediate_rep.my_boolean.push(<bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing OuterComposite".to_string())
                 }
             }
 
@@ -4711,16 +5794,13 @@ impl std::str::FromStr for OuterComposite {
 impl std::convert::TryFrom<header::IntoHeaderValue<OuterComposite>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<OuterComposite>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<OuterComposite>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for OuterComposite - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for OuterComposite - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4731,33 +5811,30 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<OuterComposi
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <OuterComposite as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <OuterComposite as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into OuterComposite - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into OuterComposite - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// Enumeration of values.
 /// Since this enum's variants do not hold data, we can easily define them as `#[repr(C)]`
 /// which helps with FFI.
 #[allow(non_camel_case_types)]
 #[repr(C)]
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum OuterEnum {
     #[serde(rename = "placed")]
@@ -4790,6 +5867,7 @@ impl std::str::FromStr for OuterEnum {
         }
     }
 }
+
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -4826,6 +5904,8 @@ impl std::ops::DerefMut for OuterNumber {
     }
 }
 
+
+
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct OuterString(String);
@@ -4844,7 +5924,7 @@ impl std::convert::From<String> for OuterString {
 
 impl std::fmt::Display for OuterString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.0)
+       write!(f, "{:?}", self.0)
     }
 }
 
@@ -4874,15 +5954,17 @@ impl std::ops::DerefMut for OuterString {
     }
 }
 
+
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Pet {
     #[serde(rename = "id")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "category")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub category: Option<models::Category>,
 
     #[serde(rename = "name")]
@@ -4892,19 +5974,127 @@ pub struct Pet {
     pub photo_urls: Vec<String>,
 
     #[serde(rename = "tags")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<models::Tag>>,
 
     /// pet status in the store
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "status")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+
 }
 
 impl Pet {
+    fn __name_for_id() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='id', complexType='long', getter='getId', setter='setId', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='id', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.id;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer",
+  "x-is-unique" : true
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={x-is-unique=true}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='id', nameInPascalCase='Id', nameInSnakeCase='ID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_id<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_id())
+        }
+}
+impl Pet {
+    fn __name_for_category() -> String {
+        String::from("CodegenProperty{openApiType='Category', baseName='category', complexType='Category', getter='getCategory', setter='setCategory', description='null', dataType='models::Category', datatypeWithEnum='models::Category', dataFormat='null', name='category', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.category;', baseType='Category', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/Category"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='category', nameInPascalCase='Category', nameInSnakeCase='CATEGORY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='Category', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/Category, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_category<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_category())
+        }
+}
+impl Pet {
+    fn __name_for_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='name', complexType='string', getter='getName', setter='setName', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='name', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.name;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='doggie', jsonSchema='{
+  "example" : "doggie",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='name', nameInPascalCase='Name', nameInSnakeCase='NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_name())
+        }
+}
+impl Pet {
+    fn __name_for_photo_urls() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='photoUrls', complexType='string', getter='getPhotoUrls', setter='setPhotoUrls', description='null', dataType='Vec<String>', datatypeWithEnum='Vec<String>', dataFormat='null', name='photo_urls', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.photoUrls;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "string"
+  },
+  "type" : "array",
+  "xml" : {
+    "name" : "photoUrl",
+    "wrapped" : true
+  }
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='string', baseName='photo_urls', complexType='string', getter='getPhotoUrls', setter='setPhotoUrls', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='photo_urls', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.photo_urls;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='photoUrls', nameInPascalCase='PhotoUrls', nameInSnakeCase='PHOTO_URLS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='photo_urls', complexType='string', getter='getPhotoUrls', setter='setPhotoUrls', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='photo_urls', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.photo_urls;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='photoUrls', nameInPascalCase='PhotoUrls', nameInSnakeCase='PHOTO_URLS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='photoUrls', nameInPascalCase='PhotoUrls', nameInSnakeCase='PHOTO_URLS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='photoUrl', xmlNamespace='null', isXmlWrapped=true, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_photo_urls<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_photo_urls())
+        }
+}
+impl Pet {
+    fn __name_for_tags() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='tags', complexType='Tag', getter='getTags', setter='setTags', description='null', dataType='Vec<models::Tag>', datatypeWithEnum='Vec<models::Tag>', dataFormat='null', name='tags', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.tags;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "$ref" : "#/components/schemas/Tag"
+  },
+  "type" : "array",
+  "xml" : {
+    "name" : "tag",
+    "wrapped" : true
+  }
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='Tag', baseName='tags', complexType='Tag', getter='getTags', setter='setTags', description='null', dataType='models::Tag', datatypeWithEnum='models::Tag', dataFormat='null', name='tags', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.tags;', baseType='Tag', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/Tag"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='tags', nameInPascalCase='Tags', nameInSnakeCase='TAGS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='Tag', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/Tag, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='Tag', baseName='tags', complexType='Tag', getter='getTags', setter='setTags', description='null', dataType='models::Tag', datatypeWithEnum='models::Tag', dataFormat='null', name='tags', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.tags;', baseType='Tag', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/Tag"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='tags', nameInPascalCase='Tags', nameInSnakeCase='TAGS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='Tag', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/Tag, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='tags', nameInPascalCase='Tags', nameInSnakeCase='TAGS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='tag', xmlNamespace='null', isXmlWrapped=true, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_tags<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_tags())
+        }
+}
+impl Pet {
+    fn __name_for_status() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='status', complexType='string', getter='getStatus', setter='setStatus', description='pet status in the store', dataType='String', datatypeWithEnum='Status', dataFormat='null', name='status', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.status;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='pet status in the store', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "pet status in the store",
+  "enum" : [ "available", "pending", "sold" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[available, pending, sold], allowableValues={enumVars=[{name=Available, isString=true, value="available"}, {name=Pending, isString=true, value="pending"}, {name=Sold, isString=true, value="sold"}], values=[available, pending, sold]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='status', nameInPascalCase='Status', nameInSnakeCase='STATUS', enumName='Status', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_status<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_status())
+        }
+}
+
+
+impl Pet {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(name: String, photo_urls: Vec<String>) -> Pet {
+    pub fn new(name: String, photo_urls: Vec<String>, ) -> Pet {
         Pet {
             id: None,
             category: None,
@@ -4922,31 +6112,37 @@ impl Pet {
 impl std::fmt::Display for Pet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.id
-                .as_ref()
-                .map(|id| ["id".to_string(), id.to_string()].join(",")),
+
+            self.id.as_ref().map(|id| {
+                [
+                    "id".to_string(),
+                    id.to_string(),
+                ].join(",")
+            }),
+
             // Skipping category in query parameter serialization
+
+
             Some("name".to_string()),
             Some(self.name.to_string()),
+
+
             Some("photoUrls".to_string()),
-            Some(
-                self.photo_urls
-                    .iter()
-                    .map(|x| x.to_string())
-                    .collect::<Vec<_>>()
-                    .join(","),
-            ),
+            Some(self.photo_urls.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(",")),
+
             // Skipping tags in query parameter serialization
-            self.status
-                .as_ref()
-                .map(|status| ["status".to_string(), status.to_string()].join(",")),
+
+
+            self.status.as_ref().map(|status| {
+                [
+                    "status".to_string(),
+                    status.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -4978,46 +6174,23 @@ impl std::str::FromStr for Pet {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err("Missing value while parsing Pet".to_string())
-                }
+                None => return std::result::Result::Err("Missing value while parsing Pet".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "id" => intermediate_rep.id.push(
-                        <i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "id" => intermediate_rep.id.push(<i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "category" => intermediate_rep.category.push(
-                        <models::Category as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
-                    ),
+                    "category" => intermediate_rep.category.push(<models::Category as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "name" => intermediate_rep.name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    "photoUrls" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in Pet".to_string(),
-                        )
-                    }
-                    "tags" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in Pet".to_string(),
-                        )
-                    }
+                    "name" => intermediate_rep.name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "photoUrls" => return std::result::Result::Err("Parsing a container in this style is not supported in Pet".to_string()),
+                    "tags" => return std::result::Result::Err("Parsing a container in this style is not supported in Pet".to_string()),
                     #[allow(clippy::redundant_clone)]
-                    "status" => intermediate_rep.status.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Pet".to_string(),
-                        )
-                    }
+                    "status" => intermediate_rep.status.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Pet".to_string())
                 }
             }
 
@@ -5029,16 +6202,8 @@ impl std::str::FromStr for Pet {
         std::result::Result::Ok(Pet {
             id: intermediate_rep.id.into_iter().next(),
             category: intermediate_rep.category.into_iter().next(),
-            name: intermediate_rep
-                .name
-                .into_iter()
-                .next()
-                .ok_or_else(|| "name missing in Pet".to_string())?,
-            photo_urls: intermediate_rep
-                .photo_urls
-                .into_iter()
-                .next()
-                .ok_or_else(|| "photoUrls missing in Pet".to_string())?,
+            name: intermediate_rep.name.into_iter().next().ok_or_else(|| "name missing in Pet".to_string())?,
+            photo_urls: intermediate_rep.photo_urls.into_iter().next().ok_or_else(|| "photoUrls missing in Pet".to_string())?,
             tags: intermediate_rep.tags.into_iter().next(),
             status: intermediate_rep.status.into_iter().next(),
         })
@@ -5054,11 +6219,10 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Pet>> for HeaderValue {
     fn try_from(hdr_value: header::IntoHeaderValue<Pet>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Pet - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Pet - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -5069,34 +6233,65 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Pet> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => match <Pet as std::str::FromStr>::from_str(value) {
-                std::result::Result::Ok(value) => {
-                    std::result::Result::Ok(header::IntoHeaderValue(value))
-                }
-                std::result::Result::Err(err) => std::result::Result::Err(format!(
-                    "Unable to convert header value '{}' into Pet - {}",
-                    value, err
-                )),
-            },
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => {
+                    match <Pet as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Pet - {}",
+                                value, err))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ReadOnlyFirst {
     #[serde(rename = "bar")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bar: Option<String>,
 
     #[serde(rename = "baz")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub baz: Option<String>,
+
 }
+
+impl ReadOnlyFirst {
+    fn __name_for_bar() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='bar', complexType='string', getter='getBar', setter='setBar', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='bar', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.bar;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "readOnly" : true,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=true, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='bar', nameInPascalCase='Bar', nameInSnakeCase='BAR', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_bar<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_bar())
+        }
+}
+impl ReadOnlyFirst {
+    fn __name_for_baz() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='baz', complexType='string', getter='getBaz', setter='setBaz', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='baz', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.baz;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='baz', nameInPascalCase='Baz', nameInSnakeCase='BAZ', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_baz<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_baz())
+        }
+}
+
 
 impl ReadOnlyFirst {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -5114,19 +6309,25 @@ impl ReadOnlyFirst {
 impl std::fmt::Display for ReadOnlyFirst {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.bar
-                .as_ref()
-                .map(|bar| ["bar".to_string(), bar.to_string()].join(",")),
-            self.baz
-                .as_ref()
-                .map(|baz| ["baz".to_string(), baz.to_string()].join(",")),
+
+            self.bar.as_ref().map(|bar| {
+                [
+                    "bar".to_string(),
+                    bar.to_string(),
+                ].join(",")
+            }),
+
+
+            self.baz.as_ref().map(|baz| {
+                [
+                    "baz".to_string(),
+                    baz.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -5154,29 +6355,17 @@ impl std::str::FromStr for ReadOnlyFirst {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing ReadOnlyFirst".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing ReadOnlyFirst".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "bar" => intermediate_rep.bar.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "bar" => intermediate_rep.bar.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "baz" => intermediate_rep.baz.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing ReadOnlyFirst".to_string(),
-                        )
-                    }
+                    "baz" => intermediate_rep.baz.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing ReadOnlyFirst".to_string())
                 }
             }
 
@@ -5198,16 +6387,13 @@ impl std::str::FromStr for ReadOnlyFirst {
 impl std::convert::TryFrom<header::IntoHeaderValue<ReadOnlyFirst>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<ReadOnlyFirst>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ReadOnlyFirst>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for ReadOnlyFirst - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ReadOnlyFirst - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -5218,38 +6404,56 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ReadOnlyFirs
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <ReadOnlyFirst as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <ReadOnlyFirst as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ReadOnlyFirst - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into ReadOnlyFirst - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// Model for testing reserved words
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Return {
     #[serde(rename = "return")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub r#return: Option<i32>,
+
 }
+
+impl Return {
+    fn __name_for_r#return() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='return', complexType='integer', getter='getR#return', setter='setR#return', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='int32', name='r#return', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.return;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int32",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='r#return', nameInPascalCase='R#return', nameInSnakeCase='R#RETURN', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_r#return<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_r#return())
+        }
+}
+
 
 impl Return {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new() -> Return {
-        Return { r#return: None }
+        Return {
+            r#return: None,
+        }
     }
 }
 
@@ -5258,16 +6462,18 @@ impl Return {
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for Return {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> = vec![self
-            .r#return
-            .as_ref()
-            .map(|r#return| ["return".to_string(), r#return.to_string()].join(","))];
+        let params: Vec<Option<String>> = vec![
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+            self.r#return.as_ref().map(|r#return| {
+                [
+                    "return".to_string(),
+                    r#return.to_string(),
+                ].join(",")
+            }),
+
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -5294,25 +6500,15 @@ impl std::str::FromStr for Return {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing Return".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing Return".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "return" => intermediate_rep.r#return.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Return".to_string(),
-                        )
-                    }
+                    "return" => intermediate_rep.r#return.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Return".to_string())
                 }
             }
 
@@ -5333,16 +6529,13 @@ impl std::str::FromStr for Return {
 impl std::convert::TryFrom<header::IntoHeaderValue<Return>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<Return>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Return>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Return - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Return - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -5353,36 +6546,65 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Return> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <Return as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <Return as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Return - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into Return - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Tag {
     #[serde(rename = "id")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "name")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
+
 }
+
+impl Tag {
+    fn __name_for_id() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='id', complexType='long', getter='getId', setter='setId', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='id', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.id;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='id', nameInPascalCase='Id', nameInSnakeCase='ID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_id<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_id())
+        }
+}
+impl Tag {
+    fn __name_for_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='name', complexType='string', getter='getName', setter='setName', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='name', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.name;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='name', nameInPascalCase='Name', nameInSnakeCase='NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_name())
+        }
+}
+
 
 impl Tag {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -5400,19 +6622,25 @@ impl Tag {
 impl std::fmt::Display for Tag {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.id
-                .as_ref()
-                .map(|id| ["id".to_string(), id.to_string()].join(",")),
-            self.name
-                .as_ref()
-                .map(|name| ["name".to_string(), name.to_string()].join(",")),
+
+            self.id.as_ref().map(|id| {
+                [
+                    "id".to_string(),
+                    id.to_string(),
+                ].join(",")
+            }),
+
+
+            self.name.as_ref().map(|name| {
+                [
+                    "name".to_string(),
+                    name.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -5440,27 +6668,17 @@ impl std::str::FromStr for Tag {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err("Missing value while parsing Tag".to_string())
-                }
+                None => return std::result::Result::Err("Missing value while parsing Tag".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "id" => intermediate_rep.id.push(
-                        <i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "id" => intermediate_rep.id.push(<i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "name" => intermediate_rep.name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Tag".to_string(),
-                        )
-                    }
+                    "name" => intermediate_rep.name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Tag".to_string())
                 }
             }
 
@@ -5485,11 +6703,10 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Tag>> for HeaderValue {
     fn try_from(hdr_value: header::IntoHeaderValue<Tag>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Tag - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Tag - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -5500,57 +6717,68 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Tag> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => match <Tag as std::str::FromStr>::from_str(value) {
-                std::result::Result::Ok(value) => {
-                    std::result::Result::Ok(header::IntoHeaderValue(value))
-                }
-                std::result::Result::Err(err) => std::result::Result::Err(format!(
-                    "Unable to convert header value '{}' into Tag - {}",
-                    value, err
-                )),
-            },
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => {
+                    match <Tag as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Tag - {}",
+                                value, err))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct TestEndpointParametersRequest {
     /// None
     #[serde(rename = "integer")]
-    #[validate(range(min = 10u8, max = 100u8))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(
+            range(min = 10u8, max = 100u8),
+        )]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub integer: Option<u8>,
 
     /// None
     #[serde(rename = "int32")]
-    #[validate(range(min = 20u8, max = 200u8))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(
+            range(min = 20u8, max = 200u8),
+        )]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub int32: Option<u8>,
 
     /// None
     #[serde(rename = "int64")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub int64: Option<i64>,
 
     /// None
     #[serde(rename = "number")]
-    #[validate(range(min = 32.1f64, max = 543.2f64))]
+    #[validate(
+            range(min = 32.1f64, max = 543.2f64),
+        )]
     pub number: f64,
 
     /// None
     #[serde(rename = "float")]
-    #[validate(range(max = 987.6f32))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(
+            range(max = 987.6f32),
+        )]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub float: Option<f32>,
 
     /// None
     #[serde(rename = "double")]
-    #[validate(range(min = 67.8f64, max = 123.4f64))]
+    #[validate(
+            range(min = 67.8f64, max = 123.4f64),
+        )]
     pub double: f64,
 
     /// None
@@ -5558,7 +6786,7 @@ pub struct TestEndpointParametersRequest {
     #[validate(
             regex(path = *RE_TESTENDPOINTPARAMETERSREQUEST_STRING),
         )]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub string: Option<String>,
 
     /// None
@@ -5574,29 +6802,252 @@ pub struct TestEndpointParametersRequest {
 
     /// None
     #[serde(rename = "binary")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub binary: Option<ByteArray>,
 
     /// None
     #[serde(rename = "date")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date: Option<chrono::naive::NaiveDate>,
 
     /// None
     #[serde(rename = "dateTime")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub date_time: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub date_time: Option<chrono::DateTime::<chrono::Utc>>,
 
     /// None
     #[serde(rename = "password")]
-    #[validate(length(min = 10, max = 64))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(
+            length(min = 10, max = 64),
+        )]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub password: Option<String>,
 
     /// None
     #[serde(rename = "callback")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub callback: Option<String>,
+
+}
+
+impl TestEndpointParametersRequest {
+    fn __name_for_integer() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='integer', complexType='integer', getter='getInteger', setter='setInteger', description='None', dataType='u8', datatypeWithEnum='i32', dataFormat='int32', name='integer', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.integer;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "None",
+  "format" : "int32",
+  "maximum" : 100,
+  "minimum" : 10,
+  "type" : "integer"
+}', minimum='10', maximum='100', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='integer', nameInPascalCase='Integer', nameInSnakeCase='INTEGER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_integer<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_integer())
+        }
+}
+impl TestEndpointParametersRequest {
+    fn __name_for_int32() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='int32', complexType='integer', getter='getInt32', setter='setInt32', description='None', dataType='u8', datatypeWithEnum='i32', dataFormat='int32', name='int32', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.int32;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "None",
+  "format" : "int32",
+  "maximum" : 200,
+  "minimum" : 20,
+  "type" : "integer"
+}', minimum='20', maximum='200', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='int32', nameInPascalCase='Int32', nameInSnakeCase='INT32', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_int32<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_int32())
+        }
+}
+impl TestEndpointParametersRequest {
+    fn __name_for_int64() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='int64', complexType='long', getter='getInt64', setter='setInt64', description='None', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='int64', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.int64;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "None",
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='int64', nameInPascalCase='Int64', nameInSnakeCase='INT64', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_int64<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_int64())
+        }
+}
+impl TestEndpointParametersRequest {
+    fn __name_for_number() -> String {
+        String::from("CodegenProperty{openApiType='number', baseName='number', complexType='number', getter='getNumber', setter='setNumber', description='None', dataType='f64', datatypeWithEnum='f64', dataFormat='null', name='number', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.number;', baseType='number', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "None",
+  "maximum" : 543.2,
+  "minimum" : 32.1,
+  "type" : "number"
+}', minimum='32.1', maximum='543.2', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=true, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='number', nameInPascalCase='Number', nameInSnakeCase='NUMBER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_number<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_number())
+        }
+}
+impl TestEndpointParametersRequest {
+    fn __name_for_float() -> String {
+        String::from("CodegenProperty{openApiType='number', baseName='float', complexType='float', getter='getFloat', setter='setFloat', description='None', dataType='f32', datatypeWithEnum='f32', dataFormat='float', name='float', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.float;', baseType='float', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "None",
+  "format" : "float",
+  "maximum" : 987.6,
+  "type" : "number"
+}', minimum='null', maximum='987.6', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=true, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='float', nameInPascalCase='Float', nameInSnakeCase='FLOAT', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=float, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_float<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_float())
+        }
+}
+impl TestEndpointParametersRequest {
+    fn __name_for_double() -> String {
+        String::from("CodegenProperty{openApiType='number', baseName='double', complexType='double', getter='getDouble', setter='setDouble', description='None', dataType='f64', datatypeWithEnum='f64', dataFormat='double', name='double', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.double;', baseType='double', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "None",
+  "format" : "double",
+  "maximum" : 123.4,
+  "minimum" : 67.8,
+  "type" : "number"
+}', minimum='67.8', maximum='123.4', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=true, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='double', nameInPascalCase='Double', nameInSnakeCase='DOUBLE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=double, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_double<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_double())
+        }
+}
+impl TestEndpointParametersRequest {
+    fn __name_for_string() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='string', complexType='string', getter='getString', setter='setString', description='None', dataType='String', datatypeWithEnum='String', dataFormat='null', name='string', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.string;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=null, minLength=null, pattern='/[a-z]/i', example='null', jsonSchema='{
+  "description" : "None",
+  "pattern" : "/[a-z]/i",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='string', nameInPascalCase='String', nameInSnakeCase='STRING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_string<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_string())
+        }
+}
+impl TestEndpointParametersRequest {
+    fn __name_for_pattern_without_delimiter() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='pattern_without_delimiter', complexType='string', getter='getPatternWithoutDelimiter', setter='setPatternWithoutDelimiter', description='None', dataType='String', datatypeWithEnum='String', dataFormat='null', name='pattern_without_delimiter', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.pattern_without_delimiter;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=null, minLength=null, pattern='^[A-Z].*', example='null', jsonSchema='{
+  "description" : "None",
+  "pattern" : "^[A-Z].*",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='patternWithoutDelimiter', nameInPascalCase='PatternWithoutDelimiter', nameInSnakeCase='PATTERN_WITHOUT_DELIMITER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_pattern_without_delimiter<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_pattern_without_delimiter())
+        }
+}
+impl TestEndpointParametersRequest {
+    fn __name_for_byte() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='byte', complexType='ByteArray', getter='getByte', setter='setByte', description='None', dataType='ByteArray', datatypeWithEnum='ByteArray', dataFormat='byte', name='byte', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.byte;', baseType='ByteArray', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "None",
+  "format" : "byte",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=true, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='byte', nameInPascalCase='Byte', nameInSnakeCase='BYTE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=byte, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_byte<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_byte())
+        }
+}
+impl TestEndpointParametersRequest {
+    fn __name_for_binary() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='binary', complexType='file', getter='getBinary', setter='setBinary', description='None', dataType='ByteArray', datatypeWithEnum='ByteArray', dataFormat='binary', name='binary', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.binary;', baseType='file', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "None",
+  "format" : "binary",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=true, isFile=true, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='binary', nameInPascalCase='Binary', nameInSnakeCase='BINARY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=binary, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_binary<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_binary())
+        }
+}
+impl TestEndpointParametersRequest {
+    fn __name_for_date() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='date', complexType='date', getter='getDate', setter='setDate', description='None', dataType='chrono::naive::NaiveDate', datatypeWithEnum='chrono::naive::NaiveDate', dataFormat='date', name='date', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.date;', baseType='date', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "None",
+  "format" : "date",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=true, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='date', nameInPascalCase='Date', nameInSnakeCase='DATE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=date, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_date<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_date())
+        }
+}
+impl TestEndpointParametersRequest {
+    fn __name_for_date_time() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='dateTime', complexType='DateTime', getter='getDateTime', setter='setDateTime', description='None', dataType='chrono::DateTime::<chrono::Utc>', datatypeWithEnum='chrono::DateTime::<chrono::Utc>', dataFormat='date-time', name='date_time', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.dateTime;', baseType='DateTime', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "None",
+  "format" : "date-time",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=true, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='dateTime', nameInPascalCase='DateTime', nameInSnakeCase='DATE_TIME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=date-time, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_date_time<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_date_time())
+        }
+}
+impl TestEndpointParametersRequest {
+    fn __name_for_password() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='password', complexType='password', getter='getPassword', setter='setPassword', description='None', dataType='String', datatypeWithEnum='String', dataFormat='password', name='password', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.password;', baseType='password', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=64, minLength=10, pattern='null', example='null', jsonSchema='{
+  "description" : "None",
+  "format" : "password",
+  "maxLength" : 64,
+  "minLength" : 10,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=true, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='password', nameInPascalCase='Password', nameInSnakeCase='PASSWORD', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=password, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_password<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_password())
+        }
+}
+impl TestEndpointParametersRequest {
+    fn __name_for_callback() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='callback', complexType='string', getter='getCallback', setter='setCallback', description='None', dataType='String', datatypeWithEnum='String', dataFormat='null', name='callback', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.callback;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='None', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "None",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='callback', nameInPascalCase='Callback', nameInSnakeCase='CALLBACK', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_callback<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_callback())
+        }
 }
 
 lazy_static::lazy_static! {
@@ -5608,12 +7059,7 @@ lazy_static::lazy_static! {
 
 impl TestEndpointParametersRequest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(
-        number: f64,
-        double: f64,
-        pattern_without_delimiter: String,
-        byte: ByteArray,
-    ) -> TestEndpointParametersRequest {
+    pub fn new(number: f64, double: f64, pattern_without_delimiter: String, byte: ByteArray, ) -> TestEndpointParametersRequest {
         TestEndpointParametersRequest {
             integer: None,
             int32: None,
@@ -5639,27 +7085,58 @@ impl TestEndpointParametersRequest {
 impl std::fmt::Display for TestEndpointParametersRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.integer
-                .as_ref()
-                .map(|integer| ["integer".to_string(), integer.to_string()].join(",")),
-            self.int32
-                .as_ref()
-                .map(|int32| ["int32".to_string(), int32.to_string()].join(",")),
-            self.int64
-                .as_ref()
-                .map(|int64| ["int64".to_string(), int64.to_string()].join(",")),
+
+            self.integer.as_ref().map(|integer| {
+                [
+                    "integer".to_string(),
+                    integer.to_string(),
+                ].join(",")
+            }),
+
+
+            self.int32.as_ref().map(|int32| {
+                [
+                    "int32".to_string(),
+                    int32.to_string(),
+                ].join(",")
+            }),
+
+
+            self.int64.as_ref().map(|int64| {
+                [
+                    "int64".to_string(),
+                    int64.to_string(),
+                ].join(",")
+            }),
+
+
             Some("number".to_string()),
             Some(self.number.to_string()),
-            self.float
-                .as_ref()
-                .map(|float| ["float".to_string(), float.to_string()].join(",")),
+
+
+            self.float.as_ref().map(|float| {
+                [
+                    "float".to_string(),
+                    float.to_string(),
+                ].join(",")
+            }),
+
+
             Some("double".to_string()),
             Some(self.double.to_string()),
-            self.string
-                .as_ref()
-                .map(|string| ["string".to_string(), string.to_string()].join(",")),
+
+
+            self.string.as_ref().map(|string| {
+                [
+                    "string".to_string(),
+                    string.to_string(),
+                ].join(",")
+            }),
+
+
             Some("pattern_without_delimiter".to_string()),
             Some(self.pattern_without_delimiter.to_string()),
+
             // Skipping byte in query parameter serialization
             // Skipping byte in query parameter serialization
 
@@ -5669,19 +7146,26 @@ impl std::fmt::Display for TestEndpointParametersRequest {
             // Skipping date in query parameter serialization
 
             // Skipping dateTime in query parameter serialization
-            self.password
-                .as_ref()
-                .map(|password| ["password".to_string(), password.to_string()].join(",")),
-            self.callback
-                .as_ref()
-                .map(|callback| ["callback".to_string(), callback.to_string()].join(",")),
+
+
+            self.password.as_ref().map(|password| {
+                [
+                    "password".to_string(),
+                    password.to_string(),
+                ].join(",")
+            }),
+
+
+            self.callback.as_ref().map(|callback| {
+                [
+                    "callback".to_string(),
+                    callback.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -5707,7 +7191,7 @@ impl std::str::FromStr for TestEndpointParametersRequest {
             pub byte: Vec<ByteArray>,
             pub binary: Vec<ByteArray>,
             pub date: Vec<chrono::naive::NaiveDate>,
-            pub date_time: Vec<chrono::DateTime<chrono::Utc>>,
+            pub date_time: Vec<chrono::DateTime::<chrono::Utc>>,
             pub password: Vec<String>,
             pub callback: Vec<String>,
         }
@@ -5721,11 +7205,7 @@ impl std::str::FromStr for TestEndpointParametersRequest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing TestEndpointParametersRequest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing TestEndpointParametersRequest".to_string())
             };
 
             if let Some(key) = key_result {
@@ -5770,30 +7250,12 @@ impl std::str::FromStr for TestEndpointParametersRequest {
             integer: intermediate_rep.integer.into_iter().next(),
             int32: intermediate_rep.int32.into_iter().next(),
             int64: intermediate_rep.int64.into_iter().next(),
-            number: intermediate_rep
-                .number
-                .into_iter()
-                .next()
-                .ok_or_else(|| "number missing in TestEndpointParametersRequest".to_string())?,
+            number: intermediate_rep.number.into_iter().next().ok_or_else(|| "number missing in TestEndpointParametersRequest".to_string())?,
             float: intermediate_rep.float.into_iter().next(),
-            double: intermediate_rep
-                .double
-                .into_iter()
-                .next()
-                .ok_or_else(|| "double missing in TestEndpointParametersRequest".to_string())?,
+            double: intermediate_rep.double.into_iter().next().ok_or_else(|| "double missing in TestEndpointParametersRequest".to_string())?,
             string: intermediate_rep.string.into_iter().next(),
-            pattern_without_delimiter: intermediate_rep
-                .pattern_without_delimiter
-                .into_iter()
-                .next()
-                .ok_or_else(|| {
-                    "pattern_without_delimiter missing in TestEndpointParametersRequest".to_string()
-                })?,
-            byte: intermediate_rep
-                .byte
-                .into_iter()
-                .next()
-                .ok_or_else(|| "byte missing in TestEndpointParametersRequest".to_string())?,
+            pattern_without_delimiter: intermediate_rep.pattern_without_delimiter.into_iter().next().ok_or_else(|| "pattern_without_delimiter missing in TestEndpointParametersRequest".to_string())?,
+            byte: intermediate_rep.byte.into_iter().next().ok_or_else(|| "byte missing in TestEndpointParametersRequest".to_string())?,
             binary: intermediate_rep.binary.into_iter().next(),
             date: intermediate_rep.date.into_iter().next(),
             date_time: intermediate_rep.date_time.into_iter().next(),
@@ -5809,16 +7271,13 @@ impl std::str::FromStr for TestEndpointParametersRequest {
 impl std::convert::TryFrom<header::IntoHeaderValue<TestEndpointParametersRequest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<TestEndpointParametersRequest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<TestEndpointParametersRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for TestEndpointParametersRequest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for TestEndpointParametersRequest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -5844,15 +7303,37 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<TestEndpoint
     }
 }
 
+
+
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct TestEnumParametersRequest {
     /// Form parameter enum test (string)
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "enum_form_string")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enum_form_string: Option<String>,
+
 }
+
+impl TestEnumParametersRequest {
+    fn __name_for_enum_form_string() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='enum_form_string', complexType='string', getter='getEnumFormString', setter='setEnumFormString', description='Form parameter enum test (string)', dataType='String', datatypeWithEnum='EnumFormString', dataFormat='null', name='enum_form_string', min='null', max='null', defaultValue='Some(r#"-efg"#.to_string())', defaultValueWithParam=' = data.enum_form_string;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='Form parameter enum test (string)', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "default" : "-efg",
+  "description" : "Form parameter enum test (string)",
+  "enum" : [ "_abc", "-efg", "(xyz)" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[_abc, -efg, (xyz)], allowableValues={enumVars=[{name=Abc, isString=true, value="_abc"}, {name=Efg, isString=true, value="-efg"}, {name=LeftParenthesisXyzRightParenthesis, isString=true, value="(xyz)"}], values=[_abc, -efg, (xyz)]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='enumFormString', nameInPascalCase='EnumFormString', nameInSnakeCase='ENUM_FORM_STRING', enumName='EnumFormString', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_enum_form_string<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_enum_form_string())
+        }
+}
+
 
 impl TestEnumParametersRequest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -5868,16 +7349,18 @@ impl TestEnumParametersRequest {
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for TestEnumParametersRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> =
-            vec![self.enum_form_string.as_ref().map(|enum_form_string| {
-                ["enum_form_string".to_string(), enum_form_string.to_string()].join(",")
-            })];
+        let params: Vec<Option<String>> = vec![
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+            self.enum_form_string.as_ref().map(|enum_form_string| {
+                [
+                    "enum_form_string".to_string(),
+                    enum_form_string.to_string(),
+                ].join(",")
+            }),
+
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -5904,25 +7387,15 @@ impl std::str::FromStr for TestEnumParametersRequest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing TestEnumParametersRequest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing TestEnumParametersRequest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "enum_form_string" => intermediate_rep.enum_form_string.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing TestEnumParametersRequest".to_string(),
-                        )
-                    }
+                    "enum_form_string" => intermediate_rep.enum_form_string.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing TestEnumParametersRequest".to_string())
                 }
             }
 
@@ -5943,16 +7416,13 @@ impl std::str::FromStr for TestEnumParametersRequest {
 impl std::convert::TryFrom<header::IntoHeaderValue<TestEnumParametersRequest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<TestEnumParametersRequest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<TestEnumParametersRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for TestEnumParametersRequest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for TestEnumParametersRequest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -5963,24 +7433,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<TestEnumPara
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <TestEnumParametersRequest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <TestEnumParametersRequest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into TestEnumParametersRequest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into TestEnumParametersRequest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -5992,12 +7461,46 @@ pub struct TestJsonFormDataRequest {
     /// field2
     #[serde(rename = "param2")]
     pub param2: String,
+
 }
 
 impl TestJsonFormDataRequest {
+    fn __name_for_param() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='param', complexType='string', getter='getParam', setter='setParam', description='field1', dataType='String', datatypeWithEnum='String', dataFormat='null', name='param', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.param;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='field1', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "field1",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='param', nameInPascalCase='Param', nameInSnakeCase='PARAM', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_param<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_param())
+        }
+}
+impl TestJsonFormDataRequest {
+    fn __name_for_param2() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='param2', complexType='string', getter='getParam2', setter='setParam2', description='field2', dataType='String', datatypeWithEnum='String', dataFormat='null', name='param2', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.param2;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='field2', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "field2",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='param2', nameInPascalCase='Param2', nameInSnakeCase='PARAM2', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_param2<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_param2())
+        }
+}
+
+
+impl TestJsonFormDataRequest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(param: String, param2: String) -> TestJsonFormDataRequest {
-        TestJsonFormDataRequest { param, param2 }
+    pub fn new(param: String, param2: String, ) -> TestJsonFormDataRequest {
+        TestJsonFormDataRequest {
+            param,
+            param2,
+        }
     }
 }
 
@@ -6007,17 +7510,17 @@ impl TestJsonFormDataRequest {
 impl std::fmt::Display for TestJsonFormDataRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             Some("param".to_string()),
             Some(self.param.to_string()),
+
+
             Some("param2".to_string()),
             Some(self.param2.to_string()),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -6045,29 +7548,17 @@ impl std::str::FromStr for TestJsonFormDataRequest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing TestJsonFormDataRequest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing TestJsonFormDataRequest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "param" => intermediate_rep.param.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "param" => intermediate_rep.param.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "param2" => intermediate_rep.param2.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing TestJsonFormDataRequest".to_string(),
-                        )
-                    }
+                    "param2" => intermediate_rep.param2.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing TestJsonFormDataRequest".to_string())
                 }
             }
 
@@ -6077,16 +7568,8 @@ impl std::str::FromStr for TestJsonFormDataRequest {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(TestJsonFormDataRequest {
-            param: intermediate_rep
-                .param
-                .into_iter()
-                .next()
-                .ok_or_else(|| "param missing in TestJsonFormDataRequest".to_string())?,
-            param2: intermediate_rep
-                .param2
-                .into_iter()
-                .next()
-                .ok_or_else(|| "param2 missing in TestJsonFormDataRequest".to_string())?,
+            param: intermediate_rep.param.into_iter().next().ok_or_else(|| "param missing in TestJsonFormDataRequest".to_string())?,
+            param2: intermediate_rep.param2.into_iter().next().ok_or_else(|| "param2 missing in TestJsonFormDataRequest".to_string())?,
         })
     }
 }
@@ -6097,16 +7580,13 @@ impl std::str::FromStr for TestJsonFormDataRequest {
 impl std::convert::TryFrom<header::IntoHeaderValue<TestJsonFormDataRequest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<TestJsonFormDataRequest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<TestJsonFormDataRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for TestJsonFormDataRequest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for TestJsonFormDataRequest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -6117,38 +7597,68 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<TestJsonForm
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <TestJsonFormDataRequest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <TestJsonFormDataRequest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into TestJsonFormDataRequest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into TestJsonFormDataRequest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct UpdatePetWithFormRequest {
     /// Updated name of the pet
     #[serde(rename = "name")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 
     /// Updated status of the pet
     #[serde(rename = "status")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+
 }
+
+impl UpdatePetWithFormRequest {
+    fn __name_for_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='name', complexType='string', getter='getName', setter='setName', description='Updated name of the pet', dataType='String', datatypeWithEnum='String', dataFormat='null', name='name', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.name;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='Updated name of the pet', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "Updated name of the pet",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='name', nameInPascalCase='Name', nameInSnakeCase='NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_name())
+        }
+}
+impl UpdatePetWithFormRequest {
+    fn __name_for_status() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='status', complexType='string', getter='getStatus', setter='setStatus', description='Updated status of the pet', dataType='String', datatypeWithEnum='String', dataFormat='null', name='status', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.status;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='Updated status of the pet', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "Updated status of the pet",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='status', nameInPascalCase='Status', nameInSnakeCase='STATUS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_status<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_status())
+        }
+}
+
 
 impl UpdatePetWithFormRequest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -6166,19 +7676,25 @@ impl UpdatePetWithFormRequest {
 impl std::fmt::Display for UpdatePetWithFormRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.name
-                .as_ref()
-                .map(|name| ["name".to_string(), name.to_string()].join(",")),
-            self.status
-                .as_ref()
-                .map(|status| ["status".to_string(), status.to_string()].join(",")),
+
+            self.name.as_ref().map(|name| {
+                [
+                    "name".to_string(),
+                    name.to_string(),
+                ].join(",")
+            }),
+
+
+            self.status.as_ref().map(|status| {
+                [
+                    "status".to_string(),
+                    status.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -6206,29 +7722,17 @@ impl std::str::FromStr for UpdatePetWithFormRequest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing UpdatePetWithFormRequest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing UpdatePetWithFormRequest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "name" => intermediate_rep.name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "name" => intermediate_rep.name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "status" => intermediate_rep.status.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing UpdatePetWithFormRequest".to_string(),
-                        )
-                    }
+                    "status" => intermediate_rep.status.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing UpdatePetWithFormRequest".to_string())
                 }
             }
 
@@ -6250,16 +7754,13 @@ impl std::str::FromStr for UpdatePetWithFormRequest {
 impl std::convert::TryFrom<header::IntoHeaderValue<UpdatePetWithFormRequest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<UpdatePetWithFormRequest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<UpdatePetWithFormRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for UpdatePetWithFormRequest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for UpdatePetWithFormRequest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -6270,38 +7771,69 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<UpdatePetWit
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <UpdatePetWithFormRequest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <UpdatePetWithFormRequest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into UpdatePetWithFormRequest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into UpdatePetWithFormRequest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct UploadFileRequest {
     /// Additional data to pass to server
     #[serde(rename = "additionalMetadata")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub additional_metadata: Option<String>,
 
     /// file to upload
     #[serde(rename = "file")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub file: Option<ByteArray>,
+
 }
+
+impl UploadFileRequest {
+    fn __name_for_additional_metadata() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='additionalMetadata', complexType='string', getter='getAdditionalMetadata', setter='setAdditionalMetadata', description='Additional data to pass to server', dataType='String', datatypeWithEnum='String', dataFormat='null', name='additional_metadata', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.additionalMetadata;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='Additional data to pass to server', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "Additional data to pass to server",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalMetadata', nameInPascalCase='AdditionalMetadata', nameInSnakeCase='ADDITIONAL_METADATA', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_additional_metadata<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_additional_metadata())
+        }
+}
+impl UploadFileRequest {
+    fn __name_for_file() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='file', complexType='file', getter='getFile', setter='setFile', description='file to upload', dataType='ByteArray', datatypeWithEnum='ByteArray', dataFormat='binary', name='file', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.file;', baseType='file', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='file to upload', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "file to upload",
+  "format" : "binary",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=true, isFile=true, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='file', nameInPascalCase='File', nameInSnakeCase='FILE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=binary, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_file<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_file())
+        }
+}
+
 
 impl UploadFileRequest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -6319,24 +7851,20 @@ impl UploadFileRequest {
 impl std::fmt::Display for UploadFileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.additional_metadata
-                .as_ref()
-                .map(|additional_metadata| {
-                    [
-                        "additionalMetadata".to_string(),
-                        additional_metadata.to_string(),
-                    ]
-                    .join(",")
-                }),
+
+            self.additional_metadata.as_ref().map(|additional_metadata| {
+                [
+                    "additionalMetadata".to_string(),
+                    additional_metadata.to_string(),
+                ].join(",")
+            }),
+
             // Skipping file in query parameter serialization
             // Skipping file in query parameter serialization
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -6364,29 +7892,16 @@ impl std::str::FromStr for UploadFileRequest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing UploadFileRequest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing UploadFileRequest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "additionalMetadata" => intermediate_rep.additional_metadata.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    "file" => return std::result::Result::Err(
-                        "Parsing binary data in this style is not supported in UploadFileRequest"
-                            .to_string(),
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing UploadFileRequest".to_string(),
-                        )
-                    }
+                    "additionalMetadata" => intermediate_rep.additional_metadata.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "file" => return std::result::Result::Err("Parsing binary data in this style is not supported in UploadFileRequest".to_string()),
+                    _ => return std::result::Result::Err("Unexpected key while parsing UploadFileRequest".to_string())
                 }
             }
 
@@ -6408,16 +7923,13 @@ impl std::str::FromStr for UploadFileRequest {
 impl std::convert::TryFrom<header::IntoHeaderValue<UploadFileRequest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<UploadFileRequest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<UploadFileRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for UploadFileRequest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for UploadFileRequest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -6428,61 +7940,171 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<UploadFileRe
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <UploadFileRequest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <UploadFileRequest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into UploadFileRequest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into UploadFileRequest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct User {
     #[serde(rename = "id")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "username")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub username: Option<String>,
 
     #[serde(rename = "firstName")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub first_name: Option<String>,
 
     #[serde(rename = "lastName")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_name: Option<String>,
 
     #[serde(rename = "email")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub email: Option<String>,
 
     #[serde(rename = "password")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub password: Option<String>,
 
     #[serde(rename = "phone")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub phone: Option<String>,
 
     /// User Status
     #[serde(rename = "userStatus")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_status: Option<i32>,
+
 }
+
+impl User {
+    fn __name_for_id() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='id', complexType='long', getter='getId', setter='setId', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='id', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.id;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer",
+  "x-is-unique" : true
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={x-is-unique=true}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='id', nameInPascalCase='Id', nameInSnakeCase='ID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_id<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_id())
+        }
+}
+impl User {
+    fn __name_for_username() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='username', complexType='string', getter='getUsername', setter='setUsername', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='username', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.username;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='username', nameInPascalCase='Username', nameInSnakeCase='USERNAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_username<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_username())
+        }
+}
+impl User {
+    fn __name_for_first_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='firstName', complexType='string', getter='getFirstName', setter='setFirstName', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='first_name', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.firstName;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='firstName', nameInPascalCase='FirstName', nameInSnakeCase='FIRST_NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_first_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_first_name())
+        }
+}
+impl User {
+    fn __name_for_last_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='lastName', complexType='string', getter='getLastName', setter='setLastName', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='last_name', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.lastName;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='lastName', nameInPascalCase='LastName', nameInSnakeCase='LAST_NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_last_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_last_name())
+        }
+}
+impl User {
+    fn __name_for_email() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='email', complexType='string', getter='getEmail', setter='setEmail', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='email', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.email;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='email', nameInPascalCase='Email', nameInSnakeCase='EMAIL', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_email<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_email())
+        }
+}
+impl User {
+    fn __name_for_password() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='password', complexType='string', getter='getPassword', setter='setPassword', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='password', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.password;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='password', nameInPascalCase='Password', nameInSnakeCase='PASSWORD', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_password<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_password())
+        }
+}
+impl User {
+    fn __name_for_phone() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='phone', complexType='string', getter='getPhone', setter='setPhone', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='phone', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.phone;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='phone', nameInPascalCase='Phone', nameInSnakeCase='PHONE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_phone<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_phone())
+        }
+}
+impl User {
+    fn __name_for_user_status() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='userStatus', complexType='integer', getter='getUserStatus', setter='setUserStatus', description='User Status', dataType='i32', datatypeWithEnum='i32', dataFormat='int32', name='user_status', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.userStatus;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='User Status', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "User Status",
+  "format" : "int32",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='userStatus', nameInPascalCase='UserStatus', nameInSnakeCase='USER_STATUS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_user_status<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_user_status())
+        }
+}
+
 
 impl User {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -6506,37 +8128,73 @@ impl User {
 impl std::fmt::Display for User {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.id
-                .as_ref()
-                .map(|id| ["id".to_string(), id.to_string()].join(",")),
-            self.username
-                .as_ref()
-                .map(|username| ["username".to_string(), username.to_string()].join(",")),
-            self.first_name
-                .as_ref()
-                .map(|first_name| ["firstName".to_string(), first_name.to_string()].join(",")),
-            self.last_name
-                .as_ref()
-                .map(|last_name| ["lastName".to_string(), last_name.to_string()].join(",")),
-            self.email
-                .as_ref()
-                .map(|email| ["email".to_string(), email.to_string()].join(",")),
-            self.password
-                .as_ref()
-                .map(|password| ["password".to_string(), password.to_string()].join(",")),
-            self.phone
-                .as_ref()
-                .map(|phone| ["phone".to_string(), phone.to_string()].join(",")),
-            self.user_status
-                .as_ref()
-                .map(|user_status| ["userStatus".to_string(), user_status.to_string()].join(",")),
+
+            self.id.as_ref().map(|id| {
+                [
+                    "id".to_string(),
+                    id.to_string(),
+                ].join(",")
+            }),
+
+
+            self.username.as_ref().map(|username| {
+                [
+                    "username".to_string(),
+                    username.to_string(),
+                ].join(",")
+            }),
+
+
+            self.first_name.as_ref().map(|first_name| {
+                [
+                    "firstName".to_string(),
+                    first_name.to_string(),
+                ].join(",")
+            }),
+
+
+            self.last_name.as_ref().map(|last_name| {
+                [
+                    "lastName".to_string(),
+                    last_name.to_string(),
+                ].join(",")
+            }),
+
+
+            self.email.as_ref().map(|email| {
+                [
+                    "email".to_string(),
+                    email.to_string(),
+                ].join(",")
+            }),
+
+
+            self.password.as_ref().map(|password| {
+                [
+                    "password".to_string(),
+                    password.to_string(),
+                ].join(",")
+            }),
+
+
+            self.phone.as_ref().map(|phone| {
+                [
+                    "phone".to_string(),
+                    phone.to_string(),
+                ].join(",")
+            }),
+
+
+            self.user_status.as_ref().map(|user_status| {
+                [
+                    "userStatus".to_string(),
+                    user_status.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -6570,51 +8228,29 @@ impl std::str::FromStr for User {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err("Missing value while parsing User".to_string())
-                }
+                None => return std::result::Result::Err("Missing value while parsing User".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "id" => intermediate_rep.id.push(
-                        <i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "id" => intermediate_rep.id.push(<i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "username" => intermediate_rep.username.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "username" => intermediate_rep.username.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "firstName" => intermediate_rep.first_name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "firstName" => intermediate_rep.first_name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "lastName" => intermediate_rep.last_name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "lastName" => intermediate_rep.last_name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "email" => intermediate_rep.email.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "email" => intermediate_rep.email.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "password" => intermediate_rep.password.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "password" => intermediate_rep.password.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "phone" => intermediate_rep.phone.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "phone" => intermediate_rep.phone.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "userStatus" => intermediate_rep.user_status.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing User".to_string(),
-                        )
-                    }
+                    "userStatus" => intermediate_rep.user_status.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing User".to_string())
                 }
             }
 
@@ -6642,16 +8278,13 @@ impl std::str::FromStr for User {
 impl std::convert::TryFrom<header::IntoHeaderValue<User>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<User>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<User>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for User - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for User - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -6662,19 +8295,20 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<User> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => match <User as std::str::FromStr>::from_str(value) {
-                std::result::Result::Ok(value) => {
-                    std::result::Result::Ok(header::IntoHeaderValue(value))
-                }
-                std::result::Result::Err(err) => std::result::Result::Err(format!(
-                    "Unable to convert header value '{}' into User - {}",
-                    value, err
-                )),
-            },
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => {
+                    match <User as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into User - {}",
+                                value, err))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+

--- a/samples/server/petstore/rust-axum/output/petstore/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/lib.rs
@@ -6,7 +6,7 @@
     unused_extern_crates,
     non_camel_case_types,
     unused_imports,
-    unused_attributes
+    unused_attributes,
 )]
 #![allow(
     clippy::derive_partial_eq_without_eq,
@@ -20,9 +20,9 @@ pub const API_VERSION: &str = "1.0.0";
 #[cfg(feature = "server")]
 pub mod server;
 
-pub mod apis;
 pub mod models;
 pub mod types;
+pub mod apis;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;

--- a/samples/server/petstore/rust-axum/output/petstore/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/models.rs
@@ -7,127 +7,203 @@ use validator::Validate;
 use crate::header;
 use crate::{models, types::*};
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct DeletePetHeaderParams {
-    pub api_key: Option<String>,
-}
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+    pub struct DeletePetHeaderParams {
+        pub api_key: Option<String>,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct DeletePetPathParams {
-    /// Pet id to delete
-    pub pet_id: i64,
-}
+            
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct DeletePetPathParams {
+            /// Pet id to delete
+                pub pet_id: i64,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct FindPetsByStatusQueryParams {
-    /// Status values that need to be considered for filter
-    /// Note: inline enums are not fully supported by openapi-generator
-    #[serde(rename = "status")]
-    pub status: Vec<String>,
-}
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct FindPetsByTagsQueryParams {
-    /// Tags to filter by
-    #[serde(rename = "tags")]
-    pub tags: Vec<String>,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct FindPetsByStatusQueryParams {
+            /// Status values that need to be considered for filter
+            /// Note: inline enums are not fully supported by openapi-generator
+                #[serde(rename = "status")]
+                pub status: Vec<String>,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct GetPetByIdPathParams {
-    /// ID of pet to return
-    pub pet_id: i64,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct FindPetsByTagsQueryParams {
+            /// Tags to filter by
+                #[serde(rename = "tags")]
+                pub tags: Vec<String>,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct UpdatePetWithFormPathParams {
-    /// ID of pet that needs to be updated
-    pub pet_id: i64,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct GetPetByIdPathParams {
+            /// ID of pet to return
+                pub pet_id: i64,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct UploadFilePathParams {
-    /// ID of pet to update
-    pub pet_id: i64,
-}
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct DeleteOrderPathParams {
-    /// ID of the order that needs to be deleted
-    pub order_id: String,
-}
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct UpdatePetWithFormPathParams {
+            /// ID of pet that needs to be updated
+                pub pet_id: i64,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct GetOrderByIdPathParams {
-    /// ID of pet that needs to be fetched
-    #[validate(range(min = 1i64, max = 5i64))]
-    pub order_id: i64,
-}
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct DeleteUserPathParams {
-    /// The name that needs to be deleted
-    pub username: String,
-}
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct UploadFilePathParams {
+            /// ID of pet to update
+                pub pet_id: i64,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct GetUserByNamePathParams {
-    /// The name that needs to be fetched. Use user1 for testing.
-    pub username: String,
-}
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct LoginUserQueryParams {
-    /// The user name for login
-    #[serde(rename = "username")]
-    #[validate(
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct DeleteOrderPathParams {
+            /// ID of the order that needs to be deleted
+                pub order_id: String,
+    }
+
+
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct GetOrderByIdPathParams {
+            /// ID of pet that needs to be fetched
+                #[validate(
+                        range(min = 1i64, max = 5i64),
+                    )]
+                pub order_id: i64,
+    }
+
+
+      
+      
+      
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct DeleteUserPathParams {
+            /// The name that needs to be deleted
+                pub username: String,
+    }
+
+
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct GetUserByNamePathParams {
+            /// The name that needs to be fetched. Use user1 for testing.
+                pub username: String,
+    }
+
+
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct LoginUserQueryParams {
+            /// The user name for login
+                #[serde(rename = "username")]
+                #[validate(
                           regex(path = *RE_LOGINUSERQUERYPARAMS_USERNAME),
                     )]
-    pub username: String,
-    /// The password for login in clear text
-    #[serde(rename = "password")]
-    pub password: String,
-}
+                pub username: String,
+            /// The password for login in clear text
+                #[serde(rename = "password")]
+                pub password: String,
+    }
 
-lazy_static::lazy_static! {
-    static ref RE_LOGINUSERQUERYPARAMS_USERNAME: regex::Regex = regex::Regex::new(r"^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$").unwrap();
-}
+    lazy_static::lazy_static! {
+        static ref RE_LOGINUSERQUERYPARAMS_USERNAME: regex::Regex = regex::Regex::new(r"^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$").unwrap();
+    }
+      
+      
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+    #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))] 
+    pub struct UpdateUserPathParams {
+            /// name that need to be deleted
+                pub username: String,
+    }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct UpdateUserPathParams {
-    /// name that need to be deleted
-    pub username: String,
-}
+
+
 
 /// Describes the result of uploading an image resource
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ApiResponse {
     #[serde(rename = "code")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<i32>,
 
     #[serde(rename = "type")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub r#type: Option<String>,
 
     #[serde(rename = "message")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+
 }
+
+impl ApiResponse {
+    fn __name_for_code() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='code', complexType='integer', getter='getCode', setter='setCode', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='int32', name='code', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.code;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int32",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='code', nameInPascalCase='Code', nameInSnakeCase='CODE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_code<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_code())
+        }
+}
+impl ApiResponse {
+    fn __name_for_r#type() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='type', complexType='string', getter='getR#type', setter='setR#type', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='r#type', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.type;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='r#type', nameInPascalCase='R#type', nameInSnakeCase='R#TYPE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_r#type<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_r#type())
+        }
+}
+impl ApiResponse {
+    fn __name_for_message() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='message', complexType='string', getter='getMessage', setter='setMessage', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='message', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.message;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='message', nameInPascalCase='Message', nameInSnakeCase='MESSAGE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_message<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_message())
+        }
+}
+
 
 impl ApiResponse {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -146,22 +222,33 @@ impl ApiResponse {
 impl std::fmt::Display for ApiResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.code
-                .as_ref()
-                .map(|code| ["code".to_string(), code.to_string()].join(",")),
-            self.r#type
-                .as_ref()
-                .map(|r#type| ["type".to_string(), r#type.to_string()].join(",")),
-            self.message
-                .as_ref()
-                .map(|message| ["message".to_string(), message.to_string()].join(",")),
+
+            self.code.as_ref().map(|code| {
+                [
+                    "code".to_string(),
+                    code.to_string(),
+                ].join(",")
+            }),
+
+
+            self.r#type.as_ref().map(|r#type| {
+                [
+                    "type".to_string(),
+                    r#type.to_string(),
+                ].join(",")
+            }),
+
+
+            self.message.as_ref().map(|message| {
+                [
+                    "message".to_string(),
+                    message.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -190,33 +277,19 @@ impl std::str::FromStr for ApiResponse {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing ApiResponse".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing ApiResponse".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "code" => intermediate_rep.code.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "code" => intermediate_rep.code.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "type" => intermediate_rep.r#type.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "type" => intermediate_rep.r#type.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "message" => intermediate_rep.message.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing ApiResponse".to_string(),
-                        )
-                    }
+                    "message" => intermediate_rep.message.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing ApiResponse".to_string())
                 }
             }
 
@@ -239,16 +312,13 @@ impl std::str::FromStr for ApiResponse {
 impl std::convert::TryFrom<header::IntoHeaderValue<ApiResponse>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<ApiResponse>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ApiResponse>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for ApiResponse - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ApiResponse - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -259,39 +329,68 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ApiResponse>
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <ApiResponse as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <ApiResponse as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ApiResponse - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into ApiResponse - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// A category for a pet
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Category {
     #[serde(rename = "id")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "name")]
     #[validate(
             regex(path = *RE_CATEGORY_NAME),
         )]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
+
+}
+
+impl Category {
+    fn __name_for_id() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='id', complexType='long', getter='getId', setter='setId', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='id', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.id;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='id', nameInPascalCase='Id', nameInSnakeCase='ID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_id<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_id())
+        }
+}
+impl Category {
+    fn __name_for_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='name', complexType='string', getter='getName', setter='setName', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='name', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.name;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$', example='null', jsonSchema='{
+  "pattern" : "^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=true, isInherited=false, discriminatorValue='null', nameInCamelCase='name', nameInPascalCase='Name', nameInSnakeCase='NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_name())
+        }
 }
 
 lazy_static::lazy_static! {
@@ -314,19 +413,25 @@ impl Category {
 impl std::fmt::Display for Category {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.id
-                .as_ref()
-                .map(|id| ["id".to_string(), id.to_string()].join(",")),
-            self.name
-                .as_ref()
-                .map(|name| ["name".to_string(), name.to_string()].join(",")),
+
+            self.id.as_ref().map(|id| {
+                [
+                    "id".to_string(),
+                    id.to_string(),
+                ].join(",")
+            }),
+
+
+            self.name.as_ref().map(|name| {
+                [
+                    "name".to_string(),
+                    name.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -354,29 +459,17 @@ impl std::str::FromStr for Category {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing Category".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing Category".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "id" => intermediate_rep.id.push(
-                        <i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "id" => intermediate_rep.id.push(<i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "name" => intermediate_rep.name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Category".to_string(),
-                        )
-                    }
+                    "name" => intermediate_rep.name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Category".to_string())
                 }
             }
 
@@ -398,16 +491,13 @@ impl std::str::FromStr for Category {
 impl std::convert::TryFrom<header::IntoHeaderValue<Category>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<Category>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Category>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Category - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Category - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -418,55 +508,142 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Category> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <Category as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <Category as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Category - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into Category - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// An order for a pets from the pet store
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Order {
     #[serde(rename = "id")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "petId")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pet_id: Option<i64>,
 
     #[serde(rename = "quantity")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub quantity: Option<i32>,
 
     #[serde(rename = "shipDate")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ship_date: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub ship_date: Option<chrono::DateTime::<chrono::Utc>>,
 
     /// Order Status
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "status")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 
     #[serde(rename = "complete")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub complete: Option<bool>,
+
 }
+
+impl Order {
+    fn __name_for_id() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='id', complexType='long', getter='getId', setter='setId', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='id', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.id;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='id', nameInPascalCase='Id', nameInSnakeCase='ID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_id<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_id())
+        }
+}
+impl Order {
+    fn __name_for_pet_id() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='petId', complexType='long', getter='getPetId', setter='setPetId', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='pet_id', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.petId;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='petId', nameInPascalCase='PetId', nameInSnakeCase='PET_ID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_pet_id<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_pet_id())
+        }
+}
+impl Order {
+    fn __name_for_quantity() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='quantity', complexType='integer', getter='getQuantity', setter='setQuantity', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='int32', name='quantity', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.quantity;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int32",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='quantity', nameInPascalCase='Quantity', nameInSnakeCase='QUANTITY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_quantity<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_quantity())
+        }
+}
+impl Order {
+    fn __name_for_ship_date() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='shipDate', complexType='DateTime', getter='getShipDate', setter='setShipDate', description='null', dataType='chrono::DateTime::<chrono::Utc>', datatypeWithEnum='chrono::DateTime::<chrono::Utc>', dataFormat='date-time', name='ship_date', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.shipDate;', baseType='DateTime', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "date-time",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=true, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='shipDate', nameInPascalCase='ShipDate', nameInSnakeCase='SHIP_DATE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=date-time, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_ship_date<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_ship_date())
+        }
+}
+impl Order {
+    fn __name_for_status() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='status', complexType='string', getter='getStatus', setter='setStatus', description='Order Status', dataType='String', datatypeWithEnum='Status', dataFormat='null', name='status', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.status;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='Order Status', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "Order Status",
+  "enum" : [ "placed", "approved", "delivered" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[placed, approved, delivered], allowableValues={enumVars=[{name=Placed, isString=true, value="placed"}, {name=Approved, isString=true, value="approved"}, {name=Delivered, isString=true, value="delivered"}], values=[placed, approved, delivered]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='status', nameInPascalCase='Status', nameInSnakeCase='STATUS', enumName='Status', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_status<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_status())
+        }
+}
+impl Order {
+    fn __name_for_complete() -> String {
+        String::from("CodegenProperty{openApiType='boolean', baseName='complete', complexType='boolean', getter='getComplete', setter='setComplete', description='null', dataType='bool', datatypeWithEnum='bool', dataFormat='null', name='complete', min='null', max='null', defaultValue='Some(false)', defaultValueWithParam=' = data.complete;', baseType='boolean', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "default" : false,
+  "type" : "boolean"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=true, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='complete', nameInPascalCase='Complete', nameInSnakeCase='COMPLETE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_complete<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_complete())
+        }
+}
+
 
 impl Order {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -488,29 +665,51 @@ impl Order {
 impl std::fmt::Display for Order {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.id
-                .as_ref()
-                .map(|id| ["id".to_string(), id.to_string()].join(",")),
-            self.pet_id
-                .as_ref()
-                .map(|pet_id| ["petId".to_string(), pet_id.to_string()].join(",")),
-            self.quantity
-                .as_ref()
-                .map(|quantity| ["quantity".to_string(), quantity.to_string()].join(",")),
+
+            self.id.as_ref().map(|id| {
+                [
+                    "id".to_string(),
+                    id.to_string(),
+                ].join(",")
+            }),
+
+
+            self.pet_id.as_ref().map(|pet_id| {
+                [
+                    "petId".to_string(),
+                    pet_id.to_string(),
+                ].join(",")
+            }),
+
+
+            self.quantity.as_ref().map(|quantity| {
+                [
+                    "quantity".to_string(),
+                    quantity.to_string(),
+                ].join(",")
+            }),
+
             // Skipping shipDate in query parameter serialization
-            self.status
-                .as_ref()
-                .map(|status| ["status".to_string(), status.to_string()].join(",")),
-            self.complete
-                .as_ref()
-                .map(|complete| ["complete".to_string(), complete.to_string()].join(",")),
+
+
+            self.status.as_ref().map(|status| {
+                [
+                    "status".to_string(),
+                    status.to_string(),
+                ].join(",")
+            }),
+
+
+            self.complete.as_ref().map(|complete| {
+                [
+                    "complete".to_string(),
+                    complete.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -528,7 +727,7 @@ impl std::str::FromStr for Order {
             pub id: Vec<i64>,
             pub pet_id: Vec<i64>,
             pub quantity: Vec<i32>,
-            pub ship_date: Vec<chrono::DateTime<chrono::Utc>>,
+            pub ship_date: Vec<chrono::DateTime::<chrono::Utc>>,
             pub status: Vec<String>,
             pub complete: Vec<bool>,
         }
@@ -542,46 +741,25 @@ impl std::str::FromStr for Order {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing Order".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing Order".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "id" => intermediate_rep.id.push(
-                        <i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "id" => intermediate_rep.id.push(<i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "petId" => intermediate_rep.pet_id.push(
-                        <i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "petId" => intermediate_rep.pet_id.push(<i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "quantity" => intermediate_rep.quantity.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "quantity" => intermediate_rep.quantity.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "shipDate" => intermediate_rep.ship_date.push(
-                        <chrono::DateTime<chrono::Utc> as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
-                    ),
+                    "shipDate" => intermediate_rep.ship_date.push(<chrono::DateTime::<chrono::Utc> as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "status" => intermediate_rep.status.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "status" => intermediate_rep.status.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "complete" => intermediate_rep.complete.push(
-                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Order".to_string(),
-                        )
-                    }
+                    "complete" => intermediate_rep.complete.push(<bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Order".to_string())
                 }
             }
 
@@ -607,16 +785,13 @@ impl std::str::FromStr for Order {
 impl std::convert::TryFrom<header::IntoHeaderValue<Order>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<Order>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Order>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Order - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Order - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -627,33 +802,34 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Order> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => match <Order as std::str::FromStr>::from_str(value) {
-                std::result::Result::Ok(value) => {
-                    std::result::Result::Ok(header::IntoHeaderValue(value))
-                }
-                std::result::Result::Err(err) => std::result::Result::Err(format!(
-                    "Unable to convert header value '{}' into Order - {}",
-                    value, err
-                )),
-            },
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => {
+                    match <Order as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Order - {}",
+                                value, err))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// A pet for sale in the pet store
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Pet {
     #[serde(rename = "id")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "category")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub category: Option<models::Category>,
 
     #[serde(rename = "name")]
@@ -663,19 +839,127 @@ pub struct Pet {
     pub photo_urls: Vec<String>,
 
     #[serde(rename = "tags")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<models::Tag>>,
 
     /// pet status in the store
-    /// Note: inline enums are not fully supported by openapi-generator
+        /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "status")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+
 }
 
 impl Pet {
+    fn __name_for_id() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='id', complexType='long', getter='getId', setter='setId', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='id', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.id;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='id', nameInPascalCase='Id', nameInSnakeCase='ID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_id<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_id())
+        }
+}
+impl Pet {
+    fn __name_for_category() -> String {
+        String::from("CodegenProperty{openApiType='Category', baseName='category', complexType='Category', getter='getCategory', setter='setCategory', description='null', dataType='models::Category', datatypeWithEnum='models::Category', dataFormat='null', name='category', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.category;', baseType='Category', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/Category"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='category', nameInPascalCase='Category', nameInSnakeCase='CATEGORY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='Category', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/Category, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_category<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_category())
+        }
+}
+impl Pet {
+    fn __name_for_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='name', complexType='string', getter='getName', setter='setName', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='name', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.name;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='doggie', jsonSchema='{
+  "example" : "doggie",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='name', nameInPascalCase='Name', nameInSnakeCase='NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_name())
+        }
+}
+impl Pet {
+    fn __name_for_photo_urls() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='photoUrls', complexType='string', getter='getPhotoUrls', setter='setPhotoUrls', description='null', dataType='Vec<String>', datatypeWithEnum='Vec<String>', dataFormat='null', name='photo_urls', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.photoUrls;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "type" : "string"
+  },
+  "type" : "array",
+  "xml" : {
+    "name" : "photoUrl",
+    "wrapped" : true
+  }
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='string', baseName='photo_urls', complexType='string', getter='getPhotoUrls', setter='setPhotoUrls', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='photo_urls', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.photo_urls;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='photoUrls', nameInPascalCase='PhotoUrls', nameInSnakeCase='PHOTO_URLS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='string', baseName='photo_urls', complexType='string', getter='getPhotoUrls', setter='setPhotoUrls', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='photo_urls', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.photo_urls;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='photoUrls', nameInPascalCase='PhotoUrls', nameInSnakeCase='PHOTO_URLS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='photoUrls', nameInPascalCase='PhotoUrls', nameInSnakeCase='PHOTO_URLS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='photoUrl', xmlNamespace='null', isXmlWrapped=true, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_photo_urls<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_photo_urls())
+        }
+}
+impl Pet {
+    fn __name_for_tags() -> String {
+        String::from("CodegenProperty{openApiType='array', baseName='tags', complexType='Tag', getter='getTags', setter='setTags', description='null', dataType='Vec<models::Tag>', datatypeWithEnum='Vec<models::Tag>', dataFormat='null', name='tags', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.tags;', baseType='array', containerType='array', containerTypeMapped='Vec', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "items" : {
+    "$ref" : "#/components/schemas/Tag"
+  },
+  "type" : "array",
+  "xml" : {
+    "name" : "tag",
+    "wrapped" : true
+  }
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=true, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=true, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=CodegenProperty{openApiType='Tag', baseName='tags', complexType='Tag', getter='getTags', setter='setTags', description='null', dataType='models::Tag', datatypeWithEnum='models::Tag', dataFormat='null', name='tags', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.tags;', baseType='Tag', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/Tag"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='tags', nameInPascalCase='Tags', nameInSnakeCase='TAGS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='Tag', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/Tag, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=CodegenProperty{openApiType='Tag', baseName='tags', complexType='Tag', getter='getTags', setter='setTags', description='null', dataType='models::Tag', datatypeWithEnum='models::Tag', dataFormat='null', name='tags', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.tags;', baseType='Tag', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/Tag"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='tags', nameInPascalCase='Tags', nameInSnakeCase='TAGS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='Tag', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/Tag, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='tags', nameInPascalCase='Tags', nameInSnakeCase='TAGS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='tag', xmlNamespace='null', isXmlWrapped=true, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_tags<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_tags())
+        }
+}
+impl Pet {
+    fn __name_for_status() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='status', complexType='string', getter='getStatus', setter='setStatus', description='pet status in the store', dataType='String', datatypeWithEnum='Status', dataFormat='null', name='status', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.status;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='pet status in the store', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "deprecated" : true,
+  "description" : "pet status in the store",
+  "enum" : [ "available", "pending", "sold" ],
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=true, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=true, isInnerEnum=true, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=[available, pending, sold], allowableValues={enumVars=[{name=Available, isString=true, value="available"}, {name=Pending, isString=true, value="pending"}, {name=Sold, isString=true, value="sold"}], values=[available, pending, sold]}, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='status', nameInPascalCase='Status', nameInSnakeCase='STATUS', enumName='Status', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_status<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_status())
+        }
+}
+
+
+impl Pet {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(name: String, photo_urls: Vec<String>) -> Pet {
+    pub fn new(name: String, photo_urls: Vec<String>, ) -> Pet {
         Pet {
             id: None,
             category: None,
@@ -693,31 +977,37 @@ impl Pet {
 impl std::fmt::Display for Pet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.id
-                .as_ref()
-                .map(|id| ["id".to_string(), id.to_string()].join(",")),
+
+            self.id.as_ref().map(|id| {
+                [
+                    "id".to_string(),
+                    id.to_string(),
+                ].join(",")
+            }),
+
             // Skipping category in query parameter serialization
+
+
             Some("name".to_string()),
             Some(self.name.to_string()),
+
+
             Some("photoUrls".to_string()),
-            Some(
-                self.photo_urls
-                    .iter()
-                    .map(|x| x.to_string())
-                    .collect::<Vec<_>>()
-                    .join(","),
-            ),
+            Some(self.photo_urls.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(",")),
+
             // Skipping tags in query parameter serialization
-            self.status
-                .as_ref()
-                .map(|status| ["status".to_string(), status.to_string()].join(",")),
+
+
+            self.status.as_ref().map(|status| {
+                [
+                    "status".to_string(),
+                    status.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -749,46 +1039,23 @@ impl std::str::FromStr for Pet {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err("Missing value while parsing Pet".to_string())
-                }
+                None => return std::result::Result::Err("Missing value while parsing Pet".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "id" => intermediate_rep.id.push(
-                        <i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "id" => intermediate_rep.id.push(<i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "category" => intermediate_rep.category.push(
-                        <models::Category as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
-                    ),
+                    "category" => intermediate_rep.category.push(<models::Category as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "name" => intermediate_rep.name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    "photoUrls" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in Pet".to_string(),
-                        )
-                    }
-                    "tags" => {
-                        return std::result::Result::Err(
-                            "Parsing a container in this style is not supported in Pet".to_string(),
-                        )
-                    }
+                    "name" => intermediate_rep.name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "photoUrls" => return std::result::Result::Err("Parsing a container in this style is not supported in Pet".to_string()),
+                    "tags" => return std::result::Result::Err("Parsing a container in this style is not supported in Pet".to_string()),
                     #[allow(clippy::redundant_clone)]
-                    "status" => intermediate_rep.status.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Pet".to_string(),
-                        )
-                    }
+                    "status" => intermediate_rep.status.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Pet".to_string())
                 }
             }
 
@@ -800,16 +1067,8 @@ impl std::str::FromStr for Pet {
         std::result::Result::Ok(Pet {
             id: intermediate_rep.id.into_iter().next(),
             category: intermediate_rep.category.into_iter().next(),
-            name: intermediate_rep
-                .name
-                .into_iter()
-                .next()
-                .ok_or_else(|| "name missing in Pet".to_string())?,
-            photo_urls: intermediate_rep
-                .photo_urls
-                .into_iter()
-                .next()
-                .ok_or_else(|| "photoUrls missing in Pet".to_string())?,
+            name: intermediate_rep.name.into_iter().next().ok_or_else(|| "name missing in Pet".to_string())?,
+            photo_urls: intermediate_rep.photo_urls.into_iter().next().ok_or_else(|| "photoUrls missing in Pet".to_string())?,
             tags: intermediate_rep.tags.into_iter().next(),
             status: intermediate_rep.status.into_iter().next(),
         })
@@ -825,11 +1084,10 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Pet>> for HeaderValue {
     fn try_from(hdr_value: header::IntoHeaderValue<Pet>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Pet - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Pet - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -840,35 +1098,66 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Pet> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => match <Pet as std::str::FromStr>::from_str(value) {
-                std::result::Result::Ok(value) => {
-                    std::result::Result::Ok(header::IntoHeaderValue(value))
-                }
-                std::result::Result::Err(err) => std::result::Result::Err(format!(
-                    "Unable to convert header value '{}' into Pet - {}",
-                    value, err
-                )),
-            },
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => {
+                    match <Pet as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Pet - {}",
+                                value, err))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// A tag for a pet
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Tag {
     #[serde(rename = "id")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "name")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
+
 }
+
+impl Tag {
+    fn __name_for_id() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='id', complexType='long', getter='getId', setter='setId', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='id', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.id;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='id', nameInPascalCase='Id', nameInSnakeCase='ID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_id<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_id())
+        }
+}
+impl Tag {
+    fn __name_for_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='name', complexType='string', getter='getName', setter='setName', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='name', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.name;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='name', nameInPascalCase='Name', nameInSnakeCase='NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_name())
+        }
+}
+
 
 impl Tag {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -886,19 +1175,25 @@ impl Tag {
 impl std::fmt::Display for Tag {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.id
-                .as_ref()
-                .map(|id| ["id".to_string(), id.to_string()].join(",")),
-            self.name
-                .as_ref()
-                .map(|name| ["name".to_string(), name.to_string()].join(",")),
+
+            self.id.as_ref().map(|id| {
+                [
+                    "id".to_string(),
+                    id.to_string(),
+                ].join(",")
+            }),
+
+
+            self.name.as_ref().map(|name| {
+                [
+                    "name".to_string(),
+                    name.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -926,27 +1221,17 @@ impl std::str::FromStr for Tag {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err("Missing value while parsing Tag".to_string())
-                }
+                None => return std::result::Result::Err("Missing value while parsing Tag".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "id" => intermediate_rep.id.push(
-                        <i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "id" => intermediate_rep.id.push(<i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "name" => intermediate_rep.name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing Tag".to_string(),
-                        )
-                    }
+                    "name" => intermediate_rep.name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Tag".to_string())
                 }
             }
 
@@ -971,11 +1256,10 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Tag>> for HeaderValue {
     fn try_from(hdr_value: header::IntoHeaderValue<Tag>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for Tag - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Tag - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -986,36 +1270,68 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<Tag> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => match <Tag as std::str::FromStr>::from_str(value) {
-                std::result::Result::Ok(value) => {
-                    std::result::Result::Ok(header::IntoHeaderValue(value))
-                }
-                std::result::Result::Err(err) => std::result::Result::Err(format!(
-                    "Unable to convert header value '{}' into Tag - {}",
-                    value, err
-                )),
-            },
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => {
+                    match <Tag as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Tag - {}",
+                                value, err))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct UpdatePetWithFormRequest {
     /// Updated name of the pet
     #[serde(rename = "name")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 
     /// Updated status of the pet
     #[serde(rename = "status")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+
 }
+
+impl UpdatePetWithFormRequest {
+    fn __name_for_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='name', complexType='string', getter='getName', setter='setName', description='Updated name of the pet', dataType='String', datatypeWithEnum='String', dataFormat='null', name='name', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.name;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='Updated name of the pet', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "Updated name of the pet",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='name', nameInPascalCase='Name', nameInSnakeCase='NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_name())
+        }
+}
+impl UpdatePetWithFormRequest {
+    fn __name_for_status() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='status', complexType='string', getter='getStatus', setter='setStatus', description='Updated status of the pet', dataType='String', datatypeWithEnum='String', dataFormat='null', name='status', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.status;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='Updated status of the pet', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "Updated status of the pet",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='status', nameInPascalCase='Status', nameInSnakeCase='STATUS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_status<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_status())
+        }
+}
+
 
 impl UpdatePetWithFormRequest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -1033,19 +1349,25 @@ impl UpdatePetWithFormRequest {
 impl std::fmt::Display for UpdatePetWithFormRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.name
-                .as_ref()
-                .map(|name| ["name".to_string(), name.to_string()].join(",")),
-            self.status
-                .as_ref()
-                .map(|status| ["status".to_string(), status.to_string()].join(",")),
+
+            self.name.as_ref().map(|name| {
+                [
+                    "name".to_string(),
+                    name.to_string(),
+                ].join(",")
+            }),
+
+
+            self.status.as_ref().map(|status| {
+                [
+                    "status".to_string(),
+                    status.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1073,29 +1395,17 @@ impl std::str::FromStr for UpdatePetWithFormRequest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing UpdatePetWithFormRequest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing UpdatePetWithFormRequest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "name" => intermediate_rep.name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "name" => intermediate_rep.name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "status" => intermediate_rep.status.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing UpdatePetWithFormRequest".to_string(),
-                        )
-                    }
+                    "status" => intermediate_rep.status.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing UpdatePetWithFormRequest".to_string())
                 }
             }
 
@@ -1117,16 +1427,13 @@ impl std::str::FromStr for UpdatePetWithFormRequest {
 impl std::convert::TryFrom<header::IntoHeaderValue<UpdatePetWithFormRequest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<UpdatePetWithFormRequest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<UpdatePetWithFormRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for UpdatePetWithFormRequest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for UpdatePetWithFormRequest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1137,38 +1444,69 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<UpdatePetWit
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <UpdatePetWithFormRequest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <UpdatePetWithFormRequest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into UpdatePetWithFormRequest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into UpdatePetWithFormRequest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct UploadFileRequest {
     /// Additional data to pass to server
     #[serde(rename = "additionalMetadata")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub additional_metadata: Option<String>,
 
     /// file to upload
     #[serde(rename = "file")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub file: Option<ByteArray>,
+
 }
+
+impl UploadFileRequest {
+    fn __name_for_additional_metadata() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='additionalMetadata', complexType='string', getter='getAdditionalMetadata', setter='setAdditionalMetadata', description='Additional data to pass to server', dataType='String', datatypeWithEnum='String', dataFormat='null', name='additional_metadata', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.additionalMetadata;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='Additional data to pass to server', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "Additional data to pass to server",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='additionalMetadata', nameInPascalCase='AdditionalMetadata', nameInSnakeCase='ADDITIONAL_METADATA', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_additional_metadata<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_additional_metadata())
+        }
+}
+impl UploadFileRequest {
+    fn __name_for_file() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='file', complexType='file', getter='getFile', setter='setFile', description='file to upload', dataType='ByteArray', datatypeWithEnum='ByteArray', dataFormat='binary', name='file', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.file;', baseType='file', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='file to upload', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "file to upload",
+  "format" : "binary",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=true, isFile=true, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='file', nameInPascalCase='File', nameInSnakeCase='FILE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=binary, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_file<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_file())
+        }
+}
+
 
 impl UploadFileRequest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -1186,24 +1524,20 @@ impl UploadFileRequest {
 impl std::fmt::Display for UploadFileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.additional_metadata
-                .as_ref()
-                .map(|additional_metadata| {
-                    [
-                        "additionalMetadata".to_string(),
-                        additional_metadata.to_string(),
-                    ]
-                    .join(",")
-                }),
+
+            self.additional_metadata.as_ref().map(|additional_metadata| {
+                [
+                    "additionalMetadata".to_string(),
+                    additional_metadata.to_string(),
+                ].join(",")
+            }),
+
             // Skipping file in query parameter serialization
             // Skipping file in query parameter serialization
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1231,29 +1565,16 @@ impl std::str::FromStr for UploadFileRequest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing UploadFileRequest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing UploadFileRequest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "additionalMetadata" => intermediate_rep.additional_metadata.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    "file" => return std::result::Result::Err(
-                        "Parsing binary data in this style is not supported in UploadFileRequest"
-                            .to_string(),
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing UploadFileRequest".to_string(),
-                        )
-                    }
+                    "additionalMetadata" => intermediate_rep.additional_metadata.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "file" => return std::result::Result::Err("Parsing binary data in this style is not supported in UploadFileRequest".to_string()),
+                    _ => return std::result::Result::Err("Unexpected key while parsing UploadFileRequest".to_string())
                 }
             }
 
@@ -1275,16 +1596,13 @@ impl std::str::FromStr for UploadFileRequest {
 impl std::convert::TryFrom<header::IntoHeaderValue<UploadFileRequest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<UploadFileRequest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<UploadFileRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for UploadFileRequest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for UploadFileRequest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1295,62 +1613,171 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<UploadFileRe
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <UploadFileRequest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <UploadFileRequest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into UploadFileRequest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into UploadFileRequest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// A User who is purchasing from the pet store
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct User {
     #[serde(rename = "id")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "username")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub username: Option<String>,
 
     #[serde(rename = "firstName")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub first_name: Option<String>,
 
     #[serde(rename = "lastName")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_name: Option<String>,
 
     #[serde(rename = "email")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub email: Option<String>,
 
     #[serde(rename = "password")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub password: Option<String>,
 
     #[serde(rename = "phone")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub phone: Option<String>,
 
     /// User Status
     #[serde(rename = "userStatus")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_status: Option<i32>,
+
 }
+
+impl User {
+    fn __name_for_id() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='id', complexType='long', getter='getId', setter='setId', description='null', dataType='i64', datatypeWithEnum='i64', dataFormat='int64', name='id', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.id;', baseType='long', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "format" : "int64",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=false, isShort=false, isLong=true, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='id', nameInPascalCase='Id', nameInSnakeCase='ID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int64, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_id<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_id())
+        }
+}
+impl User {
+    fn __name_for_username() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='username', complexType='string', getter='getUsername', setter='setUsername', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='username', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.username;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='username', nameInPascalCase='Username', nameInSnakeCase='USERNAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_username<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_username())
+        }
+}
+impl User {
+    fn __name_for_first_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='firstName', complexType='string', getter='getFirstName', setter='setFirstName', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='first_name', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.firstName;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='firstName', nameInPascalCase='FirstName', nameInSnakeCase='FIRST_NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_first_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_first_name())
+        }
+}
+impl User {
+    fn __name_for_last_name() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='lastName', complexType='string', getter='getLastName', setter='setLastName', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='last_name', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.lastName;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='lastName', nameInPascalCase='LastName', nameInSnakeCase='LAST_NAME', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_last_name<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_last_name())
+        }
+}
+impl User {
+    fn __name_for_email() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='email', complexType='string', getter='getEmail', setter='setEmail', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='email', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.email;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='email', nameInPascalCase='Email', nameInSnakeCase='EMAIL', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_email<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_email())
+        }
+}
+impl User {
+    fn __name_for_password() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='password', complexType='string', getter='getPassword', setter='setPassword', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='password', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.password;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='password', nameInPascalCase='Password', nameInSnakeCase='PASSWORD', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_password<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_password())
+        }
+}
+impl User {
+    fn __name_for_phone() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='phone', complexType='string', getter='getPhone', setter='setPhone', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='phone', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.phone;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='phone', nameInPascalCase='Phone', nameInSnakeCase='PHONE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_phone<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_phone())
+        }
+}
+impl User {
+    fn __name_for_user_status() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='userStatus', complexType='integer', getter='getUserStatus', setter='setUserStatus', description='User Status', dataType='i32', datatypeWithEnum='i32', dataFormat='int32', name='user_status', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.userStatus;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='User Status', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "User Status",
+  "format" : "int32",
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=true, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='userStatus', nameInPascalCase='UserStatus', nameInSnakeCase='USER_STATUS', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=int32, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_user_status<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_user_status())
+        }
+}
+
 
 impl User {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -1374,37 +1801,73 @@ impl User {
 impl std::fmt::Display for User {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
-            self.id
-                .as_ref()
-                .map(|id| ["id".to_string(), id.to_string()].join(",")),
-            self.username
-                .as_ref()
-                .map(|username| ["username".to_string(), username.to_string()].join(",")),
-            self.first_name
-                .as_ref()
-                .map(|first_name| ["firstName".to_string(), first_name.to_string()].join(",")),
-            self.last_name
-                .as_ref()
-                .map(|last_name| ["lastName".to_string(), last_name.to_string()].join(",")),
-            self.email
-                .as_ref()
-                .map(|email| ["email".to_string(), email.to_string()].join(",")),
-            self.password
-                .as_ref()
-                .map(|password| ["password".to_string(), password.to_string()].join(",")),
-            self.phone
-                .as_ref()
-                .map(|phone| ["phone".to_string(), phone.to_string()].join(",")),
-            self.user_status
-                .as_ref()
-                .map(|user_status| ["userStatus".to_string(), user_status.to_string()].join(",")),
+
+            self.id.as_ref().map(|id| {
+                [
+                    "id".to_string(),
+                    id.to_string(),
+                ].join(",")
+            }),
+
+
+            self.username.as_ref().map(|username| {
+                [
+                    "username".to_string(),
+                    username.to_string(),
+                ].join(",")
+            }),
+
+
+            self.first_name.as_ref().map(|first_name| {
+                [
+                    "firstName".to_string(),
+                    first_name.to_string(),
+                ].join(",")
+            }),
+
+
+            self.last_name.as_ref().map(|last_name| {
+                [
+                    "lastName".to_string(),
+                    last_name.to_string(),
+                ].join(",")
+            }),
+
+
+            self.email.as_ref().map(|email| {
+                [
+                    "email".to_string(),
+                    email.to_string(),
+                ].join(",")
+            }),
+
+
+            self.password.as_ref().map(|password| {
+                [
+                    "password".to_string(),
+                    password.to_string(),
+                ].join(",")
+            }),
+
+
+            self.phone.as_ref().map(|phone| {
+                [
+                    "phone".to_string(),
+                    phone.to_string(),
+                ].join(",")
+            }),
+
+
+            self.user_status.as_ref().map(|user_status| {
+                [
+                    "userStatus".to_string(),
+                    user_status.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1438,51 +1901,29 @@ impl std::str::FromStr for User {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err("Missing value while parsing User".to_string())
-                }
+                None => return std::result::Result::Err("Missing value while parsing User".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "id" => intermediate_rep.id.push(
-                        <i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "id" => intermediate_rep.id.push(<i64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "username" => intermediate_rep.username.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "username" => intermediate_rep.username.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "firstName" => intermediate_rep.first_name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "firstName" => intermediate_rep.first_name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "lastName" => intermediate_rep.last_name.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "lastName" => intermediate_rep.last_name.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "email" => intermediate_rep.email.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "email" => intermediate_rep.email.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "password" => intermediate_rep.password.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "password" => intermediate_rep.password.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "phone" => intermediate_rep.phone.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "phone" => intermediate_rep.phone.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "userStatus" => intermediate_rep.user_status.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing User".to_string(),
-                        )
-                    }
+                    "userStatus" => intermediate_rep.user_status.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing User".to_string())
                 }
             }
 
@@ -1510,16 +1951,13 @@ impl std::str::FromStr for User {
 impl std::convert::TryFrom<header::IntoHeaderValue<User>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<User>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<User>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for User - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for User - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1530,19 +1968,20 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<User> {
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => match <User as std::str::FromStr>::from_str(value) {
-                std::result::Result::Ok(value) => {
-                    std::result::Result::Ok(header::IntoHeaderValue(value))
-                }
-                std::result::Result::Err(err) => std::result::Result::Err(format!(
-                    "Unable to convert header value '{}' into User - {}",
-                    value, err
-                )),
-            },
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => {
+                    match <User as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into User - {}",
+                                value, err))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/src/lib.rs
@@ -6,7 +6,7 @@
     unused_extern_crates,
     non_camel_case_types,
     unused_imports,
-    unused_attributes
+    unused_attributes,
 )]
 #![allow(
     clippy::derive_partial_eq_without_eq,
@@ -20,9 +20,9 @@ pub const API_VERSION: &str = "2.3.4";
 #[cfg(feature = "server")]
 pub mod server;
 
-pub mod apis;
 pub mod models;
 pub mod types;
+pub mod apis;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/src/models.rs
@@ -7,22 +7,64 @@ use validator::Validate;
 use crate::header;
 use crate::{models, types::*};
 
+      
+      
+      
+      
+      
+      
+      
+      
+      
+
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct FooANullableContainer {
     #[serde(rename = "NullableThing")]
     #[serde(deserialize_with = "deserialize_optional_nullable")]
     #[serde(default = "default_optional_nullable")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_thing: Option<Nullable<String>>,
 
     #[serde(rename = "RequiredNullableThing")]
     pub required_nullable_thing: Nullable<String>,
+
 }
 
 impl FooANullableContainer {
+    fn __name_for_nullable_thing() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='NullableThing', complexType='string', getter='getNullableThing', setter='setNullableThing', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='nullable_thing', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.NullableThing;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "nullable" : true,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=true, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='nullableThing', nameInPascalCase='NullableThing', nameInSnakeCase='NULLABLE_THING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_nullable_thing<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_nullable_thing())
+        }
+}
+impl FooANullableContainer {
+    fn __name_for_required_nullable_thing() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='RequiredNullableThing', complexType='string', getter='getRequiredNullableThing', setter='setRequiredNullableThing', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='required_nullable_thing', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.RequiredNullableThing;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "nullable" : true,
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=true, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='requiredNullableThing', nameInPascalCase='RequiredNullableThing', nameInSnakeCase='REQUIRED_NULLABLE_THING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_required_nullable_thing<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_required_nullable_thing())
+        }
+}
+
+
+impl FooANullableContainer {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(required_nullable_thing: Nullable<String>) -> FooANullableContainer {
+    pub fn new(required_nullable_thing: Nullable<String>, ) -> FooANullableContainer {
         FooANullableContainer {
             nullable_thing: None,
             required_nullable_thing,
@@ -36,28 +78,21 @@ impl FooANullableContainer {
 impl std::fmt::Display for FooANullableContainer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             self.nullable_thing.as_ref().map(|nullable_thing| {
                 [
                     "NullableThing".to_string(),
-                    nullable_thing
-                        .as_ref()
-                        .map_or("null".to_string(), |x| x.to_string()),
-                ]
-                .join(",")
+                    nullable_thing.as_ref().map_or("null".to_string(), |x| x.to_string()),
+                ].join(",")
             }),
+
+
             Some("RequiredNullableThing".to_string()),
-            Some(
-                self.required_nullable_thing
-                    .as_ref()
-                    .map_or("null".to_string(), |x| x.to_string()),
-            ),
+            Some(self.required_nullable_thing.as_ref().map_or("null".to_string(), |x| x.to_string())),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -85,11 +120,7 @@ impl std::str::FromStr for FooANullableContainer {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing FooANullableContainer".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing FooANullableContainer".to_string())
             };
 
             if let Some(key) = key_result {
@@ -107,12 +138,8 @@ impl std::str::FromStr for FooANullableContainer {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(FooANullableContainer {
-            nullable_thing: std::result::Result::Err(
-                "Nullable types not supported in FooANullableContainer".to_string(),
-            )?,
-            required_nullable_thing: std::result::Result::Err(
-                "Nullable types not supported in FooANullableContainer".to_string(),
-            )?,
+            nullable_thing: std::result::Result::Err("Nullable types not supported in FooANullableContainer".to_string())?,
+            required_nullable_thing: std::result::Result::Err("Nullable types not supported in FooANullableContainer".to_string())?,
         })
     }
 }
@@ -123,16 +150,13 @@ impl std::str::FromStr for FooANullableContainer {
 impl std::convert::TryFrom<header::IntoHeaderValue<FooANullableContainer>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<FooANullableContainer>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<FooANullableContainer>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for FooANullableContainer - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for FooANullableContainer - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -143,24 +167,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<FooANullable
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <FooANullableContainer as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <FooANullableContainer as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into FooANullableContainer - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into FooANullableContainer - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// An additionalPropertiesObject
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -173,17 +196,13 @@ impl validator::Validate for FooAdditionalPropertiesObject {
     }
 }
 
-impl std::convert::From<std::collections::HashMap<String, String>>
-    for FooAdditionalPropertiesObject
-{
+impl std::convert::From<std::collections::HashMap<String, String>> for FooAdditionalPropertiesObject {
     fn from(x: std::collections::HashMap<String, String>) -> Self {
         FooAdditionalPropertiesObject(x)
     }
 }
 
-impl std::convert::From<FooAdditionalPropertiesObject>
-    for std::collections::HashMap<String, String>
-{
+impl std::convert::From<FooAdditionalPropertiesObject> for std::collections::HashMap<String, String> {
     fn from(x: FooAdditionalPropertiesObject) -> Self {
         x.0
     }
@@ -219,23 +238,51 @@ impl ::std::str::FromStr for FooAdditionalPropertiesObject {
     type Err = &'static str;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        std::result::Result::Err(
-            "Parsing additionalProperties for FooAdditionalPropertiesObject is not supported",
-        )
+        std::result::Result::Err("Parsing additionalProperties for FooAdditionalPropertiesObject is not supported")
     }
 }
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct FooAllOfObject {
     #[serde(rename = "sampleProperty")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sample_property: Option<String>,
 
     #[serde(rename = "sampleBaseProperty")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sample_base_property: Option<String>,
+
 }
+
+impl FooAllOfObject {
+    fn __name_for_sample_property() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='sampleProperty', complexType='string', getter='getSampleProperty', setter='setSampleProperty', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='sample_property', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.sampleProperty;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=false, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='sampleProperty', nameInPascalCase='SampleProperty', nameInSnakeCase='SAMPLE_PROPERTY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_sample_property<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_sample_property())
+        }
+}
+impl FooAllOfObject {
+    fn __name_for_sample_base_property() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='sampleBaseProperty', complexType='string', getter='getSampleBaseProperty', setter='setSampleBaseProperty', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='sample_base_property', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.sampleBaseProperty;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=false, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='sampleBaseProperty', nameInPascalCase='SampleBaseProperty', nameInSnakeCase='SAMPLE_BASE_PROPERTY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_sample_base_property<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_sample_base_property())
+        }
+}
+
 
 impl FooAllOfObject {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -253,25 +300,25 @@ impl FooAllOfObject {
 impl std::fmt::Display for FooAllOfObject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             self.sample_property.as_ref().map(|sample_property| {
-                ["sampleProperty".to_string(), sample_property.to_string()].join(",")
+                [
+                    "sampleProperty".to_string(),
+                    sample_property.to_string(),
+                ].join(",")
             }),
-            self.sample_base_property
-                .as_ref()
-                .map(|sample_base_property| {
-                    [
-                        "sampleBaseProperty".to_string(),
-                        sample_base_property.to_string(),
-                    ]
-                    .join(",")
-                }),
+
+
+            self.sample_base_property.as_ref().map(|sample_base_property| {
+                [
+                    "sampleBaseProperty".to_string(),
+                    sample_base_property.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -299,29 +346,17 @@ impl std::str::FromStr for FooAllOfObject {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing FooAllOfObject".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing FooAllOfObject".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "sampleProperty" => intermediate_rep.sample_property.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "sampleProperty" => intermediate_rep.sample_property.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "sampleBaseProperty" => intermediate_rep.sample_base_property.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing FooAllOfObject".to_string(),
-                        )
-                    }
+                    "sampleBaseProperty" => intermediate_rep.sample_base_property.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing FooAllOfObject".to_string())
                 }
             }
 
@@ -343,16 +378,13 @@ impl std::str::FromStr for FooAllOfObject {
 impl std::convert::TryFrom<header::IntoHeaderValue<FooAllOfObject>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<FooAllOfObject>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<FooAllOfObject>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for FooAllOfObject - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for FooAllOfObject - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -363,32 +395,47 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<FooAllOfObje
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <FooAllOfObject as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <FooAllOfObject as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into FooAllOfObject - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into FooAllOfObject - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct FooBaseAllOf {
     #[serde(rename = "sampleBaseProperty")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sample_base_property: Option<String>,
+
 }
+
+impl FooBaseAllOf {
+    fn __name_for_sample_base_property() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='sampleBaseProperty', complexType='string', getter='getSampleBaseProperty', setter='setSampleBaseProperty', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='sample_base_property', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.sampleBaseProperty;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='sampleBaseProperty', nameInPascalCase='SampleBaseProperty', nameInSnakeCase='SAMPLE_BASE_PROPERTY', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=true, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_sample_base_property<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_sample_base_property())
+        }
+}
+
 
 impl FooBaseAllOf {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
@@ -404,23 +451,18 @@ impl FooBaseAllOf {
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for FooBaseAllOf {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> =
-            vec![self
-                .sample_base_property
-                .as_ref()
-                .map(|sample_base_property| {
-                    [
-                        "sampleBaseProperty".to_string(),
-                        sample_base_property.to_string(),
-                    ]
-                    .join(",")
-                })];
+        let params: Vec<Option<String>> = vec![
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+            self.sample_base_property.as_ref().map(|sample_base_property| {
+                [
+                    "sampleBaseProperty".to_string(),
+                    sample_base_property.to_string(),
+                ].join(",")
+            }),
+
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -447,25 +489,15 @@ impl std::str::FromStr for FooBaseAllOf {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing FooBaseAllOf".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing FooBaseAllOf".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "sampleBaseProperty" => intermediate_rep.sample_base_property.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing FooBaseAllOf".to_string(),
-                        )
-                    }
+                    "sampleBaseProperty" => intermediate_rep.sample_base_property.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing FooBaseAllOf".to_string())
                 }
             }
 
@@ -486,16 +518,13 @@ impl std::str::FromStr for FooBaseAllOf {
 impl std::convert::TryFrom<header::IntoHeaderValue<FooBaseAllOf>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<FooBaseAllOf>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<FooBaseAllOf>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for FooBaseAllOf - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for FooBaseAllOf - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -506,24 +535,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<FooBaseAllOf
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <FooBaseAllOf as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <FooBaseAllOf as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into FooBaseAllOf - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into FooBaseAllOf - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -532,14 +560,46 @@ pub struct FooDummyPutRequest {
     pub id: String,
 
     #[serde(rename = "password")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub password: Option<String>,
+
 }
 
 impl FooDummyPutRequest {
+    fn __name_for_id() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='id', complexType='string', getter='getId', setter='setId', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='id', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.id;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='id', nameInPascalCase='Id', nameInSnakeCase='ID', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_id<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_id())
+        }
+}
+impl FooDummyPutRequest {
+    fn __name_for_password() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='password', complexType='string', getter='getPassword', setter='setPassword', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='password', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.password;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='password', nameInPascalCase='Password', nameInSnakeCase='PASSWORD', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_password<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_password())
+        }
+}
+
+
+impl FooDummyPutRequest {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(id: String) -> FooDummyPutRequest {
-        FooDummyPutRequest { id, password: None }
+    pub fn new(id: String, ) -> FooDummyPutRequest {
+        FooDummyPutRequest {
+            id,
+            password: None,
+        }
     }
 }
 
@@ -549,18 +609,21 @@ impl FooDummyPutRequest {
 impl std::fmt::Display for FooDummyPutRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             Some("id".to_string()),
             Some(self.id.to_string()),
-            self.password
-                .as_ref()
-                .map(|password| ["password".to_string(), password.to_string()].join(",")),
+
+
+            self.password.as_ref().map(|password| {
+                [
+                    "password".to_string(),
+                    password.to_string(),
+                ].join(",")
+            }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -588,29 +651,17 @@ impl std::str::FromStr for FooDummyPutRequest {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing FooDummyPutRequest".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing FooDummyPutRequest".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "id" => intermediate_rep.id.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "id" => intermediate_rep.id.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "password" => intermediate_rep.password.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing FooDummyPutRequest".to_string(),
-                        )
-                    }
+                    "password" => intermediate_rep.password.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing FooDummyPutRequest".to_string())
                 }
             }
 
@@ -620,11 +671,7 @@ impl std::str::FromStr for FooDummyPutRequest {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(FooDummyPutRequest {
-            id: intermediate_rep
-                .id
-                .into_iter()
-                .next()
-                .ok_or_else(|| "id missing in FooDummyPutRequest".to_string())?,
+            id: intermediate_rep.id.into_iter().next().ok_or_else(|| "id missing in FooDummyPutRequest".to_string())?,
             password: intermediate_rep.password.into_iter().next(),
         })
     }
@@ -636,16 +683,13 @@ impl std::str::FromStr for FooDummyPutRequest {
 impl std::convert::TryFrom<header::IntoHeaderValue<FooDummyPutRequest>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<FooDummyPutRequest>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<FooDummyPutRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for FooDummyPutRequest - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for FooDummyPutRequest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -656,24 +700,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<FooDummyPutR
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <FooDummyPutRequest as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <FooDummyPutRequest as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into FooDummyPutRequest - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into FooDummyPutRequest - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// structured response
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
@@ -681,14 +724,33 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<FooDummyPutR
 pub struct FooGetYamlResponse {
     /// Inner string
     #[serde(rename = "value")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+
 }
+
+impl FooGetYamlResponse {
+    fn __name_for_value() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='value', complexType='string', getter='getValue', setter='setValue', description='Inner string', dataType='String', datatypeWithEnum='String', dataFormat='null', name='value', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.value;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='Inner string', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "description" : "Inner string",
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='value', nameInPascalCase='Value', nameInSnakeCase='VALUE', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_value<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_value())
+        }
+}
+
 
 impl FooGetYamlResponse {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new() -> FooGetYamlResponse {
-        FooGetYamlResponse { value: None }
+        FooGetYamlResponse {
+            value: None,
+        }
     }
 }
 
@@ -697,16 +759,18 @@ impl FooGetYamlResponse {
 /// Should be implemented in a serde serializer
 impl std::fmt::Display for FooGetYamlResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> = vec![self
-            .value
-            .as_ref()
-            .map(|value| ["value".to_string(), value.to_string()].join(","))];
+        let params: Vec<Option<String>> = vec![
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+            self.value.as_ref().map(|value| {
+                [
+                    "value".to_string(),
+                    value.to_string(),
+                ].join(",")
+            }),
+
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -733,25 +797,15 @@ impl std::str::FromStr for FooGetYamlResponse {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing FooGetYamlResponse".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing FooGetYamlResponse".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "value" => intermediate_rep.value.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing FooGetYamlResponse".to_string(),
-                        )
-                    }
+                    "value" => intermediate_rep.value.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing FooGetYamlResponse".to_string())
                 }
             }
 
@@ -772,16 +826,13 @@ impl std::str::FromStr for FooGetYamlResponse {
 impl std::convert::TryFrom<header::IntoHeaderValue<FooGetYamlResponse>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<FooGetYamlResponse>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<FooGetYamlResponse>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for FooGetYamlResponse - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for FooGetYamlResponse - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -792,38 +843,55 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<FooGetYamlRe
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <FooGetYamlResponse as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <FooGetYamlResponse as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into FooGetYamlResponse - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into FooGetYamlResponse - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 /// An object of objects
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct FooObjectOfObjects {
     #[serde(rename = "inner")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub inner: Option<models::FooObjectOfObjectsInner>,
+
 }
+
+impl FooObjectOfObjects {
+    fn __name_for_inner() -> String {
+        String::from("CodegenProperty{openApiType='ObjectOfObjects_inner', baseName='inner', complexType='ObjectOfObjects_inner', getter='getInner', setter='setInner', description='null', dataType='models::FooObjectOfObjectsInner', datatypeWithEnum='models::FooObjectOfObjectsInner', dataFormat='null', name='inner', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.inner;', baseType='ObjectOfObjects_inner', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "$ref" : "#/components/schemas/ObjectOfObjects_inner"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=false, isModel=true, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='inner', nameInPascalCase='Inner', nameInSnakeCase='INNER', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=#/components/schemas/ObjectOfObjects_inner, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_inner<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_inner())
+        }
+}
+
 
 impl FooObjectOfObjects {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new() -> FooObjectOfObjects {
-        FooObjectOfObjects { inner: None }
+        FooObjectOfObjects {
+            inner: None,
+        }
     }
 }
 
@@ -837,11 +905,7 @@ impl std::fmt::Display for FooObjectOfObjects {
 
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -868,26 +932,15 @@ impl std::str::FromStr for FooObjectOfObjects {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing FooObjectOfObjects".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing FooObjectOfObjects".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "inner" => intermediate_rep.inner.push(
-                        <models::FooObjectOfObjectsInner as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing FooObjectOfObjects".to_string(),
-                        )
-                    }
+                    "inner" => intermediate_rep.inner.push(<models::FooObjectOfObjectsInner as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing FooObjectOfObjects".to_string())
                 }
             }
 
@@ -908,16 +961,13 @@ impl std::str::FromStr for FooObjectOfObjects {
 impl std::convert::TryFrom<header::IntoHeaderValue<FooObjectOfObjects>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<FooObjectOfObjects>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<FooObjectOfObjects>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for FooObjectOfObjects - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for FooObjectOfObjects - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -928,24 +978,23 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<FooObjectOfO
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <FooObjectOfObjects as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <FooObjectOfObjects as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into FooObjectOfObjects - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into FooObjectOfObjects - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -954,13 +1003,42 @@ pub struct FooObjectOfObjectsInner {
     pub required_thing: String,
 
     #[serde(rename = "optional_thing")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub optional_thing: Option<i32>,
+
 }
 
 impl FooObjectOfObjectsInner {
+    fn __name_for_required_thing() -> String {
+        String::from("CodegenProperty{openApiType='string', baseName='required_thing', complexType='string', getter='getRequiredThing', setter='setRequiredThing', description='null', dataType='String', datatypeWithEnum='String', dataFormat='null', name='required_thing', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.required_thing;', baseType='string', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "string"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=true, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=true, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='requiredThing', nameInPascalCase='RequiredThing', nameInSnakeCase='REQUIRED_THING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_required_thing<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_required_thing())
+        }
+}
+impl FooObjectOfObjectsInner {
+    fn __name_for_optional_thing() -> String {
+        String::from("CodegenProperty{openApiType='integer', baseName='optional_thing', complexType='integer', getter='getOptionalThing', setter='setOptionalThing', description='null', dataType='i32', datatypeWithEnum='i32', dataFormat='null', name='optional_thing', min='null', max='null', defaultValue='None', defaultValueWithParam=' = data.optional_thing;', baseType='integer', containerType='null', containerTypeMapped='null', title='null', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
+  "type" : "integer"
+}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, hasMoreNonReadOnly=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=true, isInteger=true, isShort=false, isLong=false, isUnboundedInteger=true, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='optionalThing', nameInPascalCase='OptionalThing', nameInSnakeCase='OPTIONAL_THING', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=false, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}")
+    }
+
+    fn __serialize_optional_thing<S>(_: &String, s: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+        {
+            s.serialize_str(&Self::__name_for_optional_thing())
+        }
+}
+
+
+impl FooObjectOfObjectsInner {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(required_thing: String) -> FooObjectOfObjectsInner {
+    pub fn new(required_thing: String, ) -> FooObjectOfObjectsInner {
         FooObjectOfObjectsInner {
             required_thing,
             optional_thing: None,
@@ -974,18 +1052,21 @@ impl FooObjectOfObjectsInner {
 impl std::fmt::Display for FooObjectOfObjectsInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
+
             Some("required_thing".to_string()),
             Some(self.required_thing.to_string()),
+
+
             self.optional_thing.as_ref().map(|optional_thing| {
-                ["optional_thing".to_string(), optional_thing.to_string()].join(",")
+                [
+                    "optional_thing".to_string(),
+                    optional_thing.to_string(),
+                ].join(",")
             }),
+
         ];
 
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
     }
 }
 
@@ -1013,29 +1094,17 @@ impl std::str::FromStr for FooObjectOfObjectsInner {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing FooObjectOfObjectsInner".to_string(),
-                    )
-                }
+                None => return std::result::Result::Err("Missing value while parsing FooObjectOfObjectsInner".to_string())
             };
 
             if let Some(key) = key_result {
                 #[allow(clippy::match_single_binding)]
                 match key {
                     #[allow(clippy::redundant_clone)]
-                    "required_thing" => intermediate_rep.required_thing.push(
-                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
+                    "required_thing" => intermediate_rep.required_thing.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "optional_thing" => intermediate_rep.optional_thing.push(
-                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing FooObjectOfObjectsInner".to_string(),
-                        )
-                    }
+                    "optional_thing" => intermediate_rep.optional_thing.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing FooObjectOfObjectsInner".to_string())
                 }
             }
 
@@ -1045,11 +1114,7 @@ impl std::str::FromStr for FooObjectOfObjectsInner {
 
         // Use the intermediate representation to return the struct
         std::result::Result::Ok(FooObjectOfObjectsInner {
-            required_thing: intermediate_rep
-                .required_thing
-                .into_iter()
-                .next()
-                .ok_or_else(|| "required_thing missing in FooObjectOfObjectsInner".to_string())?,
+            required_thing: intermediate_rep.required_thing.into_iter().next().ok_or_else(|| "required_thing missing in FooObjectOfObjectsInner".to_string())?,
             optional_thing: intermediate_rep.optional_thing.into_iter().next(),
         })
     }
@@ -1061,16 +1126,13 @@ impl std::str::FromStr for FooObjectOfObjectsInner {
 impl std::convert::TryFrom<header::IntoHeaderValue<FooObjectOfObjectsInner>> for HeaderValue {
     type Error = String;
 
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<FooObjectOfObjectsInner>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<FooObjectOfObjectsInner>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for FooObjectOfObjectsInner - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for FooObjectOfObjectsInner - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1081,21 +1143,20 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<FooObjectOfO
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <FooObjectOfObjectsInner as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
+             std::result::Result::Ok(value) => {
+                    match <FooObjectOfObjectsInner as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into FooObjectOfObjectsInner - {}",
+                                value, err))
                     }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        "Unable to convert header value '{}' into FooObjectOfObjectsInner - {}",
-                        value, err
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Unable to convert header: {:?} to string: {}",
-                hdr_value, e
-            )),
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
+
+
+


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR aims to replace the current `oneOf` and `discriminator` implementation for the rust-axum generator to one that is usable.

The idea is to generate an enum for `oneOf` models, with a variant for each specified model. It uses `untagged` when the discriminator is not specified, and `tag = "discriminator"` when it is.
This implementation however is not the default present in serde, as it lacks serialization for the discriminator field, a field that has to be specified in all `oneOf` variants per OAS, and will fail to serialize when present in the generated structure. The custom implementation allows for the field to be present, and still be able to serialize to the adequate model.
Another benefit of the custom serialization is that the variant structure can be serialized directly without the need to convert to the original enum (an option which is still available), which has its benefits when the models have further use outside the API (such as WS messages), and facilitates the use of the `frunk` crate.

TODO:
- [ ] Figure out why `./bin/generate-samples.sh bin/configs/manual/rust-axum-*` freezes, but manually generating each model still works.
- [ ] Fix the validator implementation of primitive type enum variants.
- [ ] Move model modifications from `postProcessOperationsWithModels` to its own method.

Fixes #20101 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
