### PR TITLE
Fix associative container on Json values in UE4cpp

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
@@ -298,6 +298,17 @@ inline void WriteJsonValue(JsonWriter& Writer, const TMap<FString, T>& Value)
 	Writer->WriteObjectEnd();
 }
 
+template <typename T>
+inline void WriteJsonValue(JsonWriter& Writer, const TSet<T>& Value)
+{
+	Writer->WriteArrayStart();
+	for (const auto& Element : Value)
+	{
+		WriteJsonValue(Writer, Element);
+	}
+	Writer->WriteArrayEnd();
+}
+
 //////////////////////////////////////////////////////////////////////////
 
 inline bool TryGetJsonValue(const TSharedPtr<FJsonValue>& JsonValue, FString& Value)
@@ -463,6 +474,26 @@ inline bool TryGetJsonValue(const TSharedPtr<FJsonObject>& JsonObject, const FSt
 	// Absence of optional value is not a parsing error.
 	// Nullable is handled like optional.
 	return true;
+}
+
+template <typename T>
+inline bool TryGetJsonValue(const TSharedPtr<FJsonValue>& JsonValue, TSet<T>& ArrayValue)
+{
+	const TArray<TSharedPtr<FJsonValue>>* JsonArray;
+	if (JsonValue->TryGetArray(JsonArray))
+	{
+		bool ParseSuccess = true;
+		const int32 Count = JsonArray->Num();
+		ArrayValue.Reset();
+		for (int i = 0; i < Count; i++)
+		{
+			T TmpValue;
+			ParseSuccess &= TryGetJsonValue((*JsonArray)[i], TmpValue);
+			ArrayValue.Emplace(MoveTemp(TmpValue));
+		}
+		return ParseSuccess;
+	}
+	return false;
 }
 
 {{#cppNamespaceDeclarations}}

--- a/samples/client/petstore/cpp-ue4/Public/OpenAPIHelpers.h
+++ b/samples/client/petstore/cpp-ue4/Public/OpenAPIHelpers.h
@@ -307,6 +307,17 @@ inline void WriteJsonValue(JsonWriter& Writer, const TMap<FString, T>& Value)
 	Writer->WriteObjectEnd();
 }
 
+template <typename T>
+inline void WriteJsonValue(JsonWriter& Writer, const TSet<T>& Value)
+{
+	Writer->WriteArrayStart();
+	for (const auto& Element : Value)
+	{
+		WriteJsonValue(Writer, Element);
+	}
+	Writer->WriteArrayEnd();
+}
+
 //////////////////////////////////////////////////////////////////////////
 
 inline bool TryGetJsonValue(const TSharedPtr<FJsonValue>& JsonValue, FString& Value)
@@ -472,6 +483,26 @@ inline bool TryGetJsonValue(const TSharedPtr<FJsonObject>& JsonObject, const FSt
 	// Absence of optional value is not a parsing error.
 	// Nullable is handled like optional.
 	return true;
+}
+
+template <typename T>
+inline bool TryGetJsonValue(const TSharedPtr<FJsonValue>& JsonValue, TSet<T>& ArrayValue)
+{
+	const TArray<TSharedPtr<FJsonValue>>* JsonArray;
+	if (JsonValue->TryGetArray(JsonArray))
+	{
+		bool ParseSuccess = true;
+		const int32 Count = JsonArray->Num();
+		ArrayValue.Reset();
+		for (int i = 0; i < Count; i++)
+		{
+			T TmpValue;
+			ParseSuccess &= TryGetJsonValue((*JsonArray)[i], TmpValue);
+			ArrayValue.Emplace(MoveTemp(TmpValue));
+		}
+		return ParseSuccess;
+	}
+	return false;
 }
 
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Similar to https://github.com/OpenAPITools/openapi-generator/pull/17684

Fixes compiler error when using `"uniqueItems": true,` in the schema
```cpp
11>JsonWriter.h(211): Error C2665 : 'TJsonWriter<TCHAR,TPrettyJsonPrintPolicy<CharType>>::WriteValueOnly': no overloaded function could convert all the argument types
        
```
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
- [ ] 
Tagging @Kahncode for visibility