### PR TITLE
[C][Client] Remove broken intToStr() macro, update samples

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -5,11 +5,6 @@
 
 #define MAX_NUMBER_LENGTH 16
 #define MAX_BUFFER_LENGTH 4096
-#define intToStr(dst, src) \
-    do {\
-    char dst[256];\
-    snprintf(dst, 256, "%ld", (long int)(src));\
-}while(0)
 
 {{#operations}}
 {{#operation}}
@@ -140,7 +135,7 @@ end:
     snprintf(localVarToReplace_{{paramName}}, sizeOfPathParams_{{paramName}}, "{%s}", "{{baseName}}");
 
     char localVarBuff_{{paramName}}[256];
-    intToStr(localVarBuff_{{paramName}}, {{paramName}});
+    snprintf(localVarBuff_{{paramName}}, sizeof localVarBuff_{{paramName}}, "%ld", (long){{paramName}});
 
     localVarPath = strReplace(localVarPath, localVarToReplace_{{paramName}}, localVarBuff_{{paramName}});
 
@@ -153,7 +148,7 @@ end:
     snprintf(localVarToReplace_{{paramName}}, sizeOfPathParams_{{paramName}}, "{%s}", "{{baseName}}");
 
     char localVarBuff_{{paramName}}[256];
-    intToStr(localVarBuff_{{paramName}}, *{{paramName}});
+    snprintf(localVarBuff_{{paramName}}, sizeof localVarBuff_{{paramName}}, "%ld", (long)*{{paramName}});
 
     localVarPath = strReplace(localVarPath, localVarToReplace_{{paramName}}, localVarBuff_{{paramName}});
 
@@ -166,7 +161,7 @@ end:
     snprintf(localVarToReplace_{{paramName}}, sizeOfPathParams_{{paramName}}, "{%s}", "{{baseName}}");
 
     char localVarBuff_{{paramName}}[256];
-    intToStr(localVarBuff_{{paramName}}, {{paramName}});
+    snprintf(localVarBuff_{{paramName}}, sizeof localVarBuff_{{paramName}}, "%ld", (long){{paramName}});
 
     localVarPath = strReplace(localVarPath, localVarToReplace_{{paramName}}, localVarBuff_{{paramName}});
 
@@ -179,7 +174,7 @@ end:
     snprintf(localVarToReplace_{{paramName}}, sizeOfPathParams_{{paramName}}, "{%s}", "{{baseName}}");
 
     char localVarBuff_{{paramName}}[256];
-    intToStr(localVarBuff_{{paramName}}, {{paramName}});
+    snprintf(localVarBuff_{{paramName}}, sizeof localVarBuff_{{paramName}}, "%ld", {{paramName}});
 
     localVarPath = strReplace(localVarPath, localVarToReplace_{{paramName}}, localVarBuff_{{paramName}});
 

--- a/samples/client/others/c/bearerAuth/api/DefaultAPI.c
+++ b/samples/client/others/c/bearerAuth/api/DefaultAPI.c
@@ -5,11 +5,6 @@
 
 #define MAX_NUMBER_LENGTH 16
 #define MAX_BUFFER_LENGTH 4096
-#define intToStr(dst, src) \
-    do {\
-    char dst[256];\
-    snprintf(dst, 256, "%ld", (long int)(src));\
-}while(0)
 
 
 // Returns private information.

--- a/samples/client/petstore/c-useJsonUnformatted/api/PetAPI.c
+++ b/samples/client/petstore/c-useJsonUnformatted/api/PetAPI.c
@@ -5,11 +5,6 @@
 
 #define MAX_NUMBER_LENGTH 16
 #define MAX_BUFFER_LENGTH 4096
-#define intToStr(dst, src) \
-    do {\
-    char dst[256];\
-    snprintf(dst, 256, "%ld", (long int)(src));\
-}while(0)
 
 // Functions for enum STATUS for PetAPI_findPetsByStatus
 
@@ -159,7 +154,7 @@ PetAPI_deletePet(apiClient_t *apiClient, long petId, char *api_key)
     snprintf(localVarToReplace_petId, sizeOfPathParams_petId, "{%s}", "petId");
 
     char localVarBuff_petId[256];
-    intToStr(localVarBuff_petId, petId);
+    snprintf(localVarBuff_petId, sizeof localVarBuff_petId, "%ld", petId);
 
     localVarPath = strReplace(localVarPath, localVarToReplace_petId, localVarBuff_petId);
 
@@ -501,7 +496,7 @@ PetAPI_getPetById(apiClient_t *apiClient, long petId)
     snprintf(localVarToReplace_petId, sizeOfPathParams_petId, "{%s}", "petId");
 
     char localVarBuff_petId[256];
-    intToStr(localVarBuff_petId, petId);
+    snprintf(localVarBuff_petId, sizeof localVarBuff_petId, "%ld", petId);
 
     localVarPath = strReplace(localVarPath, localVarToReplace_petId, localVarBuff_petId);
 
@@ -658,7 +653,7 @@ PetAPI_isPetAvailable(apiClient_t *apiClient, long petId)
     snprintf(localVarToReplace_petId, sizeOfPathParams_petId, "{%s}", "petId");
 
     char localVarBuff_petId[256];
-    intToStr(localVarBuff_petId, petId);
+    snprintf(localVarBuff_petId, sizeof localVarBuff_petId, "%ld", petId);
 
     localVarPath = strReplace(localVarPath, localVarToReplace_petId, localVarBuff_petId);
 
@@ -965,7 +960,7 @@ PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char *name, char *s
     snprintf(localVarToReplace_petId, sizeOfPathParams_petId, "{%s}", "petId");
 
     char localVarBuff_petId[256];
-    intToStr(localVarBuff_petId, petId);
+    snprintf(localVarBuff_petId, sizeof localVarBuff_petId, "%ld", petId);
 
     localVarPath = strReplace(localVarPath, localVarToReplace_petId, localVarBuff_petId);
 
@@ -1078,7 +1073,7 @@ PetAPI_uploadFile(apiClient_t *apiClient, long petId, char *additionalMetadata, 
     snprintf(localVarToReplace_petId, sizeOfPathParams_petId, "{%s}", "petId");
 
     char localVarBuff_petId[256];
-    intToStr(localVarBuff_petId, petId);
+    snprintf(localVarBuff_petId, sizeof localVarBuff_petId, "%ld", petId);
 
     localVarPath = strReplace(localVarPath, localVarToReplace_petId, localVarBuff_petId);
 

--- a/samples/client/petstore/c-useJsonUnformatted/api/StoreAPI.c
+++ b/samples/client/petstore/c-useJsonUnformatted/api/StoreAPI.c
@@ -5,11 +5,6 @@
 
 #define MAX_NUMBER_LENGTH 16
 #define MAX_BUFFER_LENGTH 4096
-#define intToStr(dst, src) \
-    do {\
-    char dst[256];\
-    snprintf(dst, 256, "%ld", (long int)(src));\
-}while(0)
 
 // Functions for enum RATING for StoreAPI_sendRating
 
@@ -245,7 +240,7 @@ StoreAPI_getOrderById(apiClient_t *apiClient, long orderId)
     snprintf(localVarToReplace_orderId, sizeOfPathParams_orderId, "{%s}", "orderId");
 
     char localVarBuff_orderId[256];
-    intToStr(localVarBuff_orderId, orderId);
+    snprintf(localVarBuff_orderId, sizeof localVarBuff_orderId, "%ld", orderId);
 
     localVarPath = strReplace(localVarPath, localVarToReplace_orderId, localVarBuff_orderId);
 

--- a/samples/client/petstore/c-useJsonUnformatted/api/UserAPI.c
+++ b/samples/client/petstore/c-useJsonUnformatted/api/UserAPI.c
@@ -5,11 +5,6 @@
 
 #define MAX_NUMBER_LENGTH 16
 #define MAX_BUFFER_LENGTH 4096
-#define intToStr(dst, src) \
-    do {\
-    char dst[256];\
-    snprintf(dst, 256, "%ld", (long int)(src));\
-}while(0)
 
 
 // Create user

--- a/samples/client/petstore/c/api/PetAPI.c
+++ b/samples/client/petstore/c/api/PetAPI.c
@@ -5,11 +5,6 @@
 
 #define MAX_NUMBER_LENGTH 16
 #define MAX_BUFFER_LENGTH 4096
-#define intToStr(dst, src) \
-    do {\
-    char dst[256];\
-    snprintf(dst, 256, "%ld", (long int)(src));\
-}while(0)
 
 // Functions for enum STATUS for PetAPI_findPetsByStatus
 
@@ -159,7 +154,7 @@ PetAPI_deletePet(apiClient_t *apiClient, long petId, char *api_key)
     snprintf(localVarToReplace_petId, sizeOfPathParams_petId, "{%s}", "petId");
 
     char localVarBuff_petId[256];
-    intToStr(localVarBuff_petId, petId);
+    snprintf(localVarBuff_petId, sizeof localVarBuff_petId, "%ld", petId);
 
     localVarPath = strReplace(localVarPath, localVarToReplace_petId, localVarBuff_petId);
 
@@ -501,7 +496,7 @@ PetAPI_getPetById(apiClient_t *apiClient, long petId)
     snprintf(localVarToReplace_petId, sizeOfPathParams_petId, "{%s}", "petId");
 
     char localVarBuff_petId[256];
-    intToStr(localVarBuff_petId, petId);
+    snprintf(localVarBuff_petId, sizeof localVarBuff_petId, "%ld", petId);
 
     localVarPath = strReplace(localVarPath, localVarToReplace_petId, localVarBuff_petId);
 
@@ -658,7 +653,7 @@ PetAPI_isPetAvailable(apiClient_t *apiClient, long petId)
     snprintf(localVarToReplace_petId, sizeOfPathParams_petId, "{%s}", "petId");
 
     char localVarBuff_petId[256];
-    intToStr(localVarBuff_petId, petId);
+    snprintf(localVarBuff_petId, sizeof localVarBuff_petId, "%ld", petId);
 
     localVarPath = strReplace(localVarPath, localVarToReplace_petId, localVarBuff_petId);
 
@@ -965,7 +960,7 @@ PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char *name, char *s
     snprintf(localVarToReplace_petId, sizeOfPathParams_petId, "{%s}", "petId");
 
     char localVarBuff_petId[256];
-    intToStr(localVarBuff_petId, petId);
+    snprintf(localVarBuff_petId, sizeof localVarBuff_petId, "%ld", petId);
 
     localVarPath = strReplace(localVarPath, localVarToReplace_petId, localVarBuff_petId);
 
@@ -1078,7 +1073,7 @@ PetAPI_uploadFile(apiClient_t *apiClient, long petId, char *additionalMetadata, 
     snprintf(localVarToReplace_petId, sizeOfPathParams_petId, "{%s}", "petId");
 
     char localVarBuff_petId[256];
-    intToStr(localVarBuff_petId, petId);
+    snprintf(localVarBuff_petId, sizeof localVarBuff_petId, "%ld", petId);
 
     localVarPath = strReplace(localVarPath, localVarToReplace_petId, localVarBuff_petId);
 

--- a/samples/client/petstore/c/api/StoreAPI.c
+++ b/samples/client/petstore/c/api/StoreAPI.c
@@ -5,11 +5,6 @@
 
 #define MAX_NUMBER_LENGTH 16
 #define MAX_BUFFER_LENGTH 4096
-#define intToStr(dst, src) \
-    do {\
-    char dst[256];\
-    snprintf(dst, 256, "%ld", (long int)(src));\
-}while(0)
 
 // Functions for enum RATING for StoreAPI_sendRating
 
@@ -245,7 +240,7 @@ StoreAPI_getOrderById(apiClient_t *apiClient, long orderId)
     snprintf(localVarToReplace_orderId, sizeOfPathParams_orderId, "{%s}", "orderId");
 
     char localVarBuff_orderId[256];
-    intToStr(localVarBuff_orderId, orderId);
+    snprintf(localVarBuff_orderId, sizeof localVarBuff_orderId, "%ld", orderId);
 
     localVarPath = strReplace(localVarPath, localVarToReplace_orderId, localVarBuff_orderId);
 

--- a/samples/client/petstore/c/api/UserAPI.c
+++ b/samples/client/petstore/c/api/UserAPI.c
@@ -5,11 +5,6 @@
 
 #define MAX_NUMBER_LENGTH 16
 #define MAX_BUFFER_LENGTH 4096
-#define intToStr(dst, src) \
-    do {\
-    char dst[256];\
-    snprintf(dst, 256, "%ld", (long int)(src));\
-}while(0)
 
 
 // Create user


### PR DESCRIPTION
Note: this does not fix anything else; for example all numerical types, including float and double, are still incorrectly cast to to long int before string conversion.