### PR TITLE
Fix Julia template for binary string

### DIFF
--- a/modules/openapi-generator/src/main/resources/julia-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-client/api.mustache
@@ -22,7 +22,7 @@ const _returntypes_{{operationId}}_{{classname}} = Dict{Regex,Type}(
     {{/responses}}
 )
 
-function _oacinternal_{{operationId}}(_api::{{classname}}{{#allParams}}{{#required}}, {{paramName}}::{{#dataType}}{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}} _mediaType=nothing)
+function _oacinternal_{{operationId}}(_api::{{classname}}{{#allParams}}{{#required}}, {{paramName}}::{{dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}} _mediaType=nothing)
 {{#allParams}}
 {{#hasValidation}}
 {{#maxLength}}
@@ -61,7 +61,7 @@ function _oacinternal_{{operationId}}(_api::{{classname}}{{#allParams}}{{#requir
     OpenAPI.Clients.set_param(_ctx.form, "{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{paramName}}{{#isListContainer}}; collection_format="{{collectionFormat}}"{{/isListContainer}})  # type {{dataType}}
 {{/isFile}}
 {{#isFile}}
-    OpenAPI.Clients.set_param(_ctx.file, "{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{paramName}})  # type {{#dataType}}{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/dataType}}
+    OpenAPI.Clients.set_param(_ctx.file, "{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{paramName}})  # type {{dataType}}
 {{/isFile}}
 {{/formParams}}
     OpenAPI.Clients.set_header_accept(_ctx, [{{#produces}}"{{{mediaType}}}", {{/produces}}])

--- a/modules/openapi-generator/src/main/resources/julia-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-client/api.mustache
@@ -22,7 +22,7 @@ const _returntypes_{{operationId}}_{{classname}} = Dict{Regex,Type}(
     {{/responses}}
 )
 
-function _oacinternal_{{operationId}}(_api::{{classname}}{{#allParams}}{{#required}}, {{paramName}}::{{dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}} _mediaType=nothing)
+function _oacinternal_{{operationId}}(_api::{{classname}}{{#allParams}}{{#required}}, {{paramName}}::{{#dataType}}{{#isBinary}}{{#isFile}}{{dataType}}{{/isFile}}{{^isFile}}Vector{UInt8}{{/isFile}}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}} _mediaType=nothing)
 {{#allParams}}
 {{#hasValidation}}
 {{#maxLength}}
@@ -61,7 +61,7 @@ function _oacinternal_{{operationId}}(_api::{{classname}}{{#allParams}}{{#requir
     OpenAPI.Clients.set_param(_ctx.form, "{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{paramName}}{{#isListContainer}}; collection_format="{{collectionFormat}}"{{/isListContainer}})  # type {{dataType}}
 {{/isFile}}
 {{#isFile}}
-    OpenAPI.Clients.set_param(_ctx.file, "{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{paramName}})  # type {{dataType}}
+    OpenAPI.Clients.set_param(_ctx.file, "{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{paramName}})  # type {{#dataType}}{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/dataType}}
 {{/isFile}}
 {{/formParams}}
     OpenAPI.Clients.set_header_accept(_ctx, [{{#produces}}"{{{mediaType}}}", {{/produces}}])
@@ -74,17 +74,17 @@ end
 {{/summary.length}}{{#notes.length}}{{{notes}}}
 
 {{/notes.length}}Params:
-{{#allParams}}- {{paramName}}::{{dataType}}{{#required}} (required){{/required}}
+{{#allParams}}- {{paramName}}::{{#isBinary}}{{#isFile}}{{dataType}}{{/isFile}}{{^isFile}}Vector{UInt8}{{/isFile}}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{#required}} (required){{/required}}
 {{/allParams}}
 
 Return: {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}, OpenAPI.Clients.ApiResponse
 """
-function {{operationId}}(_api::{{classname}}{{#allParams}}{{#required}}, {{paramName}}::{{dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}} _mediaType=nothing)
+function {{operationId}}(_api::{{classname}}{{#allParams}}{{#required}}, {{paramName}}::{{#isBinary}}{{#isFile}}{{dataType}}{{/isFile}}{{^isFile}}Vector{UInt8}{{/isFile}}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}} _mediaType=nothing)
     _ctx = _oacinternal_{{operationId}}(_api{{#allParams}}{{#required}}, {{paramName}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}={{paramName}},{{/required}}{{/allParams}} _mediaType=_mediaType)
     return OpenAPI.Clients.exec(_ctx)
 end
 
-function {{operationId}}(_api::{{classname}}, response_stream::Channel{{#allParams}}{{#required}}, {{paramName}}::{{dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}} _mediaType=nothing)
+function {{operationId}}(_api::{{classname}}, response_stream::Channel{{#allParams}}{{#required}}, {{paramName}}::{{#isBinary}}{{#isFile}}{{dataType}}{{/isFile}}{{^isFile}}Vector{UInt8}{{/isFile}}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}} _mediaType=nothing)
     _ctx = _oacinternal_{{operationId}}(_api{{#allParams}}{{#required}}, {{paramName}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}={{paramName}},{{/required}}{{/allParams}} _mediaType=_mediaType)
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end

--- a/modules/openapi-generator/src/main/resources/julia-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-client/api.mustache
@@ -61,7 +61,7 @@ function _oacinternal_{{operationId}}(_api::{{classname}}{{#allParams}}{{#requir
     OpenAPI.Clients.set_param(_ctx.form, "{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{paramName}}{{#isListContainer}}; collection_format="{{collectionFormat}}"{{/isListContainer}})  # type {{dataType}}
 {{/isFile}}
 {{#isFile}}
-    OpenAPI.Clients.set_param(_ctx.file, "{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{paramName}})  # type {{#dataType}}{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/dataType}}
+    OpenAPI.Clients.set_param(_ctx.file, "{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{paramName}})  # type {{#dataType}}{{#isBinary}}{{#isFile}}{{dataType}}{{/isFile}}{{^isFile}}Vector{UInt8}{{/isFile}}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/dataType}}
 {{/isFile}}
 {{/formParams}}
     OpenAPI.Clients.set_header_accept(_ctx, [{{#produces}}"{{{mediaType}}}", {{/produces}}])

--- a/modules/openapi-generator/src/main/resources/julia-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-client/api_doc.mustache
@@ -23,13 +23,13 @@ Method | HTTP request | Description
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **{{classname}}** | API context | {{/-last}}{{/allParams}}{{#allParams}}{{#required}}
-**{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{#defaultValue}}[default to {{.}}]{{/defaultValue}}{{/required}}{{/allParams}}{{#hasOptionalParams}}
+**{{paramName}}** | {{#isPrimitiveType}}**{{#isBinary}}{{#isFile}}{{dataType}}{{/isFile}}{{^isFile}}Vector{UInt8}{{/isFile}}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{#isFile}}**{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isFile}}{{/isPrimitiveType}} | {{description}} | {{^isBinary}}{{#defaultValue}}[default to {{.}}]{{/defaultValue}}{{/isBinary}}{{/required}}{{/allParams}}{{#hasOptionalParams}}
 
 ### Optional Parameters
 {{#allParams}}{{#-last}}
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}{{#allParams}}{{^required}}
- **{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{#defaultValue}}[default to {{.}}]{{/defaultValue}}{{/required}}{{/allParams}}{{/hasOptionalParams}}
+ **{{paramName}}** | {{#isPrimitiveType}}**{{#isBinary}}{{#isFile}}{{dataType}}{{/isFile}}{{^isFile}}Vector{UInt8}{{/isFile}}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{#isFile}}**{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isFile}}{{/isPrimitiveType}} | {{description}} | {{^isBinary}}{{#defaultValue}}[default to {{.}}]{{/defaultValue}}{{/isBinary}}{{/required}}{{/allParams}}{{/hasOptionalParams}}
 
 ### Return type
 

--- a/modules/openapi-generator/src/main/resources/julia-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-client/api_doc.mustache
@@ -23,7 +23,7 @@ Method | HTTP request | Description
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **{{classname}}** | API context | {{/-last}}{{/allParams}}{{#allParams}}{{#required}}
-**{{paramName}}** | {{#isPrimitiveType}}**{{#isBinary}}{{#isFile}}{{dataType}}{{/isFile}}{{^isFile}}Vector{UInt8}{{/isFile}}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{#isFile}}**{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isFile}}{{/isPrimitiveType}} | {{description}} | {{^isBinary}}{{#defaultValue}}[default to {{.}}]{{/defaultValue}}{{/isBinary}}{{/required}}{{/allParams}}{{#hasOptionalParams}}
+**{{paramName}}** | {{#isPrimitiveType}}**{{#isBinary}}{{#isFile}}{{dataType}}{{/isFile}}{{^isFile}}Vector{UInt8}{{/isFile}}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{#isFile}}**{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isFile}}{{/isPrimitiveType}} | {{description}} |{{/required}}{{/allParams}}{{#hasOptionalParams}}
 
 ### Optional Parameters
 {{#allParams}}{{#-last}}

--- a/modules/openapi-generator/src/main/resources/julia-server/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/api_doc.mustache
@@ -11,7 +11,7 @@ Method | HTTP request | Description
 {{#operations}}
 {{#operation}}
 # **{{{operationId}}}**
-> {{operationId}}(req::HTTP.Request{{#allParams}}{{#required}}, {{paramName}}::{{dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}}) -> {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}
+> {{operationId}}(req::HTTP.Request{{#allParams}}{{#required}}, {{paramName}}::{{#dataType}}{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}}) -> {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}
 
 {{{summary}}}{{#notes}}
 

--- a/modules/openapi-generator/src/main/resources/julia-server/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/api_doc.mustache
@@ -11,7 +11,7 @@ Method | HTTP request | Description
 {{#operations}}
 {{#operation}}
 # **{{{operationId}}}**
-> {{operationId}}(req::HTTP.Request{{#allParams}}{{#required}}, {{paramName}}::{{dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}}) -> {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}
+> {{operationId}}(req::HTTP.Request{{#allParams}}{{#required}}, {{paramName}}::{{#dataType}}{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}}) -> {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}
 
 {{{summary}}}{{#notes}}
 
@@ -22,7 +22,7 @@ Method | HTTP request | Description
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | {{/-last}}{{/allParams}}{{#allParams}}{{#required}}
-**{{paramName}}** | {{#isPrimitiveType}}**{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{#isFile}}**{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isFile}}{{/isPrimitiveType}}| {{description}} | {{^isBinary}}{{#defaultValue}}[default to {{.}}]{{/defaultValue}}{{/isBinary}}{{/required}}{{/allParams}}{{#hasOptionalParams}}
+**{{paramName}}** | {{#isPrimitiveType}}**{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{#isFile}}**{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isFile}}{{/isPrimitiveType}}| {{description}} |{{/required}}{{/allParams}}{{#hasOptionalParams}}
 
 ### Optional Parameters
 {{#allParams}}{{#-last}}

--- a/modules/openapi-generator/src/main/resources/julia-server/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/api_doc.mustache
@@ -11,7 +11,7 @@ Method | HTTP request | Description
 {{#operations}}
 {{#operation}}
 # **{{{operationId}}}**
-> {{operationId}}(req::HTTP.Request{{#allParams}}{{#required}}, {{paramName}}::{{#dataType}}{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}}) -> {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}
+> {{operationId}}(req::HTTP.Request{{#allParams}}{{#required}}, {{paramName}}::{{dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}}) -> {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}
 
 {{{summary}}}{{#notes}}
 
@@ -22,13 +22,13 @@ Method | HTTP request | Description
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | {{/-last}}{{/allParams}}{{#allParams}}{{#required}}
-**{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{#defaultValue}}[default to {{.}}]{{/defaultValue}}{{/required}}{{/allParams}}{{#hasOptionalParams}}
+**{{paramName}}** | {{#isPrimitiveType}}**{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{#isFile}}**{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isFile}}{{/isPrimitiveType}}| {{description}} | {{^isBinary}}{{#defaultValue}}[default to {{.}}]{{/defaultValue}}{{/isBinary}}{{/required}}{{/allParams}}{{#hasOptionalParams}}
 
 ### Optional Parameters
 {{#allParams}}{{#-last}}
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}{{#allParams}}{{^required}}
- **{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{#defaultValue}}[default to {{.}}]{{/defaultValue}}{{/required}}{{/allParams}}{{/hasOptionalParams}}
+ **{{paramName}}** | {{#isPrimitiveType}}**{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{#isFile}}**{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}**{{/isFile}}{{/isPrimitiveType}}| {{description}} | {{^isBinary}}{{#defaultValue}}[default to {{.}}]{{/defaultValue}}{{/isBinary}}{{/required}}{{/allParams}}{{/hasOptionalParams}}
 
 ### Return type
 

--- a/modules/openapi-generator/src/main/resources/julia-server/server.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/server.mustache
@@ -11,7 +11,7 @@ The following server methods must be implemented:
 {{#operation}}
 - **{{operationId}}**
     - *invocation:* {{httpMethod}} {{{path}}}
-    - *signature:* {{operationId}}(req::HTTP.Request{{#allParams}}{{#required}}, {{paramName}}::{{#dataType}}{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}}) -> {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}
+    - *signature:* {{operationId}}(req::HTTP.Request{{#allParams}}{{#required}}, {{paramName}}::{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}}) -> {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}
 {{/operation}}
 {{/operations}}
 {{/apis}}

--- a/modules/openapi-generator/src/main/resources/julia-server/server.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/server.mustache
@@ -11,7 +11,7 @@ The following server methods must be implemented:
 {{#operation}}
 - **{{operationId}}**
     - *invocation:* {{httpMethod}} {{{path}}}
-    - *signature:* {{operationId}}(req::HTTP.Request{{#allParams}}{{#required}}, {{paramName}}::{{dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}}) -> {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}
+    - *signature:* {{operationId}}(req::HTTP.Request{{#allParams}}{{#required}}, {{paramName}}::{{#dataType}}{{#isBinary}}Vector{UInt8}{{/isBinary}}{{^isBinary}}{{dataType}}{{/isBinary}}{{/dataType}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}}) -> {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}
 {{/operation}}
 {{/operations}}
 {{/apis}}

--- a/samples/client/petstore/julia/docs/FakeApi.md
+++ b/samples/client/petstore/julia/docs/FakeApi.md
@@ -20,7 +20,7 @@ test uuid default value
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **FakeApi** | API context | 
-**uuid_parameter** | **String**| test uuid default value | [default to nothing]
+**uuid_parameter** | **String** | test uuid default value |
 
 ### Return type
 

--- a/samples/client/petstore/julia/docs/PetApi.md
+++ b/samples/client/petstore/julia/docs/PetApi.md
@@ -27,7 +27,7 @@ Add a new pet to the store
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **PetApi** | API context | 
-**pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+**pet** | [**Pet**](Pet.md) | Pet object that needs to be added to the store |
 
 ### Return type
 
@@ -57,13 +57,13 @@ Deletes a pet
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **PetApi** | API context | 
-**pet_id** | **Int64**| Pet id to delete | [default to nothing]
+**pet_id** | **Int64** | Pet id to delete |
 
 ### Optional Parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **api_key** | **String**|  | [default to nothing]
+ **api_key** | **String** |  | [default to nothing]
 
 ### Return type
 
@@ -93,7 +93,7 @@ Multiple status values can be provided with comma separated strings
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **PetApi** | API context | 
-**status** | [**Vector{String}**](String.md)| Status values that need to be considered for filter | [default to nothing]
+**status** | [**Vector{String}**](String.md) | Status values that need to be considered for filter |
 
 ### Return type
 
@@ -123,7 +123,7 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **PetApi** | API context | 
-**tags** | [**Vector{String}**](String.md)| Tags to filter by | [default to nothing]
+**tags** | [**Vector{String}**](String.md) | Tags to filter by |
 
 ### Return type
 
@@ -153,7 +153,7 @@ Returns a single pet
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **PetApi** | API context | 
-**pet_id** | **Int64**| ID of pet to return | [default to nothing]
+**pet_id** | **Int64** | ID of pet to return |
 
 ### Return type
 
@@ -183,7 +183,7 @@ Update an existing pet
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **PetApi** | API context | 
-**pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+**pet** | [**Pet**](Pet.md) | Pet object that needs to be added to the store |
 
 ### Return type
 
@@ -213,14 +213,14 @@ Updates a pet in the store with form data
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **PetApi** | API context | 
-**pet_id** | **Int64**| ID of pet that needs to be updated | [default to nothing]
+**pet_id** | **Int64** | ID of pet that needs to be updated |
 
 ### Optional Parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **name** | **String**| Updated name of the pet | [default to nothing]
- **status** | **String**| Updated status of the pet | [default to nothing]
+ **name** | **String** | Updated name of the pet | [default to nothing]
+ **status** | **String** | Updated status of the pet | [default to nothing]
 
 ### Return type
 
@@ -250,14 +250,14 @@ uploads an image
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **PetApi** | API context | 
-**pet_id** | **Int64**| ID of pet to update | [default to nothing]
+**pet_id** | **Int64** | ID of pet to update |
 
 ### Optional Parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **additional_metadata** | **String**| Additional data to pass to server | [default to nothing]
- **file** | **String****String**| file to upload | [default to nothing]
+ **additional_metadata** | **String** | Additional data to pass to server | [default to nothing]
+ **file** | **String** | file to upload | 
 
 ### Return type
 

--- a/samples/client/petstore/julia/docs/StoreApi.md
+++ b/samples/client/petstore/julia/docs/StoreApi.md
@@ -23,7 +23,7 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **StoreApi** | API context | 
-**order_id** | **String**| ID of the order that needs to be deleted | [default to nothing]
+**order_id** | **String** | ID of the order that needs to be deleted |
 
 ### Return type
 
@@ -79,7 +79,7 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **StoreApi** | API context | 
-**order_id** | **Int64**| ID of pet that needs to be fetched | [default to nothing]
+**order_id** | **Int64** | ID of pet that needs to be fetched |
 
 ### Return type
 
@@ -109,7 +109,7 @@ Place an order for a pet
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **StoreApi** | API context | 
-**order** | [**Order**](Order.md)| order placed for purchasing the pet | 
+**order** | [**Order**](Order.md) | order placed for purchasing the pet |
 
 ### Return type
 

--- a/samples/client/petstore/julia/docs/UserApi.md
+++ b/samples/client/petstore/julia/docs/UserApi.md
@@ -27,7 +27,7 @@ This can only be done by the logged in user.
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **UserApi** | API context | 
-**user** | [**User**](User.md)| Created user object | 
+**user** | [**User**](User.md) | Created user object |
 
 ### Return type
 
@@ -57,7 +57,7 @@ Creates list of users with given input array
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **UserApi** | API context | 
-**user** | [**Vector{User}**](User.md)| List of user object | 
+**user** | [**Vector{User}**](User.md) | List of user object |
 
 ### Return type
 
@@ -87,7 +87,7 @@ Creates list of users with given input array
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **UserApi** | API context | 
-**user** | [**Vector{User}**](User.md)| List of user object | 
+**user** | [**Vector{User}**](User.md) | List of user object |
 
 ### Return type
 
@@ -117,7 +117,7 @@ This can only be done by the logged in user.
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **UserApi** | API context | 
-**username** | **String**| The name that needs to be deleted | [default to nothing]
+**username** | **String** | The name that needs to be deleted |
 
 ### Return type
 
@@ -147,7 +147,7 @@ Get user by user name
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **UserApi** | API context | 
-**username** | **String**| The name that needs to be fetched. Use user1 for testing. | [default to nothing]
+**username** | **String** | The name that needs to be fetched. Use user1 for testing. |
 
 ### Return type
 
@@ -177,8 +177,8 @@ Logs user into the system
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **UserApi** | API context | 
-**username** | **String**| The user name for login | [default to nothing]
-**password** | **String**| The password for login in clear text | [default to nothing]
+**username** | **String** | The user name for login |
+**password** | **String** | The password for login in clear text |
 
 ### Return type
 
@@ -234,8 +234,8 @@ This can only be done by the logged in user.
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **_api** | **UserApi** | API context | 
-**username** | **String**| name that need to be deleted | [default to nothing]
-**user** | [**User**](User.md)| Updated user object | 
+**username** | **String** | name that need to be deleted |
+**user** | [**User**](User.md) | Updated user object |
 
 ### Return type
 

--- a/samples/client/petstore/julia/src/apis/api_PetApi.jl
+++ b/samples/client/petstore/julia/src/apis/api_PetApi.jl
@@ -248,7 +248,7 @@ function _oacinternal_upload_file(_api::PetApi, pet_id::Int64; additional_metada
     _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_upload_file_PetApi, "/pet/{petId}/uploadImage", ["petstore_auth", ])
     OpenAPI.Clients.set_param(_ctx.path, "petId", pet_id)  # type Int64
     OpenAPI.Clients.set_param(_ctx.form, "additionalMetadata", additional_metadata)  # type String
-    OpenAPI.Clients.set_param(_ctx.file, "file", file)  # type Vector{UInt8}
+    OpenAPI.Clients.set_param(_ctx.file, "file", file)  # type String
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["multipart/form-data", ] : [_mediaType])
     return _ctx

--- a/samples/server/petstore/julia/docs/FakeApi.md
+++ b/samples/server/petstore/julia/docs/FakeApi.md
@@ -19,7 +19,7 @@ test uuid default value
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**uuid_parameter** | **String**| test uuid default value | [default to nothing]
+**uuid_parameter** | **String**| test uuid default value |
 
 ### Return type
 

--- a/samples/server/petstore/julia/docs/PetApi.md
+++ b/samples/server/petstore/julia/docs/PetApi.md
@@ -26,7 +26,7 @@ Add a new pet to the store
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+**pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store |
 
 ### Return type
 
@@ -55,7 +55,7 @@ Deletes a pet
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**pet_id** | **Int64**| Pet id to delete | [default to nothing]
+**pet_id** | **Int64**| Pet id to delete |
 
 ### Optional Parameters
 
@@ -90,7 +90,7 @@ Multiple status values can be provided with comma separated strings
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**status** | [**Vector{String}**](String.md)| Status values that need to be considered for filter | [default to nothing]
+**status** | [**Vector{String}**](String.md)| Status values that need to be considered for filter |
 
 ### Return type
 
@@ -119,7 +119,7 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**tags** | [**Vector{String}**](String.md)| Tags to filter by | [default to nothing]
+**tags** | [**Vector{String}**](String.md)| Tags to filter by |
 
 ### Return type
 
@@ -148,7 +148,7 @@ Returns a single pet
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**pet_id** | **Int64**| ID of pet to return | [default to nothing]
+**pet_id** | **Int64**| ID of pet to return |
 
 ### Return type
 
@@ -177,7 +177,7 @@ Update an existing pet
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+**pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store |
 
 ### Return type
 
@@ -206,7 +206,7 @@ Updates a pet in the store with form data
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**pet_id** | **Int64**| ID of pet that needs to be updated | [default to nothing]
+**pet_id** | **Int64**| ID of pet that needs to be updated |
 
 ### Optional Parameters
 
@@ -242,14 +242,14 @@ uploads an image
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**pet_id** | **Int64**| ID of pet to update | [default to nothing]
+**pet_id** | **Int64**| ID of pet to update |
 
 ### Optional Parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **additional_metadata** | **String**| Additional data to pass to server | [default to nothing]
- **file** | **String****String**| file to upload | [default to nothing]
+ **file** | **Vector{UInt8}**| file to upload | 
 
 ### Return type
 

--- a/samples/server/petstore/julia/docs/StoreApi.md
+++ b/samples/server/petstore/julia/docs/StoreApi.md
@@ -22,7 +22,7 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**order_id** | **String**| ID of the order that needs to be deleted | [default to nothing]
+**order_id** | **String**| ID of the order that needs to be deleted |
 
 ### Return type
 
@@ -76,7 +76,7 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**order_id** | **Int64**| ID of pet that needs to be fetched | [default to nothing]
+**order_id** | **Int64**| ID of pet that needs to be fetched |
 
 ### Return type
 
@@ -105,7 +105,7 @@ Place an order for a pet
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**order** | [**Order**](Order.md)| order placed for purchasing the pet | 
+**order** | [**Order**](Order.md)| order placed for purchasing the pet |
 
 ### Return type
 

--- a/samples/server/petstore/julia/docs/UserApi.md
+++ b/samples/server/petstore/julia/docs/UserApi.md
@@ -26,7 +26,7 @@ This can only be done by the logged in user.
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**user** | [**User**](User.md)| Created user object | 
+**user** | [**User**](User.md)| Created user object |
 
 ### Return type
 
@@ -55,7 +55,7 @@ Creates list of users with given input array
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**user** | [**Vector{User}**](User.md)| List of user object | 
+**user** | [**Vector{User}**](User.md)| List of user object |
 
 ### Return type
 
@@ -84,7 +84,7 @@ Creates list of users with given input array
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**user** | [**Vector{User}**](User.md)| List of user object | 
+**user** | [**Vector{User}**](User.md)| List of user object |
 
 ### Return type
 
@@ -113,7 +113,7 @@ This can only be done by the logged in user.
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**username** | **String**| The name that needs to be deleted | [default to nothing]
+**username** | **String**| The name that needs to be deleted |
 
 ### Return type
 
@@ -142,7 +142,7 @@ Get user by user name
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**username** | **String**| The name that needs to be fetched. Use user1 for testing. | [default to nothing]
+**username** | **String**| The name that needs to be fetched. Use user1 for testing. |
 
 ### Return type
 
@@ -171,8 +171,8 @@ Logs user into the system
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**username** | **String**| The user name for login | [default to nothing]
-**password** | **String**| The password for login in clear text | [default to nothing]
+**username** | **String**| The user name for login |
+**password** | **String**| The password for login in clear text |
 
 ### Return type
 
@@ -226,8 +226,8 @@ This can only be done by the logged in user.
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **req** | **HTTP.Request** | The HTTP Request object | 
-**username** | **String**| name that need to be deleted | [default to nothing]
-**user** | [**User**](User.md)| Updated user object | 
+**username** | **String**| name that need to be deleted |
+**user** | [**User**](User.md)| Updated user object |
 
 ### Return type
 


### PR DESCRIPTION
It seems there is a small issue with generated julia function signature, when handling
```yaml
application/octet-stream:
  schema:
    type: string
    format: binary
```

To better reproduce this, I set up a MWE here
https://github.com/qiaojunfeng/test-julia-OpenAPI/tree/main

Since this is a julia-specific issue, I will ping technical committee member @tanmaykm. Thanks!

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
