### PR TITLE
Ruby fix typhoeus api client multiple call with file return type

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_typhoeus_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_typhoeus_partial.mustache
@@ -4,7 +4,8 @@
     #   the data deserialized from response body (may be a Tempfile or nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)
-      tempfile = download_file(request) if opts[:return_type] == 'File'
+      tempfile = nil
+      (download_file(request) { tempfile = _1 }) if opts[:return_type] == 'File'
       response = request.run
 
       if @config.debugging
@@ -145,17 +146,15 @@
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
-      # run the request to ensure the tempfile is created successfully before returning it
-      request.run
-      if tempfile
+      request.on_complete do
+        if !tempfile
+          fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}")
+        end
         tempfile.close
         @config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
                             "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
                             "will be deleted automatically with GC. It's also recommended to delete the temp file "\
                             "explicitly with `tempfile.delete`"
-      else
-        fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}") 
+        yield tempfile if block_given?
       end
-
-      tempfile
     end

--- a/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api_client.rb
+++ b/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api_client.rb
@@ -49,7 +49,8 @@ module OpenapiClient
     #   the data deserialized from response body (may be a Tempfile or nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)
-      tempfile = download_file(request) if opts[:return_type] == 'File'
+      tempfile = nil
+      (download_file(request) { tempfile = _1 }) if opts[:return_type] == 'File'
       response = request.run
 
       if @config.debugging
@@ -188,19 +189,17 @@ module OpenapiClient
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
-      # run the request to ensure the tempfile is created successfully before returning it
-      request.run
-      if tempfile
+      request.on_complete do
+        if !tempfile
+          fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}")
+        end
         tempfile.close
         @config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
                             "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
                             "will be deleted automatically with GC. It's also recommended to delete the temp file "\
                             "explicitly with `tempfile.delete`"
-      else
-        fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}") 
+        yield tempfile if block_given?
       end
-
-      tempfile
     end
 
     # Check if the given MIME is a JSON MIME.

--- a/samples/client/petstore/ruby-autoload/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/api_client.rb
@@ -49,7 +49,8 @@ module Petstore
     #   the data deserialized from response body (may be a Tempfile or nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)
-      tempfile = download_file(request) if opts[:return_type] == 'File'
+      tempfile = nil
+      (download_file(request) { tempfile = _1 }) if opts[:return_type] == 'File'
       response = request.run
 
       if @config.debugging
@@ -188,19 +189,17 @@ module Petstore
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
-      # run the request to ensure the tempfile is created successfully before returning it
-      request.run
-      if tempfile
+      request.on_complete do
+        if !tempfile
+          fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}")
+        end
         tempfile.close
         @config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
                             "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
                             "will be deleted automatically with GC. It's also recommended to delete the temp file "\
                             "explicitly with `tempfile.delete`"
-      else
-        fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}") 
+        yield tempfile if block_given?
       end
-
-      tempfile
     end
 
     # Check if the given MIME is a JSON MIME.

--- a/samples/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_client.rb
@@ -49,7 +49,8 @@ module Petstore
     #   the data deserialized from response body (may be a Tempfile or nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)
-      tempfile = download_file(request) if opts[:return_type] == 'File'
+      tempfile = nil
+      (download_file(request) { tempfile = _1 }) if opts[:return_type] == 'File'
       response = request.run
 
       if @config.debugging
@@ -188,19 +189,17 @@ module Petstore
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
-      # run the request to ensure the tempfile is created successfully before returning it
-      request.run
-      if tempfile
+      request.on_complete do
+        if !tempfile
+          fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}")
+        end
         tempfile.close
         @config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
                             "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
                             "will be deleted automatically with GC. It's also recommended to delete the temp file "\
                             "explicitly with `tempfile.delete`"
-      else
-        fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}") 
+        yield tempfile if block_given?
       end
-
-      tempfile
     end
 
     # Check if the given MIME is a JSON MIME.

--- a/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api_client.rb
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api_client.rb
@@ -49,7 +49,8 @@ module XAuthIDAlias
     #   the data deserialized from response body (may be a Tempfile or nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)
-      tempfile = download_file(request) if opts[:return_type] == 'File'
+      tempfile = nil
+      (download_file(request) { tempfile = _1 }) if opts[:return_type] == 'File'
       response = request.run
 
       if @config.debugging
@@ -188,19 +189,17 @@ module XAuthIDAlias
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
-      # run the request to ensure the tempfile is created successfully before returning it
-      request.run
-      if tempfile
+      request.on_complete do
+        if !tempfile
+          fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}")
+        end
         tempfile.close
         @config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
                             "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
                             "will be deleted automatically with GC. It's also recommended to delete the temp file "\
                             "explicitly with `tempfile.delete`"
-      else
-        fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}") 
+        yield tempfile if block_given?
       end
-
-      tempfile
     end
 
     # Check if the given MIME is a JSON MIME.

--- a/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_client.rb
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_client.rb
@@ -49,7 +49,8 @@ module DynamicServers
     #   the data deserialized from response body (may be a Tempfile or nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)
-      tempfile = download_file(request) if opts[:return_type] == 'File'
+      tempfile = nil
+      (download_file(request) { tempfile = _1 }) if opts[:return_type] == 'File'
       response = request.run
 
       if @config.debugging
@@ -187,19 +188,17 @@ module DynamicServers
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
-      # run the request to ensure the tempfile is created successfully before returning it
-      request.run
-      if tempfile
+      request.on_complete do
+        if !tempfile
+          fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}")
+        end
         tempfile.close
         @config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
                             "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
                             "will be deleted automatically with GC. It's also recommended to delete the temp file "\
                             "explicitly with `tempfile.delete`"
-      else
-        fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}") 
+        yield tempfile if block_given?
       end
-
-      tempfile
     end
 
     # Check if the given MIME is a JSON MIME.

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_client.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_client.rb
@@ -49,7 +49,8 @@ module Petstore
     #   the data deserialized from response body (may be a Tempfile or nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)
-      tempfile = download_file(request) if opts[:return_type] == 'File'
+      tempfile = nil
+      (download_file(request) { tempfile = _1 }) if opts[:return_type] == 'File'
       response = request.run
 
       if @config.debugging
@@ -187,19 +188,17 @@ module Petstore
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
-      # run the request to ensure the tempfile is created successfully before returning it
-      request.run
-      if tempfile
+      request.on_complete do
+        if !tempfile
+          fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}")
+        end
         tempfile.close
         @config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
                             "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
                             "will be deleted automatically with GC. It's also recommended to delete the temp file "\
                             "explicitly with `tempfile.delete`"
-      else
-        fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}") 
+        yield tempfile if block_given?
       end
-
-      tempfile
     end
 
     # Check if the given MIME is a JSON MIME.


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Hi @cliffano @zlx @autopp,
When downloading File type with Typhoeus request was run two times, one in call_api method as it should be and another in download_file to ensure the file is available before a check. The call should only happen once.
I've written a fix but not quite fond of the outcome. 
