### PR TITLE
[julia] fix enum default vals, add api validations

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJuliaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJuliaCodegen.java
@@ -438,6 +438,18 @@ public abstract class AbstractJuliaCodegen extends DefaultCodegen {
     }
 
     @Override
+    public String toEnumDefaultValue(String value, String datatype) {
+        // we do not generate any separate enum structure in Julia
+        return value;
+    }
+
+    @Override
+    public String toEnumVarName(String value, String datatype) {
+        // we do not generate any separate enum structure in Julia
+        return value;
+    }
+
+    @Override
     public String escapeUnsafeCharacters(String input) {
         return input.replace("#=", "#_=").replace("=#", "=_#");
     }

--- a/modules/openapi-generator/src/main/resources/julia-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-client/api.mustache
@@ -43,6 +43,21 @@ function _oacinternal_{{operationId}}(_api::{{classname}}{{#allParams}}{{#requir
 {{#minItems}}
     OpenAPI.validate_param("{{paramName}}", "{{operationId}}", :minItems, {{paramName}}, {{minItems}})
 {{/minItems}}
+{{#uniqueItems}}
+    OpenAPI.validate_param("{{paramName}}", "{{operationId}}", :uniqueItems, {{paramName}}, {{uniqueItems}})
+{{/uniqueItems}}
+{{#maxProperties}}
+        OpenAPI.validate_param("{{paramName}}", "{{operationId}}", :maxProperties, {{paramName}}, {{maxProperties}})
+{{/maxProperties}}
+{{#minProperties}}
+        OpenAPI.validate_param("{{paramName}}", "{{operationId}}", :minProperties, {{paramName}}, {{minProperties}})
+{{/minProperties}}
+{{#pattern}}
+        OpenAPI.validate_param("{{paramName}}", "{{operationId}}", :pattern, {{paramName}}, r"{{{pattern}}}")
+{{/pattern}}
+{{#multipleOf}}
+        OpenAPI.validate_param("{{paramName}}", "{{operationId}}", :multipleOf, {{paramName}}, {{multipleOf}})
+{{/multipleOf}}
 
 {{/hasValidation}}
 {{/allParams}}

--- a/modules/openapi-generator/src/main/resources/julia-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/api.mustache
@@ -43,6 +43,21 @@ function {{operationId}}_validate(handler)
         {{#minItems}}
         OpenAPI.validate_param("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", "{{operationId}}", :minItems, openapi_params["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"], {{minItems}})
         {{/minItems}}
+        {{#uniqueItems}}
+        OpenAPI.validate_param("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", "{{operationId}}", :uniqueItems, openapi_params["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"], {{uniqueItems}})
+        {{/uniqueItems}}
+        {{#maxProperties}}
+        OpenAPI.validate_param("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", "{{operationId}}", :maxProperties, openapi_params["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"], {{maxProperties}})
+        {{/maxProperties}}
+        {{#minProperties}}
+        OpenAPI.validate_param("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", "{{operationId}}", :minProperties, openapi_params["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"], {{minProperties}})
+        {{/minProperties}}
+        {{#pattern}}
+        OpenAPI.validate_param("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", "{{operationId}}", :pattern, openapi_params["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"], r"{{{pattern}}}")
+        {{/pattern}}
+        {{#multipleOf}}
+        OpenAPI.validate_param("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", "{{operationId}}", :multipleOf, openapi_params["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"], {{multipleOf}})
+        {{/multipleOf}}
         {{/hasValidation}}{{/allParams}}
         return handler(req)
     end

--- a/samples/client/petstore/julia/src/apis/api_UserApi.jl
+++ b/samples/client/petstore/julia/src/apis/api_UserApi.jl
@@ -172,6 +172,7 @@ const _returntypes_login_user_UserApi = Dict{Regex,Type}(
 )
 
 function _oacinternal_login_user(_api::UserApi, username::String, password::String; _mediaType=nothing)
+        OpenAPI.validate_param("username", "login_user", :pattern, username, r"^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$")
 
     _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_login_user_UserApi, "/user/login", [])
     OpenAPI.Clients.set_param(_ctx.query, "username", username; style="form", is_explode=true)  # type String

--- a/samples/server/petstore/julia/src/apis/api_UserApi.jl
+++ b/samples/server/petstore/julia/src/apis/api_UserApi.jl
@@ -155,6 +155,7 @@ function login_user_validate(handler)
     function login_user_validate_handler(req::HTTP.Request)
         openapi_params = req.context[:openapi_params]
         
+        OpenAPI.validate_param("username", "login_user", :pattern, openapi_params["username"], r"^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$")
         
         return handler(req)
     end


### PR DESCRIPTION
- Fix enum default value generation. Default values were falling back to the default code generator and were being generated improperly for Julia.
- Add more validations to client and server API call handlers. These validations were already being generated for models, but were missed out for API calls.

cc: @wing328 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
