### PR TITLE
[JAVA] Jersey3 remove unused imports

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/AbstractOpenApiSchema.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/AbstractOpenApiSchema.mustache
@@ -2,9 +2,7 @@
 
 package {{modelPackage}};
 
-import {{invokerPackage}}.ApiException;
 import java.util.Objects;
-import java.lang.reflect.Type;
 import java.util.Map;
 import {{javaxPackage}}.ws.rs.core.GenericType;
 

--- a/samples/client/petstore/java/jersey3-oneOf/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
+++ b/samples/client/petstore/java/jersey3-oneOf/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
@@ -13,9 +13,7 @@
 
 package org.openapitools.client.model;
 
-import org.openapitools.client.ApiException;
 import java.util.Objects;
-import java.lang.reflect.Type;
 import java.util.Map;
 import jakarta.ws.rs.core.GenericType;
 

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
@@ -13,9 +13,7 @@
 
 package org.openapitools.client.model;
 
-import org.openapitools.client.ApiException;
 import java.util.Objects;
-import java.lang.reflect.Type;
 import java.util.Map;
 import jakarta.ws.rs.core.GenericType;
 


### PR DESCRIPTION
Remove unused imports in the `Jersey3` generation.
In particular 
```
import {{invokerPackage}}.ApiException;
``` 
creates a compilation error when the application doesn't have a class called `ApiException`.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 

