### PR TITLE
[Rust] Bump axum and axum-extra

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
@@ -427,7 +427,7 @@ public class RustAxumServerCodegen extends AbstractRustCodegen implements Codege
             for (CodegenParameter param : op.pathParams) {
                 // Replace {baseName} with {paramName} for format string
                 String paramSearch = "{" + param.baseName + "}";
-                String paramReplace = ":" + param.paramName;
+                String paramReplace = "{" + param.paramName + "}";
 
                 axumPath = axumPath.replace(paramSearch, paramReplace);
             }

--- a/modules/openapi-generator/src/main/resources/rust-axum/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/Cargo.mustache
@@ -40,8 +40,8 @@ conversion = [
 
 [dependencies]
 async-trait = "0.1"
-axum = "0.7"
-axum-extra = { version = "0.9", features = ["cookie", "multipart"] }
+axum = { version = "0.8", features = ["multipart"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/modules/openapi-generator/src/main/resources/rust-axum/apis-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/apis-mod.mustache
@@ -37,7 +37,7 @@ pub trait ErrorHandler<E: std::fmt::Debug + Send + Sync + 'static = ()> {
     async fn handle_error(
         &self,
         method: &::http::Method,
-        host: &axum::extract::Host,
+        host: &axum_extra::extract::Host,
         cookies: &axum_extra::extract::CookieJar,
         error: E
     ) -> Result<axum::response::Response, http::StatusCode> {

--- a/modules/openapi-generator/src/main/resources/rust-axum/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/apis.mustache
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/modules/openapi-generator/src/main/resources/rust-axum/server-imports.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/server-imports.mustache
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use axum::{body::Body, extract::*, response::Response, routing::*};
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use tracing::error;

--- a/samples/server/petstore/rust-axum/output/apikey-auths/Cargo.toml
+++ b/samples/server/petstore/rust-axum/output/apikey-auths/Cargo.toml
@@ -18,8 +18,8 @@ conversion = [
 
 [dependencies]
 async-trait = "0.1"
-axum = "0.7"
-axum-extra = { version = "0.9", features = ["cookie", "multipart"] }
+axum = { version = "0.8", features = ["multipart"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/samples/server/petstore/rust-axum/output/apikey-auths/src/apis/mod.rs
+++ b/samples/server/petstore/rust-axum/output/apikey-auths/src/apis/mod.rs
@@ -33,7 +33,7 @@ pub trait ErrorHandler<E: std::fmt::Debug + Send + Sync + 'static = ()> {
     async fn handle_error(
         &self,
         method: &::http::Method,
-        host: &axum::extract::Host,
+        host: &axum_extra::extract::Host,
         cookies: &axum_extra::extract::CookieJar,
         error: E,
     ) -> Result<axum::response::Response, http::StatusCode> {

--- a/samples/server/petstore/rust-axum/output/apikey-auths/src/apis/payments.rs
+++ b/samples/server/petstore/rust-axum/output/apikey-auths/src/apis/payments.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/apikey-auths/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/apikey-auths/src/server/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use axum::{body::Body, extract::*, response::Response, routing::*};
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use tracing::error;
@@ -32,7 +32,7 @@ where
             get(get_payment_methods::<I, A, E, C>),
         )
         .route(
-            "/v71/paymentMethods/:id",
+            "/v71/paymentMethods/{id}",
             get(get_payment_method_by_id::<I, A, E, C>),
         )
         .route("/v71/payments", post(post_make_payment::<I, A, E, C>))

--- a/samples/server/petstore/rust-axum/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/Cargo.toml
@@ -18,8 +18,8 @@ conversion = [
 
 [dependencies]
 async-trait = "0.1"
-axum = "0.7"
-axum-extra = { version = "0.9", features = ["cookie", "multipart"] }
+axum = { version = "0.8", features = ["multipart"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/samples/server/petstore/rust-axum/output/multipart-v3/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/src/apis/default.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/multipart-v3/src/apis/mod.rs
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/src/apis/mod.rs
@@ -8,7 +8,7 @@ pub trait ErrorHandler<E: std::fmt::Debug + Send + Sync + 'static = ()> {
     async fn handle_error(
         &self,
         method: &::http::Method,
-        host: &axum::extract::Host,
+        host: &axum_extra::extract::Host,
         cookies: &axum_extra::extract::CookieJar,
         error: E,
     ) -> Result<axum::response::Response, http::StatusCode> {

--- a/samples/server/petstore/rust-axum/output/multipart-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/src/server/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use axum::{body::Body, extract::*, response::Response, routing::*};
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use tracing::error;

--- a/samples/server/petstore/rust-axum/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/Cargo.toml
@@ -18,8 +18,8 @@ conversion = [
 
 [dependencies]
 async-trait = "0.1"
-axum = "0.7"
-axum-extra = { version = "0.9", features = ["cookie", "multipart"] }
+axum = { version = "0.8", features = ["multipart"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/default.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/info_repo.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/info_repo.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/mod.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/mod.rs
@@ -10,7 +10,7 @@ pub trait ErrorHandler<E: std::fmt::Debug + Send + Sync + 'static = ()> {
     async fn handle_error(
         &self,
         method: &::http::Method,
-        host: &axum::extract::Host,
+        host: &axum_extra::extract::Host,
         cookies: &axum_extra::extract::CookieJar,
         error: E,
     ) -> Result<axum::response::Response, http::StatusCode> {

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/repo.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/apis/repo.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/server/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use axum::{body::Body, extract::*, response::Response, routing::*};
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use tracing::error;
@@ -35,7 +35,7 @@ where
         .route("/complex-query-param",
             get(complex_query_param_get::<I, A, E>)
         )
-        .route("/enum_in_path/:path_param",
+        .route("/enum_in_path/{path_param}",
             get(enum_in_path_path_param_get::<I, A, E>)
         )
         .route("/form-test",
@@ -56,7 +56,7 @@ where
         .route("/multiget",
             get(multiget_get::<I, A, E>)
         )
-        .route("/multiple-path-params-with-very-long-path-to-test-formatting/:path_param_a/:path_param_b",
+        .route("/multiple-path-params-with-very-long-path-to-test-formatting/{path_param_a}/{path_param_b}",
             get(multiple_path_params_with_very_long_path_to_test_formatting_path_param_a_path_param_b_get::<I, A, E>)
         )
         .route("/multiple_auth_scheme",
@@ -83,7 +83,7 @@ where
         .route("/repos",
             post(create_repo::<I, A, E>)
         )
-        .route("/repos/:repo_id",
+        .route("/repos/{repo_id}",
             get(get_repo_info::<I, A, E>).get(get_repo_info::<I, A, E>)
         )
         .route("/required_octet_stream",

--- a/samples/server/petstore/rust-axum/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-axum/output/ops-v3/Cargo.toml
@@ -18,8 +18,8 @@ conversion = [
 
 [dependencies]
 async-trait = "0.1"
-axum = "0.7"
-axum-extra = { version = "0.9", features = ["cookie", "multipart"] }
+axum = { version = "0.8", features = ["multipart"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/samples/server/petstore/rust-axum/output/ops-v3/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/ops-v3/src/apis/default.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/ops-v3/src/apis/mod.rs
+++ b/samples/server/petstore/rust-axum/output/ops-v3/src/apis/mod.rs
@@ -8,7 +8,7 @@ pub trait ErrorHandler<E: std::fmt::Debug + Send + Sync + 'static = ()> {
     async fn handle_error(
         &self,
         method: &::http::Method,
-        host: &axum::extract::Host,
+        host: &axum_extra::extract::Host,
         cookies: &axum_extra::extract::CookieJar,
         error: E,
     ) -> Result<axum::response::Response, http::StatusCode> {

--- a/samples/server/petstore/rust-axum/output/ops-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/ops-v3/src/server/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use axum::{body::Body, extract::*, response::Response, routing::*};
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use tracing::error;

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -20,8 +20,8 @@ conversion = [
 
 [dependencies]
 async-trait = "0.1"
-axum = "0.7"
-axum-extra = { version = "0.9", features = ["cookie", "multipart"] }
+axum = { version = "0.8", features = ["multipart"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/another_fake.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/another_fake.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/fake.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/fake.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/fake_classname_tags123.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/fake_classname_tags123.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/mod.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/mod.rs
@@ -26,7 +26,7 @@ pub trait ErrorHandler<E: std::fmt::Debug + Send + Sync + 'static = ()> {
     async fn handle_error(
         &self,
         method: &::http::Method,
-        host: &axum::extract::Host,
+        host: &axum_extra::extract::Host,
         cookies: &axum_extra::extract::CookieJar,
         error: E,
     ) -> Result<axum::response::Response, http::StatusCode> {

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/pet.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/pet.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/store.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/store.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/user.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/apis/user.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use axum::{body::Body, extract::*, response::Response, routing::*};
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use tracing::error;
@@ -46,7 +46,7 @@ where
             put(test_body_with_query_params::<I, A, E>),
         )
         .route(
-            "/v2/fake/hyphenParam/:hyphen_param",
+            "/v2/fake/hyphenParam/{hyphen_param}",
             get(hyphen_param::<I, A, E>),
         )
         .route(
@@ -84,33 +84,27 @@ where
             post(add_pet::<I, A, E, C>).put(update_pet::<I, A, E, C>),
         )
         .route(
-            "/v2/pet/:pet_id",
+            "/v2/pet/findByStatus",
+            get(find_pets_by_status::<I, A, E, C>),
+        )
+        .route("/v2/pet/findByTags", get(find_pets_by_tags::<I, A, E, C>))
+        .route(
+            "/v2/pet/{pet_id}",
             delete(delete_pet::<I, A, E, C>)
                 .get(get_pet_by_id::<I, A, E, C>)
                 .post(update_pet_with_form::<I, A, E, C>),
         )
         .route(
-            "/v2/pet/:pet_id/uploadImage",
+            "/v2/pet/{pet_id}/uploadImage",
             post(upload_file::<I, A, E, C>),
         )
-        .route(
-            "/v2/pet/findByStatus",
-            get(find_pets_by_status::<I, A, E, C>),
-        )
-        .route("/v2/pet/findByTags", get(find_pets_by_tags::<I, A, E, C>))
         .route("/v2/store/inventory", get(get_inventory::<I, A, E, C>))
         .route("/v2/store/order", post(place_order::<I, A, E, C>))
         .route(
-            "/v2/store/order/:order_id",
+            "/v2/store/order/{order_id}",
             delete(delete_order::<I, A, E, C>).get(get_order_by_id::<I, A, E, C>),
         )
         .route("/v2/user", post(create_user::<I, A, E>))
-        .route(
-            "/v2/user/:username",
-            delete(delete_user::<I, A, E>)
-                .get(get_user_by_name::<I, A, E>)
-                .put(update_user::<I, A, E>),
-        )
         .route(
             "/v2/user/createWithArray",
             post(create_users_with_array_input::<I, A, E>),
@@ -121,6 +115,12 @@ where
         )
         .route("/v2/user/login", get(login_user::<I, A, E>))
         .route("/v2/user/logout", get(logout_user::<I, A, E>))
+        .route(
+            "/v2/user/{username}",
+            delete(delete_user::<I, A, E>)
+                .get(get_user_by_name::<I, A, E>)
+                .put(update_user::<I, A, E>),
+        )
         .with_state(api_impl)
 }
 

--- a/samples/server/petstore/rust-axum/output/petstore/Cargo.toml
+++ b/samples/server/petstore/rust-axum/output/petstore/Cargo.toml
@@ -19,8 +19,8 @@ conversion = [
 
 [dependencies]
 async-trait = "0.1"
-axum = "0.7"
-axum-extra = { version = "0.9", features = ["cookie", "multipart"] }
+axum = { version = "0.8", features = ["multipart"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/samples/server/petstore/rust-axum/output/petstore/src/apis/mod.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/apis/mod.rs
@@ -23,7 +23,7 @@ pub trait ErrorHandler<E: std::fmt::Debug + Send + Sync + 'static = ()> {
     async fn handle_error(
         &self,
         method: &::http::Method,
-        host: &axum::extract::Host,
+        host: &axum_extra::extract::Host,
         cookies: &axum_extra::extract::CookieJar,
         error: E,
     ) -> Result<axum::response::Response, http::StatusCode> {

--- a/samples/server/petstore/rust-axum/output/petstore/src/apis/pet.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/apis/pet.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/petstore/src/apis/store.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/apis/store.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/petstore/src/apis/user.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/apis/user.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/petstore/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/server/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use axum::{body::Body, extract::*, response::Response, routing::*};
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use tracing::error;
@@ -33,33 +33,27 @@ where
             post(add_pet::<I, A, E, C>).put(update_pet::<I, A, E, C>),
         )
         .route(
-            "/v2/pet/:pet_id",
+            "/v2/pet/findByStatus",
+            get(find_pets_by_status::<I, A, E, C>),
+        )
+        .route("/v2/pet/findByTags", get(find_pets_by_tags::<I, A, E, C>))
+        .route(
+            "/v2/pet/{pet_id}",
             delete(delete_pet::<I, A, E, C>)
                 .get(get_pet_by_id::<I, A, E, C>)
                 .post(update_pet_with_form::<I, A, E, C>),
         )
         .route(
-            "/v2/pet/:pet_id/uploadImage",
+            "/v2/pet/{pet_id}/uploadImage",
             post(upload_file::<I, A, E, C>),
         )
-        .route(
-            "/v2/pet/findByStatus",
-            get(find_pets_by_status::<I, A, E, C>),
-        )
-        .route("/v2/pet/findByTags", get(find_pets_by_tags::<I, A, E, C>))
         .route("/v2/store/inventory", get(get_inventory::<I, A, E, C>))
         .route("/v2/store/order", post(place_order::<I, A, E, C>))
         .route(
-            "/v2/store/order/:order_id",
+            "/v2/store/order/{order_id}",
             delete(delete_order::<I, A, E, C>).get(get_order_by_id::<I, A, E, C>),
         )
         .route("/v2/user", post(create_user::<I, A, E, C>))
-        .route(
-            "/v2/user/:username",
-            delete(delete_user::<I, A, E, C>)
-                .get(get_user_by_name::<I, A, E, C>)
-                .put(update_user::<I, A, E, C>),
-        )
         .route(
             "/v2/user/createWithArray",
             post(create_users_with_array_input::<I, A, E, C>),
@@ -70,6 +64,12 @@ where
         )
         .route("/v2/user/login", get(login_user::<I, A, E, C>))
         .route("/v2/user/logout", get(logout_user::<I, A, E, C>))
+        .route(
+            "/v2/user/{username}",
+            delete(delete_user::<I, A, E, C>)
+                .get(get_user_by_name::<I, A, E, C>)
+                .put(update_user::<I, A, E, C>),
+        )
         .with_state(api_impl)
 }
 

--- a/samples/server/petstore/rust-axum/output/ping-bearer-auth/Cargo.toml
+++ b/samples/server/petstore/rust-axum/output/ping-bearer-auth/Cargo.toml
@@ -18,8 +18,8 @@ conversion = [
 
 [dependencies]
 async-trait = "0.1"
-axum = "0.7"
-axum-extra = { version = "0.9", features = ["cookie", "multipart"] }
+axum = { version = "0.8", features = ["multipart"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/apis/default.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/apis/mod.rs
+++ b/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/apis/mod.rs
@@ -8,7 +8,7 @@ pub trait ErrorHandler<E: std::fmt::Debug + Send + Sync + 'static = ()> {
     async fn handle_error(
         &self,
         method: &::http::Method,
-        host: &axum::extract::Host,
+        host: &axum_extra::extract::Host,
         cookies: &axum_extra::extract::CookieJar,
         error: E,
     ) -> Result<axum::response::Response, http::StatusCode> {

--- a/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/server/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use axum::{body::Body, extract::*, response::Response, routing::*};
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use tracing::error;

--- a/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/Cargo.toml
+++ b/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/Cargo.toml
@@ -18,8 +18,8 @@ conversion = [
 
 [dependencies]
 async-trait = "0.1"
-axum = "0.7"
-axum-extra = { version = "0.9", features = ["cookie", "multipart"] }
+axum = { version = "0.8", features = ["multipart"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/apis/default.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/apis/mod.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/apis/mod.rs
@@ -8,7 +8,7 @@ pub trait ErrorHandler<E: std::fmt::Debug + Send + Sync + 'static = ()> {
     async fn handle_error(
         &self,
         method: &::http::Method,
-        host: &axum::extract::Host,
+        host: &axum_extra::extract::Host,
         cookies: &axum_extra::extract::CookieJar,
         error: E,
     ) -> Result<axum::response::Response, http::StatusCode> {

--- a/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/server/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use axum::{body::Body, extract::*, response::Response, routing::*};
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use tracing::error;

--- a/samples/server/petstore/rust-axum/output/rust-axum-oneof/Cargo.toml
+++ b/samples/server/petstore/rust-axum/output/rust-axum-oneof/Cargo.toml
@@ -18,8 +18,8 @@ conversion = [
 
 [dependencies]
 async-trait = "0.1"
-axum = "0.7"
-axum-extra = { version = "0.9", features = ["cookie", "multipart"] }
+axum = { version = "0.8", features = ["multipart"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/apis/default.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/apis/mod.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/apis/mod.rs
@@ -8,7 +8,7 @@ pub trait ErrorHandler<E: std::fmt::Debug + Send + Sync + 'static = ()> {
     async fn handle_error(
         &self,
         method: &::http::Method,
-        host: &axum::extract::Host,
+        host: &axum_extra::extract::Host,
         cookies: &axum_extra::extract::CookieJar,
         error: E,
     ) -> Result<axum::response::Response, http::StatusCode> {

--- a/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/server/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use axum::{body::Body, extract::*, response::Response, routing::*};
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use tracing::error;

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/Cargo.toml
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/Cargo.toml
@@ -18,8 +18,8 @@ conversion = [
 
 [dependencies]
 async-trait = "0.1"
-axum = "0.7"
-axum-extra = { version = "0.9", features = ["cookie", "multipart"] }
+axum = { version = "0.8", features = ["multipart"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/src/apis/default.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/src/apis/mod.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/src/apis/mod.rs
@@ -8,7 +8,7 @@ pub trait ErrorHandler<E: std::fmt::Debug + Send + Sync + 'static = ()> {
     async fn handle_error(
         &self,
         method: &::http::Method,
-        host: &axum::extract::Host,
+        host: &axum_extra::extract::Host,
         cookies: &axum_extra::extract::CookieJar,
         error: E,
     ) -> Result<axum::response::Response, http::StatusCode> {

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/src/server/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use axum::{body::Body, extract::*, response::Response, routing::*};
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use tracing::error;

--- a/samples/server/petstore/rust-axum/output/rust-axum-validation-test/Cargo.toml
+++ b/samples/server/petstore/rust-axum/output/rust-axum-validation-test/Cargo.toml
@@ -18,8 +18,8 @@ conversion = [
 
 [dependencies]
 async-trait = "0.1"
-axum = "0.7"
-axum-extra = { version = "0.9", features = ["cookie", "multipart"] }
+axum = { version = "0.8", features = ["multipart"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/apis/default.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/apis/default.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::*;
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::Method;
 use serde::{Deserialize, Serialize};

--- a/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/apis/mod.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/apis/mod.rs
@@ -8,7 +8,7 @@ pub trait ErrorHandler<E: std::fmt::Debug + Send + Sync + 'static = ()> {
     async fn handle_error(
         &self,
         method: &::http::Method,
-        host: &axum::extract::Host,
+        host: &axum_extra::extract::Host,
         cookies: &axum_extra::extract::CookieJar,
         error: E,
     ) -> Result<axum::response::Response, http::StatusCode> {

--- a/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/server/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use axum::{body::Body, extract::*, response::Response, routing::*};
-use axum_extra::extract::{CookieJar, Multipart};
+use axum_extra::extract::{CookieJar, Host};
 use bytes::Bytes;
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use tracing::error;


### PR DESCRIPTION
- This bump required fixing path parameters due to `matchit` transitive dependency
changes (See https://github.com/tokio-rs/axum/pull/2645).

 - The `Host` extractor has been moved from `axum` to `axum-extra`.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@frol, @farcaller, @richardwhiuk, @paladinzh, @jacob-pro ping!