### PR TITLE
[JAVA] [Jersey3] Make Jakarta Annotation API optional

### DIFF
--- a/bin/configs/java-jersey3.yaml
+++ b/bin/configs/java-jersey3.yaml
@@ -14,3 +14,4 @@ additionalProperties:
   gradleProperties: "\n# JVM arguments\norg.gradle.jvmargs=-Xmx2024m -XX:MaxPermSize=512m\n# set timeout\norg.gradle.daemon.idletimeout=3600000\n# show all warnings\norg.gradle.warning.mode=all"
   failOnUnknownProperties: true
   useReflectionEqualsHashCode: true
+  useJakartaAnnotation: true

--- a/docs/generators/java-microprofile.md
+++ b/docs/generators/java-microprofile.md
@@ -92,6 +92,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useBeanValidation|Use BeanValidation API annotations| |false|
 |useEnumCaseInsensitive|Use `equalsIgnoreCase` when String for enum comparison| |false|
 |useGzipFeature|Send gzip-encoded requests| |false|
+|useJakartaAnnotation|Use Jakarta Annotation API| |false|
 |useJakartaEe|whether to use Jakarta EE namespace instead of javax| |false|
 |useOneOfDiscriminatorLookup|Use the discriminator's mapping in oneOf to speed up the model lookup. IMPORTANT: Validation (e.g. one and only one match in oneOf's schemas) will be skipped. Only jersey2, jersey3, native, okhttp-gson support this option.| |false|
 |useOneOfInterfaces|whether to use a java interface to describe a set of oneOf options, where each option is a class that implements the interface| |false|

--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -92,6 +92,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useBeanValidation|Use BeanValidation API annotations| |false|
 |useEnumCaseInsensitive|Use `equalsIgnoreCase` when String for enum comparison| |false|
 |useGzipFeature|Send gzip-encoded requests| |false|
+|useJakartaAnnotation|Use Jakarta Annotation API| |false|
 |useJakartaEe|whether to use Jakarta EE namespace instead of javax| |false|
 |useOneOfDiscriminatorLookup|Use the discriminator's mapping in oneOf to speed up the model lookup. IMPORTANT: Validation (e.g. one and only one match in oneOf's schemas) will be skipped. Only jersey2, jersey3, native, okhttp-gson support this option.| |false|
 |useOneOfInterfaces|whether to use a java interface to describe a set of oneOf options, where each option is a class that implements the interface| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -40,6 +40,7 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
 import org.openapitools.codegen.languages.features.DocumentationProviderFeatures;
+import org.openapitools.codegen.languages.features.JakartaAnnotationFeatures;
 import org.openapitools.codegen.meta.features.*;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
@@ -193,6 +194,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
      */
     @Getter @Setter
     protected boolean useBeanValidation = false;
+    /**
+     * useJakartaAnnotation to include Jakarta Annotation API
+     */
+    @Getter @Setter
+    protected boolean useJakartaAnnotation = true;
     private Map<String, String> schemaKeyToModelNameCache = new HashMap<>();
 
     public AbstractJavaCodegen() {
@@ -421,6 +427,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         }
 
         convertPropertyToBooleanAndWriteBack(BeanValidationFeatures.USE_BEANVALIDATION, this::setUseBeanValidation);
+        convertPropertyToBooleanAndWriteBack(JakartaAnnotationFeatures.USE_JAKARTAANNOTATION, this::setUseJakartaAnnotation);
         convertPropertyToBooleanAndWriteBack(DISABLE_HTML_ESCAPING, this::setDisableHtmlEscaping);
         convertPropertyToStringAndWriteBack(BOOLEAN_GETTER_PREFIX, this::setBooleanGetterPrefix);
         convertPropertyToBooleanAndWriteBack(IGNORE_ANYOF_IN_ENUM, this::setIgnoreAnyOfInEnum);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -40,7 +40,6 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
 import org.openapitools.codegen.languages.features.DocumentationProviderFeatures;
-import org.openapitools.codegen.languages.features.JakartaAnnotationFeatures;
 import org.openapitools.codegen.meta.features.*;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
@@ -194,11 +193,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
      */
     @Getter @Setter
     protected boolean useBeanValidation = false;
-    /**
-     * useJakartaAnnotation to include Jakarta Annotation API
-     */
-    @Getter @Setter
-    protected boolean useJakartaAnnotation = true;
     private Map<String, String> schemaKeyToModelNameCache = new HashMap<>();
 
     public AbstractJavaCodegen() {
@@ -427,7 +421,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         }
 
         convertPropertyToBooleanAndWriteBack(BeanValidationFeatures.USE_BEANVALIDATION, this::setUseBeanValidation);
-        convertPropertyToBooleanAndWriteBack(JakartaAnnotationFeatures.USE_JAKARTAANNOTATION, this::setUseJakartaAnnotation);
         convertPropertyToBooleanAndWriteBack(DISABLE_HTML_ESCAPING, this::setDisableHtmlEscaping);
         convertPropertyToStringAndWriteBack(BOOLEAN_GETTER_PREFIX, this::setBooleanGetterPrefix);
         convertPropertyToBooleanAndWriteBack(IGNORE_ANYOF_IN_ENUM, this::setIgnoreAnyOfInEnum);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -49,7 +49,6 @@ import java.util.regex.Pattern;
 import static com.google.common.base.CaseFormat.LOWER_CAMEL;
 import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 import static java.util.Collections.sort;
-import static org.openapitools.codegen.languages.features.JakartaAnnotationFeatures.USE_JAKARTAANNOTATION;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
@@ -150,6 +149,12 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     protected boolean webclientBlockingOperations = false;
     @Setter protected boolean generateClientAsBean = false;
     @Setter protected boolean useEnumCaseInsensitive = false;
+
+    /**
+     * useJakartaAnnotation to include Jakarta Annotation API
+     */
+    @Getter @Setter
+    protected boolean useJakartaAnnotation = true;
 
     @Setter protected int maxAttemptsForRetry = 1;
     @Setter protected long waitTimeMillis = 10l;
@@ -413,6 +418,9 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         convertPropertyToTypeAndWriteBack(CodegenConstants.MAX_ATTEMPTS_FOR_RETRY, Integer::parseInt, this::setMaxAttemptsForRetry);
         convertPropertyToTypeAndWriteBack(CodegenConstants.WAIT_TIME_OF_THREAD, Long::parseLong, this::setWaitTimeMillis);
 
+        if (JERSEY3.equals(getLibrary())) {
+            convertPropertyToBooleanAndWriteBack(JakartaAnnotationFeatures.USE_JAKARTAANNOTATION, this::setUseJakartaAnnotation);
+        }
         final String invokerFolder = (sourceFolder + '/' + invokerPackage).replace(".", "/");
         final String apiFolder = (sourceFolder + '/' + apiPackage).replace(".", "/");
         final String modelsFolder = (sourceFolder + File.separator + modelPackage().replace('.', File.separatorChar)).replace('/', File.separatorChar);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
 import org.openapitools.codegen.languages.features.GzipFeatures;
+import org.openapitools.codegen.languages.features.JakartaAnnotationFeatures;
 import org.openapitools.codegen.languages.features.PerformBeanValidationFeatures;
 import org.openapitools.codegen.meta.features.DocumentationFeature;
 import org.openapitools.codegen.meta.features.GlobalFeature;
@@ -48,11 +49,12 @@ import java.util.regex.Pattern;
 import static com.google.common.base.CaseFormat.LOWER_CAMEL;
 import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 import static java.util.Collections.sort;
+import static org.openapitools.codegen.languages.features.JakartaAnnotationFeatures.USE_JAKARTAANNOTATION;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
 public class JavaClientCodegen extends AbstractJavaCodegen
-        implements BeanValidationFeatures, PerformBeanValidationFeatures, GzipFeatures {
+        implements BeanValidationFeatures, PerformBeanValidationFeatures, GzipFeatures, JakartaAnnotationFeatures {
 
     static final String MEDIA_TYPE = "mediaType";
 
@@ -219,6 +221,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(PARCELABLE_MODEL, "Whether to generate models for Android that implement Parcelable with the okhttp-gson library."));
         cliOptions.add(CliOption.newBoolean(USE_PLAY_WS, "Use Play! Async HTTP client (Play WS API)"));
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations"));
+        cliOptions.add(CliOption.newBoolean(USE_JAKARTAANNOTATION, "Use Jakarta Annotation API"));
         cliOptions.add(CliOption.newBoolean(PERFORM_BEANVALIDATION, "Perform BeanValidation"));
         cliOptions.add(CliOption.newBoolean(USE_GZIP_FEATURE, "Send gzip-encoded requests"));
         cliOptions.add(CliOption.newBoolean(USE_RUNTIME_EXCEPTION, "Use RuntimeException instead of Exception. Only jersey2, jersey3, okhttp-gson, vertx, microprofile support this option."));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/features/JakartaAnnotationFeatures.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/features/JakartaAnnotationFeatures.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ * Copyright 2018 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.languages.features;
+
+public interface JakartaAnnotationFeatures {
+
+    // Language supports generating Jakarta-Annotation API
+    String USE_JAKARTAANNOTATION = "useJakartaAnnotation";
+
+    void setUseJakartaAnnotation(boolean useJakartaAnnotation);
+
+}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
@@ -22,7 +22,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-{{>generatedAnnotation}}
+{{#useJakartaAnnotation}}
+{{>generatedAnnotation}}{{/useJakartaAnnotation}}
 {{#operations}}
 public class {{classname}} {
   private ApiClient apiClient;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
@@ -23,7 +23,7 @@
 @JsonTypeName("{{name}}")
 {{/isClassnameSanitized}}
 {{/jackson}}
-{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
+{{>additionalModelTypeAnnotations}}{{#useJakartaAnnotation}}{{>generatedAnnotation}}{{/useJakartaAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}
 {{{vendorExtensions.x-class-extra-annotation}}}
 {{/vendorExtensions.x-class-extra-annotation}}
@@ -81,7 +81,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   {{#deprecated}}
   @Deprecated
   {{/deprecated}}
-  {{>nullable_var_annotations}}
+  {{#useJakartaAnnotation}}{{>nullable_var_annotations}}{{/useJakartaAnnotation}}
   private {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
@@ -114,7 +114,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   {{#deprecated}}
   @Deprecated
   {{/deprecated}}
-  public {{classname}} {{name}}({{>nullable_var_annotations}} {{{datatypeWithEnum}}} {{name}}) {
+  public {{classname}} {{name}}({{#useJakartaAnnotation}}{{>nullable_var_annotations}}{{/useJakartaAnnotation}} {{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.x-enum-as-string}}
     if (!{{{nameInSnakeCase}}}_VALUES.contains({{name}})) {
       throw new IllegalArgumentException({{name}} + " is invalid. Possible values for {{name}}: " + String.join(", ", {{{nameInSnakeCase}}}_VALUES));
@@ -198,7 +198,8 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
 {{#deprecated}}
   @Deprecated
 {{/deprecated}}
-  {{>nullable_var_annotations}}
+  {{#useJakartaAnnotation}}
+  {{>nullable_var_annotations}}{{/useJakartaAnnotation}}
 {{#useBeanValidation}}
 {{>beanValidation}}
 {{/useBeanValidation}}
@@ -248,7 +249,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   @Deprecated
   {{/deprecated}}
 {{#vendorExtensions.x-setter-extra-annotation}}  {{{vendorExtensions.x-setter-extra-annotation}}}
-{{/vendorExtensions.x-setter-extra-annotation}}{{#jackson}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{> jackson_annotations}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{/jackson}}  public void {{setter}}({{>nullable_var_annotations}} {{{datatypeWithEnum}}} {{name}}) {
+{{/vendorExtensions.x-setter-extra-annotation}}{{#jackson}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{> jackson_annotations}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{/jackson}}  public void {{setter}}({{#useJakartaAnnotation}}{{>nullable_var_annotations}}{{/useJakartaAnnotation}} {{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.x-enum-as-string}}
     if (!{{{nameInSnakeCase}}}_VALUES.contains({{name}})) {
       throw new IllegalArgumentException({{name}} + " is invalid. Possible values for {{name}}: " + String.join(", ", {{{nameInSnakeCase}}}_VALUES));

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pom.mustache
@@ -368,12 +368,15 @@
             <scope>provided</scope>
         </dependency>
         {{/useBeanValidation}}
+        {{#useJakartaAnnotation}}
+        <!-- Jakarta Annotation API support -->
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <version>${jakarta-annotation-version}</version>
             <scope>provided</scope>
         </dependency>
+        {{/useJakartaAnnotation}}
         <dependency>
             <groupId>org.glassfish.jersey.connectors</groupId>
             <artifactId>jersey-apache-connector</artifactId>
@@ -408,7 +411,8 @@
         <jackson-version>2.17.1</jackson-version>
         <jackson-databind-version>2.17.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
-        <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+        {{#useJakartaAnnotation}}
+        <jakarta-annotation-version>2.1.1</jakarta-annotation-version>{{/useJakartaAnnotation}}
         <beanvalidation-version>3.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>
         {{#hasHttpSignatureMethods}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -3365,4 +3365,62 @@ public class JavaClientCodegenTest {
                 "responseBody.isBlank()? null: memberVarObjectMapper.readValue(responseBody, new TypeReference<LocationData>() {})"
         );
     }
+
+    @Test
+    public void testJerseyContainsJakartaAnnotation() {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("java")
+                .setLibrary(JERSEY3)
+                .addAdditionalProperty(JavaClientCodegen.USE_JAKARTAANNOTATION, true)
+                .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        validateJavaSourceFiles(files);
+        // check POM includes jakarta-annotation
+        assertThat(files).contains(output.resolve("pom.xml").toFile());
+        assertThat(output.resolve("pom.xml")).content()
+                .contains("<jakarta-annotation-version>");
+        assertThat(output.resolve("pom.xml")).content()
+                .contains("jakarta.annotation-api");
+        // check API
+        assertThat(output.resolve("src/main/java/org/openapitools/client/api/PetApi.java")).content()
+                .contains("@jakarta.annotation.Generated");
+        // check model
+        assertThat(output.resolve("src/main/java/org/openapitools/client/model/Category.java")).content()
+                .contains("@jakarta.annotation.Generated");
+        assertThat(output.resolve("src/main/java/org/openapitools/client/model/Category.java")).content()
+                .contains("@jakarta.annotation.Nullable");
+    }
+
+    @Test
+    public void testJerseyWithoutJakartaAnnotation() {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("java")
+                .setLibrary(JERSEY3)
+                .addAdditionalProperty(JavaClientCodegen.USE_JAKARTAANNOTATION, false)
+                .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        validateJavaSourceFiles(files);
+        // check POM includes jakarta-annotation
+        assertThat(files).contains(output.resolve("pom.xml").toFile());
+        assertThat(output.resolve("pom.xml")).content()
+                .doesNotContain("<jakarta-annotation-version>");
+        assertThat(output.resolve("pom.xml")).content()
+                .doesNotContain("jakarta.annotation-api");
+        // check API
+        assertThat(output.resolve("src/main/java/org/openapitools/client/api/PetApi.java")).content()
+                .doesNotContain("@jakarta.annotation.Generated");
+        // check model
+        assertThat(output.resolve("src/main/java/org/openapitools/client/model/Category.java")).content()
+                .doesNotContain("@jakarta.annotation.Generated");
+        assertThat(output.resolve("src/main/java/org/openapitools/client/model/Category.java")).content()
+                .doesNotContain("@jakarta.annotation.Nullable");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -3408,7 +3408,7 @@ public class JavaClientCodegenTest {
         List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
 
         validateJavaSourceFiles(files);
-        // check POM includes jakarta-annotation
+        // check POM does not include jakarta-annotation
         assertThat(files).contains(output.resolve("pom.xml").toFile());
         assertThat(output.resolve("pom.xml")).content()
                 .doesNotContain("<jakarta-annotation-version>");

--- a/samples/client/petstore/java/jersey3-oneOf/pom.xml
+++ b/samples/client/petstore/java/jersey3-oneOf/pom.xml
@@ -307,6 +307,7 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+        <!-- Jakarta Annotation API support -->
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>

--- a/samples/client/petstore/java/jersey3/pom.xml
+++ b/samples/client/petstore/java/jersey3/pom.xml
@@ -324,6 +324,7 @@
             <version>${beanvalidation-version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Jakarta Annotation API support -->
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>


### PR DESCRIPTION
Allow to skip the generation of the `jakarta-annotation-api` annotations.

Fix #20575

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 
