### PR TITLE
Using Optional.ofNullable() at the fluent setters to prevent NPE

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -151,7 +151,7 @@ public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}
   {{! begin feature: fluent setter methods }}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     {{#openApiNullable}}
-    this.{{name}} = {{#isNullable}}JsonNullable.of({{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}Optional.of({{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}}{{name}}{{#isNullable}}){{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}){{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}};
+    this.{{name}} = {{#isNullable}}JsonNullable.of({{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}Optional.ofNullable({{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}}{{name}}{{#isNullable}}){{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}){{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}};
     {{/openApiNullable}}
     {{^openApiNullable}}
     this.{{name}} = {{name}};

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -228,7 +228,7 @@ public class SpringCodegenTest {
                 .containsWithNameAndAttributes("DateTimeFormat", ImmutableMap.of("iso", "DateTimeFormat.ISO.DATE_TIME"))
                 .toProperty().toType()
                 .assertMethod("born", "LocalDate")
-                .bodyContainsLines("this.born = Optional.of(born)")
+                .bodyContainsLines("this.born = Optional.ofNullable(born)")
                 .doesNotHaveComment();
     }
 
@@ -4397,9 +4397,10 @@ public class SpringCodegenTest {
 
     private void assertWrapperMethod(JavaFileAssert javaFileAssert, String wrapperType, String type, String expectedName, String getterReturnType){
         String methodName = StringUtils.capitalize(expectedName);
+        var of = wrapperType.equals("Optional") ? "ofNullable" : "of";
         javaFileAssert.assertMethod(expectedName)
                 .hasReturnType("Animal")
-                .bodyContainsLines("this."+expectedName+" = "+wrapperType+".of("+expectedName+");", "return this;")
+                .bodyContainsLines("this." + expectedName + " = "+wrapperType+ "." + of + "(" +expectedName+");", "return this;")
                 .assertParameter(expectedName)
                 .hasType(type)
                 .toMethod()

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Category.java
@@ -26,7 +26,7 @@ public class Category {
   private Optional<@Pattern(regexp = "^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$") String> name = Optional.empty();
 
   public Category id(Long id) {
-    this.id = Optional.of(id);
+    this.id = Optional.ofNullable(id);
     return this;
   }
 
@@ -45,7 +45,7 @@ public class Category {
   }
 
   public Category name(String name) {
-    this.name = Optional.of(name);
+    this.name = Optional.ofNullable(name);
     return this;
   }
 

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -30,7 +30,7 @@ public class ModelApiResponse {
   private Optional<String> message = Optional.empty();
 
   public ModelApiResponse code(Integer code) {
-    this.code = Optional.of(code);
+    this.code = Optional.ofNullable(code);
     return this;
   }
 
@@ -49,7 +49,7 @@ public class ModelApiResponse {
   }
 
   public ModelApiResponse type(String type) {
-    this.type = Optional.of(type);
+    this.type = Optional.ofNullable(type);
     return this;
   }
 
@@ -68,7 +68,7 @@ public class ModelApiResponse {
   }
 
   public ModelApiResponse message(String message) {
-    this.message = Optional.of(message);
+    this.message = Optional.ofNullable(message);
     return this;
   }
 

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Order.java
@@ -75,7 +75,7 @@ public class Order {
   private Optional<Boolean> complete = Optional.of(false);
 
   public Order id(Long id) {
-    this.id = Optional.of(id);
+    this.id = Optional.ofNullable(id);
     return this;
   }
 
@@ -94,7 +94,7 @@ public class Order {
   }
 
   public Order petId(Long petId) {
-    this.petId = Optional.of(petId);
+    this.petId = Optional.ofNullable(petId);
     return this;
   }
 
@@ -113,7 +113,7 @@ public class Order {
   }
 
   public Order quantity(Integer quantity) {
-    this.quantity = Optional.of(quantity);
+    this.quantity = Optional.ofNullable(quantity);
     return this;
   }
 
@@ -132,7 +132,7 @@ public class Order {
   }
 
   public Order shipDate(OffsetDateTime shipDate) {
-    this.shipDate = Optional.of(shipDate);
+    this.shipDate = Optional.ofNullable(shipDate);
     return this;
   }
 
@@ -151,7 +151,7 @@ public class Order {
   }
 
   public Order status(StatusEnum status) {
-    this.status = Optional.of(status);
+    this.status = Optional.ofNullable(status);
     return this;
   }
 
@@ -170,7 +170,7 @@ public class Order {
   }
 
   public Order complete(Boolean complete) {
-    this.complete = Optional.of(complete);
+    this.complete = Optional.ofNullable(complete);
     return this;
   }
 

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
@@ -92,7 +92,7 @@ public class Pet {
   }
 
   public Pet id(Long id) {
-    this.id = Optional.of(id);
+    this.id = Optional.ofNullable(id);
     return this;
   }
 
@@ -111,7 +111,7 @@ public class Pet {
   }
 
   public Pet category(Category category) {
-    this.category = Optional.of(category);
+    this.category = Optional.ofNullable(category);
     return this;
   }
 
@@ -203,7 +203,7 @@ public class Pet {
   }
 
   public Pet status(StatusEnum status) {
-    this.status = Optional.of(status);
+    this.status = Optional.ofNullable(status);
     return this;
   }
 

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Tag.java
@@ -26,7 +26,7 @@ public class Tag {
   private Optional<String> name = Optional.empty();
 
   public Tag id(Long id) {
-    this.id = Optional.of(id);
+    this.id = Optional.ofNullable(id);
     return this;
   }
 
@@ -45,7 +45,7 @@ public class Tag {
   }
 
   public Tag name(String name) {
-    this.name = Optional.of(name);
+    this.name = Optional.ofNullable(name);
     return this;
   }
 

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/User.java
@@ -38,7 +38,7 @@ public class User {
   private Optional<Integer> userStatus = Optional.empty();
 
   public User id(Long id) {
-    this.id = Optional.of(id);
+    this.id = Optional.ofNullable(id);
     return this;
   }
 
@@ -57,7 +57,7 @@ public class User {
   }
 
   public User username(String username) {
-    this.username = Optional.of(username);
+    this.username = Optional.ofNullable(username);
     return this;
   }
 
@@ -76,7 +76,7 @@ public class User {
   }
 
   public User firstName(String firstName) {
-    this.firstName = Optional.of(firstName);
+    this.firstName = Optional.ofNullable(firstName);
     return this;
   }
 
@@ -95,7 +95,7 @@ public class User {
   }
 
   public User lastName(String lastName) {
-    this.lastName = Optional.of(lastName);
+    this.lastName = Optional.ofNullable(lastName);
     return this;
   }
 
@@ -114,7 +114,7 @@ public class User {
   }
 
   public User email(String email) {
-    this.email = Optional.of(email);
+    this.email = Optional.ofNullable(email);
     return this;
   }
 
@@ -133,7 +133,7 @@ public class User {
   }
 
   public User password(String password) {
-    this.password = Optional.of(password);
+    this.password = Optional.ofNullable(password);
     return this;
   }
 
@@ -152,7 +152,7 @@ public class User {
   }
 
   public User phone(String phone) {
-    this.phone = Optional.of(phone);
+    this.phone = Optional.ofNullable(phone);
     return this;
   }
 
@@ -171,7 +171,7 @@ public class User {
   }
 
   public User userStatus(Integer userStatus) {
-    this.userStatus = Optional.of(userStatus);
+    this.userStatus = Optional.ofNullable(userStatus);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -30,7 +30,7 @@ public class AdditionalPropertiesAnyType {
   private Optional<String> name = Optional.empty();
 
   public AdditionalPropertiesAnyType name(String name) {
-    this.name = Optional.of(name);
+    this.name = Optional.ofNullable(name);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -31,7 +31,7 @@ public class AdditionalPropertiesArray {
   private Optional<String> name = Optional.empty();
 
   public AdditionalPropertiesArray name(String name) {
-    this.name = Optional.of(name);
+    this.name = Optional.ofNullable(name);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -30,7 +30,7 @@ public class AdditionalPropertiesBoolean {
   private Optional<String> name = Optional.empty();
 
   public AdditionalPropertiesBoolean name(String name) {
-    this.name = Optional.of(name);
+    this.name = Optional.ofNullable(name);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -285,7 +285,7 @@ public class AdditionalPropertiesClass {
   }
 
   public AdditionalPropertiesClass anytype1(Object anytype1) {
-    this.anytype1 = Optional.of(anytype1);
+    this.anytype1 = Optional.ofNullable(anytype1);
     return this;
   }
 
@@ -325,7 +325,7 @@ public class AdditionalPropertiesClass {
   }
 
   public AdditionalPropertiesClass anytype3(Object anytype3) {
-    this.anytype3 = Optional.of(anytype3);
+    this.anytype3 = Optional.ofNullable(anytype3);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -30,7 +30,7 @@ public class AdditionalPropertiesInteger {
   private Optional<String> name = Optional.empty();
 
   public AdditionalPropertiesInteger name(String name) {
-    this.name = Optional.of(name);
+    this.name = Optional.ofNullable(name);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -31,7 +31,7 @@ public class AdditionalPropertiesNumber {
   private Optional<String> name = Optional.empty();
 
   public AdditionalPropertiesNumber name(String name) {
-    this.name = Optional.of(name);
+    this.name = Optional.ofNullable(name);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -31,7 +31,7 @@ public class AdditionalPropertiesObject {
   private Optional<String> name = Optional.empty();
 
   public AdditionalPropertiesObject name(String name) {
-    this.name = Optional.of(name);
+    this.name = Optional.ofNullable(name);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -30,7 +30,7 @@ public class AdditionalPropertiesString {
   private Optional<String> name = Optional.empty();
 
   public AdditionalPropertiesString name(String name) {
-    this.name = Optional.of(name);
+    this.name = Optional.ofNullable(name);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Animal.java
@@ -73,7 +73,7 @@ public class Animal {
   }
 
   public Animal color(String color) {
-    this.color = Optional.of(color);
+    this.color = Optional.ofNullable(color);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
@@ -82,7 +82,7 @@ public class BigCat extends Cat {
   }
 
   public BigCat kind(KindEnum kind) {
-    this.kind = Optional.of(kind);
+    this.kind = Optional.ofNullable(kind);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Capitalization.java
@@ -36,7 +36,7 @@ public class Capitalization {
   private Optional<String> ATT_NAME = Optional.empty();
 
   public Capitalization smallCamel(String smallCamel) {
-    this.smallCamel = Optional.of(smallCamel);
+    this.smallCamel = Optional.ofNullable(smallCamel);
     return this;
   }
 
@@ -56,7 +56,7 @@ public class Capitalization {
   }
 
   public Capitalization capitalCamel(String capitalCamel) {
-    this.capitalCamel = Optional.of(capitalCamel);
+    this.capitalCamel = Optional.ofNullable(capitalCamel);
     return this;
   }
 
@@ -76,7 +76,7 @@ public class Capitalization {
   }
 
   public Capitalization smallSnake(String smallSnake) {
-    this.smallSnake = Optional.of(smallSnake);
+    this.smallSnake = Optional.ofNullable(smallSnake);
     return this;
   }
 
@@ -96,7 +96,7 @@ public class Capitalization {
   }
 
   public Capitalization capitalSnake(String capitalSnake) {
-    this.capitalSnake = Optional.of(capitalSnake);
+    this.capitalSnake = Optional.ofNullable(capitalSnake);
     return this;
   }
 
@@ -116,7 +116,7 @@ public class Capitalization {
   }
 
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
-    this.scAETHFlowPoints = Optional.of(scAETHFlowPoints);
+    this.scAETHFlowPoints = Optional.ofNullable(scAETHFlowPoints);
     return this;
   }
 
@@ -136,7 +136,7 @@ public class Capitalization {
   }
 
   public Capitalization ATT_NAME(String ATT_NAME) {
-    this.ATT_NAME = Optional.of(ATT_NAME);
+    this.ATT_NAME = Optional.ofNullable(ATT_NAME);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
@@ -50,7 +50,7 @@ public class Cat extends Animal {
   }
 
   public Cat declawed(Boolean declawed) {
-    this.declawed = Optional.of(declawed);
+    this.declawed = Optional.ofNullable(declawed);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Category.java
@@ -39,7 +39,7 @@ public class Category {
   }
 
   public Category id(Long id) {
-    this.id = Optional.of(id);
+    this.id = Optional.ofNullable(id);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -34,7 +34,7 @@ public class ChildWithNullable extends ParentWithNullable {
   private Optional<String> otherProperty = Optional.empty();
 
   public ChildWithNullable otherProperty(String otherProperty) {
-    this.otherProperty = Optional.of(otherProperty);
+    this.otherProperty = Optional.ofNullable(otherProperty);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ClassModel.java
@@ -27,7 +27,7 @@ public class ClassModel {
   private Optional<String> propertyClass = Optional.empty();
 
   public ClassModel propertyClass(String propertyClass) {
-    this.propertyClass = Optional.of(propertyClass);
+    this.propertyClass = Optional.ofNullable(propertyClass);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Client.java
@@ -26,7 +26,7 @@ public class Client {
   private Optional<String> client = Optional.empty();
 
   public Client client(String client) {
-    this.client = Optional.of(client);
+    this.client = Optional.ofNullable(client);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Dog.java
@@ -42,7 +42,7 @@ public class Dog extends Animal {
   }
 
   public Dog breed(String breed) {
-    this.breed = Optional.of(breed);
+    this.breed = Optional.ofNullable(breed);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
@@ -103,7 +103,7 @@ public class EnumArrays {
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
-    this.justSymbol = Optional.of(justSymbol);
+    this.justSymbol = Optional.ofNullable(justSymbol);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
@@ -193,7 +193,7 @@ public class EnumTest {
   }
 
   public EnumTest enumString(EnumStringEnum enumString) {
-    this.enumString = Optional.of(enumString);
+    this.enumString = Optional.ofNullable(enumString);
     return this;
   }
 
@@ -233,7 +233,7 @@ public class EnumTest {
   }
 
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
-    this.enumInteger = Optional.of(enumInteger);
+    this.enumInteger = Optional.ofNullable(enumInteger);
     return this;
   }
 
@@ -253,7 +253,7 @@ public class EnumTest {
   }
 
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
-    this.enumNumber = Optional.of(enumNumber);
+    this.enumNumber = Optional.ofNullable(enumNumber);
     return this;
   }
 
@@ -273,7 +273,7 @@ public class EnumTest {
   }
 
   public EnumTest outerEnum(OuterEnum outerEnum) {
-    this.outerEnum = Optional.of(outerEnum);
+    this.outerEnum = Optional.ofNullable(outerEnum);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/File.java
@@ -27,7 +27,7 @@ public class File {
   private Optional<String> sourceURI = Optional.empty();
 
   public File sourceURI(String sourceURI) {
-    this.sourceURI = Optional.of(sourceURI);
+    this.sourceURI = Optional.ofNullable(sourceURI);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -33,7 +33,7 @@ public class FileSchemaTestClass {
   private List<@Valid File> files = new ArrayList<>();
 
   public FileSchemaTestClass file(File file) {
-    this.file = Optional.of(file);
+    this.file = Optional.ofNullable(file);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
@@ -76,7 +76,7 @@ public class FormatTest {
   }
 
   public FormatTest integer(Integer integer) {
-    this.integer = Optional.of(integer);
+    this.integer = Optional.ofNullable(integer);
     return this;
   }
 
@@ -98,7 +98,7 @@ public class FormatTest {
   }
 
   public FormatTest int32(Integer int32) {
-    this.int32 = Optional.of(int32);
+    this.int32 = Optional.ofNullable(int32);
     return this;
   }
 
@@ -120,7 +120,7 @@ public class FormatTest {
   }
 
   public FormatTest int64(Long int64) {
-    this.int64 = Optional.of(int64);
+    this.int64 = Optional.ofNullable(int64);
     return this;
   }
 
@@ -162,7 +162,7 @@ public class FormatTest {
   }
 
   public FormatTest _float(Float _float) {
-    this._float = Optional.of(_float);
+    this._float = Optional.ofNullable(_float);
     return this;
   }
 
@@ -184,7 +184,7 @@ public class FormatTest {
   }
 
   public FormatTest _double(Double _double) {
-    this._double = Optional.of(_double);
+    this._double = Optional.ofNullable(_double);
     return this;
   }
 
@@ -206,7 +206,7 @@ public class FormatTest {
   }
 
   public FormatTest string(String string) {
-    this.string = Optional.of(string);
+    this.string = Optional.ofNullable(string);
     return this;
   }
 
@@ -246,7 +246,7 @@ public class FormatTest {
   }
 
   public FormatTest binary(org.springframework.core.io.Resource binary) {
-    this.binary = Optional.of(binary);
+    this.binary = Optional.ofNullable(binary);
     return this;
   }
 
@@ -286,7 +286,7 @@ public class FormatTest {
   }
 
   public FormatTest dateTime(OffsetDateTime dateTime) {
-    this.dateTime = Optional.of(dateTime);
+    this.dateTime = Optional.ofNullable(dateTime);
     return this;
   }
 
@@ -306,7 +306,7 @@ public class FormatTest {
   }
 
   public FormatTest uuid(UUID uuid) {
-    this.uuid = Optional.of(uuid);
+    this.uuid = Optional.ofNullable(uuid);
     return this;
   }
 
@@ -346,7 +346,7 @@ public class FormatTest {
   }
 
   public FormatTest bigDecimal(BigDecimal bigDecimal) {
-    this.bigDecimal = Optional.of(bigDecimal);
+    this.bigDecimal = Optional.ofNullable(bigDecimal);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -30,7 +30,7 @@ public class HasOnlyReadOnly {
   private Optional<String> foo = Optional.empty();
 
   public HasOnlyReadOnly bar(String bar) {
-    this.bar = Optional.of(bar);
+    this.bar = Optional.ofNullable(bar);
     return this;
   }
 
@@ -50,7 +50,7 @@ public class HasOnlyReadOnly {
   }
 
   public HasOnlyReadOnly foo(String foo) {
-    this.foo = Optional.of(foo);
+    this.foo = Optional.ofNullable(foo);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -38,7 +38,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   private Map<String, Animal> map = new HashMap<>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
-    this.uuid = Optional.of(uuid);
+    this.uuid = Optional.ofNullable(uuid);
     return this;
   }
 
@@ -58,7 +58,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
-    this.dateTime = Optional.of(dateTime);
+    this.dateTime = Optional.ofNullable(dateTime);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Model200Response.java
@@ -31,7 +31,7 @@ public class Model200Response {
   private Optional<String> propertyClass = Optional.empty();
 
   public Model200Response name(Integer name) {
-    this.name = Optional.of(name);
+    this.name = Optional.ofNullable(name);
     return this;
   }
 
@@ -51,7 +51,7 @@ public class Model200Response {
   }
 
   public Model200Response propertyClass(String propertyClass) {
-    this.propertyClass = Optional.of(propertyClass);
+    this.propertyClass = Optional.ofNullable(propertyClass);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -32,7 +32,7 @@ public class ModelApiResponse {
   private Optional<String> message = Optional.empty();
 
   public ModelApiResponse code(Integer code) {
-    this.code = Optional.of(code);
+    this.code = Optional.ofNullable(code);
     return this;
   }
 
@@ -52,7 +52,7 @@ public class ModelApiResponse {
   }
 
   public ModelApiResponse type(String type) {
-    this.type = Optional.of(type);
+    this.type = Optional.ofNullable(type);
     return this;
   }
 
@@ -72,7 +72,7 @@ public class ModelApiResponse {
   }
 
   public ModelApiResponse message(String message) {
-    this.message = Optional.of(message);
+    this.message = Optional.ofNullable(message);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelList.java
@@ -28,7 +28,7 @@ public class ModelList {
   private Optional<String> _123list = Optional.empty();
 
   public ModelList _123list(String _123list) {
-    this._123list = Optional.of(_123list);
+    this._123list = Optional.ofNullable(_123list);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelReturn.java
@@ -29,7 +29,7 @@ public class ModelReturn {
   private Optional<Integer> _return = Optional.empty();
 
   public ModelReturn _return(Integer _return) {
-    this._return = Optional.of(_return);
+    this._return = Optional.ofNullable(_return);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Name.java
@@ -64,7 +64,7 @@ public class Name {
   }
 
   public Name snakeCase(Integer snakeCase) {
-    this.snakeCase = Optional.of(snakeCase);
+    this.snakeCase = Optional.ofNullable(snakeCase);
     return this;
   }
 
@@ -84,7 +84,7 @@ public class Name {
   }
 
   public Name property(String property) {
-    this.property = Optional.of(property);
+    this.property = Optional.ofNullable(property);
     return this;
   }
 
@@ -104,7 +104,7 @@ public class Name {
   }
 
   public Name _123number(Integer _123number) {
-    this._123number = Optional.of(_123number);
+    this._123number = Optional.ofNullable(_123number);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NumberOnly.java
@@ -27,7 +27,7 @@ public class NumberOnly {
   private Optional<BigDecimal> justNumber = Optional.empty();
 
   public NumberOnly justNumber(BigDecimal justNumber) {
-    this.justNumber = Optional.of(justNumber);
+    this.justNumber = Optional.ofNullable(justNumber);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
@@ -77,7 +77,7 @@ public class Order {
   private Optional<Boolean> complete = Optional.of(false);
 
   public Order id(Long id) {
-    this.id = Optional.of(id);
+    this.id = Optional.ofNullable(id);
     return this;
   }
 
@@ -97,7 +97,7 @@ public class Order {
   }
 
   public Order petId(Long petId) {
-    this.petId = Optional.of(petId);
+    this.petId = Optional.ofNullable(petId);
     return this;
   }
 
@@ -117,7 +117,7 @@ public class Order {
   }
 
   public Order quantity(Integer quantity) {
-    this.quantity = Optional.of(quantity);
+    this.quantity = Optional.ofNullable(quantity);
     return this;
   }
 
@@ -137,7 +137,7 @@ public class Order {
   }
 
   public Order shipDate(OffsetDateTime shipDate) {
-    this.shipDate = Optional.of(shipDate);
+    this.shipDate = Optional.ofNullable(shipDate);
     return this;
   }
 
@@ -157,7 +157,7 @@ public class Order {
   }
 
   public Order status(StatusEnum status) {
-    this.status = Optional.of(status);
+    this.status = Optional.ofNullable(status);
     return this;
   }
 
@@ -177,7 +177,7 @@ public class Order {
   }
 
   public Order complete(Boolean complete) {
-    this.complete = Optional.of(complete);
+    this.complete = Optional.ofNullable(complete);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterComposite.java
@@ -31,7 +31,7 @@ public class OuterComposite {
   private Optional<Boolean> myBoolean = Optional.empty();
 
   public OuterComposite myNumber(BigDecimal myNumber) {
-    this.myNumber = Optional.of(myNumber);
+    this.myNumber = Optional.ofNullable(myNumber);
     return this;
   }
 
@@ -51,7 +51,7 @@ public class OuterComposite {
   }
 
   public OuterComposite myString(String myString) {
-    this.myString = Optional.of(myString);
+    this.myString = Optional.ofNullable(myString);
     return this;
   }
 
@@ -71,7 +71,7 @@ public class OuterComposite {
   }
 
   public OuterComposite myBoolean(Boolean myBoolean) {
-    this.myBoolean = Optional.of(myBoolean);
+    this.myBoolean = Optional.ofNullable(myBoolean);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -77,7 +77,7 @@ public class ParentWithNullable {
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(TypeEnum type) {
-    this.type = Optional.of(type);
+    this.type = Optional.ofNullable(type);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
@@ -97,7 +97,7 @@ public class Pet {
   }
 
   public Pet id(Long id) {
-    this.id = Optional.of(id);
+    this.id = Optional.ofNullable(id);
     return this;
   }
 
@@ -117,7 +117,7 @@ public class Pet {
   }
 
   public Pet category(Category category) {
-    this.category = Optional.of(category);
+    this.category = Optional.ofNullable(category);
     return this;
   }
 
@@ -214,7 +214,7 @@ public class Pet {
   }
 
   public Pet status(StatusEnum status) {
-    this.status = Optional.of(status);
+    this.status = Optional.ofNullable(status);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -28,7 +28,7 @@ public class ReadOnlyFirst {
   private Optional<String> baz = Optional.empty();
 
   public ReadOnlyFirst bar(String bar) {
-    this.bar = Optional.of(bar);
+    this.bar = Optional.ofNullable(bar);
     return this;
   }
 
@@ -48,7 +48,7 @@ public class ReadOnlyFirst {
   }
 
   public ReadOnlyFirst baz(String baz) {
-    this.baz = Optional.of(baz);
+    this.baz = Optional.ofNullable(baz);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -32,7 +32,7 @@ public class ResponseObjectWithDifferentFieldNames {
   private Optional<String> propertyNameWithSpaces = Optional.empty();
 
   public ResponseObjectWithDifferentFieldNames normalPropertyName(String normalPropertyName) {
-    this.normalPropertyName = Optional.of(normalPropertyName);
+    this.normalPropertyName = Optional.ofNullable(normalPropertyName);
     return this;
   }
 
@@ -52,7 +52,7 @@ public class ResponseObjectWithDifferentFieldNames {
   }
 
   public ResponseObjectWithDifferentFieldNames UPPER_CASE_PROPERTY_SNAKE(String UPPER_CASE_PROPERTY_SNAKE) {
-    this.UPPER_CASE_PROPERTY_SNAKE = Optional.of(UPPER_CASE_PROPERTY_SNAKE);
+    this.UPPER_CASE_PROPERTY_SNAKE = Optional.ofNullable(UPPER_CASE_PROPERTY_SNAKE);
     return this;
   }
 
@@ -72,7 +72,7 @@ public class ResponseObjectWithDifferentFieldNames {
   }
 
   public ResponseObjectWithDifferentFieldNames lowerCasePropertyDashes(String lowerCasePropertyDashes) {
-    this.lowerCasePropertyDashes = Optional.of(lowerCasePropertyDashes);
+    this.lowerCasePropertyDashes = Optional.ofNullable(lowerCasePropertyDashes);
     return this;
   }
 
@@ -92,7 +92,7 @@ public class ResponseObjectWithDifferentFieldNames {
   }
 
   public ResponseObjectWithDifferentFieldNames propertyNameWithSpaces(String propertyNameWithSpaces) {
-    this.propertyNameWithSpaces = Optional.of(propertyNameWithSpaces);
+    this.propertyNameWithSpaces = Optional.ofNullable(propertyNameWithSpaces);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -28,7 +28,7 @@ public class SpecialModelName {
   private Optional<Long> $specialPropertyName = Optional.empty();
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
-    this.$specialPropertyName = Optional.of($specialPropertyName);
+    this.$specialPropertyName = Optional.ofNullable($specialPropertyName);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Tag.java
@@ -28,7 +28,7 @@ public class Tag {
   private Optional<String> name = Optional.empty();
 
   public Tag id(Long id) {
-    this.id = Optional.of(id);
+    this.id = Optional.ofNullable(id);
     return this;
   }
 
@@ -48,7 +48,7 @@ public class Tag {
   }
 
   public Tag name(String name) {
-    this.name = Optional.of(name);
+    this.name = Optional.ofNullable(name);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/User.java
@@ -40,7 +40,7 @@ public class User {
   private Optional<Integer> userStatus = Optional.empty();
 
   public User id(Long id) {
-    this.id = Optional.of(id);
+    this.id = Optional.ofNullable(id);
     return this;
   }
 
@@ -60,7 +60,7 @@ public class User {
   }
 
   public User username(String username) {
-    this.username = Optional.of(username);
+    this.username = Optional.ofNullable(username);
     return this;
   }
 
@@ -80,7 +80,7 @@ public class User {
   }
 
   public User firstName(String firstName) {
-    this.firstName = Optional.of(firstName);
+    this.firstName = Optional.ofNullable(firstName);
     return this;
   }
 
@@ -100,7 +100,7 @@ public class User {
   }
 
   public User lastName(String lastName) {
-    this.lastName = Optional.of(lastName);
+    this.lastName = Optional.ofNullable(lastName);
     return this;
   }
 
@@ -120,7 +120,7 @@ public class User {
   }
 
   public User email(String email) {
-    this.email = Optional.of(email);
+    this.email = Optional.ofNullable(email);
     return this;
   }
 
@@ -140,7 +140,7 @@ public class User {
   }
 
   public User password(String password) {
-    this.password = Optional.of(password);
+    this.password = Optional.ofNullable(password);
     return this;
   }
 
@@ -160,7 +160,7 @@ public class User {
   }
 
   public User phone(String phone) {
-    this.phone = Optional.of(phone);
+    this.phone = Optional.ofNullable(phone);
     return this;
   }
 
@@ -180,7 +180,7 @@ public class User {
   }
 
   public User userStatus(Integer userStatus) {
-    this.userStatus = Optional.of(userStatus);
+    this.userStatus = Optional.ofNullable(userStatus);
     return this;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/XmlItem.java
@@ -95,7 +95,7 @@ public class XmlItem {
   private List<Integer> prefixNsWrappedArray = new ArrayList<>();
 
   public XmlItem attributeString(String attributeString) {
-    this.attributeString = Optional.of(attributeString);
+    this.attributeString = Optional.ofNullable(attributeString);
     return this;
   }
 
@@ -115,7 +115,7 @@ public class XmlItem {
   }
 
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
-    this.attributeNumber = Optional.of(attributeNumber);
+    this.attributeNumber = Optional.ofNullable(attributeNumber);
     return this;
   }
 
@@ -135,7 +135,7 @@ public class XmlItem {
   }
 
   public XmlItem attributeInteger(Integer attributeInteger) {
-    this.attributeInteger = Optional.of(attributeInteger);
+    this.attributeInteger = Optional.ofNullable(attributeInteger);
     return this;
   }
 
@@ -155,7 +155,7 @@ public class XmlItem {
   }
 
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
-    this.attributeBoolean = Optional.of(attributeBoolean);
+    this.attributeBoolean = Optional.ofNullable(attributeBoolean);
     return this;
   }
 
@@ -203,7 +203,7 @@ public class XmlItem {
   }
 
   public XmlItem nameString(String nameString) {
-    this.nameString = Optional.of(nameString);
+    this.nameString = Optional.ofNullable(nameString);
     return this;
   }
 
@@ -223,7 +223,7 @@ public class XmlItem {
   }
 
   public XmlItem nameNumber(BigDecimal nameNumber) {
-    this.nameNumber = Optional.of(nameNumber);
+    this.nameNumber = Optional.ofNullable(nameNumber);
     return this;
   }
 
@@ -243,7 +243,7 @@ public class XmlItem {
   }
 
   public XmlItem nameInteger(Integer nameInteger) {
-    this.nameInteger = Optional.of(nameInteger);
+    this.nameInteger = Optional.ofNullable(nameInteger);
     return this;
   }
 
@@ -263,7 +263,7 @@ public class XmlItem {
   }
 
   public XmlItem nameBoolean(Boolean nameBoolean) {
-    this.nameBoolean = Optional.of(nameBoolean);
+    this.nameBoolean = Optional.ofNullable(nameBoolean);
     return this;
   }
 
@@ -339,7 +339,7 @@ public class XmlItem {
   }
 
   public XmlItem prefixString(String prefixString) {
-    this.prefixString = Optional.of(prefixString);
+    this.prefixString = Optional.ofNullable(prefixString);
     return this;
   }
 
@@ -359,7 +359,7 @@ public class XmlItem {
   }
 
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
-    this.prefixNumber = Optional.of(prefixNumber);
+    this.prefixNumber = Optional.ofNullable(prefixNumber);
     return this;
   }
 
@@ -379,7 +379,7 @@ public class XmlItem {
   }
 
   public XmlItem prefixInteger(Integer prefixInteger) {
-    this.prefixInteger = Optional.of(prefixInteger);
+    this.prefixInteger = Optional.ofNullable(prefixInteger);
     return this;
   }
 
@@ -399,7 +399,7 @@ public class XmlItem {
   }
 
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
-    this.prefixBoolean = Optional.of(prefixBoolean);
+    this.prefixBoolean = Optional.ofNullable(prefixBoolean);
     return this;
   }
 
@@ -475,7 +475,7 @@ public class XmlItem {
   }
 
   public XmlItem namespaceString(String namespaceString) {
-    this.namespaceString = Optional.of(namespaceString);
+    this.namespaceString = Optional.ofNullable(namespaceString);
     return this;
   }
 
@@ -495,7 +495,7 @@ public class XmlItem {
   }
 
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
-    this.namespaceNumber = Optional.of(namespaceNumber);
+    this.namespaceNumber = Optional.ofNullable(namespaceNumber);
     return this;
   }
 
@@ -515,7 +515,7 @@ public class XmlItem {
   }
 
   public XmlItem namespaceInteger(Integer namespaceInteger) {
-    this.namespaceInteger = Optional.of(namespaceInteger);
+    this.namespaceInteger = Optional.ofNullable(namespaceInteger);
     return this;
   }
 
@@ -535,7 +535,7 @@ public class XmlItem {
   }
 
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
-    this.namespaceBoolean = Optional.of(namespaceBoolean);
+    this.namespaceBoolean = Optional.ofNullable(namespaceBoolean);
     return this;
   }
 
@@ -611,7 +611,7 @@ public class XmlItem {
   }
 
   public XmlItem prefixNsString(String prefixNsString) {
-    this.prefixNsString = Optional.of(prefixNsString);
+    this.prefixNsString = Optional.ofNullable(prefixNsString);
     return this;
   }
 
@@ -631,7 +631,7 @@ public class XmlItem {
   }
 
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
-    this.prefixNsNumber = Optional.of(prefixNsNumber);
+    this.prefixNsNumber = Optional.ofNullable(prefixNsNumber);
     return this;
   }
 
@@ -651,7 +651,7 @@ public class XmlItem {
   }
 
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
-    this.prefixNsInteger = Optional.of(prefixNsInteger);
+    this.prefixNsInteger = Optional.ofNullable(prefixNsInteger);
     return this;
   }
 
@@ -671,7 +671,7 @@ public class XmlItem {
   }
 
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
-    this.prefixNsBoolean = Optional.of(prefixNsBoolean);
+    this.prefixNsBoolean = Optional.ofNullable(prefixNsBoolean);
     return this;
   }
 


### PR DESCRIPTION
Motivation:

When using `useOptional:true` it is worth to generate fluent setters that could accept `null` values properly.
Thus, they should be wrapped with `Optional.ofNullable()` not `Optional.of()`, i.e. having

```
public class Payload {
  private Optional<String> name = Optional.empty();
  ...
```
its fluent builder method should look like
```
  public Payload name(String name) {
    this.name = Optional.ofNullable(name); // NPE safe
    return this;
  }
```
instead of
```
  public Payload name(String name) {
    this.name = Optional.of(name); // might throw an NPE if name is null
    return this;
  }
```

Issues:
 - fixing https://github.com/OpenAPITools/openapi-generator/issues/17538

Modifications:
 - `pojo.mustache` improved
 - tests adjusted

 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cachescrubber @welshm @MelleD @atextor @manedev79 @javisst @borsch @banlevente @Zomzog @martin-mfg Please, have a look
- the 1st commit is an actual fix
- the 2nd commit is the samples update