### PR TITLE
[C][Client] Make custom CMAKE_C_FLAGS work

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
@@ -6,7 +6,9 @@ cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations -Werror=int-conversion")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=implicit-function-declaration")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=missing-declarations")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=int-conversion")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
@@ -15,18 +15,12 @@ option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 find_package(OpenSSL)
 
 if (OPENSSL_FOUND)
-    message (STATUS "OPENSSL found")
-
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DOPENSSL")
     if(CMAKE_VERSION VERSION_LESS 3.4)
         include_directories(${OPENSSL_INCLUDE_DIR})
         include_directories(${OPENSSL_INCLUDE_DIRS})
         link_directories(${OPENSSL_LIBRARIES})
     endif()
-
-    message(STATUS "Using OpenSSL ${OPENSSL_VERSION}")
-else()
-    message (STATUS "OpenSSL Not found.")
 endif()
 
 set(pkgName "{{projectName}}")
@@ -44,8 +38,6 @@ else()
     if(CURL_FOUND)
         include_directories(${CURL_INCLUDE_DIR})
         set(PLATFORM_LIBRARIES ${PLATFORM_LIBRARIES} ${CURL_LIBRARIES} )
-    else(CURL_FOUND)
-        message(FATAL_ERROR "Could not find the CURL library and development files.")
     endif()
 endif()
 

--- a/samples/client/others/c/bearerAuth/CMakeLists.txt
+++ b/samples/client/others/c/bearerAuth/CMakeLists.txt
@@ -6,7 +6,9 @@ cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations -Werror=int-conversion")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=implicit-function-declaration")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=missing-declarations")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=int-conversion")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 

--- a/samples/client/others/c/bearerAuth/CMakeLists.txt
+++ b/samples/client/others/c/bearerAuth/CMakeLists.txt
@@ -15,18 +15,12 @@ option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 find_package(OpenSSL)
 
 if (OPENSSL_FOUND)
-    message (STATUS "OPENSSL found")
-
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DOPENSSL")
     if(CMAKE_VERSION VERSION_LESS 3.4)
         include_directories(${OPENSSL_INCLUDE_DIR})
         include_directories(${OPENSSL_INCLUDE_DIRS})
         link_directories(${OPENSSL_LIBRARIES})
     endif()
-
-    message(STATUS "Using OpenSSL ${OPENSSL_VERSION}")
-else()
-    message (STATUS "OpenSSL Not found.")
 endif()
 
 set(pkgName "sample_api")
@@ -44,8 +38,6 @@ else()
     if(CURL_FOUND)
         include_directories(${CURL_INCLUDE_DIR})
         set(PLATFORM_LIBRARIES ${PLATFORM_LIBRARIES} ${CURL_LIBRARIES} )
-    else(CURL_FOUND)
-        message(FATAL_ERROR "Could not find the CURL library and development files.")
     endif()
 endif()
 

--- a/samples/client/petstore/c-useJsonUnformatted/CMakeLists.txt
+++ b/samples/client/petstore/c-useJsonUnformatted/CMakeLists.txt
@@ -6,7 +6,9 @@ cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations -Werror=int-conversion")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=implicit-function-declaration")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=missing-declarations")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=int-conversion")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 

--- a/samples/client/petstore/c-useJsonUnformatted/CMakeLists.txt
+++ b/samples/client/petstore/c-useJsonUnformatted/CMakeLists.txt
@@ -15,18 +15,12 @@ option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 find_package(OpenSSL)
 
 if (OPENSSL_FOUND)
-    message (STATUS "OPENSSL found")
-
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DOPENSSL")
     if(CMAKE_VERSION VERSION_LESS 3.4)
         include_directories(${OPENSSL_INCLUDE_DIR})
         include_directories(${OPENSSL_INCLUDE_DIRS})
         link_directories(${OPENSSL_LIBRARIES})
     endif()
-
-    message(STATUS "Using OpenSSL ${OPENSSL_VERSION}")
-else()
-    message (STATUS "OpenSSL Not found.")
 endif()
 
 set(pkgName "openapi_petstore")
@@ -44,8 +38,6 @@ else()
     if(CURL_FOUND)
         include_directories(${CURL_INCLUDE_DIR})
         set(PLATFORM_LIBRARIES ${PLATFORM_LIBRARIES} ${CURL_LIBRARIES} )
-    else(CURL_FOUND)
-        message(FATAL_ERROR "Could not find the CURL library and development files.")
     endif()
 endif()
 

--- a/samples/client/petstore/c/.openapi-generator-ignore
+++ b/samples/client/petstore/c/.openapi-generator-ignore
@@ -21,4 +21,3 @@
 #docs/*.md
 # Then explicitly reverse the ignore rule for a single file:
 #!docs/README.md
-CMakeLists.txt

--- a/samples/client/petstore/c/.openapi-generator/FILES
+++ b/samples/client/petstore/c/.openapi-generator/FILES
@@ -1,3 +1,4 @@
+CMakeLists.txt
 Config.cmake.in
 Packing.cmake
 README.md

--- a/samples/client/petstore/c/CMakeLists.txt
+++ b/samples/client/petstore/c/CMakeLists.txt
@@ -1,33 +1,67 @@
-cmake_minimum_required (VERSION 2.6)
-project (CGenerator)
+cmake_minimum_required (VERSION 2.6...3.10.2)
+project (CGenerator C)
 
 cmake_policy(SET CMP0063 NEW)
 
 set(CMAKE_C_VISIBILITY_PRESET default)
-set(CMAKE_CXX_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
-set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations -Werror=int-conversion")
+
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+
+find_package(OpenSSL)
+
+if (OPENSSL_FOUND)
+    message (STATUS "OPENSSL found")
+
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DOPENSSL")
+    if(CMAKE_VERSION VERSION_LESS 3.4)
+        include_directories(${OPENSSL_INCLUDE_DIR})
+        include_directories(${OPENSSL_INCLUDE_DIRS})
+        link_directories(${OPENSSL_LIBRARIES})
+    endif()
+
+    message(STATUS "Using OpenSSL ${OPENSSL_VERSION}")
+else()
+    message (STATUS "OpenSSL Not found.")
+endif()
 
 set(pkgName "openapi_petstore")
 
-find_package(CURL 7.58.0 REQUIRED)
-if(CURL_FOUND)
-	include_directories(${CURL_INCLUDE_DIR})
-	set(PLATFORM_LIBRARIES ${PLATFORM_LIBRARIES} ${CURL_LIBRARIES} )
-else(CURL_FOUND)
-	message(FATAL_ERROR "Could not find the CURL library and development files.")
+# this default version can be overridden in PreTarget.cmake
+set(PROJECT_VERSION_MAJOR 0)
+set(PROJECT_VERSION_MINOR 0)
+set(PROJECT_VERSION_PATCH 1)
+
+if( (DEFINED CURL_INCLUDE_DIR) AND (DEFINED CURL_LIBRARIES))
+    include_directories(${CURL_INCLUDE_DIR})
+    set(PLATFORM_LIBRARIES ${PLATFORM_LIBRARIES} ${CURL_LIBRARIES} )
+else()
+    find_package(CURL 7.58.0 REQUIRED)
+    if(CURL_FOUND)
+        include_directories(${CURL_INCLUDE_DIR})
+        set(PLATFORM_LIBRARIES ${PLATFORM_LIBRARIES} ${CURL_LIBRARIES} )
+    else(CURL_FOUND)
+        message(FATAL_ERROR "Could not find the CURL library and development files.")
+    endif()
 endif()
 
 set(SRCS
     src/list.c
     src/apiKey.c
     src/apiClient.c
+    src/binary.c
     external/cJSON.c
     model/object.c
+    model/mapped_model.c
     model/api_response.c
+    model/bit.c
     model/category.c
+    model/model_with_set_propertes.c
     model/order.c
     model/pet.c
+    model/preference.c
     model/tag.c
     model/user.c
     api/PetAPI.c
@@ -39,13 +73,19 @@ set(SRCS
 set(HDRS
     include/apiClient.h
     include/list.h
+    include/binary.h
     include/keyValuePair.h
     external/cJSON.h
     model/object.h
+    model/any_type.h
+    model/mapped_model.h
     model/api_response.h
+    model/bit.h
     model/category.h
+    model/model_with_set_propertes.h
     model/order.h
     model/pet.h
+    model/preference.h
     model/tag.h
     model/user.h
     api/PetAPI.h
@@ -54,12 +94,75 @@ set(HDRS
 
 )
 
-# Add library with project file with projectname as library name
-add_library(${pkgName} SHARED ${SRCS} ${HDRS})
+include(PreTarget.cmake OPTIONAL)
+
+set(PROJECT_VERSION_STRING "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+
+# Add library with project file with project name as library name
+add_library(${pkgName} ${SRCS} ${HDRS})
 # Link dependent libraries
-target_link_libraries(${pkgName} ${CURL_LIBRARIES} )
-#install library to destination
-install(TARGETS ${pkgName} DESTINATION ${CMAKE_INSTALL_PREFIX})
+if(NOT CMAKE_VERSION VERSION_LESS 3.4)
+    target_link_libraries(${pkgName} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+endif()
+target_link_libraries(${pkgName} PUBLIC ${CURL_LIBRARIES} )
+target_include_directories(
+    ${pkgName} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+include(PostTarget.cmake OPTIONAL)
+
+# installation of libraries, headers, and config files
+if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in)
+    install(TARGETS ${pkgName} DESTINATION lib)
+else()
+    include(GNUInstallDirs)
+    install(TARGETS ${pkgName} DESTINATION lib EXPORT ${pkgName}Targets)
+
+    foreach(HDR_FILE ${HDRS})
+        get_filename_component(HDR_DIRECTORY ${HDR_FILE} DIRECTORY)
+        get_filename_component(ABSOLUTE_HDR_DIRECTORY ${HDR_DIRECTORY} ABSOLUTE)
+        file(RELATIVE_PATH RELATIVE_HDR_PATH ${CMAKE_CURRENT_SOURCE_DIR} ${ABSOLUTE_HDR_DIRECTORY})
+        install(FILES ${HDR_FILE} DESTINATION include/${pkgName}/${RELATIVE_HDR_PATH})
+    endforeach()
+
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
+            "${CMAKE_CURRENT_BINARY_DIR}/${pkgName}/${pkgName}ConfigVersion.cmake"
+            VERSION "${PROJECT_VERSION_STRING}"
+            COMPATIBILITY AnyNewerVersion
+    )
+
+    export(EXPORT ${pkgName}Targets
+            FILE "${CMAKE_CURRENT_BINARY_DIR}/${pkgName}/${pkgName}Targets.cmake"
+            NAMESPACE ${pkgName}::
+            )
+
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+            "${CMAKE_CURRENT_BINARY_DIR}/${pkgName}/${pkgName}Config.cmake"
+            @ONLY
+            )
+
+    set(ConfigPackageLocation lib/cmake/${pkgName})
+    install(EXPORT ${pkgName}Targets
+            FILE
+            ${pkgName}Targets.cmake
+            NAMESPACE
+            ${pkgName}::
+            DESTINATION
+            ${ConfigPackageLocation}
+            )
+    install(
+            FILES
+            "${CMAKE_CURRENT_BINARY_DIR}/${pkgName}/${pkgName}Config.cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/${pkgName}/${pkgName}ConfigVersion.cmake"
+            DESTINATION
+            ${ConfigPackageLocation}
+    )
+endif()
+
+# make installation packages
+include(Packing.cmake OPTIONAL)
 
 # Setting file variables to null
 set(SRCS "")
@@ -72,8 +175,7 @@ set(HDRS "")
 #    unit-tests/manual-PetAPI.c
 #    unit-tests/manual-StoreAPI.c
 #    unit-tests/manual-UserAPI.c
-#    unit-tests/manual-order.c
-#    unit-tests/manual-user.c)
+#)
 
 ##set header files
 #set(HDRS
@@ -81,7 +183,7 @@ set(HDRS "")
 
 ## loop over all files in SRCS variable
 #foreach(SOURCE_FILE ${SRCS})
-#    # Get only the file name from the file as add_executable doesn't support executable with slash("/")
+#    # Get only the file name from the file as add_executable does not support executable with slash("/")
 #    get_filename_component(FILE_NAME_ONLY ${SOURCE_FILE} NAME_WE)
 #    # Remove .c from the file name and set it as executable name
 #    string( REPLACE ".c" "" EXECUTABLE_FILE ${FILE_NAME_ONLY})

--- a/samples/client/petstore/c/CMakeLists.txt
+++ b/samples/client/petstore/c/CMakeLists.txt
@@ -6,7 +6,9 @@ cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET default)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration -Werror=missing-declarations -Werror=int-conversion")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=implicit-function-declaration")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=missing-declarations")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=int-conversion")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 

--- a/samples/client/petstore/c/CMakeLists.txt
+++ b/samples/client/petstore/c/CMakeLists.txt
@@ -15,18 +15,12 @@ option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 find_package(OpenSSL)
 
 if (OPENSSL_FOUND)
-    message (STATUS "OPENSSL found")
-
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DOPENSSL")
     if(CMAKE_VERSION VERSION_LESS 3.4)
         include_directories(${OPENSSL_INCLUDE_DIR})
         include_directories(${OPENSSL_INCLUDE_DIRS})
         link_directories(${OPENSSL_LIBRARIES})
     endif()
-
-    message(STATUS "Using OpenSSL ${OPENSSL_VERSION}")
-else()
-    message (STATUS "OpenSSL Not found.")
 endif()
 
 set(pkgName "openapi_petstore")
@@ -44,8 +38,6 @@ else()
     if(CURL_FOUND)
         include_directories(${CURL_INCLUDE_DIR})
         set(PLATFORM_LIBRARIES ${PLATFORM_LIBRARIES} ${CURL_LIBRARIES} )
-    else(CURL_FOUND)
-        message(FATAL_ERROR "Could not find the CURL library and development files.")
     endif()
 endif()
 


### PR DESCRIPTION
Fixes `CMakeFiles.txt` so that the usual way to define custom C compile flags works. After the change users can set the initial value of `CMAKE_C_FLAGS` on the command line. Project-defined flags no longer replace the entire variable content but are appended instead. (Project flags still take priority if they need to override custom flags.)

For example to build a local version with architecture-specific CPU flags:

```sh
cmake -B /tmp/build -S /usr/src/whatever -DCMAKE_C_FLAGS='.march=znver3 -mtune=znver3'
```

The first commit enables `CMakeLists.txt` to be (re-)generated for one of the three C clients. It's been disabled for quite a long time, and it doesn't look like there is an actual reason for it. But please let me know if there's breakage.