### PR TITLE
[php-nextgen] Use conditional access for enumref query params

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -711,7 +711,7 @@ use {{invokerPackage}}\ObjectSerializer;
         {{#queryParams}}
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
-            ${{paramName}}{{#isEnumRef}}->value{{/isEnumRef}},
+            ${{paramName}}{{#isEnumRef}}?->value{{/isEnumRef}},
             '{{baseName}}', // param base name
             '{{#schema}}{{openApiType}}{{/schema}}', // openApiType
             '{{style}}', // style

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -424,7 +424,7 @@ class QueryApi
         ) ?? []);
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
-            $enum_ref_string_query->value,
+            $enum_ref_string_query?->value,
             'enum_ref_string_query', // param base name
             'StringEnumRef', // openApiType
             'form', // style

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -424,7 +424,7 @@ class QueryApi
         ) ?? []);
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
-            $enum_ref_string_query->value,
+            $enum_ref_string_query?->value,
             'enum_ref_string_query', // param base name
             'StringEnumRef', // openApiType
             'form', // style

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -773,7 +773,7 @@ class FakeApi
 
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
-            $enum_class->value,
+            $enum_class?->value,
             'enum-class', // param base name
             'EnumClass', // openApiType
             'form', // style


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Query parameters in the php-nextgen generator are passed to the ObjectSerializer::toQueryValue method. For enum refs (which use native PHP enums) the value property, which contains the backing string or number, is passed instead. This causes a PHP warning when the parameter is null. To prevent that, I added a `?` which causes the resulting value to be null if the parameter itself is null.

This is not required for header or path parameters, as these are already inside a null check.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
