### PR TITLE
Fix: Resolve Dart 3.5+ and json_serializable 6.9.0+ compatibility issues in generated dart-dio clients

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/pubspec.mustache
@@ -9,11 +9,12 @@ repository: {{.}}
 publish_to: {{.}}
 {{/pubPublishTo}}
 
+
 environment:
-  sdk: '>={{#useJsonSerializable}}2.17.0{{/useJsonSerializable}}{{^useJsonSerializable}}2.15.0{{/useJsonSerializable}} <4.0.0'
+  sdk: '>={{^useJsonSerializable}}2.18.0{{/useJsonSerializable}}{{#useJsonSerializable}}3.5.0{{/useJsonSerializable}} <4.0.0'
 
 dependencies:
-  dio: '^5.2.0'
+  dio: '^5.7.0'
 {{#useBuiltValue}}
   one_of: '>=1.5.0 <2.0.0'
   one_of_serializer: '>=1.5.0 <2.0.0'
@@ -21,13 +22,13 @@ dependencies:
   built_collection: '>=5.1.1 <6.0.0'
 {{/useBuiltValue}}
 {{#useEquatable}}
-  equatable: '^2.0.5'
+  equatable: '^2.0.7'
 {{/useEquatable}}
 {{#useJsonSerializable}}
-  json_annotation: '^4.4.0'
+  json_annotation: '^4.9.0'
 {{/useJsonSerializable}}
 {{#useDateLibTimeMachine}}
-  time_machine: ^0.9.16
+  time_machine: ^0.9.17
 {{/useDateLibTimeMachine}}
 
 dev_dependencies:
@@ -37,6 +38,6 @@ dev_dependencies:
 {{/useBuiltValue}}
 {{#useJsonSerializable}}
   build_runner: any
-  json_serializable: '^6.1.5'
+  json_serializable: '^6.9.3'
 {{/useJsonSerializable}}
-  test: ^1.16.0
+  test: '^1.16.0'

--- a/samples/openapi3/client/petstore/dart-dio/oneof/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/oneof/pubspec.yaml
@@ -3,11 +3,12 @@ version: 1.0.0
 description: OpenAPI API client
 homepage: homepage
 
+
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  dio: '^5.2.0'
+  dio: '^5.7.0'
   one_of: '>=1.5.0 <2.0.0'
   one_of_serializer: '>=1.5.0 <2.0.0'
   built_value: '>=8.4.0 <9.0.0'
@@ -16,4 +17,4 @@ dependencies:
 dev_dependencies:
   built_value_generator: '>=8.4.0 <9.0.0'
   build_runner: any
-  test: ^1.16.0
+  test: '^1.16.0'

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/pubspec.yaml
@@ -3,11 +3,12 @@ version: 1.0.0
 description: OpenAPI API client
 homepage: homepage
 
+
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  dio: '^5.2.0'
+  dio: '^5.7.0'
   one_of: '>=1.5.0 <2.0.0'
   one_of_serializer: '>=1.5.0 <2.0.0'
   built_value: '>=8.4.0 <9.0.0'
@@ -16,4 +17,4 @@ dependencies:
 dev_dependencies:
   built_value_generator: '>=8.4.0 <9.0.0'
   build_runner: any
-  test: ^1.16.0
+  test: '^1.16.0'

--- a/samples/openapi3/client/petstore/dart-dio/oneof_primitive/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_primitive/pubspec.yaml
@@ -3,11 +3,12 @@ version: 1.0.0
 description: OpenAPI API client
 homepage: homepage
 
+
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  dio: '^5.2.0'
+  dio: '^5.7.0'
   one_of: '>=1.5.0 <2.0.0'
   one_of_serializer: '>=1.5.0 <2.0.0'
   built_value: '>=8.4.0 <9.0.0'
@@ -16,4 +17,4 @@ dependencies:
 dev_dependencies:
   built_value_generator: '>=8.4.0 <9.0.0'
   build_runner: any
-  test: ^1.16.0
+  test: '^1.16.0'

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/pubspec.yaml
@@ -3,14 +3,15 @@ version: 1.0.0
 description: OpenAPI API client
 homepage: homepage
 
+
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=3.5.0 <4.0.0'
 
 dependencies:
-  dio: '^5.2.0'
-  json_annotation: '^4.4.0'
+  dio: '^5.7.0'
+  json_annotation: '^4.9.0'
 
 dev_dependencies:
   build_runner: any
-  json_serializable: '^6.1.5'
-  test: ^1.16.0
+  json_serializable: '^6.9.3'
+  test: '^1.16.0'

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/pubspec.yaml
@@ -3,11 +3,12 @@ version: 1.0.0
 description: OpenAPI API client
 homepage: homepage
 
+
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  dio: '^5.2.0'
+  dio: '^5.7.0'
   one_of: '>=1.5.0 <2.0.0'
   one_of_serializer: '>=1.5.0 <2.0.0'
   built_value: '>=8.4.0 <9.0.0'
@@ -16,4 +17,4 @@ dependencies:
 dev_dependencies:
   built_value_generator: '>=8.4.0 <9.0.0'
   build_runner: any
-  test: ^1.16.0
+  test: '^1.16.0'


### PR DESCRIPTION
This commit fixes compatibility problems between the generated dart-dio code, json_serializable 6.9.0+, and Dart SDK 3.5 or later.

Changes:

- Updated `pubspec.mustache`:
    - Set the minimum SDK constraint for the generated package to `>=3.5.0 <4.0.0`, reflecting the language version used in the generated code.
    - Bump `json_annotation` dependency to `^4.9.0`.
    - Bump `json_serializable` dependency to `^6.9.0`.

These changes ensure that the generated code:

- Is compatible with `json_serializable` 6.9.0+ and Dart SDK 3.5+.
- Avoids Dart 3.5+ specific syntax that causes errors on older SDKs.
- Maintains existing functionality and type safety.

@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)

PS: This minor fix has been merged into master as it's a non-breaking change targeting the upcoming 7.x.0 minor release. json_serializable 6.9.0+ mandates a minimum Dart SDK of 3.5 due to its use of newer language features. Consequently, generated dart-dio clients now also require Dart SDK 3.5 or higher. Existing projects using Dart 3.0 and higher should not be impacted because this update maintains backward compatibility for the generated code's public API and serialization format. This change primarily ensures compatibility with newer projects and going forward, which often do not support older Dart versions.

Resolves: #16117, #14863



<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
