### PR TITLE
#20390 : On enum name sanitize, convert colon to underscore

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -6524,6 +6524,9 @@ public class DefaultCodegen implements CodegenConfig {
             // input.name => input_name
             modifiable = this.sanitizeValue(modifiable, "\\.", "_", exceptions);
 
+            // input:name => input_name
+            modifiable = this.sanitizeValue(modifiable, ":", "_", exceptions);
+
             // input-name => input_name
             modifiable = this.sanitizeValue(modifiable, "-", "_", exceptions);
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
@@ -405,7 +405,7 @@ public class CrystalClientCodegen extends DefaultCodegen {
         String[] parts = modelName.split("::");
         ArrayList<String> new_parts = new ArrayList<String>();
         for (String part : parts) {
-            new_parts.add(sanitizeName(part));
+            new_parts.add(sanitizeName(part, "\\W", new ArrayList<>(List.of(":"))));
         }
         return String.join("::", new_parts);
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
@@ -274,10 +274,10 @@ public class JavaModelTest {
 
         final CodegenProperty property = cm.vars.get(0);
         Assert.assertEquals(property.baseName, "@Some:restricted%characters#to!handle+");
-        Assert.assertEquals(property.getter, "getAtSomeColonRestrictedPercentCharactersHashToExclamationHandlePlus");
-        Assert.assertEquals(property.setter, "setAtSomeColonRestrictedPercentCharactersHashToExclamationHandlePlus");
+        Assert.assertEquals(property.getter, "getAtSomeRestrictedPercentCharactersHashToExclamationHandlePlus");
+        Assert.assertEquals(property.setter, "setAtSomeRestrictedPercentCharactersHashToExclamationHandlePlus");
         Assert.assertEquals(property.dataType, "Boolean");
-        Assert.assertEquals(property.name, "atSomeColonRestrictedPercentCharactersHashToExclamationHandlePlus");
+        Assert.assertEquals(property.name, "atSomeRestrictedPercentCharactersHashToExclamationHandlePlus");
         Assert.assertNull(property.defaultValue);
         Assert.assertEquals(property.baseType, "Boolean");
         Assert.assertFalse(property.required);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -133,6 +133,7 @@ public class TypeScriptFetchClientCodegenTest {
         Assert.assertEquals(codegen.toEnumVarName("valid_var", "string"), "ValidVar");
         Assert.assertEquals(codegen.toEnumVarName("-valid_var+", "string"), "ValidVar");
         Assert.assertEquals(codegen.toEnumVarName("30valid_+var", "string"), "_30validVar");
+        Assert.assertEquals(codegen.toEnumVarName("VALID:var", "string"), "ValidVar");
 
         codegen = new TypeScriptFetchClientCodegen();
         codegen.additionalProperties().put(CodegenConstants.ENUM_PROPERTY_NAMING, "original");
@@ -142,6 +143,7 @@ public class TypeScriptFetchClientCodegenTest {
         Assert.assertEquals(codegen.toEnumVarName("valid_var", "string"), "valid_var");
         Assert.assertEquals(codegen.toEnumVarName("-valid_var+", "string"), "valid_var");
         Assert.assertEquals(codegen.toEnumVarName("30valid_+var", "string"), "_30valid_var");
+        Assert.assertEquals(codegen.toEnumVarName("VALID:var", "string"), "VALID_var");
 
         codegen = new TypeScriptFetchClientCodegen();
         codegen.additionalProperties().put(CodegenConstants.ENUM_PROPERTY_NAMING, "UPPERCASE");
@@ -153,7 +155,7 @@ public class TypeScriptFetchClientCodegenTest {
         Assert.assertEquals(codegen.toEnumVarName("-valid_+var", "string"), "MINUS_VALID_PLUS_VAR");
         Assert.assertEquals(codegen.toEnumVarName("-valid_var+", "string"), "MINUS_VALID_VAR_PLUS");
         Assert.assertEquals(codegen.toEnumVarName("30valid_+var", "string"), "_30VALID_PLUS_VAR");
-
+        Assert.assertEquals(codegen.toEnumVarName("VALID:var", "string"), "VALID_VAR");
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/OpenAPITools/openapi-generator/issues/20390

Some new tests have been added to verify that ':' is converted to '_'.

Some codegen (JavaModel and CrystalClient) have been modified to manage this new 'colon' sanitize.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
