### PR TITLE
[swift][bug] Fix generation of cases with associated values (#20560)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
@@ -17,6 +17,7 @@
 
 package org.openapitools.codegen.languages;
 
+import com.samskivert.mustache.Mustache;
 import io.swagger.v3.oas.models.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -608,6 +609,11 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
         }
         additionalProperties.put(COMBINE_DEFERRED, combineDeferred);
 
+        additionalProperties.put("transformArrayType", (Mustache.Lambda) (frag, out) -> {
+            String type = frag.execute();
+            out.write(transformArrayTypeName(type));
+        });
+
         // infrastructure destination folder
         final String infrastructureFolder = sourceFolder + File.separator + "Infrastructure";
 
@@ -1089,6 +1095,17 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
                         .replaceAll("[-_ :\\(\\)]", "")),
                 LOWERCASE_FIRST_LETTER);
     }
+
+    public String transformArrayTypeName(String type) {
+        if (!type.startsWith("[") || !type.endsWith("]")) {
+            return type;
+        }
+        String innerType = type.substring(1, type.length() - 1);
+        String transformed = transformArrayTypeName(innerType);
+
+        return "ArrayOf" + transformed;
+    }
+
 
     private Boolean isLanguageSpecificType(String name) {
         return languageSpecificPrimitives.contains(name);

--- a/modules/openapi-generator/src/main/resources/swift6/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/modelOneOf.mustache
@@ -1,6 +1,6 @@
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum {{classname}}: {{^useClasses}}Sendable, {{/useClasses}}{{#useClasses}}{{#readonlyProperties}}Sendable, {{/readonlyProperties}}{{/useClasses}}{{#useVapor}}Content{{/useVapor}}{{^useVapor}}Codable, JSONEncodable{{#vendorExtensions.x-swift-hashable}}, Hashable{{/vendorExtensions.x-swift-hashable}}{{/useVapor}} {
     {{#oneOf}}
-    case type{{.}}({{.}})
+    case type{{#transformArrayType}}{{.}}{{/transformArrayType}}({{.}})
     {{/oneOf}}
     {{#oneOfUnknownDefaultCase}}
     case unknownDefaultOpenApi
@@ -10,7 +10,7 @@
         var container = encoder.singleValueContainer()
         switch self {
         {{#oneOf}}
-        case .type{{.}}(let value):
+        case .type{{#transformArrayType}}{{.}}{{/transformArrayType}}(let value):
             try container.encode(value)
         {{/oneOf}}
         {{#oneOfUnknownDefaultCase}}
@@ -29,7 +29,7 @@
         {{^-first}}
         } else if let value = try? container.decode({{.}}.self) {
         {{/-first}}
-            self = .type{{.}}(value)
+            self = .type{{#transformArrayType}}{{.}}{{/transformArrayType}}(value)
         {{/oneOf}}
         } else {
             {{#oneOfUnknownDefaultCase}}

--- a/modules/openapi-generator/src/test/resources/bugs/issue_20560.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_20560.yaml
@@ -1,0 +1,162 @@
+openapi: 3.0.0
+info:
+  title: Completions API
+  version: 1.0.0
+  description: API for generating text completions
+
+paths:
+  /completions:
+    post:
+      summary: Create a completion
+      operationId: createCompletion
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCompletionRequest'
+      responses:
+        '200':
+          description: Successful completion response
+          content:
+            application/json:
+              schema:
+                type: object
+                # Note: Full response schema would be defined here
+
+components:
+  schemas:
+    CreateCompletionRequest:
+      type: object
+      required:
+        - model
+        - prompt
+      properties:
+        model:
+          description: ID of the model to use
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - gpt-3.5-turbo-instruct
+                - davinci-002
+                - babbage-002
+        prompt:
+          description: The prompt(s) to generate completions for
+          default: <|endoftext|>
+          oneOf:
+            - type: string
+              default: ""
+              example: This is a test.
+            - type: array
+              items:
+                type: string
+                default: ""
+                example: This is a test.
+            - type: array
+              minItems: 1
+              items:
+                type: integer
+              example: "[1212, 318, 257, 1332, 13]"
+            - type: array
+              minItems: 1
+              items:
+                type: array
+                minItems: 1
+                items:
+                  type: integer
+              example: "[[1212, 318, 257, 1332, 13]]"
+        max_tokens:
+          type: integer
+          minimum: 0
+          default: 16
+          nullable: true
+          description: The maximum number of tokens that can be generated in the completion
+        temperature:
+          type: number
+          minimum: 0
+          maximum: 2
+          default: 1
+          nullable: true
+          description: What sampling temperature to use, between 0 and 2
+        top_p:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 1
+          nullable: true
+          description: An alternative to sampling with temperature, called nucleus sampling
+        n:
+          type: integer
+          minimum: 1
+          maximum: 128
+          default: 1
+          nullable: true
+          description: How many completions to generate for each prompt
+        stream:
+          type: boolean
+          nullable: true
+          default: false
+          description: Whether to stream back partial progress
+        logprobs:
+          type: integer
+          minimum: 0
+          maximum: 5
+          nullable: true
+          description: Include the log probabilities on the most likely output tokens
+        echo:
+          type: boolean
+          default: false
+          nullable: true
+          description: Echo back the prompt in addition to the completion
+        stop:
+          description: Up to 4 sequences where the API will stop generating further tokens
+          nullable: true
+          oneOf:
+            - type: string
+              example: "\n"
+            - type: array
+              minItems: 1
+              maxItems: 4
+              items:
+                type: string
+        presence_penalty:
+          type: number
+          default: 0
+          minimum: -2
+          maximum: 2
+          nullable: true
+          description: Number between -2.0 and 2.0 for presence-based penalty
+        frequency_penalty:
+          type: number
+          default: 0
+          minimum: -2
+          maximum: 2
+          nullable: true
+          description: Number between -2.0 and 2.0 for frequency-based penalty
+        best_of:
+          type: integer
+          default: 1
+          minimum: 0
+          maximum: 20
+          nullable: true
+          description: Number of completions to generate server-side
+        logit_bias:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: integer
+          description: Modify the likelihood of specified tokens appearing
+        user:
+          type: string
+          example: user-1234
+          description: A unique identifier representing your end-user
+        seed:
+          type: integer
+          format: int64
+          nullable: true
+          description: Seed for deterministic sampling
+        suffix:
+          type: string
+          nullable: true
+          description: The suffix that comes after a completion of inserted text


### PR DESCRIPTION
Fixes incorrect generation of enum cases with associated values. #20560

```swift
master                                this PR

case typeString(String)               case typeString(String)
case type[Int]([Int])                 case typeArrayOfInt([Int])
case type[String]([String])   --->    case typeArrayOfString([String])
case type[[Int]]([[Int]])             case typeArrayOfArrayOfInt([[Int]])
```

Enum cases previously generated as `case type[Int]([Int])` become `case typeArrayOfInt([Int])`

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)