### PR TITLE
[php-*] Explicitly declare nullable parameters

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
@@ -211,15 +211,16 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
             }
 
             for (CodegenParameter param : operation.allParams) {
+                String paramType;
                 if (param.isArray || param.isMap) {
-                    param.vendorExtensions.putIfAbsent("x-php-param-type", "array");
+                    paramType = "array";
                 } else {
-                    String paramType = param.dataType;
-                    if ((!param.required || param.isNullable) && !paramType.equals("mixed")) { // optional or nullable but not mixed
-                        paramType = "?" + paramType;
-                    }
-                    param.vendorExtensions.putIfAbsent("x-php-param-type", paramType);
+                    paramType = param.dataType;
                 }
+                if ((!param.required || param.isNullable) && !paramType.equals("mixed")) { // optional or nullable but not mixed
+                    paramType = "?" + paramType;
+                }
+                param.vendorExtensions.putIfAbsent("x-php-param-type", paramType);
             }
         }
 

--- a/modules/openapi-generator/src/main/resources/php-dt-modern/ApiClientFactory.php.mustache
+++ b/modules/openapi-generator/src/main/resources/php-dt-modern/ApiClientFactory.php.mustache
@@ -16,7 +16,7 @@ class ApiClientFactory implements PM\ServiceFactoryInterface
         $this->configKey = $configKey;
     }
 
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ApiClient
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): ApiClient
     {
         $config = new OAGAC\ApiClientOptions(\array_merge($this->getServiceConfig($container), $options ?? []));
         return new ApiClient(

--- a/modules/openapi-generator/src/main/resources/php-dt/ApiClientFactory.php.mustache
+++ b/modules/openapi-generator/src/main/resources/php-dt/ApiClientFactory.php.mustache
@@ -16,7 +16,7 @@ class ApiClientFactory implements PM\ServiceFactoryInterface
         $this->configKey = $configKey;
     }
 
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ApiClient
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): ApiClient
     {
         $config = new OAGAC\ApiClientOptions(\array_merge($this->getServiceConfig($container), $options ?? []));
         return new ApiClient(

--- a/modules/openapi-generator/src/main/resources/php-mezzio-ph-modern/Factory.php.mustache
+++ b/modules/openapi-generator/src/main/resources/php-mezzio-ph-modern/Factory.php.mustache
@@ -21,7 +21,7 @@ use Laminas\Stratigility\MiddlewarePipe;
 
 class Factory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): Application
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): Application
     {
         $errorMiddleware = self::getErrorMiddleware($container);
         $pipeline = new MiddlewarePipe();

--- a/modules/openapi-generator/src/main/resources/php-mezzio-ph/Factory.php.mustache
+++ b/modules/openapi-generator/src/main/resources/php-mezzio-ph/Factory.php.mustache
@@ -21,7 +21,7 @@ use Laminas\Stratigility\MiddlewarePipe;
 
 class Factory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): Application
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): Application
     {
         $errorMiddleware = self::getErrorMiddleware($container);
         $pipeline = new MiddlewarePipe();

--- a/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
@@ -498,7 +498,7 @@ class Configuration
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
     */
-    public static function getHostString(array $hostSettings, int $hostIndex, array $variables = null): string
+    public static function getHostString(array $hostSettings, int $hostIndex, ?array $variables = null): string
     {
         if (null === $variables) {
             $variables = [];

--- a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
@@ -56,7 +56,7 @@ class ObjectSerializer
      *
      * @return scalar|object|array|null serialized form of $data
      */
-    public static function sanitizeForSerialization(mixed $data, string $type = null, string $format = null): mixed
+    public static function sanitizeForSerialization(mixed $data, ?string $type = null, ?string $format = null): mixed
     {
         if (is_scalar($data) || null === $data) {
             return $data;
@@ -388,7 +388,7 @@ class ObjectSerializer
      *
      * @return mixed a single or an array of $class instances
      */
-    public static function deserialize(mixed $data, string $class, array $httpHeaders = null): mixed
+    public static function deserialize(mixed $data, string $class, ?array $httpHeaders = null): mixed
     {
         if (null === $data) {
             return null;

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -76,9 +76,9 @@ use {{invokerPackage}}\ObjectSerializer;
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
@@ -245,7 +245,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         {{#discriminator}}
         // Initialize discriminator property with the model name.

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
@@ -87,9 +87,9 @@ class AuthApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
@@ -1745,7 +1745,7 @@ class BodyApi
      * @return string
      */
     public function testEchoBodyFreeFormObjectResponseString(
-        array $body = null,
+        ?array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): string
     {
@@ -1766,7 +1766,7 @@ class BodyApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testEchoBodyFreeFormObjectResponseStringWithHttpInfo(
-        array $body = null,
+        ?array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): array
     {
@@ -1893,7 +1893,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyFreeFormObjectResponseStringAsync(
-        array $body = null,
+        ?array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): PromiseInterface
     {
@@ -1917,7 +1917,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyFreeFormObjectResponseStringAsyncWithHttpInfo(
-        array $body = null,
+        ?array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): PromiseInterface
     {
@@ -1970,7 +1970,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyFreeFormObjectResponseStringRequest(
-        array $body = null,
+        ?array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): Request
     {

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
@@ -111,9 +111,9 @@ class BodyApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
@@ -90,9 +90,9 @@ class FormApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
@@ -84,9 +84,9 @@ class HeaderApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
@@ -84,9 +84,9 @@ class PathApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -1853,7 +1853,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeFalseArrayInteger(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): string
     {
@@ -1874,7 +1874,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerWithHttpInfo(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): array
     {
@@ -2001,7 +2001,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerAsync(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): PromiseInterface
     {
@@ -2025,7 +2025,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerAsyncWithHttpInfo(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): PromiseInterface
     {
@@ -2078,7 +2078,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerRequest(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): Request
     {
@@ -2171,7 +2171,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeFalseArrayString(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): string
     {
@@ -2192,7 +2192,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeFalseArrayStringWithHttpInfo(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): array
     {
@@ -2319,7 +2319,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayStringAsync(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): PromiseInterface
     {
@@ -2343,7 +2343,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayStringAsyncWithHttpInfo(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): PromiseInterface
     {
@@ -2396,7 +2396,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeFalseArrayStringRequest(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): Request
     {

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -111,9 +111,9 @@ class QueryApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/echo_api/php-nextgen-streaming/src/Configuration.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Configuration.php
@@ -482,7 +482,7 @@ class Configuration
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
     */
-    public static function getHostString(array $hostSettings, int $hostIndex, array $variables = null): string
+    public static function getHostString(array $hostSettings, int $hostIndex, ?array $variables = null): string
     {
         if (null === $variables) {
             $variables = [];

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Bird.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Bird.php
@@ -247,7 +247,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('size', $data ?? [], null);
         $this->setIfExists('color', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Category.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Category.php
@@ -247,7 +247,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('name', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/DataQuery.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/DataQuery.php
@@ -241,7 +241,7 @@ class DataQuery extends Query
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/DefaultValue.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/DefaultValue.php
@@ -301,7 +301,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('array_string_enum_ref_default', $data ?? [], [["success","failure"]]);
         $this->setIfExists('array_string_enum_default', $data ?? [], [["success","failure"]]);

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/NumberPropertiesOnly.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/NumberPropertiesOnly.php
@@ -253,7 +253,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('number', $data ?? [], null);
         $this->setIfExists('float', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Pet.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Pet.php
@@ -288,7 +288,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('name', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Query.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Query.php
@@ -264,7 +264,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('outcomes', $data ?? [], [["SUCCESS","FAILURE"]]);

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Tag.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Tag.php
@@ -247,7 +247,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('name', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/TestFormObjectMultipartRequestMarker.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/TestFormObjectMultipartRequestMarker.php
@@ -241,7 +241,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('name', $data ?? [], null);
     }

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
@@ -259,7 +259,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('size', $data ?? [], null);
         $this->setIfExists('color', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.php
@@ -241,7 +241,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('values', $data ?? [], null);
     }

--- a/samples/client/echo_api/php-nextgen-streaming/src/ObjectSerializer.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/ObjectSerializer.php
@@ -66,7 +66,7 @@ class ObjectSerializer
      *
      * @return scalar|object|array|null serialized form of $data
      */
-    public static function sanitizeForSerialization(mixed $data, string $type = null, string $format = null): mixed
+    public static function sanitizeForSerialization(mixed $data, ?string $type = null, ?string $format = null): mixed
     {
         if (is_scalar($data) || null === $data) {
             return $data;
@@ -398,7 +398,7 @@ class ObjectSerializer
      *
      * @return mixed a single or an array of $class instances
      */
-    public static function deserialize(mixed $data, string $class, array $httpHeaders = null): mixed
+    public static function deserialize(mixed $data, string $class, ?array $httpHeaders = null): mixed
     {
         if (null === $data) {
             return null;

--- a/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
@@ -87,9 +87,9 @@ class AuthApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
@@ -1745,7 +1745,7 @@ class BodyApi
      * @return string
      */
     public function testEchoBodyFreeFormObjectResponseString(
-        array $body = null,
+        ?array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): string
     {
@@ -1766,7 +1766,7 @@ class BodyApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testEchoBodyFreeFormObjectResponseStringWithHttpInfo(
-        array $body = null,
+        ?array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): array
     {
@@ -1893,7 +1893,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyFreeFormObjectResponseStringAsync(
-        array $body = null,
+        ?array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): PromiseInterface
     {
@@ -1917,7 +1917,7 @@ class BodyApi
      * @return PromiseInterface
      */
     public function testEchoBodyFreeFormObjectResponseStringAsyncWithHttpInfo(
-        array $body = null,
+        ?array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): PromiseInterface
     {
@@ -1970,7 +1970,7 @@ class BodyApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEchoBodyFreeFormObjectResponseStringRequest(
-        array $body = null,
+        ?array $body = null,
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): Request
     {

--- a/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
@@ -111,9 +111,9 @@ class BodyApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
@@ -90,9 +90,9 @@ class FormApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
@@ -84,9 +84,9 @@ class HeaderApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
@@ -84,9 +84,9 @@ class PathApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -1853,7 +1853,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeFalseArrayInteger(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): string
     {
@@ -1874,7 +1874,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerWithHttpInfo(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): array
     {
@@ -2001,7 +2001,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerAsync(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): PromiseInterface
     {
@@ -2025,7 +2025,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerAsyncWithHttpInfo(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): PromiseInterface
     {
@@ -2078,7 +2078,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeFalseArrayIntegerRequest(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayInteger'][0]
     ): Request
     {
@@ -2171,7 +2171,7 @@ class QueryApi
      * @return string
      */
     public function testQueryStyleFormExplodeFalseArrayString(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): string
     {
@@ -2192,7 +2192,7 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryStyleFormExplodeFalseArrayStringWithHttpInfo(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): array
     {
@@ -2319,7 +2319,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayStringAsync(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): PromiseInterface
     {
@@ -2343,7 +2343,7 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testQueryStyleFormExplodeFalseArrayStringAsyncWithHttpInfo(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): PromiseInterface
     {
@@ -2396,7 +2396,7 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryStyleFormExplodeFalseArrayStringRequest(
-        array $query_object = null,
+        ?array $query_object = null,
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): Request
     {

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -111,9 +111,9 @@ class QueryApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/echo_api/php-nextgen/src/Configuration.php
+++ b/samples/client/echo_api/php-nextgen/src/Configuration.php
@@ -482,7 +482,7 @@ class Configuration
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
     */
-    public static function getHostString(array $hostSettings, int $hostIndex, array $variables = null): string
+    public static function getHostString(array $hostSettings, int $hostIndex, ?array $variables = null): string
     {
         if (null === $variables) {
             $variables = [];

--- a/samples/client/echo_api/php-nextgen/src/Model/Bird.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Bird.php
@@ -247,7 +247,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('size', $data ?? [], null);
         $this->setIfExists('color', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen/src/Model/Category.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Category.php
@@ -247,7 +247,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('name', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen/src/Model/DataQuery.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/DataQuery.php
@@ -241,7 +241,7 @@ class DataQuery extends Query
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/samples/client/echo_api/php-nextgen/src/Model/DefaultValue.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/DefaultValue.php
@@ -301,7 +301,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('array_string_enum_ref_default', $data ?? [], [["success","failure"]]);
         $this->setIfExists('array_string_enum_default', $data ?? [], [["success","failure"]]);

--- a/samples/client/echo_api/php-nextgen/src/Model/NumberPropertiesOnly.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/NumberPropertiesOnly.php
@@ -253,7 +253,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('number', $data ?? [], null);
         $this->setIfExists('float', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen/src/Model/Pet.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Pet.php
@@ -288,7 +288,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('name', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen/src/Model/Query.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Query.php
@@ -264,7 +264,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('outcomes', $data ?? [], [["SUCCESS","FAILURE"]]);

--- a/samples/client/echo_api/php-nextgen/src/Model/Tag.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Tag.php
@@ -247,7 +247,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('name', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen/src/Model/TestFormObjectMultipartRequestMarker.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/TestFormObjectMultipartRequestMarker.php
@@ -241,7 +241,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('name', $data ?? [], null);
     }

--- a/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
@@ -259,7 +259,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('size', $data ?? [], null);
         $this->setIfExists('color', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.php
@@ -241,7 +241,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('values', $data ?? [], null);
     }

--- a/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
+++ b/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
@@ -66,7 +66,7 @@ class ObjectSerializer
      *
      * @return scalar|object|array|null serialized form of $data
      */
-    public static function sanitizeForSerialization(mixed $data, string $type = null, string $format = null): mixed
+    public static function sanitizeForSerialization(mixed $data, ?string $type = null, ?string $format = null): mixed
     {
         if (is_scalar($data) || null === $data) {
             return $data;
@@ -398,7 +398,7 @@ class ObjectSerializer
      *
      * @return mixed a single or an array of $class instances
      */
-    public static function deserialize(mixed $data, string $class, array $httpHeaders = null): mixed
+    public static function deserialize(mixed $data, string $class, ?array $httpHeaders = null): mixed
     {
         if (null === $data) {
             return null;

--- a/samples/client/petstore/php-dt-modern/src/App/ApiClientFactory.php
+++ b/samples/client/petstore/php-dt-modern/src/App/ApiClientFactory.php
@@ -16,7 +16,7 @@ class ApiClientFactory implements PM\ServiceFactoryInterface
         $this->configKey = $configKey;
     }
 
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ApiClient
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): ApiClient
     {
         $config = new OAGAC\ApiClientOptions(\array_merge($this->getServiceConfig($container), $options ?? []));
         return new ApiClient(

--- a/samples/client/petstore/php-dt/src/App/ApiClientFactory.php
+++ b/samples/client/petstore/php-dt/src/App/ApiClientFactory.php
@@ -16,7 +16,7 @@ class ApiClientFactory implements PM\ServiceFactoryInterface
         $this->configKey = $configKey;
     }
 
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ApiClient
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): ApiClient
     {
         $config = new OAGAC\ApiClientOptions(\array_merge($this->getServiceConfig($container), $options ?? []));
         return new ApiClient(

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
@@ -83,9 +83,9 @@ class AnotherFakeApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
@@ -83,9 +83,9 @@ class DefaultApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -4728,14 +4728,14 @@ class FakeApi
      * @return void
      */
     public function testEnumParameters(
-        array $enum_header_string_array = ['$'],
+        ?array $enum_header_string_array = ['$'],
         ?string $enum_header_string = '-efg',
-        array $enum_query_string_array = ['$'],
+        ?array $enum_query_string_array = ['$'],
         ?string $enum_query_string = '-efg',
         ?int $enum_query_integer = null,
         ?float $enum_query_double = null,
-        array $enum_query_model_array = null,
-        array $enum_form_string_array = ['$'],
+        ?array $enum_query_model_array = null,
+        ?array $enum_form_string_array = ['$'],
         ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): void
@@ -4764,14 +4764,14 @@ class FakeApi
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function testEnumParametersWithHttpInfo(
-        array $enum_header_string_array = ['$'],
+        ?array $enum_header_string_array = ['$'],
         ?string $enum_header_string = '-efg',
-        array $enum_query_string_array = ['$'],
+        ?array $enum_query_string_array = ['$'],
         ?string $enum_query_string = '-efg',
         ?int $enum_query_integer = null,
         ?float $enum_query_double = null,
-        array $enum_query_model_array = null,
-        array $enum_form_string_array = ['$'],
+        ?array $enum_query_model_array = null,
+        ?array $enum_form_string_array = ['$'],
         ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): array
@@ -4830,14 +4830,14 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testEnumParametersAsync(
-        array $enum_header_string_array = ['$'],
+        ?array $enum_header_string_array = ['$'],
         ?string $enum_header_string = '-efg',
-        array $enum_query_string_array = ['$'],
+        ?array $enum_query_string_array = ['$'],
         ?string $enum_query_string = '-efg',
         ?int $enum_query_integer = null,
         ?float $enum_query_double = null,
-        array $enum_query_model_array = null,
-        array $enum_form_string_array = ['$'],
+        ?array $enum_query_model_array = null,
+        ?array $enum_form_string_array = ['$'],
         ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): PromiseInterface
@@ -4870,14 +4870,14 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testEnumParametersAsyncWithHttpInfo(
-        array $enum_header_string_array = ['$'],
+        ?array $enum_header_string_array = ['$'],
         ?string $enum_header_string = '-efg',
-        array $enum_query_string_array = ['$'],
+        ?array $enum_query_string_array = ['$'],
         ?string $enum_query_string = '-efg',
         ?int $enum_query_integer = null,
         ?float $enum_query_double = null,
-        array $enum_query_model_array = null,
-        array $enum_form_string_array = ['$'],
+        ?array $enum_query_model_array = null,
+        ?array $enum_form_string_array = ['$'],
         ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): PromiseInterface
@@ -4926,14 +4926,14 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEnumParametersRequest(
-        array $enum_header_string_array = ['$'],
+        ?array $enum_header_string_array = ['$'],
         ?string $enum_header_string = '-efg',
-        array $enum_query_string_array = ['$'],
+        ?array $enum_query_string_array = ['$'],
         ?string $enum_query_string = '-efg',
         ?int $enum_query_integer = null,
         ?float $enum_query_double = null,
-        array $enum_query_model_array = null,
-        array $enum_form_string_array = ['$'],
+        ?array $enum_query_model_array = null,
+        ?array $enum_form_string_array = ['$'],
         ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): Request
@@ -6369,7 +6369,7 @@ class FakeApi
         array $url,
         array $context,
         string $allow_empty,
-        array $language = null,
+        ?array $language = null,
         string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
     ): void
     {
@@ -6399,7 +6399,7 @@ class FakeApi
         array $url,
         array $context,
         string $allow_empty,
-        array $language = null,
+        ?array $language = null,
         string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
     ): array
     {
@@ -6459,7 +6459,7 @@ class FakeApi
         array $url,
         array $context,
         string $allow_empty,
-        array $language = null,
+        ?array $language = null,
         string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
     ): PromiseInterface
     {
@@ -6493,7 +6493,7 @@ class FakeApi
         array $url,
         array $context,
         string $allow_empty,
-        array $language = null,
+        ?array $language = null,
         string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
     ): PromiseInterface
     {
@@ -6545,7 +6545,7 @@ class FakeApi
         array $url,
         array $context,
         string $allow_empty,
-        array $language = null,
+        ?array $language = null,
         string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
     ): Request
     {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -150,9 +150,9 @@ class FakeApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
@@ -83,9 +83,9 @@ class FakeClassnameTags123Api
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -109,9 +109,9 @@ class PetApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -92,9 +92,9 @@ class StoreApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -104,9 +104,9 @@ class UserApi
      * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Configuration.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Configuration.php
@@ -518,7 +518,7 @@ class Configuration
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
     */
-    public static function getHostString(array $hostSettings, int $hostIndex, array $variables = null): string
+    public static function getHostString(array $hostSettings, int $hostIndex, ?array $variables = null): string
     {
         if (null === $variables) {
             $variables = [];

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
@@ -246,7 +246,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('map_property', $data ?? [], null);
         $this->setIfExists('map_of_map_property', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
@@ -246,7 +246,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('username', $data ?? [], null);
         $this->setIfExists('single_ref_type', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
@@ -248,7 +248,7 @@ class Animal implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         // Initialize discriminator property with the model name.
         $this->container['class_name'] = static::$openAPIModelName;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
@@ -252,7 +252,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('code', $data ?? [], null);
         $this->setIfExists('type', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfArrayOfNumberOnly.php
@@ -240,7 +240,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSeria
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('array_array_number', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfNumberOnly.php
@@ -240,7 +240,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('array_number', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
@@ -252,7 +252,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('array_of_string', $data ?? [], null);
         $this->setIfExists('array_array_of_integer', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
@@ -270,7 +270,7 @@ class Capitalization implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('small_camel', $data ?? [], null);
         $this->setIfExists('capital_camel', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
@@ -228,7 +228,7 @@ class Cat extends Animal
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
@@ -246,7 +246,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('name', $data ?? [], 'default-name');

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ChildWithNullable.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ChildWithNullable.php
@@ -228,7 +228,7 @@ class ChildWithNullable extends ParentWithNullable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ClassModel.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ClassModel.php
@@ -241,7 +241,7 @@ class ClassModel implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('_class', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Client.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Client.php
@@ -240,7 +240,7 @@ class Client implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('client', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DeprecatedObject.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DeprecatedObject.php
@@ -240,7 +240,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('name', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
@@ -228,7 +228,7 @@ class Dog extends Animal
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
@@ -276,7 +276,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('just_symbol', $data ?? [], null);
         $this->setIfExists('array_enum', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
@@ -346,7 +346,7 @@ class EnumTest implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('enum_string', $data ?? [], null);
         $this->setIfExists('enum_string_required', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
@@ -246,7 +246,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, JsonS
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('some_id', $data ?? [], null);
         $this->setIfExists('some_map', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/File.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/File.php
@@ -241,7 +241,7 @@ class File implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('source_uri', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
@@ -246,7 +246,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('file', $data ?? [], null);
         $this->setIfExists('files', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Foo.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Foo.php
@@ -240,7 +240,7 @@ class Foo implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('bar', $data ?? [], 'bar');
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FooGetDefaultResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FooGetDefaultResponse.php
@@ -240,7 +240,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('string', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
@@ -336,7 +336,7 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('integer', $data ?? [], null);
         $this->setIfExists('int32', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
@@ -246,7 +246,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('bar', $data ?? [], null);
         $this->setIfExists('foo', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HealthCheckResult.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HealthCheckResult.php
@@ -241,7 +241,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('nullable_message', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
@@ -273,7 +273,7 @@ class MapTest implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('map_map_of_string', $data ?? [], null);
         $this->setIfExists('map_of_enum_string', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -252,7 +252,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('uuid', $data ?? [], null);
         $this->setIfExists('date_time', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
@@ -247,7 +247,7 @@ class Model200Response implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('name', $data ?? [], null);
         $this->setIfExists('class', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelList.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelList.php
@@ -240,7 +240,7 @@ class ModelList implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('_123_list', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelReturn.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelReturn.php
@@ -241,7 +241,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('return', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
@@ -259,7 +259,7 @@ class Name implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('name', $data ?? [], null);
         $this->setIfExists('snake_case', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
@@ -306,7 +306,7 @@ class NullableClass implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('integer_prop', $data ?? [], null);
         $this->setIfExists('number_prop', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NumberOnly.php
@@ -240,7 +240,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('just_number', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
@@ -258,7 +258,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, JsonSer
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('uuid', $data ?? [], null);
         $this->setIfExists('id', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
@@ -287,7 +287,7 @@ class Order implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('pet_id', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
@@ -252,7 +252,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('my_number', $data ?? [], null);
         $this->setIfExists('my_string', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterObjectWithEnumProperty.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterObjectWithEnumProperty.php
@@ -240,7 +240,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, JsonSe
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('value', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ParentWithNullable.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ParentWithNullable.php
@@ -259,7 +259,7 @@ class ParentWithNullable implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         // Initialize discriminator property with the model name.
         $this->container['type'] = static::$openAPIModelName;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
@@ -287,7 +287,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('category', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
@@ -246,7 +246,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('bar', $data ?? [], null);
         $this->setIfExists('baz', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SpecialModelName.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SpecialModelName.php
@@ -240,7 +240,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('special_property_name', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
@@ -246,7 +246,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('name', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/TestInlineFreeformAdditionalPropertiesRequest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/TestInlineFreeformAdditionalPropertiesRequest.php
@@ -240,7 +240,7 @@ class TestInlineFreeformAdditionalPropertiesRequest implements ModelInterface, A
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('some_property', $data ?? [], null);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
@@ -282,7 +282,7 @@ class User implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @param array $data Associated array of property values initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('username', $data ?? [], null);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
@@ -65,7 +65,7 @@ class ObjectSerializer
      *
      * @return scalar|object|array|null serialized form of $data
      */
-    public static function sanitizeForSerialization(mixed $data, string $type = null, string $format = null): mixed
+    public static function sanitizeForSerialization(mixed $data, ?string $type = null, ?string $format = null): mixed
     {
         if (is_scalar($data) || null === $data) {
             return $data;
@@ -397,7 +397,7 @@ class ObjectSerializer
      *
      * @return mixed a single or an array of $class instances
      */
-    public static function deserialize(mixed $data, string $class, array $httpHeaders = null): mixed
+    public static function deserialize(mixed $data, string $class, ?array $httpHeaders = null): mixed
     {
         if (null === $data) {
             return null;

--- a/samples/server/petstore/php-mezzio-ph-modern/src/App/Factory.php
+++ b/samples/server/petstore/php-mezzio-ph-modern/src/App/Factory.php
@@ -21,7 +21,7 @@ use Laminas\Stratigility\MiddlewarePipe;
 
 class Factory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): Application
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): Application
     {
         $errorMiddleware = self::getErrorMiddleware($container);
         $pipeline = new MiddlewarePipe();

--- a/samples/server/petstore/php-mezzio-ph/src/App/Factory.php
+++ b/samples/server/petstore/php-mezzio-ph/src/App/Factory.php
@@ -21,7 +21,7 @@ use Laminas\Stratigility\MiddlewarePipe;
 
 class Factory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): Application
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): Application
     {
         $errorMiddleware = self::getErrorMiddleware($container);
         $pipeline = new MiddlewarePipe();


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
PR #20243 fixed some deprecation warnings from PHP 8.4 in the PHP generator. This PR applies the same fixes to the other PHP clients.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon