### PR TITLE
fix #16412 elixir outer enum bug

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/deserializer.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/deserializer.ex.mustache
@@ -91,8 +91,12 @@ defmodule {{moduleName}}.Deserializer do
     end
   end
 
-  defp to_struct(map_or_list, module)
+  defp to_struct(value, module)
   defp to_struct(nil, _), do: nil
+  
+  defp to_struct(binary, module) when is_binary(binary) and is_atom(module) do
+    module.decode(binary)
+  end
 
   defp to_struct(list, module) when is_list(list) and is_atom(module) do
     Enum.map(list, &to_struct(&1, module))

--- a/samples/client/petstore/elixir/lib/openapi_petstore/deserializer.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/deserializer.ex
@@ -93,8 +93,12 @@ defmodule OpenapiPetstore.Deserializer do
     end
   end
 
-  defp to_struct(map_or_list, module)
+  defp to_struct(value, module)
   defp to_struct(nil, _), do: nil
+  
+  defp to_struct(binary, module) when is_binary(binary) and is_atom(module) do
+    module.decode(binary)
+  end
 
   defp to_struct(list, module) when is_list(list) and is_atom(module) do
     Enum.map(list, &to_struct(&1, module))

--- a/samples/client/petstore/elixir/test/outer_enum_test.exs
+++ b/samples/client/petstore/elixir/test/outer_enum_test.exs
@@ -1,0 +1,23 @@
+defmodule OuterEnumTest do
+  use ExUnit.Case, async: true
+
+  alias OpenapiPetstore.Deserializer
+  alias OpenapiPetstore.Model.EnumTest
+
+  @valid_json """
+  {
+    "enum_string": "UPPER",
+    "outerEnum": "placed"
+  }
+  """
+
+  @tag timeout: :infinity
+  test "jason_decode/2 with valid JSON" do
+    assert Deserializer.jason_decode(@valid_json, EnumTest) ==
+             {:ok,
+              %EnumTest{
+                enum_string: "UPPER",
+                outerEnum: "placed"
+              }}
+  end
+end


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This fixes a bug where an outer enum isn't properly deserialized in the generated Elixir client. See this issue. https://github.com/OpenAPITools/openapi-generator/issues/16412

I added one test to exercise the failure case, which I got from this PR https://github.com/OpenAPITools/openapi-generator/pull/19435 as I was searching to see if anyone else had been having the same problem I ran into. 

@tobbbles I grabbed your failing test from #19435 and included it here to speed things up. Thank you for your prior work on this. It pointed me in the right direction.

Real team effort here!

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Relates to https://github.com/OpenAPITools/openapi-generator/issues/16412

This PR fixes a bug in the Elixir generator @mrmstn 


