### PR TITLE
[kotlin-client][jvm-spring-restclient] Extract data from PartConfig for multipart/form-data requests in ApiClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/infrastructure/ApiClient.kt.mustache
@@ -46,8 +46,23 @@ import org.springframework.util.LinkedMultiValueMap
     private fun <I> RestClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =
         apply { requestConfig.headers.forEach { (name, value) -> header(name, value) } }
 
-    private fun <I : Any> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>) =
-        apply { if (requestConfig.body != null) body(requestConfig.body) }
+    private fun <I : Any> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
+        when {
+            requestConfig.headers[HttpHeaders.CONTENT_TYPE] == MediaType.MULTIPART_FORM_DATA_VALUE -> {
+                val parts = LinkedMultiValueMap<String, Any>()
+                (requestConfig.body as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                    if (part.body != null) {
+                        parts.add(name, part.body)
+                    }
+                }
+                return apply { body(parts) }
+            }
+
+            else -> {
+                return apply { if (requestConfig.body != null) body(requestConfig.body) }
+            }
+        }
+    }
 }
 
 {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -46,8 +46,23 @@ open class ApiClient(protected val client: RestClient) {
     private fun <I> RestClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =
         apply { requestConfig.headers.forEach { (name, value) -> header(name, value) } }
 
-    private fun <I : Any> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>) =
-        apply { if (requestConfig.body != null) body(requestConfig.body) }
+    private fun <I : Any> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
+        when {
+            requestConfig.headers[HttpHeaders.CONTENT_TYPE] == MediaType.MULTIPART_FORM_DATA_VALUE -> {
+                val parts = LinkedMultiValueMap<String, Any>()
+                (requestConfig.body as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                    if (part.body != null) {
+                        parts.add(name, part.body)
+                    }
+                }
+                return apply { body(parts) }
+            }
+
+            else -> {
+                return apply { if (requestConfig.body != null) body(requestConfig.body) }
+            }
+        }
+    }
 }
 
 inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -46,8 +46,23 @@ open class ApiClient(protected val client: RestClient) {
     private fun <I> RestClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =
         apply { requestConfig.headers.forEach { (name, value) -> header(name, value) } }
 
-    private fun <I : Any> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>) =
-        apply { if (requestConfig.body != null) body(requestConfig.body) }
+    private fun <I : Any> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
+        when {
+            requestConfig.headers[HttpHeaders.CONTENT_TYPE] == MediaType.MULTIPART_FORM_DATA_VALUE -> {
+                val parts = LinkedMultiValueMap<String, Any>()
+                (requestConfig.body as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                    if (part.body != null) {
+                        parts.add(name, part.body)
+                    }
+                }
+                return apply { body(parts) }
+            }
+
+            else -> {
+                return apply { if (requestConfig.body != null) body(requestConfig.body) }
+            }
+        }
+    }
 }
 
 inline fun <reified T: Any> parseDateToQueryString(value : T): String {


### PR DESCRIPTION
Should fix the following error that was appearing when generating a API for multipart/form-data requests with kotlin jvm-spring-restclient: Fixes https://github.com/OpenAPITools/openapi-generator/issues/20597

Content type 'multipart/form-data' not supported for bodyType=java.util.Collections$SingletonMap

Technical comitee: @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
