### PR TITLE
[csharp][generichost] Removed a using statement

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/RateLimitProvider`1.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/RateLimitProvider`1.mustache
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace {{packageName}}.{{clientPackage}}
 {
@@ -17,7 +16,7 @@ namespace {{packageName}}.{{clientPackage}}
     /// <typeparam name="TTokenBase"></typeparam>
     {{>visibility}} class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new{{^net70OrLater}} Dictionary<string, Channel<TTokenBase>>{{/net70OrLater}}();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new{{^net70OrLater}} Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>{{/net70OrLater}}();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -29,12 +28,12 @@ namespace {{packageName}}.{{clientPackage}}
                 token.StartTimer(token.Timeout ?? TimeSpan.FromMilliseconds(40));
 
             {{#lambda.copy}}
-            BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+            global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
             {
-                FullMode = BoundedChannelFullMode.DropWrite
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
-            AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+            AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             {{/lambda.copy}}
             {{#hasApiKeyMethods}}
             if (container is TokenContainer<ApiKeyToken> apiKeyTokenContainer)
@@ -43,12 +42,12 @@ namespace {{packageName}}.{{clientPackage}}
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
@@ -64,14 +63,14 @@ namespace {{packageName}}.{{clientPackage}}
             {{/lambda.paste}}
             {{/hasApiKeyMethods}}
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default{{^netstandard20OrLater}}(global::System.Threading.CancellationToken){{/netstandard20OrLater}})
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase>{{nrt?}} tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>{{nrt?}} tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -14,7 +14,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -24,7 +23,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -41,32 +40,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase>? tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -32,21 +31,21 @@ namespace Org.OpenAPITools.Client
             foreach(TTokenBase token in _tokens)
                 token.StartTimer(token.Timeout ?? TimeSpan.FromMilliseconds(40));
 
-            BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+            global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
             {
-                FullMode = BoundedChannelFullMode.DropWrite
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
-            AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+            AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -32,21 +31,21 @@ namespace Org.OpenAPITools.Client
             foreach(TTokenBase token in _tokens)
                 token.StartTimer(token.Timeout ?? TimeSpan.FromMilliseconds(40));
 
-            BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+            global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
             {
-                FullMode = BoundedChannelFullMode.DropWrite
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
-            AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+            AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -32,21 +31,21 @@ namespace Org.OpenAPITools.Client
             foreach(TTokenBase token in _tokens)
                 token.StartTimer(token.Timeout ?? TimeSpan.FromMilliseconds(40));
 
-            BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+            global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
             {
-                FullMode = BoundedChannelFullMode.DropWrite
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
-            AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+            AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -38,32 +37,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -32,21 +31,21 @@ namespace Org.OpenAPITools.Client
             foreach(TTokenBase token in _tokens)
                 token.StartTimer(token.Timeout ?? TimeSpan.FromMilliseconds(40));
 
-            BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+            global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
             {
-                FullMode = BoundedChannelFullMode.DropWrite
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
-            AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+            AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -38,32 +37,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -32,21 +31,21 @@ namespace Org.OpenAPITools.Client
             foreach(TTokenBase token in _tokens)
                 token.StartTimer(token.Timeout ?? TimeSpan.FromMilliseconds(40));
 
-            BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+            global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
             {
-                FullMode = BoundedChannelFullMode.DropWrite
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
-            AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+            AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -32,21 +31,21 @@ namespace Org.OpenAPITools.Client
             foreach(TTokenBase token in _tokens)
                 token.StartTimer(token.Timeout ?? TimeSpan.FromMilliseconds(40));
 
-            BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+            global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
             {
-                FullMode = BoundedChannelFullMode.DropWrite
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
-            AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+            AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -32,21 +31,21 @@ namespace Org.OpenAPITools.Client
             foreach(TTokenBase token in _tokens)
                 token.StartTimer(token.Timeout ?? TimeSpan.FromMilliseconds(40));
 
-            BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+            global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
             {
-                FullMode = BoundedChannelFullMode.DropWrite
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
-            AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+            AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -32,21 +31,21 @@ namespace Org.OpenAPITools.Client
             foreach(TTokenBase token in _tokens)
                 token.StartTimer(token.Timeout ?? TimeSpan.FromMilliseconds(40));
 
-            BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+            global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
             {
-                FullMode = BoundedChannelFullMode.DropWrite
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
-            AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+            AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -38,32 +37,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -32,21 +31,21 @@ namespace Org.OpenAPITools.Client
             foreach(TTokenBase token in _tokens)
                 token.StartTimer(token.Timeout ?? TimeSpan.FromMilliseconds(40));
 
-            BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+            global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
             {
-                FullMode = BoundedChannelFullMode.DropWrite
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
-            AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+            AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -38,32 +37,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -32,21 +31,21 @@ namespace Org.OpenAPITools.Client
             foreach(TTokenBase token in _tokens)
                 token.StartTimer(token.Timeout ?? TimeSpan.FromMilliseconds(40));
 
-            BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+            global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
             {
-                FullMode = BoundedChannelFullMode.DropWrite
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
-            AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+            AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -38,32 +37,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -13,7 +13,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -23,7 +22,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -40,32 +39,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase>? tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -38,32 +37,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -13,7 +13,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -23,7 +22,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -40,32 +39,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase>? tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -38,32 +37,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -13,7 +13,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -23,7 +22,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -40,32 +39,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase>? tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -38,32 +37,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -13,7 +13,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -23,7 +22,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -40,32 +39,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase>? tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Channels;
 
 namespace Org.OpenAPITools.Client
 {
@@ -21,7 +20,7 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        internal Dictionary<string, Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, Channel<TTokenBase>>();
+        internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -38,32 +37,32 @@ namespace Org.OpenAPITools.Client
 
                 foreach (string header in headers)
                 {
-                    BoundedChannelOptions options = new BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
+                    global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = BoundedChannelFullMode.DropWrite
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
-                    AvailableTokens.Add(header, Channel.CreateBounded<TTokenBase>(options));
+                    AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
                 }
             }
             else
             {
-                BoundedChannelOptions options = new BoundedChannelOptions(_tokens.Length)
+                global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(_tokens.Length)
                 {
-                    FullMode = BoundedChannelFullMode.DropWrite
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
-                AvailableTokens.Add(string.Empty, Channel.CreateBounded<TTokenBase>(options));
+                AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
             }
 
-            foreach(Channel<TTokenBase> tokens in AvailableTokens.Values)
+            foreach(global::System.Threading.Channels.Channel<TTokenBase> tokens in AvailableTokens.Values)
                 for (int i = 0; i < _tokens.Length; i++)
                     _tokens[i].TokenBecameAvailable += ((sender) => tokens.Writer.TryWrite((TTokenBase) sender));
         }
 
         internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
-            if (!AvailableTokens.TryGetValue(header, out Channel<TTokenBase> tokens))
+            if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");
 
             return await tokens.Reader.ReadAsync(cancellation).ConfigureAwait(false);


### PR DESCRIPTION
Fixes https://github.com/OpenAPITools/openapi-generator/issues/19682

No need for samples to change other than what is here because we can't test every package name an end user may use. Instead, we should avoid using using statements.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
