### PR TITLE
fix outer enum number bug elixir generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/deserializer.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/deserializer.ex.mustache
@@ -94,10 +94,6 @@ defmodule {{moduleName}}.Deserializer do
   defp to_struct(value, module)
   defp to_struct(nil, _), do: nil
   
-  defp to_struct(binary, module) when is_binary(binary) and is_atom(module) do
-    module.decode(binary)
-  end
-
   defp to_struct(list, module) when is_list(list) and is_atom(module) do
     Enum.map(list, &to_struct(&1, module))
   end
@@ -112,5 +108,9 @@ defmodule {{moduleName}}.Deserializer do
       Map.replace(acc, field, Map.get(map, Atom.to_string(field)))
     end)
     |> module.decode()
+  end
+
+  defp to_struct(value, module) when is_atom(module) do
+    module.decode(value)
   end
 end

--- a/samples/client/petstore/elixir/lib/openapi_petstore/deserializer.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/deserializer.ex
@@ -96,10 +96,6 @@ defmodule OpenapiPetstore.Deserializer do
   defp to_struct(value, module)
   defp to_struct(nil, _), do: nil
   
-  defp to_struct(binary, module) when is_binary(binary) and is_atom(module) do
-    module.decode(binary)
-  end
-
   defp to_struct(list, module) when is_list(list) and is_atom(module) do
     Enum.map(list, &to_struct(&1, module))
   end
@@ -114,5 +110,9 @@ defmodule OpenapiPetstore.Deserializer do
       Map.replace(acc, field, Map.get(map, Atom.to_string(field)))
     end)
     |> module.decode()
+  end
+
+  defp to_struct(value, module) when is_atom(module) do
+    module.decode(value)
   end
 end

--- a/samples/client/petstore/elixir/test/outer_enum_test.exs
+++ b/samples/client/petstore/elixir/test/outer_enum_test.exs
@@ -7,7 +7,9 @@ defmodule OuterEnumTest do
   @valid_json """
   {
     "enum_string": "UPPER",
-    "outerEnum": "placed"
+    "enum_number": 1.1,
+    "outerEnum": "placed",
+    "outerEnumInteger": 1
   }
   """
 
@@ -17,7 +19,9 @@ defmodule OuterEnumTest do
              {:ok,
               %EnumTest{
                 enum_string: "UPPER",
-                outerEnum: "placed"
+                enum_number: 1.1,
+                outerEnum: "placed",
+                outerEnumInteger: 1
               }}
   end
 end


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This is a more complete fix for a bug where an outer enum isn't properly deserialized in the generated Elixir client. See this issue. https://github.com/OpenAPITools/openapi-generator/issues/16412

My previous PR (https://github.com/OpenAPITools/openapi-generator/pull/20587) addressed the outer enum string bug. This follow-up PR fixes the issue more generally and updates the relevant test to ensure other outer enum types work as expected.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

This PR is a follow up bug fix in the Elixir generator @mrmstn (see previous PR #20587)
