### PR TITLE
Add flag skipDefaultUserAgent to skip setting user agent in TypeScrip…

### DIFF
--- a/bin/configs/typescript-axios-es6-target.yaml
+++ b/bin/configs/typescript-axios-es6-target.yaml
@@ -8,3 +8,4 @@ additionalProperties:
   npmName: '@openapitools/typescript-axios-petstore'
   npmRepository: https://skimdb.npmjs.com/registry
   snapshot: false
+  skipDefaultUserAgent: true

--- a/docs/generators/typescript.md
+++ b/docs/generators/typescript.md
@@ -38,6 +38,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |paramNaming|Naming convention for parameters: 'camelCase', 'PascalCase', 'snake_case' and 'original', which keeps the original name| |camelCase|
 |platform|Specifies the platform the code should run on. The default is 'node' for the 'request' framework and 'browser' otherwise.|<dl><dt>**browser**</dt><dd>browser</dd><dt>**node**</dt><dd>node</dd><dt>**deno**</dt><dd>deno</dd></dl>|browser|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
+|skipDefaultUserAgent|Skip setting default user-agent in configuration.ts| |false|
 |snapshot|When setting this property to true, the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -75,6 +75,8 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
 
     private static final String USE_OBJECT_PARAMS_SWITCH = "useObjectParameters";
     private static final String USE_OBJECT_PARAMS_DESC = "Use aggregate parameter objects as function arguments for api operations instead of passing each parameter as a separate function argument.";
+    public static final String SKIP_DEFAULT_USER_AGENT = "skipDefaultUserAgent";
+    public static final String SKIP_DEFAULT_USER_AGENT_DESC = "Skip setting default user-agent in configuration.ts";
 
     private final Map<String, String> frameworkToHttpLibMap;
 
@@ -120,6 +122,7 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
         cliOptions.add(new CliOption(TypeScriptClientCodegen.USE_OBJECT_PARAMS_SWITCH, TypeScriptClientCodegen.USE_OBJECT_PARAMS_DESC).defaultValue("false"));
         cliOptions.add(new CliOption(TypeScriptClientCodegen.USE_INVERSIFY_SWITCH, TypeScriptClientCodegen.USE_INVERSIFY_SWITCH_DESC).defaultValue("false"));
         cliOptions.add(new CliOption(TypeScriptClientCodegen.IMPORT_FILE_EXTENSION_SWITCH, TypeScriptClientCodegen.IMPORT_FILE_EXTENSION_SWITCH_DESC));
+        cliOptions.add(new CliOption(TypeScriptClientCodegen.SKIP_DEFAULT_USER_AGENT, TypeScriptClientCodegen.SKIP_DEFAULT_USER_AGENT_DESC).defaultValue("false"));
 
         CliOption frameworkOption = new CliOption(TypeScriptClientCodegen.FRAMEWORK_SWITCH, TypeScriptClientCodegen.FRAMEWORK_SWITCH_DESC);
         for (String option : TypeScriptClientCodegen.FRAMEWORKS) {

--- a/modules/openapi-generator/src/main/resources/typescript-axios/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/configuration.mustache
@@ -81,9 +81,11 @@ export class Configuration {
         this.baseOptions = {
             ...param.baseOptions,
             headers: {
+                {{^skipDefaultUserAgent}}
                 {{#httpUserAgent}}
                 'User-Agent': "{{httpUserAgent}}",
                 {{/httpUserAgent}}
+                {{/skipDefaultUserAgent}}
                 ...param.baseOptions?.headers,
             },
         };


### PR DESCRIPTION
closes #20600

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@TiFu  @taxpon  @sebastianhaas  @kenisteward  @Vrolijkx  @macjohnny  @topce  @akehir  @petejohansonxo  @amakhrov  @davidgamero  @mkusaka  @joscha 