### PR TITLE
[PHP][php-nextgen] Improve method parameter typing

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
@@ -203,7 +203,11 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
                 if (param.isArray || param.isMap) {
                     param.vendorExtensions.putIfAbsent("x-php-param-type", "array");
                 } else {
-                    param.vendorExtensions.putIfAbsent("x-php-param-type", param.dataType);
+                    String paramType = param.dataType;
+                    if ((!param.required || param.isNullable) && !paramType.equals("mixed")) { // optional or nullable but not mixed
+                        paramType = "?" + paramType;
+                    }
+                    param.vendorExtensions.putIfAbsent("x-php-param-type", paramType);
                 }
             }
         }

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -172,7 +172,7 @@ use {{invokerPackage}}\ObjectSerializer;
     public function {{operationId}}(
     {{^vendorExtensions.x-group-parameters}}
     {{#allParams}}
-        {{^required}}?{{/required}}{{vendorExtensions.x-php-param-type}} ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
+        {{vendorExtensions.x-php-param-type}} ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
     {{/allParams}}
     {{#servers}}
     {{#-first}}
@@ -247,7 +247,7 @@ use {{invokerPackage}}\ObjectSerializer;
     public function {{operationId}}WithHttpInfo(
     {{^vendorExtensions.x-group-parameters}}
     {{#allParams}}
-        {{^required}}?{{/required}}{{vendorExtensions.x-php-param-type}} ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
+        {{vendorExtensions.x-php-param-type}} ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
     {{/allParams}}
     {{#servers}}
     {{#-first}}
@@ -446,7 +446,7 @@ use {{invokerPackage}}\ObjectSerializer;
     public function {{operationId}}Async(
     {{^vendorExtensions.x-group-parameters}}
     {{#allParams}}
-        {{^required}}?{{/required}}{{vendorExtensions.x-php-param-type}} ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
+        {{vendorExtensions.x-php-param-type}} ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
     {{/allParams}}
     {{#servers}}
     {{#-first}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -524,7 +524,7 @@ use {{invokerPackage}}\ObjectSerializer;
     public function {{operationId}}AsyncWithHttpInfo(
     {{^vendorExtensions.x-group-parameters}}
     {{#allParams}}
-        ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
+        {{vendorExtensions.x-php-param-type}} ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
     {{/allParams}}
     {{#servers}}
     {{#-first}}
@@ -630,7 +630,7 @@ use {{invokerPackage}}\ObjectSerializer;
     public function {{operationId}}Request(
     {{^vendorExtensions.x-group-parameters}}
     {{#allParams}}
-        ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
+        {{vendorExtensions.x-php-param-type}} ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
     {{/allParams}}
     {{#servers}}
     {{#-first}}

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
@@ -1745,7 +1745,7 @@ class BodyApi
      * @return string
      */
     public function testEchoBodyFreeFormObjectResponseString(
-        ?array $body = null,
+        array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): string
     {
@@ -1766,7 +1766,7 @@ class BodyApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testEchoBodyFreeFormObjectResponseStringWithHttpInfo(
-        ?array $body = null,
+        array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): array
     {
@@ -1893,7 +1893,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyFreeFormObjectResponseStringAsync(
-        ?array $body = null,
+        array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): PromiseInterface
     {

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
@@ -633,7 +633,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testBodyApplicationOctetstreamBinaryAsyncWithHttpInfo(
-        $body = null,
+        ?\Psr\Http\Message\StreamInterface $body = null,
         string $contentType = self::contentTypes['testBodyApplicationOctetstreamBinary'][0]
     ): PromiseInterface
     {
@@ -686,7 +686,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testBodyApplicationOctetstreamBinaryRequest(
-        $body = null,
+        ?\Psr\Http\Message\StreamInterface $body = null,
         string $contentType = self::contentTypes['testBodyApplicationOctetstreamBinary'][0]
     ): Request
     {
@@ -949,7 +949,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testBodyMultipartFormdataArrayOfBinaryAsyncWithHttpInfo(
-        $files,
+        array $files,
         string $contentType = self::contentTypes['testBodyMultipartFormdataArrayOfBinary'][0]
     ): PromiseInterface
     {
@@ -1002,7 +1002,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testBodyMultipartFormdataArrayOfBinaryRequest(
-        $files,
+        array $files,
         string $contentType = self::contentTypes['testBodyMultipartFormdataArrayOfBinary'][0]
     ): Request
     {
@@ -1278,7 +1278,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testBodyMultipartFormdataSingleBinaryAsyncWithHttpInfo(
-        $my_file = null,
+        ?\Psr\Http\Message\StreamInterface $my_file = null,
         string $contentType = self::contentTypes['testBodyMultipartFormdataSingleBinary'][0]
     ): PromiseInterface
     {
@@ -1331,7 +1331,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testBodyMultipartFormdataSingleBinaryRequest(
-        $my_file = null,
+        ?\Psr\Http\Message\StreamInterface $my_file = null,
         string $contentType = self::contentTypes['testBodyMultipartFormdataSingleBinary'][0]
     ): Request
     {
@@ -1601,7 +1601,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyAllOfPetAsyncWithHttpInfo(
-        $pet = null,
+        ?\OpenAPI\Client\Model\Pet $pet = null,
         string $contentType = self::contentTypes['testEchoBodyAllOfPet'][0]
     ): PromiseInterface
     {
@@ -1654,7 +1654,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyAllOfPetRequest(
-        $pet = null,
+        ?\OpenAPI\Client\Model\Pet $pet = null,
         string $contentType = self::contentTypes['testEchoBodyAllOfPet'][0]
     ): Request
     {
@@ -1917,7 +1917,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyFreeFormObjectResponseStringAsyncWithHttpInfo(
-        $body = null,
+        array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): PromiseInterface
     {
@@ -1970,7 +1970,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyFreeFormObjectResponseStringRequest(
-        $body = null,
+        array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): Request
     {
@@ -2233,7 +2233,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyPetAsyncWithHttpInfo(
-        $pet = null,
+        ?\OpenAPI\Client\Model\Pet $pet = null,
         string $contentType = self::contentTypes['testEchoBodyPet'][0]
     ): PromiseInterface
     {
@@ -2286,7 +2286,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyPetRequest(
-        $pet = null,
+        ?\OpenAPI\Client\Model\Pet $pet = null,
         string $contentType = self::contentTypes['testEchoBodyPet'][0]
     ): Request
     {
@@ -2549,7 +2549,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyPetResponseStringAsyncWithHttpInfo(
-        $pet = null,
+        ?\OpenAPI\Client\Model\Pet $pet = null,
         string $contentType = self::contentTypes['testEchoBodyPetResponseString'][0]
     ): PromiseInterface
     {
@@ -2602,7 +2602,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyPetResponseStringRequest(
-        $pet = null,
+        ?\OpenAPI\Client\Model\Pet $pet = null,
         string $contentType = self::contentTypes['testEchoBodyPetResponseString'][0]
     ): Request
     {
@@ -2865,7 +2865,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyStringEnumAsyncWithHttpInfo(
-        $body = null,
+        ?string $body = null,
         string $contentType = self::contentTypes['testEchoBodyStringEnum'][0]
     ): PromiseInterface
     {
@@ -2918,7 +2918,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyStringEnumRequest(
-        $body = null,
+        ?string $body = null,
         string $contentType = self::contentTypes['testEchoBodyStringEnum'][0]
     ): Request
     {
@@ -3181,7 +3181,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyTagResponseStringAsyncWithHttpInfo(
-        $tag = null,
+        ?\OpenAPI\Client\Model\Tag $tag = null,
         string $contentType = self::contentTypes['testEchoBodyTagResponseString'][0]
     ): PromiseInterface
     {
@@ -3234,7 +3234,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyTagResponseStringRequest(
-        $tag = null,
+        ?\OpenAPI\Client\Model\Tag $tag = null,
         string $contentType = self::contentTypes['testEchoBodyTagResponseString'][0]
     ): Request
     {

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
@@ -328,9 +328,9 @@ class FormApi
      * @return PromiseInterface
      */
     public function testFormIntegerBooleanStringAsyncWithHttpInfo(
-        $integer_form = null,
-        $boolean_form = null,
-        $string_form = null,
+        ?int $integer_form = null,
+        ?bool $boolean_form = null,
+        ?string $string_form = null,
         string $contentType = self::contentTypes['testFormIntegerBooleanString'][0]
     ): PromiseInterface
     {
@@ -385,9 +385,9 @@ class FormApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testFormIntegerBooleanStringRequest(
-        $integer_form = null,
-        $boolean_form = null,
-        $string_form = null,
+        ?int $integer_form = null,
+        ?bool $boolean_form = null,
+        ?string $string_form = null,
         string $contentType = self::contentTypes['testFormIntegerBooleanString'][0]
     ): Request
     {
@@ -657,7 +657,7 @@ class FormApi
      * @return PromiseInterface
      */
     public function testFormObjectMultipartAsyncWithHttpInfo(
-        $marker,
+        \OpenAPI\Client\Model\TestFormObjectMultipartRequestMarker $marker,
         string $contentType = self::contentTypes['testFormObjectMultipart'][0]
     ): PromiseInterface
     {
@@ -710,7 +710,7 @@ class FormApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testFormObjectMultipartRequest(
-        $marker,
+        \OpenAPI\Client\Model\TestFormObjectMultipartRequestMarker $marker,
         string $contentType = self::contentTypes['testFormObjectMultipart'][0]
     ): Request
     {
@@ -1011,12 +1011,12 @@ class FormApi
      * @return PromiseInterface
      */
     public function testFormOneofAsyncWithHttpInfo(
-        $form1 = null,
-        $form2 = null,
-        $form3 = null,
-        $form4 = null,
-        $id = null,
-        $name = null,
+        ?string $form1 = null,
+        ?int $form2 = null,
+        ?string $form3 = null,
+        ?bool $form4 = null,
+        ?int $id = null,
+        ?string $name = null,
         string $contentType = self::contentTypes['testFormOneof'][0]
     ): PromiseInterface
     {
@@ -1074,12 +1074,12 @@ class FormApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testFormOneofRequest(
-        $form1 = null,
-        $form2 = null,
-        $form3 = null,
-        $form4 = null,
-        $id = null,
-        $name = null,
+        ?string $form1 = null,
+        ?int $form2 = null,
+        ?string $form3 = null,
+        ?bool $form4 = null,
+        ?int $id = null,
+        ?string $name = null,
         string $contentType = self::contentTypes['testFormOneof'][0]
     ): Request
     {

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
@@ -336,11 +336,11 @@ class HeaderApi
      * @return PromiseInterface
      */
     public function testHeaderIntegerBooleanStringEnumsAsyncWithHttpInfo(
-        $integer_header = null,
-        $boolean_header = null,
-        $string_header = null,
-        $enum_nonref_string_header = null,
-        $enum_ref_string_header = null,
+        ?int $integer_header = null,
+        ?bool $boolean_header = null,
+        ?string $string_header = null,
+        ?string $enum_nonref_string_header = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_header = null,
         string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): PromiseInterface
     {
@@ -397,11 +397,11 @@ class HeaderApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testHeaderIntegerBooleanStringEnumsRequest(
-        $integer_header = null,
-        $boolean_header = null,
-        $string_header = null,
-        $enum_nonref_string_header = null,
-        $enum_ref_string_header = null,
+        ?int $integer_header = null,
+        ?bool $boolean_header = null,
+        ?string $string_header = null,
+        ?string $enum_nonref_string_header = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_header = null,
         string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): Request
     {

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
@@ -329,10 +329,10 @@ class PathApi
      * @return PromiseInterface
      */
     public function testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathAsyncWithHttpInfo(
-        $path_string,
-        $path_integer,
-        $enum_nonref_string_path,
-        $enum_ref_string_path,
+        string $path_string,
+        int $path_integer,
+        string $enum_nonref_string_path,
+        \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path,
         string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): PromiseInterface
     {
@@ -388,10 +388,10 @@ class PathApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequest(
-        $path_string,
-        $path_integer,
-        $enum_nonref_string_path,
-        $enum_ref_string_path,
+        string $path_string,
+        int $path_integer,
+        string $enum_nonref_string_path,
+        \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path,
         string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): Request
     {

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -1853,7 +1853,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeFalseArrayInteger(
-        ?array $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): string
     {
@@ -1874,7 +1874,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerWithHttpInfo(
-        ?array $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): array
     {
@@ -2001,7 +2001,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerAsync(
-        ?array $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): PromiseInterface
     {
@@ -2171,7 +2171,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeFalseArrayString(
-        ?array $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): string
     {
@@ -2192,7 +2192,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeFalseArrayStringWithHttpInfo(
-        ?array $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): array
     {
@@ -2319,7 +2319,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayStringAsync(
-        ?array $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): PromiseInterface
     {

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -342,8 +342,8 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testEnumRefStringAsyncWithHttpInfo(
-        $enum_nonref_string_query = null,
-        $enum_ref_string_query = null,
+        ?string $enum_nonref_string_query = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): PromiseInterface
     {
@@ -397,8 +397,8 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEnumRefStringRequest(
-        $enum_nonref_string_query = null,
-        $enum_ref_string_query = null,
+        ?string $enum_nonref_string_query = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): Request
     {
@@ -687,9 +687,9 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryDatetimeDateStringAsyncWithHttpInfo(
-        $datetime_query = null,
-        $date_query = null,
-        $string_query = null,
+        ?\DateTime $datetime_query = null,
+        ?\DateTime $date_query = null,
+        ?string $string_query = null,
         string $contentType = self::contentTypes['testQueryDatetimeDateString'][0]
     ): PromiseInterface
     {
@@ -744,9 +744,9 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryDatetimeDateStringRequest(
-        $datetime_query = null,
-        $date_query = null,
-        $string_query = null,
+        ?\DateTime $datetime_query = null,
+        ?\DateTime $date_query = null,
+        ?string $string_query = null,
         string $contentType = self::contentTypes['testQueryDatetimeDateString'][0]
     ): Request
     {
@@ -1045,9 +1045,9 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryIntegerBooleanStringAsyncWithHttpInfo(
-        $integer_query = null,
-        $boolean_query = null,
-        $string_query = null,
+        ?int $integer_query = null,
+        ?bool $boolean_query = null,
+        ?string $string_query = null,
         string $contentType = self::contentTypes['testQueryIntegerBooleanString'][0]
     ): PromiseInterface
     {
@@ -1102,9 +1102,9 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryIntegerBooleanStringRequest(
-        $integer_query = null,
-        $boolean_query = null,
-        $string_query = null,
+        ?int $integer_query = null,
+        ?bool $boolean_query = null,
+        ?string $string_query = null,
         string $contentType = self::contentTypes['testQueryIntegerBooleanString'][0]
     ): Request
     {
@@ -1389,7 +1389,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAsyncWithHttpInfo(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'][0]
     ): PromiseInterface
     {
@@ -1442,7 +1442,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectRequest(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'][0]
     ): Request
     {
@@ -1707,7 +1707,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAllOfAsyncWithHttpInfo(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'][0]
     ): PromiseInterface
     {
@@ -1760,7 +1760,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAllOfRequest(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'][0]
     ): Request
     {
@@ -2025,7 +2025,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerAsyncWithHttpInfo(
-        $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): PromiseInterface
     {
@@ -2078,7 +2078,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerRequest(
-        $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): Request
     {
@@ -2343,7 +2343,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayStringAsyncWithHttpInfo(
-        $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): PromiseInterface
     {
@@ -2396,7 +2396,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeFalseArrayStringRequest(
-        $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): Request
     {
@@ -2661,7 +2661,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeTrueArrayStringAsyncWithHttpInfo(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueArrayString'][0]
     ): PromiseInterface
     {
@@ -2714,7 +2714,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeTrueArrayStringRequest(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueArrayString'][0]
     ): Request
     {
@@ -2979,7 +2979,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeTrueObjectAsyncWithHttpInfo(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObject'][0]
     ): PromiseInterface
     {
@@ -3032,7 +3032,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeTrueObjectRequest(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObject'][0]
     ): Request
     {
@@ -3297,7 +3297,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeTrueObjectAllOfAsyncWithHttpInfo(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\DataQuery $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'][0]
     ): PromiseInterface
     {
@@ -3350,7 +3350,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeTrueObjectAllOfRequest(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\DataQuery $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'][0]
     ): Request
     {

--- a/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
@@ -1745,7 +1745,7 @@ class BodyApi
      * @return string
      */
     public function testEchoBodyFreeFormObjectResponseString(
-        ?array $body = null,
+        array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): string
     {
@@ -1766,7 +1766,7 @@ class BodyApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testEchoBodyFreeFormObjectResponseStringWithHttpInfo(
-        ?array $body = null,
+        array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): array
     {
@@ -1893,7 +1893,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyFreeFormObjectResponseStringAsync(
-        ?array $body = null,
+        array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): PromiseInterface
     {

--- a/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
@@ -633,7 +633,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testBodyApplicationOctetstreamBinaryAsyncWithHttpInfo(
-        $body = null,
+        ?\SplFileObject $body = null,
         string $contentType = self::contentTypes['testBodyApplicationOctetstreamBinary'][0]
     ): PromiseInterface
     {
@@ -686,7 +686,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testBodyApplicationOctetstreamBinaryRequest(
-        $body = null,
+        ?\SplFileObject $body = null,
         string $contentType = self::contentTypes['testBodyApplicationOctetstreamBinary'][0]
     ): Request
     {
@@ -949,7 +949,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testBodyMultipartFormdataArrayOfBinaryAsyncWithHttpInfo(
-        $files,
+        array $files,
         string $contentType = self::contentTypes['testBodyMultipartFormdataArrayOfBinary'][0]
     ): PromiseInterface
     {
@@ -1002,7 +1002,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testBodyMultipartFormdataArrayOfBinaryRequest(
-        $files,
+        array $files,
         string $contentType = self::contentTypes['testBodyMultipartFormdataArrayOfBinary'][0]
     ): Request
     {
@@ -1278,7 +1278,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testBodyMultipartFormdataSingleBinaryAsyncWithHttpInfo(
-        $my_file = null,
+        ?\SplFileObject $my_file = null,
         string $contentType = self::contentTypes['testBodyMultipartFormdataSingleBinary'][0]
     ): PromiseInterface
     {
@@ -1331,7 +1331,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testBodyMultipartFormdataSingleBinaryRequest(
-        $my_file = null,
+        ?\SplFileObject $my_file = null,
         string $contentType = self::contentTypes['testBodyMultipartFormdataSingleBinary'][0]
     ): Request
     {
@@ -1601,7 +1601,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyAllOfPetAsyncWithHttpInfo(
-        $pet = null,
+        ?\OpenAPI\Client\Model\Pet $pet = null,
         string $contentType = self::contentTypes['testEchoBodyAllOfPet'][0]
     ): PromiseInterface
     {
@@ -1654,7 +1654,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyAllOfPetRequest(
-        $pet = null,
+        ?\OpenAPI\Client\Model\Pet $pet = null,
         string $contentType = self::contentTypes['testEchoBodyAllOfPet'][0]
     ): Request
     {
@@ -1917,7 +1917,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyFreeFormObjectResponseStringAsyncWithHttpInfo(
-        $body = null,
+        array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): PromiseInterface
     {
@@ -1970,7 +1970,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyFreeFormObjectResponseStringRequest(
-        $body = null,
+        array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): Request
     {
@@ -2233,7 +2233,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyPetAsyncWithHttpInfo(
-        $pet = null,
+        ?\OpenAPI\Client\Model\Pet $pet = null,
         string $contentType = self::contentTypes['testEchoBodyPet'][0]
     ): PromiseInterface
     {
@@ -2286,7 +2286,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyPetRequest(
-        $pet = null,
+        ?\OpenAPI\Client\Model\Pet $pet = null,
         string $contentType = self::contentTypes['testEchoBodyPet'][0]
     ): Request
     {
@@ -2549,7 +2549,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyPetResponseStringAsyncWithHttpInfo(
-        $pet = null,
+        ?\OpenAPI\Client\Model\Pet $pet = null,
         string $contentType = self::contentTypes['testEchoBodyPetResponseString'][0]
     ): PromiseInterface
     {
@@ -2602,7 +2602,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyPetResponseStringRequest(
-        $pet = null,
+        ?\OpenAPI\Client\Model\Pet $pet = null,
         string $contentType = self::contentTypes['testEchoBodyPetResponseString'][0]
     ): Request
     {
@@ -2865,7 +2865,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyStringEnumAsyncWithHttpInfo(
-        $body = null,
+        ?string $body = null,
         string $contentType = self::contentTypes['testEchoBodyStringEnum'][0]
     ): PromiseInterface
     {
@@ -2918,7 +2918,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyStringEnumRequest(
-        $body = null,
+        ?string $body = null,
         string $contentType = self::contentTypes['testEchoBodyStringEnum'][0]
     ): Request
     {
@@ -3181,7 +3181,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyTagResponseStringAsyncWithHttpInfo(
-        $tag = null,
+        ?\OpenAPI\Client\Model\Tag $tag = null,
         string $contentType = self::contentTypes['testEchoBodyTagResponseString'][0]
     ): PromiseInterface
     {
@@ -3234,7 +3234,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyTagResponseStringRequest(
-        $tag = null,
+        ?\OpenAPI\Client\Model\Tag $tag = null,
         string $contentType = self::contentTypes['testEchoBodyTagResponseString'][0]
     ): Request
     {

--- a/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
@@ -328,9 +328,9 @@ class FormApi
      * @return PromiseInterface
      */
     public function testFormIntegerBooleanStringAsyncWithHttpInfo(
-        $integer_form = null,
-        $boolean_form = null,
-        $string_form = null,
+        ?int $integer_form = null,
+        ?bool $boolean_form = null,
+        ?string $string_form = null,
         string $contentType = self::contentTypes['testFormIntegerBooleanString'][0]
     ): PromiseInterface
     {
@@ -385,9 +385,9 @@ class FormApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testFormIntegerBooleanStringRequest(
-        $integer_form = null,
-        $boolean_form = null,
-        $string_form = null,
+        ?int $integer_form = null,
+        ?bool $boolean_form = null,
+        ?string $string_form = null,
         string $contentType = self::contentTypes['testFormIntegerBooleanString'][0]
     ): Request
     {
@@ -657,7 +657,7 @@ class FormApi
      * @return PromiseInterface
      */
     public function testFormObjectMultipartAsyncWithHttpInfo(
-        $marker,
+        \OpenAPI\Client\Model\TestFormObjectMultipartRequestMarker $marker,
         string $contentType = self::contentTypes['testFormObjectMultipart'][0]
     ): PromiseInterface
     {
@@ -710,7 +710,7 @@ class FormApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testFormObjectMultipartRequest(
-        $marker,
+        \OpenAPI\Client\Model\TestFormObjectMultipartRequestMarker $marker,
         string $contentType = self::contentTypes['testFormObjectMultipart'][0]
     ): Request
     {
@@ -1011,12 +1011,12 @@ class FormApi
      * @return PromiseInterface
      */
     public function testFormOneofAsyncWithHttpInfo(
-        $form1 = null,
-        $form2 = null,
-        $form3 = null,
-        $form4 = null,
-        $id = null,
-        $name = null,
+        ?string $form1 = null,
+        ?int $form2 = null,
+        ?string $form3 = null,
+        ?bool $form4 = null,
+        ?int $id = null,
+        ?string $name = null,
         string $contentType = self::contentTypes['testFormOneof'][0]
     ): PromiseInterface
     {
@@ -1074,12 +1074,12 @@ class FormApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testFormOneofRequest(
-        $form1 = null,
-        $form2 = null,
-        $form3 = null,
-        $form4 = null,
-        $id = null,
-        $name = null,
+        ?string $form1 = null,
+        ?int $form2 = null,
+        ?string $form3 = null,
+        ?bool $form4 = null,
+        ?int $id = null,
+        ?string $name = null,
         string $contentType = self::contentTypes['testFormOneof'][0]
     ): Request
     {

--- a/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
@@ -336,11 +336,11 @@ class HeaderApi
      * @return PromiseInterface
      */
     public function testHeaderIntegerBooleanStringEnumsAsyncWithHttpInfo(
-        $integer_header = null,
-        $boolean_header = null,
-        $string_header = null,
-        $enum_nonref_string_header = null,
-        $enum_ref_string_header = null,
+        ?int $integer_header = null,
+        ?bool $boolean_header = null,
+        ?string $string_header = null,
+        ?string $enum_nonref_string_header = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_header = null,
         string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): PromiseInterface
     {
@@ -397,11 +397,11 @@ class HeaderApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testHeaderIntegerBooleanStringEnumsRequest(
-        $integer_header = null,
-        $boolean_header = null,
-        $string_header = null,
-        $enum_nonref_string_header = null,
-        $enum_ref_string_header = null,
+        ?int $integer_header = null,
+        ?bool $boolean_header = null,
+        ?string $string_header = null,
+        ?string $enum_nonref_string_header = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_header = null,
         string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): Request
     {

--- a/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
@@ -329,10 +329,10 @@ class PathApi
      * @return PromiseInterface
      */
     public function testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathAsyncWithHttpInfo(
-        $path_string,
-        $path_integer,
-        $enum_nonref_string_path,
-        $enum_ref_string_path,
+        string $path_string,
+        int $path_integer,
+        string $enum_nonref_string_path,
+        \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path,
         string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): PromiseInterface
     {
@@ -388,10 +388,10 @@ class PathApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequest(
-        $path_string,
-        $path_integer,
-        $enum_nonref_string_path,
-        $enum_ref_string_path,
+        string $path_string,
+        int $path_integer,
+        string $enum_nonref_string_path,
+        \OpenAPI\Client\Model\StringEnumRef $enum_ref_string_path,
         string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): Request
     {

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -1853,7 +1853,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeFalseArrayInteger(
-        ?array $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): string
     {
@@ -1874,7 +1874,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerWithHttpInfo(
-        ?array $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): array
     {
@@ -2001,7 +2001,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerAsync(
-        ?array $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): PromiseInterface
     {
@@ -2171,7 +2171,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeFalseArrayString(
-        ?array $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): string
     {
@@ -2192,7 +2192,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeFalseArrayStringWithHttpInfo(
-        ?array $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): array
     {
@@ -2319,7 +2319,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayStringAsync(
-        ?array $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): PromiseInterface
     {

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -342,8 +342,8 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testEnumRefStringAsyncWithHttpInfo(
-        $enum_nonref_string_query = null,
-        $enum_ref_string_query = null,
+        ?string $enum_nonref_string_query = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): PromiseInterface
     {
@@ -397,8 +397,8 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEnumRefStringRequest(
-        $enum_nonref_string_query = null,
-        $enum_ref_string_query = null,
+        ?string $enum_nonref_string_query = null,
+        ?\OpenAPI\Client\Model\StringEnumRef $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): Request
     {
@@ -687,9 +687,9 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryDatetimeDateStringAsyncWithHttpInfo(
-        $datetime_query = null,
-        $date_query = null,
-        $string_query = null,
+        ?\DateTime $datetime_query = null,
+        ?\DateTime $date_query = null,
+        ?string $string_query = null,
         string $contentType = self::contentTypes['testQueryDatetimeDateString'][0]
     ): PromiseInterface
     {
@@ -744,9 +744,9 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryDatetimeDateStringRequest(
-        $datetime_query = null,
-        $date_query = null,
-        $string_query = null,
+        ?\DateTime $datetime_query = null,
+        ?\DateTime $date_query = null,
+        ?string $string_query = null,
         string $contentType = self::contentTypes['testQueryDatetimeDateString'][0]
     ): Request
     {
@@ -1045,9 +1045,9 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryIntegerBooleanStringAsyncWithHttpInfo(
-        $integer_query = null,
-        $boolean_query = null,
-        $string_query = null,
+        ?int $integer_query = null,
+        ?bool $boolean_query = null,
+        ?string $string_query = null,
         string $contentType = self::contentTypes['testQueryIntegerBooleanString'][0]
     ): PromiseInterface
     {
@@ -1102,9 +1102,9 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryIntegerBooleanStringRequest(
-        $integer_query = null,
-        $boolean_query = null,
-        $string_query = null,
+        ?int $integer_query = null,
+        ?bool $boolean_query = null,
+        ?string $string_query = null,
         string $contentType = self::contentTypes['testQueryIntegerBooleanString'][0]
     ): Request
     {
@@ -1389,7 +1389,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAsyncWithHttpInfo(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'][0]
     ): PromiseInterface
     {
@@ -1442,7 +1442,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectRequest(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObject'][0]
     ): Request
     {
@@ -1707,7 +1707,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAllOfAsyncWithHttpInfo(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'][0]
     ): PromiseInterface
     {
@@ -1760,7 +1760,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleDeepObjectExplodeTrueObjectAllOfRequest(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'][0]
     ): Request
     {
@@ -2025,7 +2025,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerAsyncWithHttpInfo(
-        $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): PromiseInterface
     {
@@ -2078,7 +2078,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerRequest(
-        $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): Request
     {
@@ -2343,7 +2343,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayStringAsyncWithHttpInfo(
-        $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): PromiseInterface
     {
@@ -2396,7 +2396,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeFalseArrayStringRequest(
-        $query_object = null,
+        array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): Request
     {
@@ -2661,7 +2661,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeTrueArrayStringAsyncWithHttpInfo(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueArrayString'][0]
     ): PromiseInterface
     {
@@ -2714,7 +2714,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeTrueArrayStringRequest(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueArrayString'][0]
     ): Request
     {
@@ -2979,7 +2979,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeTrueObjectAsyncWithHttpInfo(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObject'][0]
     ): PromiseInterface
     {
@@ -3032,7 +3032,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeTrueObjectRequest(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\Pet $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObject'][0]
     ): Request
     {
@@ -3297,7 +3297,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeTrueObjectAllOfAsyncWithHttpInfo(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\DataQuery $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'][0]
     ): PromiseInterface
     {
@@ -3350,7 +3350,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeTrueObjectAllOfRequest(
-        $query_object = null,
+        ?\OpenAPI\Client\Model\DataQuery $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'][0]
     ): Request
     {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
@@ -307,7 +307,7 @@ class AnotherFakeApi
      * @return PromiseInterface
      */
     public function call123TestSpecialTagsAsyncWithHttpInfo(
-        $client,
+        \OpenAPI\Client\Model\Client $client,
         string $contentType = self::contentTypes['call123TestSpecialTags'][0]
     ): PromiseInterface
     {
@@ -360,7 +360,7 @@ class AnotherFakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function call123TestSpecialTagsRequest(
-        $client,
+        \OpenAPI\Client\Model\Client $client,
         string $contentType = self::contentTypes['call123TestSpecialTags'][0]
     ): Request
     {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -3207,7 +3207,7 @@ class FakeApi
      * @return void
      */
     public function testBodyWithBinary(
-        \SplFileObject $body,
+        ?\SplFileObject $body,
         string $contentType = self::contentTypes['testBodyWithBinary'][0]
     ): void
     {
@@ -3225,7 +3225,7 @@ class FakeApi
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function testBodyWithBinaryWithHttpInfo(
-        \SplFileObject $body,
+        ?\SplFileObject $body,
         string $contentType = self::contentTypes['testBodyWithBinary'][0]
     ): array
     {
@@ -3273,7 +3273,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testBodyWithBinaryAsync(
-        \SplFileObject $body,
+        ?\SplFileObject $body,
         string $contentType = self::contentTypes['testBodyWithBinary'][0]
     ): PromiseInterface
     {
@@ -4728,14 +4728,14 @@ class FakeApi
      * @return void
      */
     public function testEnumParameters(
-        ?array $enum_header_string_array = ['$'],
+        array $enum_header_string_array = ['$'],
         ?string $enum_header_string = '-efg',
-        ?array $enum_query_string_array = ['$'],
+        array $enum_query_string_array = ['$'],
         ?string $enum_query_string = '-efg',
         ?int $enum_query_integer = null,
         ?float $enum_query_double = null,
-        ?array $enum_query_model_array = null,
-        ?array $enum_form_string_array = ['$'],
+        array $enum_query_model_array = null,
+        array $enum_form_string_array = ['$'],
         ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): void
@@ -4764,14 +4764,14 @@ class FakeApi
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function testEnumParametersWithHttpInfo(
-        ?array $enum_header_string_array = ['$'],
+        array $enum_header_string_array = ['$'],
         ?string $enum_header_string = '-efg',
-        ?array $enum_query_string_array = ['$'],
+        array $enum_query_string_array = ['$'],
         ?string $enum_query_string = '-efg',
         ?int $enum_query_integer = null,
         ?float $enum_query_double = null,
-        ?array $enum_query_model_array = null,
-        ?array $enum_form_string_array = ['$'],
+        array $enum_query_model_array = null,
+        array $enum_form_string_array = ['$'],
         ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): array
@@ -4830,14 +4830,14 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testEnumParametersAsync(
-        ?array $enum_header_string_array = ['$'],
+        array $enum_header_string_array = ['$'],
         ?string $enum_header_string = '-efg',
-        ?array $enum_query_string_array = ['$'],
+        array $enum_query_string_array = ['$'],
         ?string $enum_query_string = '-efg',
         ?int $enum_query_integer = null,
         ?float $enum_query_double = null,
-        ?array $enum_query_model_array = null,
-        ?array $enum_form_string_array = ['$'],
+        array $enum_query_model_array = null,
+        array $enum_form_string_array = ['$'],
         ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): PromiseInterface
@@ -6369,7 +6369,7 @@ class FakeApi
         array $url,
         array $context,
         string $allow_empty,
-        ?array $language = null,
+        array $language = null,
         string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
     ): void
     {
@@ -6399,7 +6399,7 @@ class FakeApi
         array $url,
         array $context,
         string $allow_empty,
-        ?array $language = null,
+        array $language = null,
         string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
     ): array
     {
@@ -6459,7 +6459,7 @@ class FakeApi
         array $url,
         array $context,
         string $allow_empty,
-        ?array $language = null,
+        array $language = null,
         string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
     ): PromiseInterface
     {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -678,9 +678,9 @@ class FakeApi
      * @return PromiseInterface
      */
     public function fakeEnumEndpointAsyncWithHttpInfo(
-        $enum_class,
-        $enum_class_array,
-        $enum_class_map,
+        \OpenAPI\Client\Model\EnumClass $enum_class,
+        array $enum_class_array,
+        array $enum_class_map,
         string $contentType = self::contentTypes['fakeEnumEndpoint'][0]
     ): PromiseInterface
     {
@@ -735,9 +735,9 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakeEnumEndpointRequest(
-        $enum_class,
-        $enum_class_array,
-        $enum_class_map,
+        \OpenAPI\Client\Model\EnumClass $enum_class,
+        array $enum_class_array,
+        array $enum_class_map,
         string $contentType = self::contentTypes['fakeEnumEndpoint'][0]
     ): Request
     {
@@ -1274,9 +1274,9 @@ class FakeApi
      * @return PromiseInterface
      */
     public function fakeHttpSignatureTestAsyncWithHttpInfo(
-        $pet,
-        $query_1 = null,
-        $header_1 = null,
+        \OpenAPI\Client\Model\Pet $pet,
+        ?string $query_1 = null,
+        ?string $header_1 = null,
         string $contentType = self::contentTypes['fakeHttpSignatureTest'][0]
     ): PromiseInterface
     {
@@ -1318,9 +1318,9 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakeHttpSignatureTestRequest(
-        $pet,
-        $query_1 = null,
-        $header_1 = null,
+        \OpenAPI\Client\Model\Pet $pet,
+        ?string $query_1 = null,
+        ?string $header_1 = null,
         string $contentType = self::contentTypes['fakeHttpSignatureTest'][0]
     ): Request
     {
@@ -1596,7 +1596,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function fakeOuterBooleanSerializeAsyncWithHttpInfo(
-        $body = null,
+        ?bool $body = null,
         string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0]
     ): PromiseInterface
     {
@@ -1649,7 +1649,7 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakeOuterBooleanSerializeRequest(
-        $body = null,
+        ?bool $body = null,
         string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0]
     ): Request
     {
@@ -1904,7 +1904,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function fakeOuterCompositeSerializeAsyncWithHttpInfo(
-        $outer_composite = null,
+        ?\OpenAPI\Client\Model\OuterComposite $outer_composite = null,
         string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0]
     ): PromiseInterface
     {
@@ -1957,7 +1957,7 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakeOuterCompositeSerializeRequest(
-        $outer_composite = null,
+        ?\OpenAPI\Client\Model\OuterComposite $outer_composite = null,
         string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0]
     ): Request
     {
@@ -2212,7 +2212,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function fakeOuterNumberSerializeAsyncWithHttpInfo(
-        $body = null,
+        ?float $body = null,
         string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0]
     ): PromiseInterface
     {
@@ -2265,7 +2265,7 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakeOuterNumberSerializeRequest(
-        $body = null,
+        ?float $body = null,
         string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0]
     ): Request
     {
@@ -2520,7 +2520,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function fakeOuterStringSerializeAsyncWithHttpInfo(
-        $body = null,
+        ?string $body = null,
         string $contentType = self::contentTypes['fakeOuterStringSerialize'][0]
     ): PromiseInterface
     {
@@ -2573,7 +2573,7 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakeOuterStringSerializeRequest(
-        $body = null,
+        ?string $body = null,
         string $contentType = self::contentTypes['fakeOuterStringSerialize'][0]
     ): Request
     {
@@ -2828,7 +2828,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function fakePropertyEnumIntegerSerializeAsyncWithHttpInfo(
-        $outer_object_with_enum_property,
+        \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property,
         string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0]
     ): PromiseInterface
     {
@@ -2881,7 +2881,7 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakePropertyEnumIntegerSerializeRequest(
-        $outer_object_with_enum_property,
+        \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property,
         string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0]
     ): Request
     {
@@ -3072,7 +3072,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testAdditionalPropertiesReferenceAsyncWithHttpInfo(
-        $request_body,
+        array $request_body,
         string $contentType = self::contentTypes['testAdditionalPropertiesReference'][0]
     ): PromiseInterface
     {
@@ -3112,7 +3112,7 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testAdditionalPropertiesReferenceRequest(
-        $request_body,
+        array $request_body,
         string $contentType = self::contentTypes['testAdditionalPropertiesReference'][0]
     ): Request
     {
@@ -3295,7 +3295,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testBodyWithBinaryAsyncWithHttpInfo(
-        $body,
+        ?\SplFileObject $body,
         string $contentType = self::contentTypes['testBodyWithBinary'][0]
     ): PromiseInterface
     {
@@ -3335,7 +3335,7 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testBodyWithBinaryRequest(
-        $body,
+        ?\SplFileObject $body,
         string $contentType = self::contentTypes['testBodyWithBinary'][0]
     ): Request
     {
@@ -3518,7 +3518,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testBodyWithFileSchemaAsyncWithHttpInfo(
-        $file_schema_test_class,
+        \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class,
         string $contentType = self::contentTypes['testBodyWithFileSchema'][0]
     ): PromiseInterface
     {
@@ -3558,7 +3558,7 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testBodyWithFileSchemaRequest(
-        $file_schema_test_class,
+        \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class,
         string $contentType = self::contentTypes['testBodyWithFileSchema'][0]
     ): Request
     {
@@ -3748,8 +3748,8 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testBodyWithQueryParamsAsyncWithHttpInfo(
-        $query,
-        $user,
+        string $query,
+        \OpenAPI\Client\Model\User $user,
         string $contentType = self::contentTypes['testBodyWithQueryParams'][0]
     ): PromiseInterface
     {
@@ -3790,8 +3790,8 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testBodyWithQueryParamsRequest(
-        $query,
-        $user,
+        string $query,
+        \OpenAPI\Client\Model\User $user,
         string $contentType = self::contentTypes['testBodyWithQueryParams'][0]
     ): Request
     {
@@ -4076,7 +4076,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testClientModelAsyncWithHttpInfo(
-        $client,
+        \OpenAPI\Client\Model\Client $client,
         string $contentType = self::contentTypes['testClientModel'][0]
     ): PromiseInterface
     {
@@ -4129,7 +4129,7 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testClientModelRequest(
-        $client,
+        \OpenAPI\Client\Model\Client $client,
         string $contentType = self::contentTypes['testClientModel'][0]
     ): Request
     {
@@ -4411,20 +4411,20 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testEndpointParametersAsyncWithHttpInfo(
-        $number,
-        $double,
-        $pattern_without_delimiter,
-        $byte,
-        $integer = null,
-        $int32 = null,
-        $int64 = null,
-        $float = null,
-        $string = null,
-        $binary = null,
-        $date = null,
-        $date_time = null,
-        $password = null,
-        $callback = null,
+        float $number,
+        float $double,
+        string $pattern_without_delimiter,
+        string $byte,
+        ?int $integer = null,
+        ?int $int32 = null,
+        ?int $int64 = null,
+        ?float $float = null,
+        ?string $string = null,
+        ?\SplFileObject $binary = null,
+        ?\DateTime $date = null,
+        ?\DateTime $date_time = null,
+        ?string $password = null,
+        ?string $callback = null,
         string $contentType = self::contentTypes['testEndpointParameters'][0]
     ): PromiseInterface
     {
@@ -4477,20 +4477,20 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEndpointParametersRequest(
-        $number,
-        $double,
-        $pattern_without_delimiter,
-        $byte,
-        $integer = null,
-        $int32 = null,
-        $int64 = null,
-        $float = null,
-        $string = null,
-        $binary = null,
-        $date = null,
-        $date_time = null,
-        $password = null,
-        $callback = null,
+        float $number,
+        float $double,
+        string $pattern_without_delimiter,
+        string $byte,
+        ?int $integer = null,
+        ?int $int32 = null,
+        ?int $int64 = null,
+        ?float $float = null,
+        ?string $string = null,
+        ?\SplFileObject $binary = null,
+        ?\DateTime $date = null,
+        ?\DateTime $date_time = null,
+        ?string $password = null,
+        ?string $callback = null,
         string $contentType = self::contentTypes['testEndpointParameters'][0]
     ): Request
     {
@@ -4870,15 +4870,15 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testEnumParametersAsyncWithHttpInfo(
-        $enum_header_string_array = ['$'],
-        $enum_header_string = '-efg',
-        $enum_query_string_array = ['$'],
-        $enum_query_string = '-efg',
-        $enum_query_integer = null,
-        $enum_query_double = null,
-        $enum_query_model_array = null,
-        $enum_form_string_array = ['$'],
-        $enum_form_string = '-efg',
+        array $enum_header_string_array = ['$'],
+        ?string $enum_header_string = '-efg',
+        array $enum_query_string_array = ['$'],
+        ?string $enum_query_string = '-efg',
+        ?int $enum_query_integer = null,
+        ?float $enum_query_double = null,
+        array $enum_query_model_array = null,
+        array $enum_form_string_array = ['$'],
+        ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): PromiseInterface
     {
@@ -4926,15 +4926,15 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEnumParametersRequest(
-        $enum_header_string_array = ['$'],
-        $enum_header_string = '-efg',
-        $enum_query_string_array = ['$'],
-        $enum_query_string = '-efg',
-        $enum_query_integer = null,
-        $enum_query_double = null,
-        $enum_query_model_array = null,
-        $enum_form_string_array = ['$'],
-        $enum_form_string = '-efg',
+        array $enum_header_string_array = ['$'],
+        ?string $enum_header_string = '-efg',
+        array $enum_query_string_array = ['$'],
+        ?string $enum_query_string = '-efg',
+        ?int $enum_query_integer = null,
+        ?float $enum_query_double = null,
+        array $enum_query_model_array = null,
+        array $enum_form_string_array = ['$'],
+        ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): Request
     {
@@ -5511,7 +5511,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testInlineAdditionalPropertiesAsyncWithHttpInfo(
-        $request_body,
+        array $request_body,
         string $contentType = self::contentTypes['testInlineAdditionalProperties'][0]
     ): PromiseInterface
     {
@@ -5551,7 +5551,7 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testInlineAdditionalPropertiesRequest(
-        $request_body,
+        array $request_body,
         string $contentType = self::contentTypes['testInlineAdditionalProperties'][0]
     ): Request
     {
@@ -5742,7 +5742,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testInlineFreeformAdditionalPropertiesAsyncWithHttpInfo(
-        $test_inline_freeform_additional_properties_request,
+        \OpenAPI\Client\Model\TestInlineFreeformAdditionalPropertiesRequest $test_inline_freeform_additional_properties_request,
         string $contentType = self::contentTypes['testInlineFreeformAdditionalProperties'][0]
     ): PromiseInterface
     {
@@ -5782,7 +5782,7 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testInlineFreeformAdditionalPropertiesRequest(
-        $test_inline_freeform_additional_properties_request,
+        \OpenAPI\Client\Model\TestInlineFreeformAdditionalPropertiesRequest $test_inline_freeform_additional_properties_request,
         string $contentType = self::contentTypes['testInlineFreeformAdditionalProperties'][0]
     ): Request
     {
@@ -5980,8 +5980,8 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testJsonFormDataAsyncWithHttpInfo(
-        $param,
-        $param2,
+        string $param,
+        string $param2,
         string $contentType = self::contentTypes['testJsonFormData'][0]
     ): PromiseInterface
     {
@@ -6022,8 +6022,8 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testJsonFormDataRequest(
-        $param,
-        $param2,
+        string $param,
+        string $param2,
         string $contentType = self::contentTypes['testJsonFormData'][0]
     ): Request
     {
@@ -6222,7 +6222,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testNullableAsyncWithHttpInfo(
-        $child_with_nullable,
+        \OpenAPI\Client\Model\ChildWithNullable $child_with_nullable,
         string $contentType = self::contentTypes['testNullable'][0]
     ): PromiseInterface
     {
@@ -6262,7 +6262,7 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testNullableRequest(
-        $child_with_nullable,
+        \OpenAPI\Client\Model\ChildWithNullable $child_with_nullable,
         string $contentType = self::contentTypes['testNullable'][0]
     ): Request
     {
@@ -6487,13 +6487,13 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testQueryParameterCollectionFormatAsyncWithHttpInfo(
-        $pipe,
-        $ioutil,
-        $http,
-        $url,
-        $context,
-        $allow_empty,
-        $language = null,
+        array $pipe,
+        array $ioutil,
+        array $http,
+        array $url,
+        array $context,
+        string $allow_empty,
+        array $language = null,
         string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
     ): PromiseInterface
     {
@@ -6539,13 +6539,13 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryParameterCollectionFormatRequest(
-        $pipe,
-        $ioutil,
-        $http,
-        $url,
-        $context,
-        $allow_empty,
-        $language = null,
+        array $pipe,
+        array $ioutil,
+        array $http,
+        array $url,
+        array $context,
+        string $allow_empty,
+        array $language = null,
         string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
     ): Request
     {
@@ -6828,7 +6828,7 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testStringMapReferenceAsyncWithHttpInfo(
-        $request_body,
+        array $request_body,
         string $contentType = self::contentTypes['testStringMapReference'][0]
     ): PromiseInterface
     {
@@ -6868,7 +6868,7 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testStringMapReferenceRequest(
-        $request_body,
+        array $request_body,
         string $contentType = self::contentTypes['testStringMapReference'][0]
     ): Request
     {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
@@ -307,7 +307,7 @@ class FakeClassnameTags123Api
      * @return PromiseInterface
      */
     public function testClassnameAsyncWithHttpInfo(
-        $client,
+        \OpenAPI\Client\Model\Client $client,
         string $contentType = self::contentTypes['testClassname'][0]
     ): PromiseInterface
     {
@@ -360,7 +360,7 @@ class FakeClassnameTags123Api
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testClassnameRequest(
-        $client,
+        \OpenAPI\Client\Model\Client $client,
         string $contentType = self::contentTypes['testClassname'][0]
     ): Request
     {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -333,7 +333,7 @@ class PetApi
      * @return PromiseInterface
      */
     public function addPetAsyncWithHttpInfo(
-        $pet,
+        \OpenAPI\Client\Model\Pet $pet,
         ?int $hostIndex = null,
         array $variables = [],
         string $contentType = self::contentTypes['addPet'][0]
@@ -393,7 +393,7 @@ class PetApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function addPetRequest(
-        $pet,
+        \OpenAPI\Client\Model\Pet $pet,
         ?int $hostIndex = null,
         array $variables = [],
         string $contentType = self::contentTypes['addPet'][0]
@@ -649,8 +649,8 @@ class PetApi
      * @return PromiseInterface
      */
     public function deletePetAsyncWithHttpInfo(
-        $pet_id,
-        $api_key = null,
+        int $pet_id,
+        ?string $api_key = null,
         string $contentType = self::contentTypes['deletePet'][0]
     ): PromiseInterface
     {
@@ -691,8 +691,8 @@ class PetApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function deletePetRequest(
-        $pet_id,
-        $api_key = null,
+        int $pet_id,
+        ?string $api_key = null,
         string $contentType = self::contentTypes['deletePet'][0]
     ): Request
     {
@@ -971,7 +971,7 @@ class PetApi
      * @return PromiseInterface
      */
     public function findPetsByStatusAsyncWithHttpInfo(
-        $status,
+        array $status,
         string $contentType = self::contentTypes['findPetsByStatus'][0]
     ): PromiseInterface
     {
@@ -1024,7 +1024,7 @@ class PetApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function findPetsByStatusRequest(
-        $status,
+        array $status,
         string $contentType = self::contentTypes['findPetsByStatus'][0]
     ): Request
     {
@@ -1303,7 +1303,7 @@ class PetApi
      * @deprecated
      */
     public function findPetsByTagsAsyncWithHttpInfo(
-        $tags,
+        array $tags,
         string $contentType = self::contentTypes['findPetsByTags'][0]
     ): PromiseInterface
     {
@@ -1357,7 +1357,7 @@ class PetApi
      * @deprecated
      */
     public function findPetsByTagsRequest(
-        $tags,
+        array $tags,
         string $contentType = self::contentTypes['findPetsByTags'][0]
     ): Request
     {
@@ -1632,7 +1632,7 @@ class PetApi
      * @return PromiseInterface
      */
     public function getPetByIdAsyncWithHttpInfo(
-        $pet_id,
+        int $pet_id,
         string $contentType = self::contentTypes['getPetById'][0]
     ): PromiseInterface
     {
@@ -1685,7 +1685,7 @@ class PetApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function getPetByIdRequest(
-        $pet_id,
+        int $pet_id,
         string $contentType = self::contentTypes['getPetById'][0]
     ): Request
     {
@@ -1960,7 +1960,7 @@ class PetApi
      * @return PromiseInterface
      */
     public function updatePetAsyncWithHttpInfo(
-        $pet,
+        \OpenAPI\Client\Model\Pet $pet,
         ?int $hostIndex = null,
         array $variables = [],
         string $contentType = self::contentTypes['updatePet'][0]
@@ -2020,7 +2020,7 @@ class PetApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function updatePetRequest(
-        $pet,
+        \OpenAPI\Client\Model\Pet $pet,
         ?int $hostIndex = null,
         array $variables = [],
         string $contentType = self::contentTypes['updatePet'][0]
@@ -2283,9 +2283,9 @@ class PetApi
      * @return PromiseInterface
      */
     public function updatePetWithFormAsyncWithHttpInfo(
-        $pet_id,
-        $name = null,
-        $status = null,
+        int $pet_id,
+        ?string $name = null,
+        ?string $status = null,
         string $contentType = self::contentTypes['updatePetWithForm'][0]
     ): PromiseInterface
     {
@@ -2327,9 +2327,9 @@ class PetApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function updatePetWithFormRequest(
-        $pet_id,
-        $name = null,
-        $status = null,
+        int $pet_id,
+        ?string $name = null,
+        ?string $status = null,
         string $contentType = self::contentTypes['updatePetWithForm'][0]
     ): Request
     {
@@ -2627,9 +2627,9 @@ class PetApi
      * @return PromiseInterface
      */
     public function uploadFileAsyncWithHttpInfo(
-        $pet_id,
-        $additional_metadata = null,
-        $file = null,
+        int $pet_id,
+        ?string $additional_metadata = null,
+        ?\SplFileObject $file = null,
         string $contentType = self::contentTypes['uploadFile'][0]
     ): PromiseInterface
     {
@@ -2684,9 +2684,9 @@ class PetApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function uploadFileRequest(
-        $pet_id,
-        $additional_metadata = null,
-        $file = null,
+        int $pet_id,
+        ?string $additional_metadata = null,
+        ?\SplFileObject $file = null,
         string $contentType = self::contentTypes['uploadFile'][0]
     ): Request
     {
@@ -2994,9 +2994,9 @@ class PetApi
      * @return PromiseInterface
      */
     public function uploadFileWithRequiredFileAsyncWithHttpInfo(
-        $pet_id,
-        $required_file,
-        $additional_metadata = null,
+        int $pet_id,
+        \SplFileObject $required_file,
+        ?string $additional_metadata = null,
         string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0]
     ): PromiseInterface
     {
@@ -3051,9 +3051,9 @@ class PetApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function uploadFileWithRequiredFileRequest(
-        $pet_id,
-        $required_file,
-        $additional_metadata = null,
+        int $pet_id,
+        \SplFileObject $required_file,
+        ?string $additional_metadata = null,
         string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0]
     ): Request
     {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -238,7 +238,7 @@ class StoreApi
      * @return PromiseInterface
      */
     public function deleteOrderAsyncWithHttpInfo(
-        $order_id,
+        string $order_id,
         string $contentType = self::contentTypes['deleteOrder'][0]
     ): PromiseInterface
     {
@@ -278,7 +278,7 @@ class StoreApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function deleteOrderRequest(
-        $order_id,
+        string $order_id,
         string $contentType = self::contentTypes['deleteOrder'][0]
     ): Request
     {
@@ -851,7 +851,7 @@ class StoreApi
      * @return PromiseInterface
      */
     public function getOrderByIdAsyncWithHttpInfo(
-        $order_id,
+        int $order_id,
         string $contentType = self::contentTypes['getOrderById'][0]
     ): PromiseInterface
     {
@@ -904,7 +904,7 @@ class StoreApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function getOrderByIdRequest(
-        $order_id,
+        int $order_id,
         string $contentType = self::contentTypes['getOrderById'][0]
     ): Request
     {
@@ -1180,7 +1180,7 @@ class StoreApi
      * @return PromiseInterface
      */
     public function placeOrderAsyncWithHttpInfo(
-        $order,
+        \OpenAPI\Client\Model\Order $order,
         string $contentType = self::contentTypes['placeOrder'][0]
     ): PromiseInterface
     {
@@ -1233,7 +1233,7 @@ class StoreApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function placeOrderRequest(
-        $order,
+        \OpenAPI\Client\Model\Order $order,
         string $contentType = self::contentTypes['placeOrder'][0]
     ): Request
     {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -250,7 +250,7 @@ class UserApi
      * @return PromiseInterface
      */
     public function createUserAsyncWithHttpInfo(
-        $user,
+        \OpenAPI\Client\Model\User $user,
         string $contentType = self::contentTypes['createUser'][0]
     ): PromiseInterface
     {
@@ -290,7 +290,7 @@ class UserApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function createUserRequest(
-        $user,
+        \OpenAPI\Client\Model\User $user,
         string $contentType = self::contentTypes['createUser'][0]
     ): Request
     {
@@ -481,7 +481,7 @@ class UserApi
      * @return PromiseInterface
      */
     public function createUsersWithArrayInputAsyncWithHttpInfo(
-        $user,
+        array $user,
         string $contentType = self::contentTypes['createUsersWithArrayInput'][0]
     ): PromiseInterface
     {
@@ -521,7 +521,7 @@ class UserApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function createUsersWithArrayInputRequest(
-        $user,
+        array $user,
         string $contentType = self::contentTypes['createUsersWithArrayInput'][0]
     ): Request
     {
@@ -712,7 +712,7 @@ class UserApi
      * @return PromiseInterface
      */
     public function createUsersWithListInputAsyncWithHttpInfo(
-        $user,
+        array $user,
         string $contentType = self::contentTypes['createUsersWithListInput'][0]
     ): PromiseInterface
     {
@@ -752,7 +752,7 @@ class UserApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function createUsersWithListInputRequest(
-        $user,
+        array $user,
         string $contentType = self::contentTypes['createUsersWithListInput'][0]
     ): Request
     {
@@ -943,7 +943,7 @@ class UserApi
      * @return PromiseInterface
      */
     public function deleteUserAsyncWithHttpInfo(
-        $username,
+        string $username,
         string $contentType = self::contentTypes['deleteUser'][0]
     ): PromiseInterface
     {
@@ -983,7 +983,7 @@ class UserApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function deleteUserRequest(
-        $username,
+        string $username,
         string $contentType = self::contentTypes['deleteUser'][0]
     ): Request
     {
@@ -1253,7 +1253,7 @@ class UserApi
      * @return PromiseInterface
      */
     public function getUserByNameAsyncWithHttpInfo(
-        $username,
+        string $username,
         string $contentType = self::contentTypes['getUserByName'][0]
     ): PromiseInterface
     {
@@ -1306,7 +1306,7 @@ class UserApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function getUserByNameRequest(
-        $username,
+        string $username,
         string $contentType = self::contentTypes['getUserByName'][0]
     ): Request
     {
@@ -1583,8 +1583,8 @@ class UserApi
      * @return PromiseInterface
      */
     public function loginUserAsyncWithHttpInfo(
-        $username,
-        $password,
+        string $username,
+        string $password,
         string $contentType = self::contentTypes['loginUser'][0]
     ): PromiseInterface
     {
@@ -1638,8 +1638,8 @@ class UserApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function loginUserRequest(
-        $username,
-        $password,
+        string $username,
+        string $password,
         string $contentType = self::contentTypes['loginUser'][0]
     ): Request
     {
@@ -2062,8 +2062,8 @@ class UserApi
      * @return PromiseInterface
      */
     public function updateUserAsyncWithHttpInfo(
-        $username,
-        $user,
+        string $username,
+        \OpenAPI\Client\Model\User $user,
         string $contentType = self::contentTypes['updateUser'][0]
     ): PromiseInterface
     {
@@ -2104,8 +2104,8 @@ class UserApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function updateUserRequest(
-        $username,
-        $user,
+        string $username,
+        \OpenAPI\Client\Model\User $user,
         string $contentType = self::contentTypes['updateUser'][0]
     ): Request
     {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR addresses the following issues:

- If a parameter does not have a type specified and is not required, the invalid type declaration `?mixed` is generated (fix #20335)
- If a parameter is required but nullable, the generated type does not allow null values
- The methods `{operationId}Request` and `{operationId}AsyncWithHttpInfo` have no parameter types

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon