### PR TITLE
Patch which is ido not overwrite supporting file

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -1098,6 +1098,10 @@ public class DefaultGenerator implements Generator {
                     }
                 }
 
+                if(new File(outputFilename).exists() && !support.isCanOverwrite()) {
+                    this.templateProcessor.skip(outputFilename, String.format(Locale.ROOT, "Skipped existing overwiting file %s as overwriting is disabled by the template.", support.getDestinationFilename()));
+                    continue;
+                }
 
                 boolean shouldGenerate = true;
                 if (supportingFilesToGenerate != null && !supportingFilesToGenerate.isEmpty()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -1099,7 +1099,7 @@ public class DefaultGenerator implements Generator {
                 }
 
                 if(new File(outputFilename).exists() && !support.isCanOverwrite()) {
-                    this.templateProcessor.skip(outputFilename, String.format(Locale.ROOT, "Skipped existing overwiting file %s as overwriting is disabled by the template.", support.getDestinationFilename()));
+                    this.templateProcessor.skip(outputFilename, String.format(Locale.ROOT, "Skipped overwiting existing file %s as overwriting is disabled by used generator.", support.getDestinationFilename()));
                     continue;
                 }
 


### PR DESCRIPTION
@martin-mfg  In java class org.openapitools.codegen.SupportingFile exists a method named *doNotOverwrite* which should be used to indicate a "supporting file which should not overwrite a file of the same name.". However, I could not find an implementation of this anywhere in the Java DefaultGenerator.

This patch is simply implementing this behaviour as described in javadoc of the class I mentioned. If the file exists, and the file will be skipped and corresponding status message is set.
Feel free to modify the patch or change the logged text to a more obvious one using the right terminology.

Thank you for the great work!
Rob

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
