### PR TITLE
Fix a few issues with the C generator (part 7)

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations")
+set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations -Werror=int-conversion")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -275,7 +275,7 @@ end:
     {{/isFile}}
     {{^isFile}}
     char *keyForm_{{paramName}} = NULL;
-    {{#isPrimitiveType}}{{#isNumber}}{{{dataType}}}{{/isNumber}}{{#isLong}}{{{dataType}}}{{/isLong}}{{#isInteger}}{{{dataType}}}{{/isInteger}}{{#isDouble}}{{{dataType}}}{{/isDouble}}{{#isFloat}}{{{dataType}}}{{/isFloat}}{{#isBoolean}}{{dataType}}{{/isBoolean}}{{#isEnum}}{{#isString}}{{projectName}}_{{operationId}}_{{baseName}}_e{{/isString}}{{/isEnum}}{{^isEnum}}{{#isString}}{{{dataType}}} *{{/isString}}{{/isEnum}}{{#isByteArray}}{{{dataType}}} *{{/isByteArray}}{{#isDate}}{{{dataType}}}{{/isDate}}{{#isDateTime}}{{{dataType}}}{{/isDateTime}}{{#isFile}}{{{dataType}}}{{/isFile}}{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{^isEnum}}{{{dataType}}}_t *{{/isEnum}}{{/isModel}}{{^isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{/isModel}}{{#isUuid}}{{dataType}} *{{/isUuid}}{{#isEmail}}{{dataType}}{{/isEmail}}{{/isPrimitiveType}} valueForm_{{paramName}} = 0;
+    {{#isPrimitiveType}}{{#isNumber}}{{{dataType}}}{{/isNumber}}{{#isLong}}{{{dataType}}}{{/isLong}}{{#isInteger}}{{{dataType}}}{{/isInteger}}{{#isDouble}}{{{dataType}}}{{/isDouble}}{{#isFloat}}{{{dataType}}}{{/isFloat}}{{#isBoolean}}char *{{/isBoolean}}{{#isEnum}}{{#isString}}{{projectName}}_{{operationId}}_{{baseName}}_e{{/isString}}{{/isEnum}}{{^isEnum}}{{#isString}}{{{dataType}}} *{{/isString}}{{/isEnum}}{{#isByteArray}}{{{dataType}}} *{{/isByteArray}}{{#isDate}}{{{dataType}}}{{/isDate}}{{#isDateTime}}{{{dataType}}}{{/isDateTime}}{{#isFile}}{{{dataType}}}{{/isFile}}{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{^isEnum}}{{{dataType}}}_t *{{/isEnum}}{{/isModel}}{{^isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{/isModel}}{{#isUuid}}{{dataType}} *{{/isUuid}}{{#isEmail}}{{dataType}}{{/isEmail}}{{/isPrimitiveType}} valueForm_{{paramName}} = 0;
     keyValuePair_t *keyPairForm_{{paramName}} = 0;
     {{/isFile}}
     if ({{paramName}} != {{^isEnum}}NULL{{/isEnum}}{{#isEnum}}0{{/isEnum}})
@@ -301,7 +301,7 @@ end:
         valueForm_{{paramName}} = {{#isString}}{{^isEnum}}strdup({{/isEnum}}{{/isString}}({{{paramName}}}){{#isString}}{{^isEnum}}){{/isEnum}}{{/isString}};
         {{/isBoolean}}
         {{/isInteger}}
-        keyPairForm_{{paramName}} = keyValuePair_create(keyForm_{{paramName}},{{#isString}}{{#isEnum}}(void *){{/isEnum}}{{/isString}}{{^isString}}&{{/isString}}valueForm_{{paramName}});
+        keyPairForm_{{paramName}} = keyValuePair_create(keyForm_{{paramName}},{{#isString}}{{#isEnum}}(void *){{/isEnum}}{{/isString}}{{^isString}}{{^isBoolean}}&{{/isBoolean}}{{/isString}}valueForm_{{paramName}});
         list_addElement(localVarFormParameters,keyPairForm_{{paramName}});
         {{/isFile}}
     }

--- a/modules/openapi-generator/src/test/resources/2_0/c/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/c/petstore.yaml
@@ -395,6 +395,25 @@ paths:
           schema:
             type: string
             description: Thank you message
+  '/store/recommend':
+    post:
+      tags:
+        - store
+      summary: Would you recommend our service to a friend?
+      description: ''
+      operationId: sendRecommend
+      parameters:
+        - in: formData
+          name: recommend
+          description: Would you recommend us or not?
+          required: no
+          type: boolean
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: string
+            description: Thank you message
   /store/daysWithoutIncident:
     get:
       tags:

--- a/samples/client/others/c/bearerAuth/CMakeLists.txt
+++ b/samples/client/others/c/bearerAuth/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations")
+set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations -Werror=int-conversion")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 

--- a/samples/client/petstore/c-useJsonUnformatted/CMakeLists.txt
+++ b/samples/client/petstore/c-useJsonUnformatted/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations")
+set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations -Werror=int-conversion")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 

--- a/samples/client/petstore/c-useJsonUnformatted/README.md
+++ b/samples/client/petstore/c-useJsonUnformatted/README.md
@@ -84,6 +84,7 @@ Category | Method | HTTP request | Description
 *StoreAPI* | [**StoreAPI_placeOrder**](docs/StoreAPI.md#StoreAPI_placeOrder) | **POST** /store/order | Place an order for a pet
 *StoreAPI* | [**StoreAPI_sendFeedback**](docs/StoreAPI.md#StoreAPI_sendFeedback) | **POST** /store/feedback | Send us a feedback message
 *StoreAPI* | [**StoreAPI_sendRating**](docs/StoreAPI.md#StoreAPI_sendRating) | **POST** /store/rating/{rating} | How would you rate our service?
+*StoreAPI* | [**StoreAPI_sendRecommend**](docs/StoreAPI.md#StoreAPI_sendRecommend) | **POST** /store/recommend | Would you recommend our service to a friend?
 *UserAPI* | [**UserAPI_createUser**](docs/UserAPI.md#UserAPI_createUser) | **POST** /user | Create user
 *UserAPI* | [**UserAPI_createUsersWithArrayInput**](docs/UserAPI.md#UserAPI_createUsersWithArrayInput) | **POST** /user/createWithArray | Creates list of users with given input array
 *UserAPI* | [**UserAPI_createUsersWithListInput**](docs/UserAPI.md#UserAPI_createUsersWithListInput) | **POST** /user/createWithList | Creates list of users with given input array

--- a/samples/client/petstore/c-useJsonUnformatted/api/StoreAPI.c
+++ b/samples/client/petstore/c-useJsonUnformatted/api/StoreAPI.c
@@ -541,3 +541,85 @@ end:
 
 }
 
+// Would you recommend our service to a friend?
+//
+char*
+StoreAPI_sendRecommend(apiClient_t *apiClient, int *recommend)
+{
+    list_t    *localVarQueryParameters = NULL;
+    list_t    *localVarHeaderParameters = NULL;
+    list_t    *localVarFormParameters = list_createList();
+    list_t *localVarHeaderType = list_createList();
+    list_t *localVarContentType = list_createList();
+    char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
+
+    // clear the error code from the previous api call
+    apiClient->response_code = 0;
+
+    // create the path
+    long sizeOfPath = strlen("/store/recommend")+1;
+    char *localVarPath = malloc(sizeOfPath);
+    snprintf(localVarPath, sizeOfPath, "/store/recommend");
+
+
+
+
+
+    // form parameters
+    char *keyForm_recommend = NULL;
+    char * valueForm_recommend = 0;
+    keyValuePair_t *keyPairForm_recommend = 0;
+    if (recommend != NULL)
+    {
+        keyForm_recommend = strdup("recommend");
+        valueForm_recommend = calloc(1,MAX_NUMBER_LENGTH);
+        snprintf(valueForm_recommend, MAX_NUMBER_LENGTH, "%d", *recommend);
+        keyPairForm_recommend = keyValuePair_create(keyForm_recommend,valueForm_recommend);
+        list_addElement(localVarFormParameters,keyPairForm_recommend);
+    }
+    list_addElement(localVarHeaderType,"*/*"); //produces
+    list_addElement(localVarContentType,"multipart/form-data"); //consumes
+    apiClient_invoke(apiClient,
+                    localVarPath,
+                    localVarQueryParameters,
+                    localVarHeaderParameters,
+                    localVarFormParameters,
+                    localVarHeaderType,
+                    localVarContentType,
+                    localVarBodyParameters,
+                    localVarBodyLength,
+                    "POST");
+
+    // uncomment below to debug the error response
+    //if (apiClient->response_code == 200) {
+    //    printf("%s\n","successful operation");
+    //}
+    //primitive return type simple string
+    char* elementToReturn = NULL;
+    if(apiClient->response_code >= 200 && apiClient->response_code < 300)
+        elementToReturn = strdup((char*)apiClient->dataReceived);
+
+    if (apiClient->dataReceived) {
+        free(apiClient->dataReceived);
+        apiClient->dataReceived = NULL;
+        apiClient->dataReceivedLen = 0;
+    }
+    
+    
+    list_freeList(localVarFormParameters);
+    list_freeList(localVarHeaderType);
+    list_freeList(localVarContentType);
+    free(localVarPath);
+    if (keyForm_recommend) {
+        free(keyForm_recommend);
+        keyForm_recommend = NULL;
+    }
+    free(keyPairForm_recommend);
+    return elementToReturn;
+end:
+    free(localVarPath);
+    return NULL;
+
+}
+

--- a/samples/client/petstore/c-useJsonUnformatted/api/StoreAPI.h
+++ b/samples/client/petstore/c-useJsonUnformatted/api/StoreAPI.h
@@ -53,3 +53,9 @@ char*
 StoreAPI_sendRating(apiClient_t *apiClient, openapi_petstore_sendRating_rating_e rating);
 
 
+// Would you recommend our service to a friend?
+//
+char*
+StoreAPI_sendRecommend(apiClient_t *apiClient, int *recommend);
+
+

--- a/samples/client/petstore/c-useJsonUnformatted/docs/StoreAPI.md
+++ b/samples/client/petstore/c-useJsonUnformatted/docs/StoreAPI.md
@@ -10,6 +10,7 @@ Method | HTTP request | Description
 [**StoreAPI_placeOrder**](StoreAPI.md#StoreAPI_placeOrder) | **POST** /store/order | Place an order for a pet
 [**StoreAPI_sendFeedback**](StoreAPI.md#StoreAPI_sendFeedback) | **POST** /store/feedback | Send us a feedback message
 [**StoreAPI_sendRating**](StoreAPI.md#StoreAPI_sendRating) | **POST** /store/rating/{rating} | How would you rate our service?
+[**StoreAPI_sendRecommend**](StoreAPI.md#StoreAPI_sendRecommend) | **POST** /store/recommend | Would you recommend our service to a friend?
 
 
 # **StoreAPI_deleteOrder**
@@ -191,6 +192,36 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
+ - **Accept**: */*
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **StoreAPI_sendRecommend**
+```c
+// Would you recommend our service to a friend?
+//
+char* StoreAPI_sendRecommend(apiClient_t *apiClient, int *recommend);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration |
+**recommend** | **int \*** | Would you recommend us or not? | [optional] 
+
+### Return type
+
+char*
+
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: multipart/form-data
  - **Accept**: */*
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/client/petstore/c/README.md
+++ b/samples/client/petstore/c/README.md
@@ -84,6 +84,7 @@ Category | Method | HTTP request | Description
 *StoreAPI* | [**StoreAPI_placeOrder**](docs/StoreAPI.md#StoreAPI_placeOrder) | **POST** /store/order | Place an order for a pet
 *StoreAPI* | [**StoreAPI_sendFeedback**](docs/StoreAPI.md#StoreAPI_sendFeedback) | **POST** /store/feedback | Send us a feedback message
 *StoreAPI* | [**StoreAPI_sendRating**](docs/StoreAPI.md#StoreAPI_sendRating) | **POST** /store/rating/{rating} | How would you rate our service?
+*StoreAPI* | [**StoreAPI_sendRecommend**](docs/StoreAPI.md#StoreAPI_sendRecommend) | **POST** /store/recommend | Would you recommend our service to a friend?
 *UserAPI* | [**UserAPI_createUser**](docs/UserAPI.md#UserAPI_createUser) | **POST** /user | Create user
 *UserAPI* | [**UserAPI_createUsersWithArrayInput**](docs/UserAPI.md#UserAPI_createUsersWithArrayInput) | **POST** /user/createWithArray | Creates list of users with given input array
 *UserAPI* | [**UserAPI_createUsersWithListInput**](docs/UserAPI.md#UserAPI_createUsersWithListInput) | **POST** /user/createWithList | Creates list of users with given input array

--- a/samples/client/petstore/c/api/StoreAPI.c
+++ b/samples/client/petstore/c/api/StoreAPI.c
@@ -541,3 +541,85 @@ end:
 
 }
 
+// Would you recommend our service to a friend?
+//
+char*
+StoreAPI_sendRecommend(apiClient_t *apiClient, int *recommend)
+{
+    list_t    *localVarQueryParameters = NULL;
+    list_t    *localVarHeaderParameters = NULL;
+    list_t    *localVarFormParameters = list_createList();
+    list_t *localVarHeaderType = list_createList();
+    list_t *localVarContentType = list_createList();
+    char      *localVarBodyParameters = NULL;
+    size_t     localVarBodyLength = 0;
+
+    // clear the error code from the previous api call
+    apiClient->response_code = 0;
+
+    // create the path
+    long sizeOfPath = strlen("/store/recommend")+1;
+    char *localVarPath = malloc(sizeOfPath);
+    snprintf(localVarPath, sizeOfPath, "/store/recommend");
+
+
+
+
+
+    // form parameters
+    char *keyForm_recommend = NULL;
+    char * valueForm_recommend = 0;
+    keyValuePair_t *keyPairForm_recommend = 0;
+    if (recommend != NULL)
+    {
+        keyForm_recommend = strdup("recommend");
+        valueForm_recommend = calloc(1,MAX_NUMBER_LENGTH);
+        snprintf(valueForm_recommend, MAX_NUMBER_LENGTH, "%d", *recommend);
+        keyPairForm_recommend = keyValuePair_create(keyForm_recommend,valueForm_recommend);
+        list_addElement(localVarFormParameters,keyPairForm_recommend);
+    }
+    list_addElement(localVarHeaderType,"*/*"); //produces
+    list_addElement(localVarContentType,"multipart/form-data"); //consumes
+    apiClient_invoke(apiClient,
+                    localVarPath,
+                    localVarQueryParameters,
+                    localVarHeaderParameters,
+                    localVarFormParameters,
+                    localVarHeaderType,
+                    localVarContentType,
+                    localVarBodyParameters,
+                    localVarBodyLength,
+                    "POST");
+
+    // uncomment below to debug the error response
+    //if (apiClient->response_code == 200) {
+    //    printf("%s\n","successful operation");
+    //}
+    //primitive return type simple string
+    char* elementToReturn = NULL;
+    if(apiClient->response_code >= 200 && apiClient->response_code < 300)
+        elementToReturn = strdup((char*)apiClient->dataReceived);
+
+    if (apiClient->dataReceived) {
+        free(apiClient->dataReceived);
+        apiClient->dataReceived = NULL;
+        apiClient->dataReceivedLen = 0;
+    }
+    
+    
+    list_freeList(localVarFormParameters);
+    list_freeList(localVarHeaderType);
+    list_freeList(localVarContentType);
+    free(localVarPath);
+    if (keyForm_recommend) {
+        free(keyForm_recommend);
+        keyForm_recommend = NULL;
+    }
+    free(keyPairForm_recommend);
+    return elementToReturn;
+end:
+    free(localVarPath);
+    return NULL;
+
+}
+

--- a/samples/client/petstore/c/api/StoreAPI.h
+++ b/samples/client/petstore/c/api/StoreAPI.h
@@ -53,3 +53,9 @@ char*
 StoreAPI_sendRating(apiClient_t *apiClient, openapi_petstore_sendRating_rating_e rating);
 
 
+// Would you recommend our service to a friend?
+//
+char*
+StoreAPI_sendRecommend(apiClient_t *apiClient, int *recommend);
+
+

--- a/samples/client/petstore/c/docs/StoreAPI.md
+++ b/samples/client/petstore/c/docs/StoreAPI.md
@@ -10,6 +10,7 @@ Method | HTTP request | Description
 [**StoreAPI_placeOrder**](StoreAPI.md#StoreAPI_placeOrder) | **POST** /store/order | Place an order for a pet
 [**StoreAPI_sendFeedback**](StoreAPI.md#StoreAPI_sendFeedback) | **POST** /store/feedback | Send us a feedback message
 [**StoreAPI_sendRating**](StoreAPI.md#StoreAPI_sendRating) | **POST** /store/rating/{rating} | How would you rate our service?
+[**StoreAPI_sendRecommend**](StoreAPI.md#StoreAPI_sendRecommend) | **POST** /store/recommend | Would you recommend our service to a friend?
 
 
 # **StoreAPI_deleteOrder**
@@ -191,6 +192,36 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
+ - **Accept**: */*
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **StoreAPI_sendRecommend**
+```c
+// Would you recommend our service to a friend?
+//
+char* StoreAPI_sendRecommend(apiClient_t *apiClient, int *recommend);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration |
+**recommend** | **int \*** | Would you recommend us or not? | [optional] 
+
+### Return type
+
+char*
+
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: multipart/form-data
  - **Accept**: */*
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)


### PR DESCRIPTION
Another new warning I've noticed when building our api with the latest version:

```
/root/avh-api/c/api/api/ArmAPI.c: In function ‘ArmAPI_v1CreateImage’:
/root/avh-api/c/api/api/ArmAPI.c:1346:32: error: assignment to ‘int’ from ‘void *’ makes integer from pointer without a cast [-Werror=int-conversion]
 1346 |         valueForm_encapsulated = calloc(1,MAX_NUMBER_LENGTH);
      |                                ^
/root/avh-api/c/api/api/ArmAPI.c:1347:18: error: passing argument 1 of ‘snprintf’ makes pointer from integer without a cast [-Werror=int-conversion]
 1347 |         snprintf(valueForm_encapsulated, MAX_NUMBER_LENGTH, "%d", *encapsulated);
      |                  ^~~~~~~~~~~~~~~~~~~~~~
      |                  |
      |                  int
In file included from /root/avh-api/c/api/api/ArmAPI.c:2:
/usr/include/stdio.h:378:39: note: expected ‘char * restrict’ but argument is of type ‘int’
  378 | extern int snprintf (char *__restrict __s, size_t __maxlen,
      |                      ~~~~~~~~~~~~~~~~~^~~
```

This is not actually a regression, the code was always broken but recent changes made the warning show up. This pull request does the following:

1. Update the test schema to cover this broken case.
2. Change the compiler flags to ban implicit int to pointer conversions, so that automated testing will not miss these warnings.
3. Fix the actual bug, changing the type of `valueForm` to `char *`.

There are other issues with formData input. I think valueForm should become `char *` for all types, not just bool. But this involves bigger changes, so I might look into it at some later time.