### PR TITLE
[typescript-axios] Conditionally set user-agent

### DIFF
--- a/bin/configs/typescript-axios-echo-api.yaml
+++ b/bin/configs/typescript-axios-echo-api.yaml
@@ -2,6 +2,7 @@ generatorName: typescript-axios
 outputDir: samples/client/echo_api/typescript-axios/build
 inputSpec: modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
 templateDir: modules/openapi-generator/src/main/resources/typescript-axios
+httpUserAgent: EchoApi/1.0.0
 additionalProperties:
   artifactId: echo-api-typescript-axios
   hideGenerationTimestamp: "true"

--- a/modules/openapi-generator/src/main/resources/typescript-axios/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/configuration.mustache
@@ -79,11 +79,13 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
+                {{#httpUserAgent}}
+                'User-Agent': "{{httpUserAgent}}",
+                {{/httpUserAgent}}
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator{{#npmVersion}}/{{npmVersion}}{{/npmVersion}}/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/echo_api/typescript-axios/build/configuration.ts
+++ b/samples/client/echo_api/typescript-axios/build/configuration.ts
@@ -90,11 +90,11 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
+                'User-Agent': "EchoApi/1.0.0",
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/1.0.0/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/configuration.ts
+++ b/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/petstore/typescript-axios/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/petstore/typescript-axios/builds/es6-target/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/1.0.0/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/1.0.0/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces-and-with-single-request-param/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces-and-with-single-request-param/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/1.0.0/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/1.0.0/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/configuration.ts
@@ -90,11 +90,10 @@ export class Configuration {
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = {
+            ...param.baseOptions,
             headers: {
                 ...param.baseOptions?.headers,
-                'User-Agent': "OpenAPI-Generator/typescript-axios"
             },
-            ...param.baseOptions
         };
         this.formDataCtor = param.formDataCtor;
     }


### PR DESCRIPTION
The change in #20067 has caused some issues with clients which run in a Browser. This commit replaces that change, leaving the default User-Agent for axios unmodified, and only sets the User-Agent if the `http-user-agent` parameter is provided during generation time.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@macjohnny