### PR TITLE
[Rust-Axum] Update tests to not use templates

### DIFF
--- a/bin/utils/test_file_list.yaml
+++ b/bin/utils/test_file_list.yaml
@@ -50,7 +50,7 @@
 - filename: "samples/openapi3/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/model/ZebraTest.java"
   sha256: 15eeb6d8a9a79d0f1930b861540d9c5780d6c49ea4fdb68269ac3e7ec481e142
 # rust axum test files
-- filename: "samples/server/petstore/rust-axum/output/rust-axum-oneof/src/tests.rs"
-  sha256: 3d4198174018cc7fd9d4bcffd950609a5bd306cf03b2fa780516f4e22a566e8c
-- filename: "samples/server/petstore/rust-axum/output/openapi-v3/src/tests.rs"
-  sha256: 356ac684b1fce91b153c63caefc1fe7472ea600ac436a19631e16bc00e986c50
+- filename: "samples/server/petstore/rust-axum/output/rust-axum-oneof/tests/oneof_with_discriminator.rs"
+  sha256: 2d4f5a069fdcb3057bb078d5e75b3de63cd477b97725e457079df24bd2c30600
+- filename: "samples/server/petstore/rust-axum/output/openapi-v3/tests/oneof_with_discriminator.rs"
+  sha256: e72fbf81a9849dc7abb7e2169f2fc355c8b1cf991c0e2ffc083126abd9e966e7

--- a/bin/utils/test_file_list.yaml
+++ b/bin/utils/test_file_list.yaml
@@ -52,5 +52,5 @@
 # rust axum test files
 - filename: "samples/server/petstore/rust-axum/output/rust-axum-oneof/tests/oneof_with_discriminator.rs"
   sha256: 2d4f5a069fdcb3057bb078d5e75b3de63cd477b97725e457079df24bd2c30600
-- filename: "samples/server/petstore/rust-axum/output/openapi-v3/tests/oneof_with_discriminator.rs"
+- filename: "samples/server/petstore/rust-axum/output/openapi-v3/tests/oneof_untagged.rs"
   sha256: e72fbf81a9849dc7abb7e2169f2fc355c8b1cf991c0e2ffc083126abd9e966e7

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
@@ -236,8 +236,6 @@ public class RustAxumServerCodegen extends AbstractRustCodegen implements Codege
         supportingFiles.add(new SupportingFile("header.mustache", "src", "header.rs"));
         supportingFiles.add(new SupportingFile("server-mod.mustache", "src/server", "mod.rs"));
         supportingFiles.add(new SupportingFile("apis-mod.mustache", apiPackage().replace('.', File.separatorChar), "mod.rs"));
-        // The file gets overwritten regardless
-        supportingFiles.add(new SupportingFile("tests.mustache", "src", "tests.rs").doNotOverwrite());
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md").doNotOverwrite());
     }
 

--- a/modules/openapi-generator/src/main/resources/rust-axum/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/lib.mustache
@@ -28,6 +28,3 @@ pub mod apis;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;
-
-#[cfg(test)]
-mod tests;

--- a/modules/openapi-generator/src/main/resources/rust-axum/tests.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/tests.mustache
@@ -1,9 +1,0 @@
-#[test]
-fn std_test() {
-    assert!(true);
-}
-
-#[tokio::test]
-async fn tokio_test() {
-    assert!(true);
-}

--- a/samples/server/petstore/rust-axum/output/apikey-auths/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-axum/output/apikey-auths/.openapi-generator/FILES
@@ -7,5 +7,4 @@ src/header.rs
 src/lib.rs
 src/models.rs
 src/server/mod.rs
-src/tests.rs
 src/types.rs

--- a/samples/server/petstore/rust-axum/output/apikey-auths/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/apikey-auths/src/lib.rs
@@ -26,6 +26,3 @@ pub mod types;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;
-
-#[cfg(test)]
-mod tests;

--- a/samples/server/petstore/rust-axum/output/apikey-auths/src/tests.rs
+++ b/samples/server/petstore/rust-axum/output/apikey-auths/src/tests.rs
@@ -1,9 +1,0 @@
-#[test]
-fn std_test() {
-    assert!(true);
-}
-
-#[tokio::test]
-async fn tokio_test() {
-    assert!(true);
-}

--- a/samples/server/petstore/rust-axum/output/multipart-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/.openapi-generator/FILES
@@ -7,5 +7,4 @@ src/header.rs
 src/lib.rs
 src/models.rs
 src/server/mod.rs
-src/tests.rs
 src/types.rs

--- a/samples/server/petstore/rust-axum/output/multipart-v3/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/src/lib.rs
@@ -26,6 +26,3 @@ pub mod types;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;
-
-#[cfg(test)]
-mod tests;

--- a/samples/server/petstore/rust-axum/output/multipart-v3/src/tests.rs
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/src/tests.rs
@@ -1,9 +1,0 @@
-#[test]
-fn std_test() {
-    assert!(true);
-}
-
-#[tokio::test]
-async fn tokio_test() {
-    assert!(true);
-}

--- a/samples/server/petstore/rust-axum/output/openapi-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/.openapi-generator/FILES
@@ -9,5 +9,4 @@ src/header.rs
 src/lib.rs
 src/models.rs
 src/server/mod.rs
-src/tests.rs
 src/types.rs

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/lib.rs
@@ -26,6 +26,3 @@ pub mod types;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;
-
-#[cfg(test)]
-mod tests;

--- a/samples/server/petstore/rust-axum/output/openapi-v3/tests/oneof_untagged.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/tests/oneof_untagged.rs
@@ -1,7 +1,7 @@
+use openapi_v3::models::OneOfGet200Response;
+
 #[test]
 fn test_oneof_schema_untagged() {
-    use crate::models::OneOfGet200Response;
-
     #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
     struct Test {
         value: OneOfGet200Response,
@@ -33,9 +33,4 @@ fn test_oneof_schema_untagged() {
         serde_json::to_string(&test4).expect("Serialization error"),
         test6
     );
-}
-
-#[tokio::test]
-async fn tokio_test() {
-    assert!(true);
 }

--- a/samples/server/petstore/rust-axum/output/ops-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-axum/output/ops-v3/.openapi-generator/FILES
@@ -7,5 +7,4 @@ src/header.rs
 src/lib.rs
 src/models.rs
 src/server/mod.rs
-src/tests.rs
 src/types.rs

--- a/samples/server/petstore/rust-axum/output/ops-v3/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/ops-v3/src/lib.rs
@@ -26,6 +26,3 @@ pub mod types;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;
-
-#[cfg(test)]
-mod tests;

--- a/samples/server/petstore/rust-axum/output/ops-v3/src/tests.rs
+++ b/samples/server/petstore/rust-axum/output/ops-v3/src/tests.rs
@@ -1,9 +1,0 @@
-#[test]
-fn std_test() {
-    assert!(true);
-}
-
-#[tokio::test]
-async fn tokio_test() {
-    assert!(true);
-}

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/.openapi-generator/FILES
@@ -12,5 +12,4 @@ src/header.rs
 src/lib.rs
 src/models.rs
 src/server/mod.rs
-src/tests.rs
 src/types.rs

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -26,6 +26,3 @@ pub mod types;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;
-
-#[cfg(test)]
-mod tests;

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/tests.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/tests.rs
@@ -1,9 +1,0 @@
-#[test]
-fn std_test() {
-    assert!(true);
-}
-
-#[tokio::test]
-async fn tokio_test() {
-    assert!(true);
-}

--- a/samples/server/petstore/rust-axum/output/petstore/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-axum/output/petstore/.openapi-generator/FILES
@@ -9,5 +9,4 @@ src/header.rs
 src/lib.rs
 src/models.rs
 src/server/mod.rs
-src/tests.rs
 src/types.rs

--- a/samples/server/petstore/rust-axum/output/petstore/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/lib.rs
@@ -26,6 +26,3 @@ pub mod types;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;
-
-#[cfg(test)]
-mod tests;

--- a/samples/server/petstore/rust-axum/output/petstore/src/tests.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/tests.rs
@@ -1,9 +1,0 @@
-#[test]
-fn std_test() {
-    assert!(true);
-}
-
-#[tokio::test]
-async fn tokio_test() {
-    assert!(true);
-}

--- a/samples/server/petstore/rust-axum/output/ping-bearer-auth/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-axum/output/ping-bearer-auth/.openapi-generator/FILES
@@ -7,5 +7,4 @@ src/header.rs
 src/lib.rs
 src/models.rs
 src/server/mod.rs
-src/tests.rs
 src/types.rs

--- a/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/lib.rs
@@ -26,6 +26,3 @@ pub mod types;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;
-
-#[cfg(test)]
-mod tests;

--- a/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/tests.rs
+++ b/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/tests.rs
@@ -1,9 +1,0 @@
-#[test]
-fn std_test() {
-    assert!(true);
-}
-
-#[tokio::test]
-async fn tokio_test() {
-    assert!(true);
-}

--- a/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/.openapi-generator/FILES
@@ -7,5 +7,4 @@ src/header.rs
 src/lib.rs
 src/models.rs
 src/server/mod.rs
-src/tests.rs
 src/types.rs

--- a/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/lib.rs
@@ -26,6 +26,3 @@ pub mod types;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;
-
-#[cfg(test)]
-mod tests;

--- a/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/tests.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/tests.rs
@@ -1,9 +1,0 @@
-#[test]
-fn std_test() {
-    assert!(true);
-}
-
-#[tokio::test]
-async fn tokio_test() {
-    assert!(true);
-}

--- a/samples/server/petstore/rust-axum/output/rust-axum-oneof/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-axum/output/rust-axum-oneof/.openapi-generator/FILES
@@ -7,5 +7,4 @@ src/header.rs
 src/lib.rs
 src/models.rs
 src/server/mod.rs
-src/tests.rs
 src/types.rs

--- a/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/lib.rs
@@ -26,6 +26,3 @@ pub mod types;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;
-
-#[cfg(test)]
-mod tests;

--- a/samples/server/petstore/rust-axum/output/rust-axum-oneof/tests/oneof_with_discriminator.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-oneof/tests/oneof_with_discriminator.rs
@@ -1,7 +1,7 @@
+use rust_axum_oneof::models::*;
+
 #[test]
 fn test_oneof_schema_with_discriminator() {
-    use crate::models::*;
-
     let test0 = r#"{"op": "ignored", "d": {"welcome_message": "test0"}}"#;
 
     let test1 = r#"{"op": "Hello", "d": {"welcome_message": "test1"}}"#;
@@ -93,9 +93,4 @@ fn test_oneof_schema_with_discriminator() {
         serde_json::to_string(&test12).expect("Serialization error"),
         test15
     );
-}
-
-#[tokio::test]
-async fn tokio_test() {
-    assert!(true);
 }

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/.openapi-generator/FILES
@@ -7,5 +7,4 @@ src/header.rs
 src/lib.rs
 src/models.rs
 src/server/mod.rs
-src/tests.rs
 src/types.rs

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/src/lib.rs
@@ -26,6 +26,3 @@ pub mod types;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;
-
-#[cfg(test)]
-mod tests;

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/src/tests.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/src/tests.rs
@@ -1,9 +1,0 @@
-#[test]
-fn std_test() {
-    assert!(true);
-}
-
-#[tokio::test]
-async fn tokio_test() {
-    assert!(true);
-}

--- a/samples/server/petstore/rust-axum/output/rust-axum-validation-test/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-axum/output/rust-axum-validation-test/.openapi-generator/FILES
@@ -7,5 +7,4 @@ src/header.rs
 src/lib.rs
 src/models.rs
 src/server/mod.rs
-src/tests.rs
 src/types.rs

--- a/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/lib.rs
@@ -26,6 +26,3 @@ pub mod types;
 
 #[cfg(feature = "server")]
 pub(crate) mod header;
-
-#[cfg(test)]
-mod tests;

--- a/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/tests.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/tests.rs
@@ -1,9 +1,0 @@
-#[test]
-fn std_test() {
-    assert!(true);
-}
-
-#[tokio::test]
-async fn tokio_test() {
-    assert!(true);
-}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes #20416

Replaced the template generated tests with [cargo integrated tests](https://doc.rust-lang.org/book/ch11-03-test-organization.html#integration-tests). I was not aware of this feature, and it completely solves the issue.

```mvn
# Command used to update the samples
mvn clean &&
./bin/generate-samples.sh bin/configs/manual/rust-axum-* &&
mvn integration-test -f samples/server/petstore/rust-axum/pom.xml
```

@wing328 @linxGnu 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request, and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples, as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.