### PR TITLE
C overhead fixes

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -254,7 +254,7 @@ end:
         valueQuery_{{{paramName}}} = {{#isString}}{{^isEnum}}strdup({{/isEnum}}{{/isString}}({{{paramName}}}){{#isString}}{{^isEnum}}){{/isEnum}}{{/isString}};
         {{/isBoolean}}
         {{/isInteger}}
-        keyPairQuery_{{paramName}} = keyValuePair_create(keyQuery_{{{paramName}}}, {{#isEnum}}(void *)strdup({{{operationId}}}_{{enumName}}_ToString(
+        keyPairQuery_{{paramName}} = keyValuePair_create(keyQuery_{{{paramName}}}, {{#isEnum}}strdup({{{operationId}}}_{{enumName}}_ToString(
         {{/isEnum}}{{^isString}}{{^isInteger}}{{^isBoolean}}&{{/isBoolean}}{{/isInteger}}{{/isString}}valueQuery_{{{paramName}}}{{#isEnum}})){{/isEnum}});
         list_addElement(localVarQueryParameters,keyPairQuery_{{paramName}});
         {{/isArray}}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -108,9 +108,7 @@ end:
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("{{{path}}}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "{{{path}}}");
+    char *localVarPath = strdup("{{{path}}}");
 
     {{#pathParams}}
     {{#isString}}
@@ -126,7 +124,7 @@ end:
     {{#pathParams}}
 
     // Path Params
-    long sizeOfPathParams_{{{paramName}}} = {{#pathParams}}{{#isLong}}sizeof({{paramName}})+3{{/isLong}}{{#isString}}strlen({{^isEnum}}{{paramName}}{{/isEnum}}{{#isEnum}}{{{operationId}}}_{{enumName}}_ToString({{paramName}}){{/isEnum}})+3{{/isString}}{{^-last}} + {{/-last}}{{/pathParams}} + strlen("{ {{baseName}} }");
+    long sizeOfPathParams_{{{paramName}}} = {{#pathParams}}{{#isLong}}sizeof({{paramName}})+3{{/isLong}}{{#isString}}strlen({{^isEnum}}{{paramName}}{{/isEnum}}{{#isEnum}}{{{operationId}}}_{{enumName}}_ToString({{paramName}}){{/isEnum}})+3{{/isString}}{{^-last}} + {{/-last}}{{/pathParams}} + sizeof("{ {{baseName}} }") - 1;
     {{#isNumeric}}
     if({{paramName}} == 0){
         goto end;

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -286,36 +286,26 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
         if(headerType != NULL) {
             list_ForEach(listEntry, headerType) {
-                if(strstr(listEntry->data,
-                          "xml") == NULL)
+                if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffHeader = malloc(strlen(
-                                    "Accept: ") +
-                                        strlen(listEntry->
-                                               data) + 1);
+                    buffHeader = malloc(strlen("Accept: ") +
+                                        strlen(listEntry->data) + 1);
                     sprintf(buffHeader, "%s%s", "Accept: ",
                             (char *) listEntry->data);
-                    headers = curl_slist_append(headers,
-                                                buffHeader);
+                    headers = curl_slist_append(headers, buffHeader);
                     free(buffHeader);
                 }
             }
         }
         if(contentType != NULL) {
             list_ForEach(listEntry, contentType) {
-                if(strstr(listEntry->data,
-                          "xml") == NULL)
+                if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffContent =
-                        malloc(strlen(
-                                   "Content-Type: ") + strlen(
-                                   listEntry->data) +
-                               1);
-                    sprintf(buffContent, "%s%s",
-                            "Content-Type: ",
+                    buffContent = malloc(strlen("Content-Type: ") +
+                                         strlen(listEntry->data) + 1);
+                    sprintf(buffContent, "%s%s", "Content-Type: ",
                             (char *) listEntry->data);
-                    headers = curl_slist_append(headers,
-                                                buffContent);
+                    headers = curl_slist_append(headers, buffContent);
                     free(buffContent);
                     buffContent = NULL;
                 }

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -286,13 +286,12 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
         if(headerType != NULL) {
             list_ForEach(listEntry, headerType) {
-                if(strstr((char *) listEntry->data,
+                if(strstr(listEntry->data,
                           "xml") == NULL)
                 {
                     buffHeader = malloc(strlen(
                                     "Accept: ") +
-                                        strlen((char *)
-                                               listEntry->
+                                        strlen(listEntry->
                                                data) + 1);
                     sprintf(buffHeader, "%s%s", "Accept: ",
                             (char *) listEntry->data);
@@ -304,13 +303,12 @@ void apiClient_invoke(apiClient_t    *apiClient,
         }
         if(contentType != NULL) {
             list_ForEach(listEntry, contentType) {
-                if(strstr((char *) listEntry->data,
+                if(strstr(listEntry->data,
                           "xml") == NULL)
                 {
                     buffContent =
                         malloc(strlen(
                                    "Content-Type: ") + strlen(
-                                   (char *)
                                    listEntry->data) +
                                1);
                     sprintf(buffContent, "%s%s",
@@ -594,8 +592,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
 size_t writeDataCallback(void *buffer, size_t size, size_t nmemb, void *userp) {
     size_t size_this_time = nmemb * size;
-    apiClient_t *apiClient = (apiClient_t *)userp;
-    apiClient->dataReceived = (char *)realloc( apiClient->dataReceived, apiClient->dataReceivedLen + size_this_time + 1);
+    apiClient_t *apiClient = userp;
+    apiClient->dataReceived = realloc( apiClient->dataReceived, apiClient->dataReceivedLen + size_this_time + 1);
     memcpy((char *)apiClient->dataReceived + apiClient->dataReceivedLen, buffer, size_this_time);
     apiClient->dataReceivedLen += size_this_time;
     ((char*)apiClient->dataReceived)[apiClient->dataReceivedLen] = '\0'; // the space size of (apiClient->dataReceived) = dataReceivedLen + 1

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -173,10 +173,11 @@ void sslConfig_free(sslConfig_t *sslConfig) {
     free(sslConfig);
 }
 
-static void replaceSpaceWithPlus(char *stringToProcess) {
-    for(int i = 0; i < strlen(stringToProcess); i++) {
-        if(stringToProcess[i] == ' ') {
-            stringToProcess[i] = '+';
+static void replaceSpaceWithPlus(char *str) {
+    if (str) {
+        for (; *str; str++) {
+            if (*str == ' ')
+                *str = '+';
         }
     }
 }
@@ -288,9 +289,9 @@ void apiClient_invoke(apiClient_t    *apiClient,
             list_ForEach(listEntry, headerType) {
                 if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffHeader = malloc(strlen("Accept: ") +
-                                        strlen(listEntry->data) + 1);
-                    sprintf(buffHeader, "%s%s", "Accept: ",
+                    buffHeader = malloc(sizeof("Accept: ") +
+                                        strlen(listEntry->data));
+                    sprintf(buffHeader, "Accept: %s",
                             (char *) listEntry->data);
                     headers = curl_slist_append(headers, buffHeader);
                     free(buffHeader);
@@ -301,9 +302,9 @@ void apiClient_invoke(apiClient_t    *apiClient,
             list_ForEach(listEntry, contentType) {
                 if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffContent = malloc(strlen("Content-Type: ") +
-                                         strlen(listEntry->data) + 1);
-                    sprintf(buffContent, "%s%s", "Content-Type: ",
+                    buffContent = malloc(sizeof("Content-Type: ") +
+                                         strlen(listEntry->data));
+                    sprintf(buffContent, "Content-Type: %s",
                             (char *) listEntry->data);
                     headers = curl_slist_append(headers, buffContent);
                     free(buffContent);

--- a/modules/openapi-generator/src/main/resources/C-libcurl/list.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/list.c.mustache
@@ -20,7 +20,7 @@ void listEntry_free(listEntry_t *listEntry, void *additionalData) {
 }
 
 void listEntry_printAsInt(listEntry_t *listEntry, void *additionalData) {
-    printf("%i\n", *((int *) (listEntry->data)));
+    printf("%i\n", *(int *)listEntry->data);
 }
 
 list_t *list_createList() {

--- a/modules/openapi-generator/src/main/resources/C-libcurl/list.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/list.c.mustache
@@ -176,8 +176,8 @@ char* findStrInStrList(list_t *strList, const char *str)
 
     listEntry_t* listEntry = NULL;
     list_ForEach(listEntry, strList) {
-        if (strstr((char*)listEntry->data, str) != NULL) {
-            return (char*)listEntry->data;
+        if (strstr(listEntry->data, str) != NULL) {
+            return listEntry->data;
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -402,7 +402,7 @@ void {{classname}}_free({{classname}}_t *{{classname}}) {
     {{#isMap}}
     if ({{{classname}}}->{{{name}}}) {
         list_ForEach(listEntry, {{classname}}->{{name}}) {
-            keyValuePair_t *localKeyValue = (keyValuePair_t*) listEntry->data;
+            keyValuePair_t *localKeyValue = listEntry->data;
             free (localKeyValue->key);
             free (localKeyValue->value);
             keyValuePair_free(localKeyValue);
@@ -570,7 +570,7 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     list_ForEach({{{name}}}ListEntry, {{{classname}}}->{{{name}}}) {
     {{#items}}
     {{#isString}}
-    if(cJSON_AddStringToObject({{{name}}}, "", (char*){{{name}}}ListEntry->data) == NULL)
+    if(cJSON_AddStringToObject({{{name}}}, "", {{{name}}}ListEntry->data) == NULL)
     {
         goto fail;
     }
@@ -617,16 +617,16 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     listEntry_t *{{{name}}}ListEntry;
     if ({{{classname}}}->{{{name}}}) {
     list_ForEach({{{name}}}ListEntry, {{{classname}}}->{{{name}}}) {
-        keyValuePair_t *localKeyValue = (keyValuePair_t*){{{name}}}ListEntry->data;
+        keyValuePair_t *localKeyValue = {{{name}}}ListEntry->data;
         {{#items}}
         {{#isString}}
-        if(cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL)
+        if(cJSON_AddStringToObject(localMapObject, localKeyValue->key, localKeyValue->value) == NULL)
         {
             goto fail;
         }
         {{/isString}}
         {{#isByteArray}}
-        if(cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL)
+        if(cJSON_AddStringToObject(localMapObject, localKeyValue->key, localKeyValue->value) == NULL)
         {
             goto fail;
         }
@@ -848,7 +848,7 @@ fail:
         {
             goto end;
         }
-        double *{{{name}}}_local_value = (double *)calloc(1, sizeof(double));
+        double *{{{name}}}_local_value = calloc(1, sizeof(double));
         if(!{{{name}}}_local_value)
         {
             goto end;
@@ -1088,7 +1088,7 @@ end:
     if ({{{name}}}List) {
         listEntry_t *listEntry = NULL;
         list_ForEach(listEntry, {{{name}}}List) {
-            keyValuePair_t *localKeyValue = (keyValuePair_t*) listEntry->data;
+            keyValuePair_t *localKeyValue = listEntry->data;
             free(localKeyValue->key);
             localKeyValue->key = NULL;
             {{#items}}

--- a/samples/client/others/c/bearerAuth/api/DefaultAPI.c
+++ b/samples/client/others/c/bearerAuth/api/DefaultAPI.c
@@ -26,9 +26,7 @@ DefaultAPI_privateGet(apiClient_t *apiClient)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/private")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/private");
+    char *localVarPath = strdup("/private");
 
 
 
@@ -98,9 +96,7 @@ DefaultAPI_publicGet(apiClient_t *apiClient)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/public")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/public");
+    char *localVarPath = strdup("/public");
 
 
 
@@ -170,9 +166,7 @@ DefaultAPI_usersGet(apiClient_t *apiClient)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/users")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/users");
+    char *localVarPath = strdup("/users");
 
 
 

--- a/samples/client/others/c/bearerAuth/src/apiClient.c
+++ b/samples/client/others/c/bearerAuth/src/apiClient.c
@@ -89,10 +89,11 @@ void sslConfig_free(sslConfig_t *sslConfig) {
     free(sslConfig);
 }
 
-static void replaceSpaceWithPlus(char *stringToProcess) {
-    for(int i = 0; i < strlen(stringToProcess); i++) {
-        if(stringToProcess[i] == ' ') {
-            stringToProcess[i] = '+';
+static void replaceSpaceWithPlus(char *str) {
+    if (str) {
+        for (; *str; str++) {
+            if (*str == ' ')
+                *str = '+';
         }
     }
 }
@@ -204,9 +205,9 @@ void apiClient_invoke(apiClient_t    *apiClient,
             list_ForEach(listEntry, headerType) {
                 if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffHeader = malloc(strlen("Accept: ") +
-                                        strlen(listEntry->data) + 1);
-                    sprintf(buffHeader, "%s%s", "Accept: ",
+                    buffHeader = malloc(sizeof("Accept: ") +
+                                        strlen(listEntry->data));
+                    sprintf(buffHeader, "Accept: %s",
                             (char *) listEntry->data);
                     headers = curl_slist_append(headers, buffHeader);
                     free(buffHeader);
@@ -217,9 +218,9 @@ void apiClient_invoke(apiClient_t    *apiClient,
             list_ForEach(listEntry, contentType) {
                 if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffContent = malloc(strlen("Content-Type: ") +
-                                         strlen(listEntry->data) + 1);
-                    sprintf(buffContent, "%s%s", "Content-Type: ",
+                    buffContent = malloc(sizeof("Content-Type: ") +
+                                         strlen(listEntry->data));
+                    sprintf(buffContent, "Content-Type: %s",
                             (char *) listEntry->data);
                     headers = curl_slist_append(headers, buffContent);
                     free(buffContent);

--- a/samples/client/others/c/bearerAuth/src/apiClient.c
+++ b/samples/client/others/c/bearerAuth/src/apiClient.c
@@ -202,36 +202,26 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
         if(headerType != NULL) {
             list_ForEach(listEntry, headerType) {
-                if(strstr(listEntry->data,
-                          "xml") == NULL)
+                if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffHeader = malloc(strlen(
-                                    "Accept: ") +
-                                        strlen(listEntry->
-                                               data) + 1);
+                    buffHeader = malloc(strlen("Accept: ") +
+                                        strlen(listEntry->data) + 1);
                     sprintf(buffHeader, "%s%s", "Accept: ",
                             (char *) listEntry->data);
-                    headers = curl_slist_append(headers,
-                                                buffHeader);
+                    headers = curl_slist_append(headers, buffHeader);
                     free(buffHeader);
                 }
             }
         }
         if(contentType != NULL) {
             list_ForEach(listEntry, contentType) {
-                if(strstr(listEntry->data,
-                          "xml") == NULL)
+                if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffContent =
-                        malloc(strlen(
-                                   "Content-Type: ") + strlen(
-                                   listEntry->data) +
-                               1);
-                    sprintf(buffContent, "%s%s",
-                            "Content-Type: ",
+                    buffContent = malloc(strlen("Content-Type: ") +
+                                         strlen(listEntry->data) + 1);
+                    sprintf(buffContent, "%s%s", "Content-Type: ",
                             (char *) listEntry->data);
-                    headers = curl_slist_append(headers,
-                                                buffContent);
+                    headers = curl_slist_append(headers, buffContent);
                     free(buffContent);
                     buffContent = NULL;
                 }

--- a/samples/client/others/c/bearerAuth/src/apiClient.c
+++ b/samples/client/others/c/bearerAuth/src/apiClient.c
@@ -202,13 +202,12 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
         if(headerType != NULL) {
             list_ForEach(listEntry, headerType) {
-                if(strstr((char *) listEntry->data,
+                if(strstr(listEntry->data,
                           "xml") == NULL)
                 {
                     buffHeader = malloc(strlen(
                                     "Accept: ") +
-                                        strlen((char *)
-                                               listEntry->
+                                        strlen(listEntry->
                                                data) + 1);
                     sprintf(buffHeader, "%s%s", "Accept: ",
                             (char *) listEntry->data);
@@ -220,13 +219,12 @@ void apiClient_invoke(apiClient_t    *apiClient,
         }
         if(contentType != NULL) {
             list_ForEach(listEntry, contentType) {
-                if(strstr((char *) listEntry->data,
+                if(strstr(listEntry->data,
                           "xml") == NULL)
                 {
                     buffContent =
                         malloc(strlen(
                                    "Content-Type: ") + strlen(
-                                   (char *)
                                    listEntry->data) +
                                1);
                     sprintf(buffContent, "%s%s",
@@ -438,8 +436,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
 size_t writeDataCallback(void *buffer, size_t size, size_t nmemb, void *userp) {
     size_t size_this_time = nmemb * size;
-    apiClient_t *apiClient = (apiClient_t *)userp;
-    apiClient->dataReceived = (char *)realloc( apiClient->dataReceived, apiClient->dataReceivedLen + size_this_time + 1);
+    apiClient_t *apiClient = userp;
+    apiClient->dataReceived = realloc( apiClient->dataReceived, apiClient->dataReceivedLen + size_this_time + 1);
     memcpy((char *)apiClient->dataReceived + apiClient->dataReceivedLen, buffer, size_this_time);
     apiClient->dataReceivedLen += size_this_time;
     ((char*)apiClient->dataReceived)[apiClient->dataReceivedLen] = '\0'; // the space size of (apiClient->dataReceived) = dataReceivedLen + 1

--- a/samples/client/others/c/bearerAuth/src/list.c
+++ b/samples/client/others/c/bearerAuth/src/list.c
@@ -20,7 +20,7 @@ void listEntry_free(listEntry_t *listEntry, void *additionalData) {
 }
 
 void listEntry_printAsInt(listEntry_t *listEntry, void *additionalData) {
-    printf("%i\n", *((int *) (listEntry->data)));
+    printf("%i\n", *(int *)listEntry->data);
 }
 
 list_t *list_createList() {

--- a/samples/client/others/c/bearerAuth/src/list.c
+++ b/samples/client/others/c/bearerAuth/src/list.c
@@ -176,8 +176,8 @@ char* findStrInStrList(list_t *strList, const char *str)
 
     listEntry_t* listEntry = NULL;
     list_ForEach(listEntry, strList) {
-        if (strstr((char*)listEntry->data, str) != NULL) {
-            return (char*)listEntry->data;
+        if (strstr(listEntry->data, str) != NULL) {
+            return listEntry->data;
         }
     }
 

--- a/samples/client/petstore/c-useJsonUnformatted/api/PetAPI.c
+++ b/samples/client/petstore/c-useJsonUnformatted/api/PetAPI.c
@@ -67,9 +67,7 @@ PetAPI_addPet(apiClient_t *apiClient, pet_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet");
+    char *localVarPath = strdup("/pet");
 
 
 
@@ -139,14 +137,12 @@ PetAPI_deletePet(apiClient_t *apiClient, long petId, char *api_key)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/{petId}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/{petId}");
+    char *localVarPath = strdup("/pet/{petId}");
 
 
 
     // Path Params
-    long sizeOfPathParams_petId = sizeof(petId)+3 + strlen("{ petId }");
+    long sizeOfPathParams_petId = sizeof(petId)+3 + sizeof("{ petId }") - 1;
     if(petId == 0){
         goto end;
     }
@@ -232,9 +228,7 @@ PetAPI_findPetsByStatus(apiClient_t *apiClient, list_t *status)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/findByStatus")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/findByStatus");
+    char *localVarPath = strdup("/pet/findByStatus");
 
 
 
@@ -325,9 +319,7 @@ PetAPI_findPetsByTags(apiClient_t *apiClient, list_t *tags)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/findByTags")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/findByTags");
+    char *localVarPath = strdup("/pet/findByTags");
 
 
 
@@ -416,9 +408,7 @@ PetAPI_getDaysWithoutIncident(apiClient_t *apiClient)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/daysWithoutIncident")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/daysWithoutIncident");
+    char *localVarPath = strdup("/store/daysWithoutIncident");
 
 
 
@@ -481,14 +471,12 @@ PetAPI_getPetById(apiClient_t *apiClient, long petId)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/{petId}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/{petId}");
+    char *localVarPath = strdup("/pet/{petId}");
 
 
 
     // Path Params
-    long sizeOfPathParams_petId = sizeof(petId)+3 + strlen("{ petId }");
+    long sizeOfPathParams_petId = sizeof(petId)+3 + sizeof("{ petId }") - 1;
     if(petId == 0){
         goto end;
     }
@@ -575,9 +563,7 @@ PetAPI_getPicture(apiClient_t *apiClient)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/picture")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/picture");
+    char *localVarPath = strdup("/pet/picture");
 
 
 
@@ -638,14 +624,12 @@ PetAPI_isPetAvailable(apiClient_t *apiClient, long petId)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/{petId}/isAvailable")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/{petId}/isAvailable");
+    char *localVarPath = strdup("/pet/{petId}/isAvailable");
 
 
 
     // Path Params
-    long sizeOfPathParams_petId = sizeof(petId)+3 + strlen("{ petId }");
+    long sizeOfPathParams_petId = sizeof(petId)+3 + sizeof("{ petId }") - 1;
     if(petId == 0){
         goto end;
     }
@@ -723,9 +707,7 @@ PetAPI_sharePicture(apiClient_t *apiClient, binary_t* picture)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/picture")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/picture");
+    char *localVarPath = strdup("/pet/picture");
 
 
 
@@ -794,9 +776,7 @@ PetAPI_specialtyPet(apiClient_t *apiClient)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/specialty")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/specialty");
+    char *localVarPath = strdup("/pet/specialty");
 
 
 
@@ -865,9 +845,7 @@ PetAPI_updatePet(apiClient_t *apiClient, pet_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet");
+    char *localVarPath = strdup("/pet");
 
 
 
@@ -945,14 +923,12 @@ PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char *name, char *s
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/{petId}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/{petId}");
+    char *localVarPath = strdup("/pet/{petId}");
 
 
 
     // Path Params
-    long sizeOfPathParams_petId = sizeof(petId)+3 + strlen("{ petId }");
+    long sizeOfPathParams_petId = sizeof(petId)+3 + sizeof("{ petId }") - 1;
     if(petId == 0){
         goto end;
     }
@@ -1058,14 +1034,12 @@ PetAPI_uploadFile(apiClient_t *apiClient, long petId, char *additionalMetadata, 
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/{petId}/uploadImage")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/{petId}/uploadImage");
+    char *localVarPath = strdup("/pet/{petId}/uploadImage");
 
 
 
     // Path Params
-    long sizeOfPathParams_petId = sizeof(petId)+3 + strlen("{ petId }");
+    long sizeOfPathParams_petId = sizeof(petId)+3 + sizeof("{ petId }") - 1;
     if(petId == 0){
         goto end;
     }

--- a/samples/client/petstore/c-useJsonUnformatted/api/StoreAPI.c
+++ b/samples/client/petstore/c-useJsonUnformatted/api/StoreAPI.c
@@ -78,16 +78,14 @@ StoreAPI_deleteOrder(apiClient_t *apiClient, char *orderId)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/order/{orderId}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/order/{orderId}");
+    char *localVarPath = strdup("/store/order/{orderId}");
 
     if(!orderId)
         goto end;
 
 
     // Path Params
-    long sizeOfPathParams_orderId = strlen(orderId)+3 + strlen("{ orderId }");
+    long sizeOfPathParams_orderId = strlen(orderId)+3 + sizeof("{ orderId }") - 1;
     if(orderId == NULL) {
         goto end;
     }
@@ -152,9 +150,7 @@ StoreAPI_getInventory(apiClient_t *apiClient)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/inventory")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/inventory");
+    char *localVarPath = strdup("/store/inventory");
 
 
 
@@ -225,14 +221,12 @@ StoreAPI_getOrderById(apiClient_t *apiClient, long orderId)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/order/{orderId}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/order/{orderId}");
+    char *localVarPath = strdup("/store/order/{orderId}");
 
 
 
     // Path Params
-    long sizeOfPathParams_orderId = sizeof(orderId)+3 + strlen("{ orderId }");
+    long sizeOfPathParams_orderId = sizeof(orderId)+3 + sizeof("{ orderId }") - 1;
     if(orderId == 0){
         goto end;
     }
@@ -319,9 +313,7 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/order")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/order");
+    char *localVarPath = strdup("/store/order");
 
 
 
@@ -409,9 +401,7 @@ StoreAPI_sendFeedback(apiClient_t *apiClient, char *feedback)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/feedback")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/feedback");
+    char *localVarPath = strdup("/store/feedback");
 
 
 
@@ -477,16 +467,14 @@ StoreAPI_sendRating(apiClient_t *apiClient, openapi_petstore_sendRating_rating_e
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/rating/{rating}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/rating/{rating}");
+    char *localVarPath = strdup("/store/rating/{rating}");
 
     if(!rating)
         goto end;
 
 
     // Path Params
-    long sizeOfPathParams_rating = strlen(sendRating_RATING_ToString(rating))+3 + strlen("{ rating }");
+    long sizeOfPathParams_rating = strlen(sendRating_RATING_ToString(rating))+3 + sizeof("{ rating }") - 1;
     if(rating == 0) {
         goto end;
     }
@@ -553,9 +541,7 @@ StoreAPI_sendRecommend(apiClient_t *apiClient, int *recommend)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/recommend")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/recommend");
+    char *localVarPath = strdup("/store/recommend");
 
 
 

--- a/samples/client/petstore/c-useJsonUnformatted/api/UserAPI.c
+++ b/samples/client/petstore/c-useJsonUnformatted/api/UserAPI.c
@@ -26,9 +26,7 @@ UserAPI_createUser(apiClient_t *apiClient, user_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user");
+    char *localVarPath = strdup("/user");
 
 
 
@@ -96,9 +94,7 @@ UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/createWithArray")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/createWithArray");
+    char *localVarPath = strdup("/user/createWithArray");
 
 
 
@@ -194,9 +190,7 @@ UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/createWithList")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/createWithList");
+    char *localVarPath = strdup("/user/createWithList");
 
 
 
@@ -294,16 +288,14 @@ UserAPI_deleteUser(apiClient_t *apiClient, char *username)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/{username}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/{username}");
+    char *localVarPath = strdup("/user/{username}");
 
     if(!username)
         goto end;
 
 
     // Path Params
-    long sizeOfPathParams_username = strlen(username)+3 + strlen("{ username }");
+    long sizeOfPathParams_username = strlen(username)+3 + sizeof("{ username }") - 1;
     if(username == NULL) {
         goto end;
     }
@@ -366,16 +358,14 @@ UserAPI_getUserByName(apiClient_t *apiClient, char *username)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/{username}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/{username}");
+    char *localVarPath = strdup("/user/{username}");
 
     if(!username)
         goto end;
 
 
     // Path Params
-    long sizeOfPathParams_username = strlen(username)+3 + strlen("{ username }");
+    long sizeOfPathParams_username = strlen(username)+3 + sizeof("{ username }") - 1;
     if(username == NULL) {
         goto end;
     }
@@ -458,9 +448,7 @@ UserAPI_loginUser(apiClient_t *apiClient, char *username, char *password)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/login")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/login");
+    char *localVarPath = strdup("/user/login");
 
 
 
@@ -574,9 +562,7 @@ UserAPI_logoutUser(apiClient_t *apiClient)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/logout")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/logout");
+    char *localVarPath = strdup("/user/logout");
 
 
 
@@ -631,9 +617,7 @@ UserAPI_testIntAndBool(apiClient_t *apiClient, int *keep, int *keepDay)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/testIntAndBool")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/testIntAndBool");
+    char *localVarPath = strdup("/user/testIntAndBool");
 
 
 
@@ -714,16 +698,14 @@ UserAPI_updateUser(apiClient_t *apiClient, char *username, user_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/{username}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/{username}");
+    char *localVarPath = strdup("/user/{username}");
 
     if(!username)
         goto end;
 
 
     // Path Params
-    long sizeOfPathParams_username = strlen(username)+3 + strlen("{ username }");
+    long sizeOfPathParams_username = strlen(username)+3 + sizeof("{ username }") - 1;
     if(username == NULL) {
         goto end;
     }

--- a/samples/client/petstore/c-useJsonUnformatted/model/model_with_set_propertes.c
+++ b/samples/client/petstore/c-useJsonUnformatted/model/model_with_set_propertes.c
@@ -88,7 +88,7 @@ cJSON *model_with_set_propertes_convertToJSON(model_with_set_propertes_t *model_
 
     listEntry_t *string_setListEntry;
     list_ForEach(string_setListEntry, model_with_set_propertes->string_set) {
-    if(cJSON_AddStringToObject(string_set, "", (char*)string_setListEntry->data) == NULL)
+    if(cJSON_AddStringToObject(string_set, "", string_setListEntry->data) == NULL)
     {
         goto fail;
     }

--- a/samples/client/petstore/c-useJsonUnformatted/model/pet.c
+++ b/samples/client/petstore/c-useJsonUnformatted/model/pet.c
@@ -141,7 +141,7 @@ cJSON *pet_convertToJSON(pet_t *pet) {
 
     listEntry_t *photo_urlsListEntry;
     list_ForEach(photo_urlsListEntry, pet->photo_urls) {
-    if(cJSON_AddStringToObject(photo_urls, "", (char*)photo_urlsListEntry->data) == NULL)
+    if(cJSON_AddStringToObject(photo_urls, "", photo_urlsListEntry->data) == NULL)
     {
         goto fail;
     }

--- a/samples/client/petstore/c-useJsonUnformatted/model/user.c
+++ b/samples/client/petstore/c-useJsonUnformatted/model/user.c
@@ -97,7 +97,7 @@ void user_free(user_t *user) {
     }
     if (user->extra) {
         list_ForEach(listEntry, user->extra) {
-            keyValuePair_t *localKeyValue = (keyValuePair_t*) listEntry->data;
+            keyValuePair_t *localKeyValue = listEntry->data;
             free (localKeyValue->key);
             free (localKeyValue->value);
             keyValuePair_free(localKeyValue);
@@ -185,7 +185,7 @@ cJSON *user_convertToJSON(user_t *user) {
     listEntry_t *extraListEntry;
     if (user->extra) {
     list_ForEach(extraListEntry, user->extra) {
-        keyValuePair_t *localKeyValue = (keyValuePair_t*)extraListEntry->data;
+        keyValuePair_t *localKeyValue = extraListEntry->data;
     }
     }
     }
@@ -368,7 +368,7 @@ end:
     if (extraList) {
         listEntry_t *listEntry = NULL;
         list_ForEach(listEntry, extraList) {
-            keyValuePair_t *localKeyValue = (keyValuePair_t*) listEntry->data;
+            keyValuePair_t *localKeyValue = listEntry->data;
             free(localKeyValue->key);
             localKeyValue->key = NULL;
             keyValuePair_free(localKeyValue);

--- a/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
+++ b/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
@@ -229,13 +229,12 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
         if(headerType != NULL) {
             list_ForEach(listEntry, headerType) {
-                if(strstr((char *) listEntry->data,
+                if(strstr(listEntry->data,
                           "xml") == NULL)
                 {
                     buffHeader = malloc(strlen(
                                     "Accept: ") +
-                                        strlen((char *)
-                                               listEntry->
+                                        strlen(listEntry->
                                                data) + 1);
                     sprintf(buffHeader, "%s%s", "Accept: ",
                             (char *) listEntry->data);
@@ -247,13 +246,12 @@ void apiClient_invoke(apiClient_t    *apiClient,
         }
         if(contentType != NULL) {
             list_ForEach(listEntry, contentType) {
-                if(strstr((char *) listEntry->data,
+                if(strstr(listEntry->data,
                           "xml") == NULL)
                 {
                     buffContent =
                         malloc(strlen(
                                    "Content-Type: ") + strlen(
-                                   (char *)
                                    listEntry->data) +
                                1);
                     sprintf(buffContent, "%s%s",
@@ -475,8 +473,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
 size_t writeDataCallback(void *buffer, size_t size, size_t nmemb, void *userp) {
     size_t size_this_time = nmemb * size;
-    apiClient_t *apiClient = (apiClient_t *)userp;
-    apiClient->dataReceived = (char *)realloc( apiClient->dataReceived, apiClient->dataReceivedLen + size_this_time + 1);
+    apiClient_t *apiClient = userp;
+    apiClient->dataReceived = realloc( apiClient->dataReceived, apiClient->dataReceivedLen + size_this_time + 1);
     memcpy((char *)apiClient->dataReceived + apiClient->dataReceivedLen, buffer, size_this_time);
     apiClient->dataReceivedLen += size_this_time;
     ((char*)apiClient->dataReceived)[apiClient->dataReceivedLen] = '\0'; // the space size of (apiClient->dataReceived) = dataReceivedLen + 1

--- a/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
+++ b/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
@@ -229,36 +229,26 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
         if(headerType != NULL) {
             list_ForEach(listEntry, headerType) {
-                if(strstr(listEntry->data,
-                          "xml") == NULL)
+                if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffHeader = malloc(strlen(
-                                    "Accept: ") +
-                                        strlen(listEntry->
-                                               data) + 1);
+                    buffHeader = malloc(strlen("Accept: ") +
+                                        strlen(listEntry->data) + 1);
                     sprintf(buffHeader, "%s%s", "Accept: ",
                             (char *) listEntry->data);
-                    headers = curl_slist_append(headers,
-                                                buffHeader);
+                    headers = curl_slist_append(headers, buffHeader);
                     free(buffHeader);
                 }
             }
         }
         if(contentType != NULL) {
             list_ForEach(listEntry, contentType) {
-                if(strstr(listEntry->data,
-                          "xml") == NULL)
+                if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffContent =
-                        malloc(strlen(
-                                   "Content-Type: ") + strlen(
-                                   listEntry->data) +
-                               1);
-                    sprintf(buffContent, "%s%s",
-                            "Content-Type: ",
+                    buffContent = malloc(strlen("Content-Type: ") +
+                                         strlen(listEntry->data) + 1);
+                    sprintf(buffContent, "%s%s", "Content-Type: ",
                             (char *) listEntry->data);
-                    headers = curl_slist_append(headers,
-                                                buffContent);
+                    headers = curl_slist_append(headers, buffContent);
                     free(buffContent);
                     buffContent = NULL;
                 }

--- a/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
+++ b/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
@@ -116,10 +116,11 @@ void sslConfig_free(sslConfig_t *sslConfig) {
     free(sslConfig);
 }
 
-static void replaceSpaceWithPlus(char *stringToProcess) {
-    for(int i = 0; i < strlen(stringToProcess); i++) {
-        if(stringToProcess[i] == ' ') {
-            stringToProcess[i] = '+';
+static void replaceSpaceWithPlus(char *str) {
+    if (str) {
+        for (; *str; str++) {
+            if (*str == ' ')
+                *str = '+';
         }
     }
 }
@@ -231,9 +232,9 @@ void apiClient_invoke(apiClient_t    *apiClient,
             list_ForEach(listEntry, headerType) {
                 if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffHeader = malloc(strlen("Accept: ") +
-                                        strlen(listEntry->data) + 1);
-                    sprintf(buffHeader, "%s%s", "Accept: ",
+                    buffHeader = malloc(sizeof("Accept: ") +
+                                        strlen(listEntry->data));
+                    sprintf(buffHeader, "Accept: %s",
                             (char *) listEntry->data);
                     headers = curl_slist_append(headers, buffHeader);
                     free(buffHeader);
@@ -244,9 +245,9 @@ void apiClient_invoke(apiClient_t    *apiClient,
             list_ForEach(listEntry, contentType) {
                 if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffContent = malloc(strlen("Content-Type: ") +
-                                         strlen(listEntry->data) + 1);
-                    sprintf(buffContent, "%s%s", "Content-Type: ",
+                    buffContent = malloc(sizeof("Content-Type: ") +
+                                         strlen(listEntry->data));
+                    sprintf(buffContent, "Content-Type: %s",
                             (char *) listEntry->data);
                     headers = curl_slist_append(headers, buffContent);
                     free(buffContent);

--- a/samples/client/petstore/c-useJsonUnformatted/src/list.c
+++ b/samples/client/petstore/c-useJsonUnformatted/src/list.c
@@ -20,7 +20,7 @@ void listEntry_free(listEntry_t *listEntry, void *additionalData) {
 }
 
 void listEntry_printAsInt(listEntry_t *listEntry, void *additionalData) {
-    printf("%i\n", *((int *) (listEntry->data)));
+    printf("%i\n", *(int *)listEntry->data);
 }
 
 list_t *list_createList() {

--- a/samples/client/petstore/c-useJsonUnformatted/src/list.c
+++ b/samples/client/petstore/c-useJsonUnformatted/src/list.c
@@ -176,8 +176,8 @@ char* findStrInStrList(list_t *strList, const char *str)
 
     listEntry_t* listEntry = NULL;
     list_ForEach(listEntry, strList) {
-        if (strstr((char*)listEntry->data, str) != NULL) {
-            return (char*)listEntry->data;
+        if (strstr(listEntry->data, str) != NULL) {
+            return listEntry->data;
         }
     }
 

--- a/samples/client/petstore/c/api/PetAPI.c
+++ b/samples/client/petstore/c/api/PetAPI.c
@@ -67,9 +67,7 @@ PetAPI_addPet(apiClient_t *apiClient, pet_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet");
+    char *localVarPath = strdup("/pet");
 
 
 
@@ -139,14 +137,12 @@ PetAPI_deletePet(apiClient_t *apiClient, long petId, char *api_key)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/{petId}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/{petId}");
+    char *localVarPath = strdup("/pet/{petId}");
 
 
 
     // Path Params
-    long sizeOfPathParams_petId = sizeof(petId)+3 + strlen("{ petId }");
+    long sizeOfPathParams_petId = sizeof(petId)+3 + sizeof("{ petId }") - 1;
     if(petId == 0){
         goto end;
     }
@@ -232,9 +228,7 @@ PetAPI_findPetsByStatus(apiClient_t *apiClient, list_t *status)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/findByStatus")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/findByStatus");
+    char *localVarPath = strdup("/pet/findByStatus");
 
 
 
@@ -325,9 +319,7 @@ PetAPI_findPetsByTags(apiClient_t *apiClient, list_t *tags)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/findByTags")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/findByTags");
+    char *localVarPath = strdup("/pet/findByTags");
 
 
 
@@ -416,9 +408,7 @@ PetAPI_getDaysWithoutIncident(apiClient_t *apiClient)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/daysWithoutIncident")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/daysWithoutIncident");
+    char *localVarPath = strdup("/store/daysWithoutIncident");
 
 
 
@@ -481,14 +471,12 @@ PetAPI_getPetById(apiClient_t *apiClient, long petId)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/{petId}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/{petId}");
+    char *localVarPath = strdup("/pet/{petId}");
 
 
 
     // Path Params
-    long sizeOfPathParams_petId = sizeof(petId)+3 + strlen("{ petId }");
+    long sizeOfPathParams_petId = sizeof(petId)+3 + sizeof("{ petId }") - 1;
     if(petId == 0){
         goto end;
     }
@@ -575,9 +563,7 @@ PetAPI_getPicture(apiClient_t *apiClient)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/picture")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/picture");
+    char *localVarPath = strdup("/pet/picture");
 
 
 
@@ -638,14 +624,12 @@ PetAPI_isPetAvailable(apiClient_t *apiClient, long petId)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/{petId}/isAvailable")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/{petId}/isAvailable");
+    char *localVarPath = strdup("/pet/{petId}/isAvailable");
 
 
 
     // Path Params
-    long sizeOfPathParams_petId = sizeof(petId)+3 + strlen("{ petId }");
+    long sizeOfPathParams_petId = sizeof(petId)+3 + sizeof("{ petId }") - 1;
     if(petId == 0){
         goto end;
     }
@@ -723,9 +707,7 @@ PetAPI_sharePicture(apiClient_t *apiClient, binary_t* picture)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/picture")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/picture");
+    char *localVarPath = strdup("/pet/picture");
 
 
 
@@ -794,9 +776,7 @@ PetAPI_specialtyPet(apiClient_t *apiClient)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/specialty")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/specialty");
+    char *localVarPath = strdup("/pet/specialty");
 
 
 
@@ -865,9 +845,7 @@ PetAPI_updatePet(apiClient_t *apiClient, pet_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet");
+    char *localVarPath = strdup("/pet");
 
 
 
@@ -945,14 +923,12 @@ PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char *name, char *s
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/{petId}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/{petId}");
+    char *localVarPath = strdup("/pet/{petId}");
 
 
 
     // Path Params
-    long sizeOfPathParams_petId = sizeof(petId)+3 + strlen("{ petId }");
+    long sizeOfPathParams_petId = sizeof(petId)+3 + sizeof("{ petId }") - 1;
     if(petId == 0){
         goto end;
     }
@@ -1058,14 +1034,12 @@ PetAPI_uploadFile(apiClient_t *apiClient, long petId, char *additionalMetadata, 
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/pet/{petId}/uploadImage")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/pet/{petId}/uploadImage");
+    char *localVarPath = strdup("/pet/{petId}/uploadImage");
 
 
 
     // Path Params
-    long sizeOfPathParams_petId = sizeof(petId)+3 + strlen("{ petId }");
+    long sizeOfPathParams_petId = sizeof(petId)+3 + sizeof("{ petId }") - 1;
     if(petId == 0){
         goto end;
     }

--- a/samples/client/petstore/c/api/StoreAPI.c
+++ b/samples/client/petstore/c/api/StoreAPI.c
@@ -78,16 +78,14 @@ StoreAPI_deleteOrder(apiClient_t *apiClient, char *orderId)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/order/{orderId}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/order/{orderId}");
+    char *localVarPath = strdup("/store/order/{orderId}");
 
     if(!orderId)
         goto end;
 
 
     // Path Params
-    long sizeOfPathParams_orderId = strlen(orderId)+3 + strlen("{ orderId }");
+    long sizeOfPathParams_orderId = strlen(orderId)+3 + sizeof("{ orderId }") - 1;
     if(orderId == NULL) {
         goto end;
     }
@@ -152,9 +150,7 @@ StoreAPI_getInventory(apiClient_t *apiClient)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/inventory")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/inventory");
+    char *localVarPath = strdup("/store/inventory");
 
 
 
@@ -225,14 +221,12 @@ StoreAPI_getOrderById(apiClient_t *apiClient, long orderId)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/order/{orderId}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/order/{orderId}");
+    char *localVarPath = strdup("/store/order/{orderId}");
 
 
 
     // Path Params
-    long sizeOfPathParams_orderId = sizeof(orderId)+3 + strlen("{ orderId }");
+    long sizeOfPathParams_orderId = sizeof(orderId)+3 + sizeof("{ orderId }") - 1;
     if(orderId == 0){
         goto end;
     }
@@ -319,9 +313,7 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/order")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/order");
+    char *localVarPath = strdup("/store/order");
 
 
 
@@ -409,9 +401,7 @@ StoreAPI_sendFeedback(apiClient_t *apiClient, char *feedback)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/feedback")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/feedback");
+    char *localVarPath = strdup("/store/feedback");
 
 
 
@@ -477,16 +467,14 @@ StoreAPI_sendRating(apiClient_t *apiClient, openapi_petstore_sendRating_rating_e
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/rating/{rating}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/rating/{rating}");
+    char *localVarPath = strdup("/store/rating/{rating}");
 
     if(!rating)
         goto end;
 
 
     // Path Params
-    long sizeOfPathParams_rating = strlen(sendRating_RATING_ToString(rating))+3 + strlen("{ rating }");
+    long sizeOfPathParams_rating = strlen(sendRating_RATING_ToString(rating))+3 + sizeof("{ rating }") - 1;
     if(rating == 0) {
         goto end;
     }
@@ -553,9 +541,7 @@ StoreAPI_sendRecommend(apiClient_t *apiClient, int *recommend)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/store/recommend")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/store/recommend");
+    char *localVarPath = strdup("/store/recommend");
 
 
 

--- a/samples/client/petstore/c/api/UserAPI.c
+++ b/samples/client/petstore/c/api/UserAPI.c
@@ -26,9 +26,7 @@ UserAPI_createUser(apiClient_t *apiClient, user_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user");
+    char *localVarPath = strdup("/user");
 
 
 
@@ -96,9 +94,7 @@ UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/createWithArray")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/createWithArray");
+    char *localVarPath = strdup("/user/createWithArray");
 
 
 
@@ -194,9 +190,7 @@ UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/createWithList")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/createWithList");
+    char *localVarPath = strdup("/user/createWithList");
 
 
 
@@ -294,16 +288,14 @@ UserAPI_deleteUser(apiClient_t *apiClient, char *username)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/{username}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/{username}");
+    char *localVarPath = strdup("/user/{username}");
 
     if(!username)
         goto end;
 
 
     // Path Params
-    long sizeOfPathParams_username = strlen(username)+3 + strlen("{ username }");
+    long sizeOfPathParams_username = strlen(username)+3 + sizeof("{ username }") - 1;
     if(username == NULL) {
         goto end;
     }
@@ -366,16 +358,14 @@ UserAPI_getUserByName(apiClient_t *apiClient, char *username)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/{username}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/{username}");
+    char *localVarPath = strdup("/user/{username}");
 
     if(!username)
         goto end;
 
 
     // Path Params
-    long sizeOfPathParams_username = strlen(username)+3 + strlen("{ username }");
+    long sizeOfPathParams_username = strlen(username)+3 + sizeof("{ username }") - 1;
     if(username == NULL) {
         goto end;
     }
@@ -458,9 +448,7 @@ UserAPI_loginUser(apiClient_t *apiClient, char *username, char *password)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/login")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/login");
+    char *localVarPath = strdup("/user/login");
 
 
 
@@ -574,9 +562,7 @@ UserAPI_logoutUser(apiClient_t *apiClient)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/logout")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/logout");
+    char *localVarPath = strdup("/user/logout");
 
 
 
@@ -631,9 +617,7 @@ UserAPI_testIntAndBool(apiClient_t *apiClient, int *keep, int *keepDay)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/testIntAndBool")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/testIntAndBool");
+    char *localVarPath = strdup("/user/testIntAndBool");
 
 
 
@@ -714,16 +698,14 @@ UserAPI_updateUser(apiClient_t *apiClient, char *username, user_t *body)
     apiClient->response_code = 0;
 
     // create the path
-    long sizeOfPath = strlen("/user/{username}")+1;
-    char *localVarPath = malloc(sizeOfPath);
-    snprintf(localVarPath, sizeOfPath, "/user/{username}");
+    char *localVarPath = strdup("/user/{username}");
 
     if(!username)
         goto end;
 
 
     // Path Params
-    long sizeOfPathParams_username = strlen(username)+3 + strlen("{ username }");
+    long sizeOfPathParams_username = strlen(username)+3 + sizeof("{ username }") - 1;
     if(username == NULL) {
         goto end;
     }

--- a/samples/client/petstore/c/model/model_with_set_propertes.c
+++ b/samples/client/petstore/c/model/model_with_set_propertes.c
@@ -88,7 +88,7 @@ cJSON *model_with_set_propertes_convertToJSON(model_with_set_propertes_t *model_
 
     listEntry_t *string_setListEntry;
     list_ForEach(string_setListEntry, model_with_set_propertes->string_set) {
-    if(cJSON_AddStringToObject(string_set, "", (char*)string_setListEntry->data) == NULL)
+    if(cJSON_AddStringToObject(string_set, "", string_setListEntry->data) == NULL)
     {
         goto fail;
     }

--- a/samples/client/petstore/c/model/pet.c
+++ b/samples/client/petstore/c/model/pet.c
@@ -141,7 +141,7 @@ cJSON *pet_convertToJSON(pet_t *pet) {
 
     listEntry_t *photo_urlsListEntry;
     list_ForEach(photo_urlsListEntry, pet->photo_urls) {
-    if(cJSON_AddStringToObject(photo_urls, "", (char*)photo_urlsListEntry->data) == NULL)
+    if(cJSON_AddStringToObject(photo_urls, "", photo_urlsListEntry->data) == NULL)
     {
         goto fail;
     }

--- a/samples/client/petstore/c/model/user.c
+++ b/samples/client/petstore/c/model/user.c
@@ -97,7 +97,7 @@ void user_free(user_t *user) {
     }
     if (user->extra) {
         list_ForEach(listEntry, user->extra) {
-            keyValuePair_t *localKeyValue = (keyValuePair_t*) listEntry->data;
+            keyValuePair_t *localKeyValue = listEntry->data;
             free (localKeyValue->key);
             free (localKeyValue->value);
             keyValuePair_free(localKeyValue);
@@ -185,7 +185,7 @@ cJSON *user_convertToJSON(user_t *user) {
     listEntry_t *extraListEntry;
     if (user->extra) {
     list_ForEach(extraListEntry, user->extra) {
-        keyValuePair_t *localKeyValue = (keyValuePair_t*)extraListEntry->data;
+        keyValuePair_t *localKeyValue = extraListEntry->data;
     }
     }
     }
@@ -368,7 +368,7 @@ end:
     if (extraList) {
         listEntry_t *listEntry = NULL;
         list_ForEach(listEntry, extraList) {
-            keyValuePair_t *localKeyValue = (keyValuePair_t*) listEntry->data;
+            keyValuePair_t *localKeyValue = listEntry->data;
             free(localKeyValue->key);
             localKeyValue->key = NULL;
             keyValuePair_free(localKeyValue);

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -229,13 +229,12 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
         if(headerType != NULL) {
             list_ForEach(listEntry, headerType) {
-                if(strstr((char *) listEntry->data,
+                if(strstr(listEntry->data,
                           "xml") == NULL)
                 {
                     buffHeader = malloc(strlen(
                                     "Accept: ") +
-                                        strlen((char *)
-                                               listEntry->
+                                        strlen(listEntry->
                                                data) + 1);
                     sprintf(buffHeader, "%s%s", "Accept: ",
                             (char *) listEntry->data);
@@ -247,13 +246,12 @@ void apiClient_invoke(apiClient_t    *apiClient,
         }
         if(contentType != NULL) {
             list_ForEach(listEntry, contentType) {
-                if(strstr((char *) listEntry->data,
+                if(strstr(listEntry->data,
                           "xml") == NULL)
                 {
                     buffContent =
                         malloc(strlen(
                                    "Content-Type: ") + strlen(
-                                   (char *)
                                    listEntry->data) +
                                1);
                     sprintf(buffContent, "%s%s",
@@ -475,8 +473,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
 size_t writeDataCallback(void *buffer, size_t size, size_t nmemb, void *userp) {
     size_t size_this_time = nmemb * size;
-    apiClient_t *apiClient = (apiClient_t *)userp;
-    apiClient->dataReceived = (char *)realloc( apiClient->dataReceived, apiClient->dataReceivedLen + size_this_time + 1);
+    apiClient_t *apiClient = userp;
+    apiClient->dataReceived = realloc( apiClient->dataReceived, apiClient->dataReceivedLen + size_this_time + 1);
     memcpy((char *)apiClient->dataReceived + apiClient->dataReceivedLen, buffer, size_this_time);
     apiClient->dataReceivedLen += size_this_time;
     ((char*)apiClient->dataReceived)[apiClient->dataReceivedLen] = '\0'; // the space size of (apiClient->dataReceived) = dataReceivedLen + 1

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -229,36 +229,26 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
         if(headerType != NULL) {
             list_ForEach(listEntry, headerType) {
-                if(strstr(listEntry->data,
-                          "xml") == NULL)
+                if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffHeader = malloc(strlen(
-                                    "Accept: ") +
-                                        strlen(listEntry->
-                                               data) + 1);
+                    buffHeader = malloc(strlen("Accept: ") +
+                                        strlen(listEntry->data) + 1);
                     sprintf(buffHeader, "%s%s", "Accept: ",
                             (char *) listEntry->data);
-                    headers = curl_slist_append(headers,
-                                                buffHeader);
+                    headers = curl_slist_append(headers, buffHeader);
                     free(buffHeader);
                 }
             }
         }
         if(contentType != NULL) {
             list_ForEach(listEntry, contentType) {
-                if(strstr(listEntry->data,
-                          "xml") == NULL)
+                if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffContent =
-                        malloc(strlen(
-                                   "Content-Type: ") + strlen(
-                                   listEntry->data) +
-                               1);
-                    sprintf(buffContent, "%s%s",
-                            "Content-Type: ",
+                    buffContent = malloc(strlen("Content-Type: ") +
+                                         strlen(listEntry->data) + 1);
+                    sprintf(buffContent, "%s%s", "Content-Type: ",
                             (char *) listEntry->data);
-                    headers = curl_slist_append(headers,
-                                                buffContent);
+                    headers = curl_slist_append(headers, buffContent);
                     free(buffContent);
                     buffContent = NULL;
                 }

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -116,10 +116,11 @@ void sslConfig_free(sslConfig_t *sslConfig) {
     free(sslConfig);
 }
 
-static void replaceSpaceWithPlus(char *stringToProcess) {
-    for(int i = 0; i < strlen(stringToProcess); i++) {
-        if(stringToProcess[i] == ' ') {
-            stringToProcess[i] = '+';
+static void replaceSpaceWithPlus(char *str) {
+    if (str) {
+        for (; *str; str++) {
+            if (*str == ' ')
+                *str = '+';
         }
     }
 }
@@ -231,9 +232,9 @@ void apiClient_invoke(apiClient_t    *apiClient,
             list_ForEach(listEntry, headerType) {
                 if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffHeader = malloc(strlen("Accept: ") +
-                                        strlen(listEntry->data) + 1);
-                    sprintf(buffHeader, "%s%s", "Accept: ",
+                    buffHeader = malloc(sizeof("Accept: ") +
+                                        strlen(listEntry->data));
+                    sprintf(buffHeader, "Accept: %s",
                             (char *) listEntry->data);
                     headers = curl_slist_append(headers, buffHeader);
                     free(buffHeader);
@@ -244,9 +245,9 @@ void apiClient_invoke(apiClient_t    *apiClient,
             list_ForEach(listEntry, contentType) {
                 if(strstr(listEntry->data, "xml") == NULL)
                 {
-                    buffContent = malloc(strlen("Content-Type: ") +
-                                         strlen(listEntry->data) + 1);
-                    sprintf(buffContent, "%s%s", "Content-Type: ",
+                    buffContent = malloc(sizeof("Content-Type: ") +
+                                         strlen(listEntry->data));
+                    sprintf(buffContent, "Content-Type: %s",
                             (char *) listEntry->data);
                     headers = curl_slist_append(headers, buffContent);
                     free(buffContent);

--- a/samples/client/petstore/c/src/list.c
+++ b/samples/client/petstore/c/src/list.c
@@ -20,7 +20,7 @@ void listEntry_free(listEntry_t *listEntry, void *additionalData) {
 }
 
 void listEntry_printAsInt(listEntry_t *listEntry, void *additionalData) {
-    printf("%i\n", *((int *) (listEntry->data)));
+    printf("%i\n", *(int *)listEntry->data);
 }
 
 list_t *list_createList() {

--- a/samples/client/petstore/c/src/list.c
+++ b/samples/client/petstore/c/src/list.c
@@ -176,8 +176,8 @@ char* findStrInStrList(list_t *strList, const char *str)
 
     listEntry_t* listEntry = NULL;
     list_ForEach(listEntry, strList) {
-        if (strstr((char*)listEntry->data, str) != NULL) {
-            return (char*)listEntry->data;
+        if (strstr(listEntry->data, str) != NULL) {
+            return listEntry->data;
         }
     }
 


### PR DESCRIPTION
Cut down on redundant `strlen()` churn and similar somewhat. Functionality does not change, just runtime cost.

Request: when merging would it be possible to _not_ squash the three commits but instead just rebase? Mashing even a moderately small changeset like this into a monolithic single diff makes reading the git log significantly more taxing cognitively. You can always do `git diff HEAD~3 HEAD` to see a combined diff, but you can't recover the lost information after squashing.