### PR TITLE
ISSUE: #17373 [BUG] [Go-server] invalid composite literal type string

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -591,7 +591,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{paramName}}Param := r.Header.Get("{{baseName}}")
 	{{/isHeaderParam}}
 	{{#isBodyParam}}
-	{{paramName}}Param := {{dataType}}{}
+	var {{paramName}}Param {{dataType}}
 	d := json.NewDecoder(r.Body)
 	{{^isAdditionalPropertiesTrue}}
 	d.DisallowUnknownFields()

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_pet.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_pet.go
@@ -97,7 +97,7 @@ func (c *PetAPIController) Routes() Routes {
 
 // UpdatePet - Update an existing pet
 func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
+	var petParam Pet
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&petParam); err != nil {
@@ -124,7 +124,7 @@ func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
 
 // AddPet - Add a new pet to the store
 func (c *PetAPIController) AddPet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
+	var petParam Pet
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&petParam); err != nil {

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_store.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_store.go
@@ -88,7 +88,7 @@ func (c *StoreAPIController) GetInventory(w http.ResponseWriter, r *http.Request
 
 // PlaceOrder - Place an order for a pet
 func (c *StoreAPIController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
-	orderParam := Order{}
+	var orderParam Order
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&orderParam); err != nil {

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_user.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_user.go
@@ -96,7 +96,7 @@ func (c *UserAPIController) Routes() Routes {
 
 // CreateUser - Create user
 func (c *UserAPIController) CreateUser(w http.ResponseWriter, r *http.Request) {
-	userParam := User{}
+	var userParam User
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {
@@ -123,7 +123,7 @@ func (c *UserAPIController) CreateUser(w http.ResponseWriter, r *http.Request) {
 
 // CreateUsersWithArrayInput - Creates list of users with given input array
 func (c *UserAPIController) CreateUsersWithArrayInput(w http.ResponseWriter, r *http.Request) {
-	userParam := []User{}
+	var userParam []User
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {
@@ -148,7 +148,7 @@ func (c *UserAPIController) CreateUsersWithArrayInput(w http.ResponseWriter, r *
 
 // CreateUsersWithListInput - Creates list of users with given input array
 func (c *UserAPIController) CreateUsersWithListInput(w http.ResponseWriter, r *http.Request) {
-	userParam := []User{}
+	var userParam []User
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {
@@ -312,7 +312,7 @@ func (c *UserAPIController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		c.errorHandler(w, r, &RequiredError{"username"}, nil)
 		return
 	}
-	userParam := User{}
+	var userParam User
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {

--- a/samples/server/others/go-server/no-body-path-params/go/api_body.go
+++ b/samples/server/others/go-server/no-body-path-params/go/api_body.go
@@ -59,7 +59,7 @@ func (c *BodyAPIController) Routes() Routes {
 
 // Body - summary
 func (c *BodyAPIController) Body(w http.ResponseWriter, r *http.Request) {
-	bodyRequestParam := BodyRequest{}
+	var bodyRequestParam BodyRequest
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&bodyRequestParam); err != nil {

--- a/samples/server/others/go-server/no-body-path-params/go/api_both.go
+++ b/samples/server/others/go-server/no-body-path-params/go/api_both.go
@@ -67,7 +67,7 @@ func (c *BothAPIController) Both(w http.ResponseWriter, r *http.Request) {
 		c.errorHandler(w, r, &RequiredError{"pathParam"}, nil)
 		return
 	}
-	bodyRequestParam := BodyRequest{}
+	var bodyRequestParam BodyRequest
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&bodyRequestParam); err != nil {

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -128,7 +128,7 @@ func (c *PetAPIController) Routes() Routes {
 
 // UpdatePet - Update an existing pet
 func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
+	var petParam Pet
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&petParam); err != nil {
@@ -155,7 +155,7 @@ func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
 
 // AddPet - Add a new pet to the store
 func (c *PetAPIController) AddPet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
+	var petParam Pet
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&petParam); err != nil {

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -88,7 +88,7 @@ func (c *StoreAPIController) GetInventory(w http.ResponseWriter, r *http.Request
 
 // PlaceOrder - Place an order for a pet
 func (c *StoreAPIController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
-	orderParam := Order{}
+	var orderParam Order
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&orderParam); err != nil {

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -96,7 +96,7 @@ func (c *UserAPIController) Routes() Routes {
 
 // CreateUser - Create user
 func (c *UserAPIController) CreateUser(w http.ResponseWriter, r *http.Request) {
-	userParam := User{}
+	var userParam User
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {
@@ -123,7 +123,7 @@ func (c *UserAPIController) CreateUser(w http.ResponseWriter, r *http.Request) {
 
 // CreateUsersWithArrayInput - Creates list of users with given input array
 func (c *UserAPIController) CreateUsersWithArrayInput(w http.ResponseWriter, r *http.Request) {
-	userParam := []User{}
+	var userParam []User
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {
@@ -148,7 +148,7 @@ func (c *UserAPIController) CreateUsersWithArrayInput(w http.ResponseWriter, r *
 
 // CreateUsersWithListInput - Creates list of users with given input array
 func (c *UserAPIController) CreateUsersWithListInput(w http.ResponseWriter, r *http.Request) {
-	userParam := []User{}
+	var userParam []User
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {
@@ -258,7 +258,7 @@ func (c *UserAPIController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		c.errorHandler(w, r, &RequiredError{"username"}, nil)
 		return
 	}
-	userParam := User{}
+	var userParam User
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {

--- a/samples/server/petstore/go-chi-server/go/api_pet.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet.go
@@ -128,7 +128,7 @@ func (c *PetAPIController) Routes() Routes {
 
 // UpdatePet - Update an existing pet
 func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
+	var petParam Pet
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&petParam); err != nil {
@@ -155,7 +155,7 @@ func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
 
 // AddPet - Add a new pet to the store
 func (c *PetAPIController) AddPet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
+	var petParam Pet
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&petParam); err != nil {

--- a/samples/server/petstore/go-chi-server/go/api_store.go
+++ b/samples/server/petstore/go-chi-server/go/api_store.go
@@ -88,7 +88,7 @@ func (c *StoreAPIController) GetInventory(w http.ResponseWriter, r *http.Request
 
 // PlaceOrder - Place an order for a pet
 func (c *StoreAPIController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
-	orderParam := Order{}
+	var orderParam Order
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&orderParam); err != nil {

--- a/samples/server/petstore/go-chi-server/go/api_user.go
+++ b/samples/server/petstore/go-chi-server/go/api_user.go
@@ -96,7 +96,7 @@ func (c *UserAPIController) Routes() Routes {
 
 // CreateUser - Create user
 func (c *UserAPIController) CreateUser(w http.ResponseWriter, r *http.Request) {
-	userParam := User{}
+	var userParam User
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {
@@ -123,7 +123,7 @@ func (c *UserAPIController) CreateUser(w http.ResponseWriter, r *http.Request) {
 
 // CreateUsersWithArrayInput - Creates list of users with given input array
 func (c *UserAPIController) CreateUsersWithArrayInput(w http.ResponseWriter, r *http.Request) {
-	userParam := []User{}
+	var userParam []User
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {
@@ -148,7 +148,7 @@ func (c *UserAPIController) CreateUsersWithArrayInput(w http.ResponseWriter, r *
 
 // CreateUsersWithListInput - Creates list of users with given input array
 func (c *UserAPIController) CreateUsersWithListInput(w http.ResponseWriter, r *http.Request) {
-	userParam := []User{}
+	var userParam []User
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {
@@ -256,7 +256,7 @@ func (c *UserAPIController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		c.errorHandler(w, r, &RequiredError{"username"}, nil)
 		return
 	}
-	userParam := User{}
+	var userParam User
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {


### PR DESCRIPTION
The patch does an alternative initialization of a Go-lang variable, such that a custom pre-check and multiple alternative `:=` initialization would be needed in the mustache template. This fixes #17373 which would generate invalid code like:

```
  nameParam := string{} // error: "invalid composite literal type string"
```

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax  @grokify  @kemokemo @jirikuncar @ph4r5h4d  @lwj5 